### PR TITLE
Fix registering of reactors twice

### DIFF
--- a/Source/Clients/DotNET/Reactions/Reactors.cs
+++ b/Source/Clients/DotNET/Reactions/Reactors.cs
@@ -29,6 +29,9 @@ public class Reactors : IReactors
     readonly ILoggerFactory _loggerFactory;
     readonly IDictionary<Type, ReactorHandler> _handlers = new Dictionary<Type, ReactorHandler>();
 
+    bool _registered;
+    static readonly object _registerLock = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Reactors"/> class.
     /// </summary>
@@ -93,10 +96,21 @@ public class Reactors : IReactors
     /// <inheritdoc/>
     public Task Register()
     {
+        if (_registered)
+        {
+            return Task.CompletedTask;
+        }
+
         foreach (var handler in _handlers.Values)
         {
             RegisterReactor(handler);
         }
+
+        lock (_registerLock)
+        {
+            _registered = true;
+        }
+
         return Task.CompletedTask;
     }
 

--- a/Source/Clients/DotNET/Reactions/Reactors.cs
+++ b/Source/Clients/DotNET/Reactions/Reactors.cs
@@ -18,6 +18,8 @@ namespace Cratis.Chronicle.Reactors;
 /// </summary>
 public class Reactors : IReactors
 {
+    static readonly object _registerLock = new();
+
     readonly IEventStore _eventStore;
     readonly IEventTypes _eventTypes;
     readonly IClientArtifactsProvider _clientArtifactsProvider;
@@ -30,7 +32,6 @@ public class Reactors : IReactors
     readonly IDictionary<Type, ReactorHandler> _handlers = new Dictionary<Type, ReactorHandler>();
 
     bool _registered;
-    static readonly object _registerLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Reactors"/> class.

--- a/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriber.cs
+++ b/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriber.cs
@@ -8,7 +8,6 @@ using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Grains.Observation.Placement;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
 
 namespace Cratis.Chronicle.Grains.Observation.Reactors.Clients;
 

--- a/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriber.cs
+++ b/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriber.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Grains.Observation.Placement;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
 
 namespace Cratis.Chronicle.Grains.Observation.Reactors.Clients;
 
@@ -74,12 +75,14 @@ public class ReactorObserverSubscriber(
                 tcs);
             return await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException taskCanceledException)
         {
+            logger.OnNextException(taskCanceledException, _observerId, _eventStore, _namespace);
             return ObserverSubscriberResult.Failed(EventSequenceNumber.Unavailable, "Task was cancelled");
         }
-        catch (TimeoutException)
+        catch (TimeoutException timeoutException)
         {
+            logger.OnNextException(timeoutException, _observerId, _eventStore, _namespace);
             return ObserverSubscriberResult.Failed(EventSequenceNumber.Unavailable, "Timeout");
         }
     }

--- a/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriberLogMessages.cs
+++ b/Source/Kernel/Grains/Observation/Reactions/Clients/ReactorObserverSubscriberLogMessages.cs
@@ -9,8 +9,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Grains.Observation.Reactors.Clients;
 
-internal static partial class ReactorsubscriberLogMessages
+internal static partial class ReactorObserverSubscriberLogMessages
 {
     [LoggerMessage(LogLevel.Trace, "Reactor {ObserverId} in event store {EventStore} for namespace {Namespace} received event of type {EventTypeId} in sequence {EventSequenceId} with sequence number {EventSequenceNumber}")]
     internal static partial void EventReceived(this ILogger<ReactorObserverSubscriber> logger, ObserverId observerId, EventStoreName eventStore, EventStoreNamespaceName @namespace, EventTypeId eventTypeId, EventSequenceId eventSequenceId, EventSequenceNumber eventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Error, "Reactor {ObserverId} in event store {EventStore} for namespace {Namespace} encountered an error")]
+    internal static partial void OnNextException(this ILogger<ReactorObserverSubscriber> logger, Exception ex, ObserverId observerId, EventStoreName eventStore, EventStoreNamespaceName @namespace);
 }


### PR DESCRIPTION
### Fixed

- Ensure running of Register method only once for Reactors.
- Improve error logging.

Related to: https://github.com/Cratis/Chronicle/issues/1324
Fixes also: https://github.com/Cratis/Chronicle/issues/1411

