### PR TITLE
Fix/aggregate root result events ordering

### DIFF
--- a/Source/Clients/DotNET.Specs/Aggregates/for_AggregateRootMutation/when_committing/with_two_uncommitted_events.cs
+++ b/Source/Clients/DotNET.Specs/Aggregates/for_AggregateRootMutation/when_committing/with_two_uncommitted_events.cs
@@ -38,6 +38,12 @@ public class with_two_uncommitted_events : given.an_aggregate_mutation
 
     [Fact] void should_return_a_successful_commit_result() => _result.IsSuccess.ShouldBeTrue();
     [Fact] void should_return_the_correct_events_in_the_commit_result() => _result.Events.ShouldContainOnly(_events);
+    [Fact] void should_have_events_in_unit_of_work_in_correct_order()
+    {
+        var events = _unitOfWork.GetEvents().ToArray();
+        events[0].ShouldEqual(_firstEvent);
+        events[1].ShouldEqual(_secondEvent);
+    }
     [Fact] void should_commit_the_unit_of_work() => _unitOfWork.Received(1).Commit();
     [Fact] void should_clear_the_uncommitted_events() => _mutation.UncommittedEvents.ShouldBeEmpty();
 }

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_it_has_events_and_append_returns_constraints_and_errors.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_it_has_events_and_append_returns_constraints_and_errors.cs
@@ -45,6 +45,13 @@ public class and_it_has_events_and_append_returns_constraints_and_errors : given
 
     [Fact] void should_append_events_to_event_sequence() => _events.ShouldContainOnly(new(_firstEventEventSourceId, _firstEvent, _firstEventCausation), new(_secondEventEventSourceId, _secondEvent, _secondEventCausation));
     [Fact] void should_have_events_in_unit_of_work() => _unitOfWork.GetEvents().ShouldContainOnly(_firstEvent, _secondEvent);
+    [Fact] void should_have_events_in_unit_of_work_in_correct_order()
+    {
+        var events = _unitOfWork.GetEvents().ToArray();
+        events[0].ShouldEqual(_firstEvent);
+        events[1].ShouldEqual(_secondEvent);
+    }
+
     [Fact] void should_call_on_completed() => _onCompletedCalled.ShouldBeTrue();
     [Fact] void should_have_constraint_violations() => _unitOfWork.GetConstraintViolations().ShouldContainOnly(_result.ConstraintViolations);
     [Fact] void should_have_errors() => _unitOfWork.GetAppendErrors().ShouldContainOnly(_result.Errors);

--- a/Source/Clients/DotNET/Aggregates/AggregateRoot.cs
+++ b/Source/Clients/DotNET/Aggregates/AggregateRoot.cs
@@ -26,8 +26,7 @@ public class AggregateRoot : IAggregateRoot
     protected bool IsNew => !_context.HasEventsForRehydration;
 
     /// <inheritdoc/>
-    public async Task Apply<T>(T @event)
-        where T : class => await _mutation.Apply(@event);
+    public async Task Apply(object @event) => await _mutation.Apply(@event);
 
     /// <inheritdoc/>
     public async Task<AggregateRootCommitResult> Commit()

--- a/Source/Clients/DotNET/Aggregates/AggregateRootCommitResult.cs
+++ b/Source/Clients/DotNET/Aggregates/AggregateRootCommitResult.cs
@@ -14,7 +14,7 @@ namespace Cratis.Chronicle.Aggregates;
 public class AggregateRootCommitResult
 {
     /// <summary>
-    /// Gets a value indicating whether or not the commit was successful.
+    /// Gets list of committed events ordered by their sequence number.
     /// </summary>
     public IEnumerable<object> Events { get; init; } = [];
 
@@ -24,7 +24,7 @@ public class AggregateRootCommitResult
     public IEnumerable<ConstraintViolation> ConstraintViolations { get; init; } = [];
 
     /// <summary>
-    /// Gets a value indicating whether or not the commit was successful.
+    /// Gets a value indicating whether the commit was successful.
     /// </summary>
     public bool IsSuccess => !ConstraintViolations.Any();
 
@@ -51,13 +51,11 @@ public class AggregateRootCommitResult
     /// </summary>
     /// <param name="unitOfWork"><see cref="IUnitOfWork"/> to create from.</param>
     /// <returns>A new instance of <see cref="AggregateRootCommitResult"/>.</returns>
-    public static AggregateRootCommitResult CreateFrom(IUnitOfWork unitOfWork)
-    {
-        return new AggregateRootCommitResult
+    public static AggregateRootCommitResult CreateFrom(IUnitOfWork unitOfWork) =>
+        new()
         {
             Events = unitOfWork.GetEvents(),
             ConstraintViolations = unitOfWork.GetConstraintViolations(),
             Errors = unitOfWork.GetAppendErrors()
         };
-    }
 }

