### PR TITLE
Adding a reset method for a unit of work, to be able to reset to initial state

### DIFF
--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_then_resetting_and_then_committing.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_then_resetting_and_then_committing.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_comitting;
+
+public class and_then_resetting_and_then_committing : given.a_unit_of_work
+{
+    Exception _exception;
+
+    async Task Establish()
+    {
+        await _unitOfWork.Commit();
+        await _unitOfWork.Reset();
+    }
+
+    async Task Because() => _exception = await Catch.Exception(_unitOfWork.Commit);
+
+    [Fact] void should_not_throw_already_committed() => _exception.ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_rolling_back/and_then_resetting_and_then_committing.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_rolling_back/and_then_resetting_and_then_committing.cs
@@ -1,18 +1,19 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_rolling_Back;
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_rolling_back;
 
-public class and_it_is_already_rolled_back : given.a_unit_of_work
+public class and_then_resetting_and_then_committing : given.a_unit_of_work
 {
     Exception _exception;
 
     async Task Establish()
     {
         await _unitOfWork.Rollback();
+        await _unitOfWork.Reset();
     }
 
     async Task Because() => _exception = await Catch.Exception(_unitOfWork.Rollback);
 
-    [Fact] void should_throw_any_exception() => _exception.ShouldBeOfExactType<UnitOfWorkIsAlreadyRolledBack>();
+    [Fact] void should_not_throw_any_exception() => _exception.ShouldBeNull();
 }

--- a/Source/Clients/DotNET/Transactions/IUnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/IUnitOfWork.cs
@@ -72,6 +72,12 @@ public interface IUnitOfWork : IDisposable
     Task Rollback();
 
     /// <summary>
+    /// Reset the <see cref="IUnitOfWork"/> to its initial state.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task Reset();
+
+    /// <summary>
     /// Set callback to be called when completed.
     /// </summary>
     /// <param name="callback">The callback to call.</param>

--- a/Source/Clients/DotNET/Transactions/UnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWork.cs
@@ -70,7 +70,6 @@ public class UnitOfWork(
     public async Task Commit()
     {
         ThrowIfUnitOfWorkIsCompleted();
-        _isCommitted = true;
 
         foreach (var (eventSequenceId, events) in _events)
         {
@@ -85,6 +84,7 @@ public class UnitOfWork(
             _lastCommittedEventSequenceNumber = result.SequenceNumbers.OrderBy(_ => _.Value).LastOrDefault();
         }
 
+        _isCommitted = true;
         _onCompleted(this);
     }
 
@@ -97,6 +97,20 @@ public class UnitOfWork(
         _constraintViolations.Clear();
 
         _onCompleted(this);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task Reset()
+    {
+        _events.Clear();
+        _constraintViolations.Clear();
+        _appendErrors.Clear();
+        _isCommitted = false;
+        _isRolledBack = false;
+        _lastCommittedEventSequenceNumber = null;
+        _currentSequenceNumber = EventSequenceNumber.First;
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
### Added

- Added a `Reset()` method on `IUnitOfWork` to be able to reset a unit of work to its initial state.
