### PR TITLE
Passing along the request type for the recommendation to `ToBsonDocument`

### DIFF
--- a/Source/Kernel/MongoDB/Operations/MongoDBRecommendationStorage.cs
+++ b/Source/Kernel/MongoDB/Operations/MongoDBRecommendationStorage.cs
@@ -67,7 +67,7 @@ public class MongoDBRecommendationStorage : IRecommendationStorage
         {
             var request = recommendationState.Request;
             recommendationState.Request = null!;
-            requestAsDocument = request.ToBsonDocument();
+            requestAsDocument = request.ToBsonDocument(request.GetType());
         }
 
         var document = recommendationState.ToBsonDocument();


### PR DESCRIPTION
### Fixed

- Passing along the request type on recommendation to `.ToBsonDocument()` as it then will pick the correct serializer.
