### PR TITLE
Fix/immediate-projections

### DIFF
--- a/.vscode/projects.json
+++ b/.vscode/projects.json
@@ -2,27 +2,27 @@
     {
         "name": "Server",
         "path": "${workspaceFolder}/Source/Kernel/Server",
-        "outputPath": "${workspaceFolder}/Source/Kernel/Server/bin/Debug/net8.0/Cratis.Chronicle.Server.dll"
+        "outputPath": "${workspaceFolder}/Source/Kernel/Server/bin/Debug/net9.0/Cratis.Chronicle.Server.dll"
     },
     {
         "name": "API",
         "path": "${workspaceFolder}/Source/Api",
-        "outputPath": "${workspaceFolder}/Source/Api/bin/Debug/net8.0/Cratis.Chronicle.Api.dll"
+        "outputPath": "${workspaceFolder}/Source/Api/bin/Debug/net9.0/Cratis.Chronicle.Api.dll"
     },
     {
         "name": "AspNetCore Sample",
         "path": "${workspaceFolder}/Samples/AspNetCore",
-        "outputPath": "${workspaceFolder}/Samples/AspNetCore/bin/Debug/net8.0/AspNetCore.dll"
+        "outputPath": "${workspaceFolder}/Samples/AspNetCore/bin/Debug/net9.0/AspNetCore.dll"
     },
     {
         "name": "Basic Sample",
         "path": "${workspaceFolder}/Samples/Basic",
-        "outputPath": "${workspaceFolder}/Samples/Basic/bin/Debug/net8.0/Basic.dll"
+        "outputPath": "${workspaceFolder}/Samples/Basic/bin/Debug/net9.0/Basic.dll"
     },
     {
         "name": "Orleans Sample",
         "path": "${workspaceFolder}/Samples/Orleans",
-        "outputPath": "${workspaceFolder}/Samples/Orleans/bin/Debug/net8.0/Orleans.dll"
+        "outputPath": "${workspaceFolder}/Samples/Orleans/bin/Debug/net9.0/Orleans.dll"
     },
     {
         "name": "DotNET Client",
@@ -31,6 +31,6 @@
     {
         "name": "AssemblyFixer",
         "path": "${workspaceFolder}/Source/Clients/AssemblyFixer",
-        "outputPath": "${workspaceFolder}/Source/Clients/AssemblyFixer/bin/Debug/net8.0/AssemblyFixer.dll"
+        "outputPath": "${workspaceFolder}/Source/Clients/AssemblyFixer/bin/Debug/net9.0/AssemblyFixer.dll"
     }
 ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,104 +1,126 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ApplicationModel>14.15.1</ApplicationModel>
-    <Fundamentals>6.0.2</Fundamentals>
-    <Orleans>9.0.1</Orleans>
-  </PropertyGroup>
-  <ItemGroup>
-    <!-- System -->
-    <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageVersion Include="System.Reactive" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <!-- Microsoft -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="$(Fundamentals)" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="$(Fundamentals)" />
-    <PackageVersion Include="Cratis.Applications" Version="$(ApplicationModel)" />
-    <PackageVersion Include="Cratis.Applications.MongoDB" Version="$(ApplicationModel)" />
-    <PackageVersion Include="Cratis.Applications.Orleans" Version="$(ApplicationModel)" />
-    <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="$(ApplicationModel)" />
-    <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="$(ApplicationModel)" />
-    <!-- Orleans -->
-    <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Server" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization.Abstractions" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Reminders" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.Sdk" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.BroadcastChannel" Version="$(Orleans)" />
-    <PackageVersion Include="Microsoft.Orleans.TestingHost" Version="$(Orleans)" />
-    <PackageVersion Include="OrleansTestKit" Version="8.2.2" />
-    <PackageVersion Include="OrleansDashboard" Version="8.2.0" />
-    <!-- Open Telemetry -->
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
-    <!-- Roslyn-->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <!-- Analysis -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Orleans.Analyzers" Version="$(Orleans)" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.182" />
-    <!-- Not categorized -->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="castle.core" Version="5.1.1" />
-    <PackageVersion Include="docfx.console" Version="2.59.4" />
-    <PackageVersion Include="humanizer" Version="2.14.1" />
-    <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
-    <PackageVersion Include="NJsonSchema" Version="11.1.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
-    <PackageVersion Include="Polly.Core" Version="8.5.0" />
-    <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.33">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
-    <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageVersion Include="mongodb.driver" Version="3.1.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
-    <PackageVersion Include="automapper" Version="13.0.1" />
-    <PackageVersion Include="FluentValidation" Version="11.11.0" />
-    <PackageVersion Include="handlebars.net" Version="2.1.6" />
-    <PackageVersion Include="OneOf" Version="3.0.271" />
-    <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
-    <!-- Testing & Specifications -->
-    <PackageVersion Include="Cratis.Specifications" Version="3.0.4" />
-    <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
-    <PackageVersion Include="Testcontainers" Version="4.0.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <ApplicationModel>14.15.7</ApplicationModel>
+        <Fundamentals>6.0.3</Fundamentals>
+        <Orleans>9.0.1</Orleans>
+    </PropertyGroup>
+    <ItemGroup>
+        <!-- System -->
+        <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
+        <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
+        <PackageVersion Include="System.Reactive" Version="6.0.1" />
+        <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+        <!-- Microsoft -->
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+        <!-- Cratis -->
+        <PackageVersion Include="Cratis.Fundamentals" Version="$(Fundamentals)" />
+        <PackageVersion Include="Cratis.Metrics.Roslyn" Version="$(Fundamentals)" />
+        <PackageVersion Include="Cratis.Applications" Version="$(ApplicationModel)" />
+        <PackageVersion Include="Cratis.Applications.MongoDB" Version="$(ApplicationModel)" />
+        <PackageVersion Include="Cratis.Applications.Orleans" Version="$(ApplicationModel)" />
+        <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="$(ApplicationModel)" />
+        <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="$(ApplicationModel)" />
+        <!-- Orleans -->
+        <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Client" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Server" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Serialization" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Serialization.Abstractions" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Reminders" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.Sdk" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.BroadcastChannel" Version="$(Orleans)" />
+        <PackageVersion Include="Microsoft.Orleans.TestingHost" Version="$(Orleans)" />
+        <PackageVersion Include="OrleansTestKit" Version="8.2.2" />
+        <PackageVersion Include="OrleansDashboard" Version="8.2.0" />
+        <!-- Open Telemetry -->
+        <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+        <!-- Roslyn-->
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+        <!-- Analysis -->
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Orleans.Analyzers" Version="$(Orleans)" />
+        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" NoWarn="NU5104" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
+        <PackageVersion Include="Meziantou.Analyzer" Version="2.0.182" />
+        <!-- Not categorized -->
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageVersion Include="castle.core" Version="5.1.1" />
+        <PackageVersion Include="docfx.console" Version="2.59.4" />
+        <PackageVersion Include="humanizer" Version="2.14.1" />
+        <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
+        <PackageVersion Include="NJsonSchema" Version="11.1.0" />
+        <PackageVersion Include="Polly.Core" Version="8.5.0" />
+        <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.33">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
+        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
+        <PackageVersion Include="mongodb.driver" Version="3.1.0" />
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+        <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />
+        <PackageVersion Include="automapper" Version="13.0.1" />
+        <PackageVersion Include="FluentValidation" Version="11.11.0" />
+        <PackageVersion Include="handlebars.net" Version="2.1.6" />
+        <PackageVersion Include="OneOf" Version="3.0.271" />
+        <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
+        <!-- Testing & Specifications -->
+        <PackageVersion Include="Cratis.Specifications" Version="3.0.4" />
+        <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
+        <PackageVersion Include="Testcontainers" Version="4.0.0" />
+        <PackageVersion Include="xunit" Version="2.9.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+        <PackageVersion Include="NSubstitute" Version="5.3.0" />
+        <PackageVersion Include="Microsoft.NET.Test.SDK" Version="17.12.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+        <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+        <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+        <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+        <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.10.0" />
+    </ItemGroup>
 </Project>

--- a/Integration/Orleans.InProcess/Orleans.InProcess.csproj
+++ b/Integration/Orleans.InProcess/Orleans.InProcess.csproj
@@ -5,23 +5,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Base\Base.csproj" />
-      <ProjectReference Include="..\..\Source\Clients\AspNetCore\AspNetCore.csproj" />
-      <ProjectReference Include="..\..\Source\Clients\Orleans.InProcess\Orleans.InProcess.csproj" />
-      <ProjectReference Include="..\..\Source\Kernel\Storage.MongoDB\Storage.MongoDB.csproj" />
+        <ProjectReference Include="..\Base\Base.csproj" />
+        <ProjectReference Include="..\..\Source\Clients\AspNetCore\AspNetCore.csproj" />
+        <ProjectReference Include="..\..\Source\Clients\Orleans.InProcess\Orleans.InProcess.csproj" />
+        <ProjectReference Include="..\..\Source\Kernel\Storage.MongoDB\Storage.MongoDB.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Condition=" '$(TargetFramework)' == 'net9.0' "/>
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Condition=" '$(TargetFramework)' == 'net8.0' " VersionOverride="9.0.0"/>
-      <PackageReference Include="Cratis.Applications.MongoDB" />
-      <PackageReference Include="Polly.Core" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Cratis.Applications.MongoDB" />
+        <PackageReference Include="Polly.Core" />
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="AggregateRoots\Domain\" />
-      <Folder Include="AggregateRoots\Scenarios\given\" />
-      <Folder Include="for_Observers\when_appending_event\" />
+        <Folder Include="AggregateRoots\Domain\" />
+        <Folder Include="AggregateRoots\Scenarios\given\" />
+        <Folder Include="for_Observers\when_appending_event\" />
     </ItemGroup>
 
 </Project>

--- a/Source/Clients/DotNET.Specs/Rules/for_RuleModelValidator/given/two_rule_sets.cs
+++ b/Source/Clients/DotNET.Specs/Rules/for_RuleModelValidator/given/two_rule_sets.cs
@@ -28,17 +28,17 @@ public class two_rule_sets : Specification
 
         _validator = new([_firstRuleSet, _secondRuleSet], _rules);
 
-        _firstRuleSetValidationResult = new ValidationResult(new[]
-        {
+        _firstRuleSetValidationResult = new ValidationResult(
+        [
             new ValidationFailure("FirstRuleSetFirstProp", "First RuleSet First Prop Failed"),
             new ValidationFailure("FirstRuleSetSecondProp", "First RuleSet Second Prop Failed"),
-        });
+        ]);
 
-        _secondRuleSetValidationResult = new ValidationResult(new[]
-        {
+        _secondRuleSetValidationResult = new ValidationResult(
+        [
             new ValidationFailure("SecondRuleSetFirstProp", "Second RuleSet First Prop Failed"),
             new ValidationFailure("SecondRuleSetSecondProp", "Second RuleSet Second Prop Failed"),
-        });
+        ]);
 
         _firstRuleSetAsValidator.Validate(Arg.Any<IValidationContext>()).Returns(_firstRuleSetValidationResult);
         _secondRuleSetAsValidator.Validate(Arg.Any<IValidationContext>()).Returns(_secondRuleSetValidationResult);

--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -175,7 +175,12 @@ public class ImmediateProjection(
             var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, @event, state);
             var keyResolver = _projection!.GetKeyResolverFor(@event.Metadata.Type);
             var key = await keyResolver(_eventSequenceStorage!, @event);
-            var context = new ProjectionEventContext(key, @event, changeset, _projection.OperationTypes[@event.Metadata.Type], false);
+            var context = new ProjectionEventContext(
+                key,
+                @event,
+                changeset,
+                _projection.GetOperationTypeFor(@event.Metadata.Type),
+                false);
 
             await HandleEventFor(_projection!, context);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_complex_structure_to_expando_object.cs
@@ -54,10 +54,10 @@ public class when_converting_complex_structure_to_expando_object : given.an_expa
                 new BsonString("second"),
                 new BsonString("third")
             }.AsEnumerable())),