--- a/Source/Clients/DotNET/Aggregates/AggregateRootMutation.cs
+++ b/Source/Clients/DotNET/Aggregates/AggregateRootMutation.cs
@@ -47,10 +47,9 @@ public class AggregateRootMutation(
     public IAggregateRootMutator Mutator => mutator;
 
     /// <inheritdoc/>
-    public async Task Apply<TEvent>(TEvent @event)
-        where TEvent : class
+    public async Task Apply(object @event)
     {
-        typeof(TEvent).ValidateEventType();
+        @event.GetType().ValidateEventType();
         var causation = new Causation(DateTimeOffset.Now, CausationType, new Dictionary<string, string>
         {
             { CausationAggregateRootTypeProperty, aggregateRootContext.AggregateRoot.GetType().AssemblyQualifiedName! },

--- a/Source/Clients/DotNET/Aggregates/IAggregateRoot.cs
+++ b/Source/Clients/DotNET/Aggregates/IAggregateRoot.cs
@@ -11,11 +11,9 @@ public interface IAggregateRoot
     /// <summary>
     /// Apply a single event to the aggregate root.
     /// </summary>
-    /// <typeparam name="T">Type of event to apply.</typeparam>
     /// <param name="event">Event to apply.</param>
     /// <returns>Awaitable task.</returns>
-    Task Apply<T>(T @event)
-        where T : class;
+    Task Apply(object @event);
 
     /// <summary>
     /// Commits the aggregate root.

--- a/Source/Clients/DotNET/Aggregates/IAggregateRootMutation.cs
+++ b/Source/Clients/DotNET/Aggregates/IAggregateRootMutation.cs
@@ -34,11 +34,9 @@ public interface IAggregateRootMutation
     /// <summary>
     /// Apply a single event to the aggregate root mutation.
     /// </summary>
-    /// <typeparam name="TEvent">Type of event to apply.</typeparam>
     /// <param name="event">Event to apply.</param>
     /// <returns>Awaitable task.</returns>
-    Task Apply<TEvent>(TEvent @event)
-        where TEvent : class;
+    Task Apply(object @event);
 
     /// <summary>
     /// Commit the mutation.

--- a/Source/Clients/DotNET/Events/EventTypeExtensions.cs
+++ b/Source/Clients/DotNET/Events/EventTypeExtensions.cs
@@ -18,6 +18,11 @@ public static class EventTypeExtensions
     /// <returns>True if it is an event type, false if not.</returns>
     public static bool IsEventType(this Type type, IEnumerable<Type> eventTypes)
     {
+        if (type == typeof(object))
+        {
+            return false;
+        }
+
         if (type.GetCustomAttribute<EventTypeAttribute>() != null)
         {
             return true;

--- a/Source/Clients/DotNET/Transactions/UnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWork.cs
@@ -53,7 +53,9 @@ public class UnitOfWork(
 
     /// <inheritdoc/>
     public IEnumerable<object> GetEvents() =>
-        _events.Values.SelectMany(_ => _).Select(_ => _.Event).ToArray();
+        _events.Values.SelectMany(_ => _)
+            .OrderBy(_ => _.SequenceNumber.Value)
+            .Select(_ => _.Event).ToArray();
 
     /// <inheritdoc/>
     public IEnumerable<AppendError> GetAppendErrors() => [.. _appendErrors];

--- a/Source/Clients/Orleans/Aggregates/AggregateRoot.cs
+++ b/Source/Clients/Orleans/Aggregates/AggregateRoot.cs
@@ -66,8 +66,7 @@ public class AggregateRoot : Grain, IAggregateRoot, IAggregateRootContextHolder
     }
 
     /// <inheritdoc/>
-    public Task Apply<T>(T @event)
-        where T : class
+    public Task Apply(object @event)
     {
         return _mutation?.Apply(@event) ?? Task.CompletedTask;
     }
@@ -137,8 +136,7 @@ public class AggregateRoot<TState> : Grain, IAggregateRoot, IAggregateRootContex
     }
 
     /// <inheritdoc/>
-    public Task Apply<T>(T @event)
-        where T : class
+    public Task Apply(object @event)
     {
         return _mutation?.Apply(@event) ?? Task.CompletedTask;
     }

--- a/Source/Clients/XUnit/Aggregates/AggregateRootCommitResultShouldExtensions.cs
+++ b/Source/Clients/XUnit/Aggregates/AggregateRootCommitResultShouldExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
+using Xunit.Sdk;
 
 namespace Cratis.Chronicle.Aggregates;
 
@@ -41,6 +42,52 @@ public static class AggregateRootCommitResultShouldExtensions
     {
         var containsAll = result.Events.All(e => events.Contains(e));
         Assert.True(containsAll, "Expected all events to be present, but some were missing");
+    }
+
+    /// <summary>
+    /// Asserts that the <see cref="AggregateRootCommitResult"/> contains a specific set of events based on the predicates, with strict ordering.
+    /// </summary>
+    /// <param name="result"><see cref="AggregateRootCommitResult"/> to assert.</param>
+    /// <param name="predicates">The assertion predicates to match in order.</param>
+    /// <exception cref="XunitException">Throws when number of events does not match number of predicates.</exception>
+    public static void ShouldContainEvents(this AggregateRootCommitResult result, params Action<object>[] predicates)
+    {
+        var events = result.Events.ToArray();
+        if (events.Length != predicates.Length)
+        {
+            throw new XunitException("Number of events does not match number of predicates");
+        }
+
+        for (var i = 0; i < events.Length; i++)
+        {
+            predicates[i](events[i]);
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the <see cref="AggregateRootCommitResult"/> contains events in loose ordering based on the given predicates.
+    /// </summary>
+    /// <remarks>
+    /// This method is useful if you want to ensure some consistency on event ordering, but you cannot 100% guarantee the ordering of all events.
+    /// </remarks>
+    /// <param name="result"><see cref="AggregateRootCommitResult"/> to assert.</param>
+    /// <param name="predicates">The assertion predicates to match in order.</param>
+    /// <exception cref="XunitException">Throws when the order of the matches is off.</exception>
+    public static void ShouldContainEventsInOrder(this AggregateRootCommitResult result, params Func<object, bool>[] predicates)
+    {
+        var events = result.Events.ToList();
+        var lastFoundIndex = 0;
+        for (var i = 0; i < predicates.Length; i++)
+        {
+            var predicate = predicates[i];
+            var foundIndex = events.FindIndex(lastFoundIndex, _ => predicate(_));
+            if (foundIndex == -1)
+            {
+                throw new XunitException($"Could not find an event matching predicate {i + 1} after the event matching the last predicate");
+            }
+
+            lastFoundIndex = foundIndex + 1;
+        }
     }
 
     /// <summary>
@@ -98,5 +145,31 @@ public static class AggregateRootCommitResultShouldExtensions
     {
         var matches = result.Events.Count(_ => _ is TEvent && predicate((_ as TEvent)!));
         Assert.True(matches == 0, $"Expected no events of type {typeof(TEvent).FullName} according to predicate, but found {matches}");
+    }
+
+    /// <summary>
+    /// Performs a type and match check on the given event.
+    /// </summary>
+    /// <param name="subject">The event to check.</param>
+    /// <param name="match">The match predicate that should be true.</param>
+    /// <typeparam name="TEvent">Type of the event to assert.</typeparam>
+    public static void ShouldMatchEvent<TEvent>(this object subject, Func<TEvent, bool> match)
+        where TEvent : class
+    {
+        var evt = Assert.IsType<TEvent>(subject);
+        Assert.True(match(evt));
+    }
+
+    /// <summary>
+    /// Performs a type check and assertion on the given event.
+    /// </summary>
+    /// <param name="subject">The event to check.</param>
+    /// <param name="assert">The assertion predicate.</param>
+    /// <typeparam name="TEvent">Type of the event to assert.</typeparam>
+    public static void AssertOnEvent<TEvent>(this object subject, Action<TEvent> assert)
+        where TEvent : class
+    {
+        var evt = Assert.IsType<TEvent>(subject);
+        assert(evt);
     }
 }


### PR DESCRIPTION
### Added

- More assertion helpers to AggregateRootCommitResult

### Changed

- Apply method now accepts object instead of generic typed TEvent

### Fixed

- UnitOfWork.GetEvents() now returns ordered list of events based on event sequence number
