### PR TITLE
Fix/orleans-serialization

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ApplicationModel>14.1.4</ApplicationModel>
-    <Fundamentals>5.6.1</Fundamentals>
-    <Fundamentals>5.6.1</Fundamentals>
+    <ApplicationModel>14.7.1</ApplicationModel>
+    <Fundamentals>5.6.2</Fundamentals>
+    <Fundamentals>5.6.2</Fundamentals>
     <Orleans>8.2.0</Orleans>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/Clients/Orleans/Transactions/UnitOfWorkIncomingCallFilter.cs
+++ b/Source/Clients/Orleans/Transactions/UnitOfWorkIncomingCallFilter.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Orleans.Aggregates;
 using Cratis.Chronicle.Transactions;
-using Cratis.Execution;
 using IAggregateRoot = Cratis.Chronicle.Orleans.Aggregates.IAggregateRoot;
 
 namespace Cratis.Chronicle.Orleans.Transactions;
@@ -23,7 +22,7 @@ public class UnitOfWorkIncomingCallFilter(
     /// <inheritdoc/>
     public async Task Invoke(IIncomingGrainCallContext context)
     {
-        if (RequestContext.Get(Constants.CorrelationIdKey) is CorrelationId correlationId &&
+        if (RequestContext.Get(Constants.CorrelationIdKey) is Guid correlationId &&
             context.IsMessageToAggregateRoot() &&
             unitOfWorkManager.TryGetFor(correlationId, out var unitOfWork))
         {

--- a/Source/Clients/Orleans/Transactions/UnitOfWorkOutgoingCallFilter.cs
+++ b/Source/Clients/Orleans/Transactions/UnitOfWorkOutgoingCallFilter.cs
@@ -16,7 +16,7 @@ public class UnitOfWorkOutgoingCallFilter(IUnitOfWorkManager unitOfWorkManager) 
     public async Task Invoke(IOutgoingGrainCallContext context)
     {
         var correlationId = unitOfWorkManager.HasCurrent ? unitOfWorkManager.Current.CorrelationId : CorrelationId.New();
-        RequestContext.Set(Constants.CorrelationIdKey, correlationId);
+        RequestContext.Set(Constants.CorrelationIdKey, correlationId.Value);
         if (context.IsMessageToAggregateRoot() && !unitOfWorkManager.HasCurrent)
         {
             unitOfWorkManager.Begin(correlationId);

--- a/Source/Kernel/Setup/Serialization/AppendedEventSerializer.cs
+++ b/Source/Kernel/Setup/Serialization/AppendedEventSerializer.cs
@@ -36,7 +36,14 @@ public class AppendedEventSerializer(
     public bool IsSupportedType(Type type) => type == typeof(AppendedEvent);
 
     /// <inheritdoc/>
-    public bool? IsTypeAllowed(Type type) => type == typeof(AppendedEvent);
+    public bool? IsTypeAllowed(Type type)
+    {
+        if (type == typeof(AppendedEvent))
+        {
+            return true;
+        }
+        return null;
+    }
 
     /// <inheritdoc/>
     public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)


### PR DESCRIPTION
### Fixed

- Fixed the `AppendedEventSerializer` and its implementation of the Orleans `ITypeFilter` to not disallow all other types and just focus on `AppendedEvent`.
- Fixed the Orleans incoming and outgoing call filters for Unit of Work to work with the underlying `Guid` value for the `CorrelationId`. This fixes serialization issues when running in a cluster.