-            new("children", new BsonArray(new BsonDocument[]
-            {
+            new("children", new BsonArray(
+            [
                 child
-            })),
+            ])),
             new("stringDictionary", new BsonDocument(new BsonElement[]
             {
                 new("first", "firstValue"),

--- a/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
@@ -293,13 +293,13 @@ public class EventSequenceStorage(
         var sort = PipelineStageDefinitionBuilder.Sort<BsonDocument>(/*lang=json*/ "{ '_id' : -1 }");
         var limit = PipelineStageDefinitionBuilder.Limit<BsonDocument>(1);
         var tailProjection = PipelineStageDefinitionBuilder.Project<BsonDocument>(/*lang=json*/ $"{{ '{nameof(TailEventSequenceNumbers.Tail)}': '$_id'}}");
-        var tailPipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create(new[] { sort, limit, tailProjection });
+        var tailPipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create([sort, limit, tailProjection]);
         var tailFacet = AggregateFacet.Create("tail", tailPipeline);
 
         var filter = Builders<BsonDocument>.Filter.In(nameof(Event.Type).ToCamelCase(), eventTypes.Select(_ => _.Id));
         var tailForEventTypesMatch = PipelineStageDefinitionBuilder.Match(filter);
         var tailForEventTypesProjection = PipelineStageDefinitionBuilder.Project<BsonDocument>(/*lang=json*/ $"{{ '{nameof(TailEventSequenceNumbers.TailForEventTypes)}': '$_id'}}");
-        var tailForEventTypesPipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create(new[] { tailForEventTypesMatch, sort, limit, tailForEventTypesProjection });
+        var tailForEventTypesPipeline = PipelineDefinition<BsonDocument, BsonDocument>.Create([tailForEventTypesMatch, sort, limit, tailForEventTypesProjection]);
         var tailForEventTypesFacet = AggregateFacet.Create("tailForEventTypes", tailForEventTypesPipeline);
 
         var sequenceNumbers = collection


### PR DESCRIPTION
### Fixed

- Fixing the internals of the `ImmediateProjection` subsystem that caused an exception for children projections. The result was that if you had a `RulesFor<>` or used the `.GetInstanceById()` on the client projections API for a projection that had children, it never returned any results. An exception was caught internally and it just produces empty result.
- Independent versions of Microsoft / System dependencies between .NET8 and .NET9, rather than using .NET9 versions only.
- Static code analysis rules that was violated.
