### PR TITLE
Fixing embedding of XmlDocs

### DIFF
--- a/Source/Api/Api.XmlDoc.csproj
+++ b/Source/Api/Api.XmlDoc.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-    <Import Project="Common.props" />
+    <Import Project="$(MSBuildThisFileDirectory)/Common.props" />
     <PropertyGroup>
         <AssemblyName>$(XmlDocsAssemblyName)</AssemblyName>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Source/Api/Api.XmlDoc.csproj
+++ b/Source/Api/Api.XmlDoc.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+    <Import Project="Common.props" />
+    <PropertyGroup>
+        <AssemblyName>$(XmlDocsAssemblyName)</AssemblyName>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+</Project>

--- a/Source/Api/Api.csproj
+++ b/Source/Api/Api.csproj
@@ -1,31 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+    <!-- Since we have 2 .csproj files basically doing the same thing, we keep common properties and items in -->
+    <Import Project="Common.props" />
+
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <AssemblyName>Cratis.Chronicle.Api</AssemblyName>
-        <RootNamespace>Cratis.Chronicle.Api</RootNamespace>
-        <ResourceNamespace>$(RootNamespace)</ResourceNamespace>
-        <InvariantGlobalization>true</InvariantGlobalization>
-        <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>
-        <ServerGarbageCollection>false</ServerGarbageCollection>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);RCS1140;CS1998</NoWarn>
         <DisableProxyGenerator Condition="'$(DisableProxyGenerator)' == ''">false</DisableProxyGenerator>
     </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
-        <ProjectReference Include="../Kernel/Grains.Interfaces/Grains.Interfaces.csproj" />
-        <ProjectReference Include="../Kernel/Storage/Storage.csproj" />
-        <ProjectReference Include="../Kernel/Concepts/Concepts.csproj" />
-        <ProjectReference Include="../Kernel/Contracts/Contracts.csproj" />
-    </ItemGroup>
+    <!-- We need to build ourselves, effectively, since we need the XML Docs file as something we can embed as a resource-->
+    <Target Name="GenerateXmlDocumentation" BeforeTargets="BeforeBuild">
+        <MSBuild Projects="Api.XmlDoc.csproj" Targets="Build"/>
+    </Target>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
-        <PackageReference Include="Cratis.Applications" />
-        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" />
+        <EmbeddedResource Include="$(OutputPath)$(XmlDocsAssemblyName).xml">
+            <LogicalName>$(ResourceNamespace).XmlDocs.xml</LogicalName>
+        </EmbeddedResource>
     </ItemGroup>
 
     <PropertyGroup Condition="'$(DisableProxyGenerator)' != 'true'">
@@ -35,11 +24,5 @@
 
     <ItemGroup Condition="'$(DisableProxyGenerator)' != 'true'">
         <PackageReference Include="Cratis.Applications.ProxyGenerator.Build" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <EmbeddedResource Include="$(OutputPath)$(AssemblyName).xml">
-            <LogicalName>$(ResourceNamespace).XmlDocs.xml</LogicalName>
-        </EmbeddedResource>
     </ItemGroup>
 </Project>

--- a/Source/Api/Api.csproj
+++ b/Source/Api/Api.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <!-- Since we have 2 .csproj files basically doing the same thing, we keep common properties and items in -->
-    <Import Project="Common.props" />
+    <Import Project="$(MSBuildThisFileDirectory)/Common.props" />
 
     <PropertyGroup>
         <DisableProxyGenerator Condition="'$(DisableProxyGenerator)' == ''">false</DisableProxyGenerator>

--- a/Source/Api/Common.props
+++ b/Source/Api/Common.props
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <AssemblyName>Cratis.Chronicle.Api</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Api</RootNamespace>
+        <ResourceNamespace>$(RootNamespace)</ResourceNamespace>
+        <InvariantGlobalization>true</InvariantGlobalization>
+        <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>
+        <ServerGarbageCollection>false</ServerGarbageCollection>
+        <NoWarn>$(NoWarn);RCS1140;CS1998;IDE0005;SA0001</NoWarn>
+        <XmlDocsAssemblyName>$(AssemblyName).XmlDocs</XmlDocsAssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
+        <ProjectReference Include="../Kernel/Grains.Interfaces/Grains.Interfaces.csproj" />
+        <ProjectReference Include="../Kernel/Storage/Storage.csproj" />
+        <ProjectReference Include="../Kernel/Concepts/Concepts.csproj" />
+        <ProjectReference Include="../Kernel/Contracts/Contracts.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+        <PackageReference Include="Cratis.Applications" />
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" />
+    </ItemGroup>
+</Project>

--- a/Source/Api/GlobalUsings.cs
+++ b/Source/Api/GlobalUsings.cs
@@ -3,3 +3,4 @@
 
 global using Cratis.Concepts;
 global using Microsoft.AspNetCore.Mvc;
+global using Orleans;


### PR DESCRIPTION
### Fixed

- Fixing Xml docs used in Swagger to use an embedded file instead of trying to find a physical file on disk that is not there. This caused the Embedded workbench to not load.
