### PR TITLE
Setting EventSourceType property when appending many for each event

### DIFF
--- a/Source/Clients/DotNET/EventSequences/EventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/EventSequence.cs
@@ -115,6 +115,7 @@ public class EventSequence(
             var eventType = eventTypes.GetEventTypeFor(@event.Event.GetType());
             return new Contracts.Events.EventToAppend
             {
+                EventSourceType = @event.EventSourceType,
                 EventSourceId = @event.EventSourceId,
                 EventStreamType = @event.EventStreamType,
                 EventStreamId = @event.EventStreamId,


### PR DESCRIPTION
### Fixed

- `EventSourceType` was not set on request to Kernel for appending many, causing `NullReferenceException` during conversion to the `EventSourceTypeId` inside Kernel. This is now fixed.
