### PR TITLE
set explicit package version 8.0.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,5 +31,6 @@
         <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All"/>
         <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All"/>
         <PackageReference Include="Meziantou.Analyzer" PrivateAssets="All"/>
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="automapper" Version="13.0.1" />
     <PackageVersion Include="FluentValidation" Version="11.10.0" />
     <PackageVersion Include="handlebars.net" Version="2.1.6" />


### PR DESCRIPTION
### Security

- Addresses the [vulnerability in System.Text.Json 8.0.0](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) by setting explicit global version to latest stable 8.0.4