### PR TITLE
Embed Xml docs for API into Assembly

### DIFF
--- a/Source/Api/Api.csproj
+++ b/Source/Api/Api.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>Cratis.Chronicle.Api</AssemblyName>
         <RootNamespace>Cratis.Chronicle.Api</RootNamespace>
+        <ResourceNamespace>$(RootNamespace)</ResourceNamespace>
         <InvariantGlobalization>true</InvariantGlobalization>
         <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>
         <ServerGarbageCollection>false</ServerGarbageCollection>
@@ -34,5 +35,11 @@
 
     <ItemGroup Condition="'$(DisableProxyGenerator)' != 'true'">
         <PackageReference Include="Cratis.Applications.ProxyGenerator.Build" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="$(OutputPath)$(AssemblyName).xml">
+            <LogicalName>$(ResourceNamespace).XmlDocs.xml</LogicalName>
+        </EmbeddedResource>
     </ItemGroup>
 </Project>

--- a/Source/Api/ApiServiceCollectionExtensions.cs
+++ b/Source/Api/ApiServiceCollectionExtensions.cs
@@ -5,6 +5,8 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Xml;
+using System.Xml.XPath;
 
 namespace Cratis.Api.Server;
 
@@ -30,8 +32,14 @@ public static class ApiServiceCollectionExtensions
 
         services.AddSwaggerGen(options =>
         {
-            var filePath = Path.Combine(AppContext.BaseDirectory, typeof(Startup).Assembly.GetName().Name + ".xml");
-            options.IncludeXmlComments(filePath);
+            options.IncludeXmlComments(() =>
+            {
+                var type = typeof(ApiServiceCollectionExtensions);
+                var resourceName = $"{type.Assembly.GetName().Name}.XmlDocs.xml";
+                var stream = type.Assembly.GetManifestResourceStream(resourceName);
+                var reader = XmlReader.Create(stream!);
+                return new XPathDocument(reader);
+            });
         });
         return services;
     }


### PR DESCRIPTION
### Fixed

- Fixing Xml docs used in Swagger to use an embedded file instead of trying to find a physical file on disk that is not there. This caused the Embedded workbench to not load.
