### PR TITLE
Comparing the Id of the observer Id to get the correct observers

### DIFF
--- a/Source/Kernel/MongoDB/Observation/MongoDBObserverStorage.cs
+++ b/Source/Kernel/MongoDB/Observation/MongoDBObserverStorage.cs
@@ -35,12 +35,15 @@ public class MongoDBObserverStorage : IObserverStorage
             .First()));
 
     /// <inheritdoc/>
-    public Task<IEnumerable<ObserverInformation>> GetObserversForEventTypes(IEnumerable<EventType> eventTypes) =>
-        Task.FromResult(Collection
+    public Task<IEnumerable<ObserverInformation>> GetObserversForEventTypes(IEnumerable<EventType> eventTypes)
+    {
+        var eventTypeIds = eventTypes.Select(_ => _.Id).ToArray();
+        return Task.FromResult(Collection
             .Find(_ => true)
             .ToEnumerable()
-            .Where(_ => _.EventTypes.Any(_ => eventTypes.Contains(_)))
+            .Where(observer => observer.EventTypes.Any(_ => eventTypeIds.Contains(_.Id)))
             .Select(_ => ToObserverInformation(_)).ToArray().AsEnumerable());
+    }
 
     /// <inheritdoc/>
     public Task<IEnumerable<ObserverInformation>> GetAllObservers() =>


### PR DESCRIPTION
### Fixed

- FIxing so that observers gets called properly after a redaction. There was an error in the query for getting observers based on event types.
