### PR TITLE
Fixing what gets exposed on the RemoveWith API - so we don't expose more than what is possible

### DIFF
--- a/Source/Clients/DotNET/Projections/IProjectionBuilder.cs
+++ b/Source/Clients/DotNET/Projections/IProjectionBuilder.cs
@@ -70,7 +70,7 @@ public interface IProjectionBuilder<TModel, TBuilder>
     /// <typeparam name="TEvent">Type of event.</typeparam>
     /// <param name="builderCallback">Optional callback for building.</param>
     /// <returns>Builder continuation.</returns>
-    TBuilder RemovedWith<TEvent>(Action<IRemovedWithBuilder<TModel, TEvent, TBuilder>>? builderCallback = default);
+    TBuilder RemovedWith<TEvent>(Action<RemovedWithBuilder<TModel, TEvent>>? builderCallback = default);
 
     /// <summary>
     /// Start building the children projection for a specific child model.

--- a/Source/Clients/DotNET/Projections/ProjectionBuilder.cs
+++ b/Source/Clients/DotNET/Projections/ProjectionBuilder.cs
@@ -137,7 +137,7 @@ public class ProjectionBuilder<TModel, TBuilder>(
     }
 
     /// <inheritdoc/>
-    public TBuilder RemovedWith<TEvent>(Action<IRemovedWithBuilder<TModel, TEvent, TBuilder>>? builderCallback = default)
+    public TBuilder RemovedWith<TEvent>(Action<RemovedWithBuilder<TModel, TEvent>>? builderCallback = default)
     {
         var type = typeof(TEvent);
 
@@ -147,7 +147,7 @@ public class ProjectionBuilder<TModel, TBuilder>(
         }
 
         var removedWithEvent = eventTypes.GetEventTypeFor(typeof(TEvent)).ToContract();
-        var removedWithBuilder = new RemovedWithBuilder<TModel, TEvent, TBuilder>();
+        var removedWithBuilder = new RemovedWithBuilder<TModel, TEvent>();
         builderCallback?.Invoke(removedWithBuilder);
         _removedWithDefinitions[removedWithEvent] = removedWithBuilder.Build();
 

--- a/Source/Clients/DotNET/Projections/RemovedWithBuilder.cs
+++ b/Source/Clients/DotNET/Projections/RemovedWithBuilder.cs
@@ -10,9 +10,7 @@ namespace Cratis.Chronicle.Projections;
 /// </summary>
 /// <typeparam name="TModel">Model to build for.</typeparam>
 /// <typeparam name="TEvent">Event to build for.</typeparam>
-/// <typeparam name="TBuilder">Type of actual builder.</typeparam>
-public class RemovedWithBuilder<TModel, TEvent, TBuilder> : KeyBuilder<TEvent, TBuilder>, IRemovedWithBuilder<TModel, TEvent, TBuilder>
-    where TBuilder : class
+public class RemovedWithBuilder<TModel, TEvent> : KeyBuilder<TEvent, RemovedWithBuilder<TModel, TEvent>>, IRemovedWithBuilder<TModel, TEvent, RemovedWithBuilder<TModel, TEvent>>
 {
     /// <inheritdoc/>
     public RemovedWithDefinition Build() => new()


### PR DESCRIPTION
### Fixed

- Limiting the API surface for `RemoveWith()` to only what it is capable of and also setting up the correct return type for the inherited `KeyBuilder`.
