### PR TITLE
Integration tests/jobs

### DIFF
--- a/Integration/Orleans.InProcess/JobsHelpers.cs
+++ b/Integration/Orleans.InProcess/JobsHelpers.cs
@@ -37,17 +37,19 @@ public static class JobsHelpers
     /// </summary>
     /// <param name="eventStore"><see cref="IEventStore"/> to work with.</param>
     /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <param name="includeStatuses">The statuses a job can have.</param>
     /// <returns>Awaitable task.</returns>
-    public static async Task WaitForThereToBeNoJobs(this IEventStore eventStore, TimeSpan? timeout = default)
+    public static async Task<IEnumerable<Job>> WaitForThereToBeNoJobs(this IEventStore eventStore, TimeSpan? timeout = default, params JobStatus[] includeStatuses)
     {
         timeout ??= TimeSpan.FromSeconds(5);
         var jobs = await eventStore.GetJobs();
         using var cts = new CancellationTokenSource(timeout.Value);
-        while (jobs.Any() && !cts.IsCancellationRequested)
+        while (jobs.Any() && !jobs.All(_ => includeStatuses.Contains(_.Status)) && !cts.IsCancellationRequested)
         {
             jobs = await eventStore.GetJobs();
             await Task.Delay(20, cts.Token);
         }
+        return jobs;
     }
 
     static Task<IEnumerable<Job>> GetJobs(this IEventStore eventStore) =>

--- a/Integration/Orleans.InProcess/for_Reactors/ReactorThatCanFail.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/ReactorThatCanFail.cs
@@ -10,16 +10,16 @@ namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors;
 public class ReactorThatCanFail(TaskCompletionSource tcs) : IReactor
 {
     public bool ShouldFail { get; set; }
+    public TimeSpan HandleTime { get; set; } = TimeSpan.Zero;
 
-    public Task OnSomeEvent(SomeEvent evt, EventContext ctx)
+    public async Task OnSomeEvent(SomeEvent evt, EventContext ctx)
     {
         tcs.SetResult();
+        await Task.Delay(HandleTime);
         if (ShouldFail)
         {
             ShouldFail = false;
             throw new Exception("Something went wrong");
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
@@ -4,22 +4,25 @@
 using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Grains.Observation.Jobs;
 using Cratis.Chronicle.Integration.Base;
 using Cratis.Chronicle.Storage.Observation;
 using Humanizer;
-using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_handling_event.and_it_fails.but_not_second_time.context;
+using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_handling_event.and_it_fails.and_needs_to_catch_up.context;
 using ObserverRunningState = Cratis.Chronicle.Concepts.Observation.ObserverRunningState;
 
 namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_handling_event.and_it_fails;
 
 [Collection(GlobalCollection.Name)]
-public class but_not_second_time(context context) : Given<context>(context)
+public class and_needs_to_catch_up(context context) : Given<context>(context)
 {
-    public class context(GlobalFixture globalFixture) : given.a_reactor_observing_an_event_that_can_fail(globalFixture, 2)
+    public class context(GlobalFixture globalFixture) : given.a_reactor_observing_an_event_that_can_fail(globalFixture, 3)
     {
         public IEnumerable<FailedPartition> FailedPartitionsBeforeRetry;
         public IEnumerable<FailedPartition> FailedPartitionsAfterRetry;
         public IEnumerable<Job> Jobs;
+        public IEnumerable<Job> JobsWithCatchUp;
+        public IEnumerable<Job> JobsAfterCompleted;
         public SomeEvent Event;
         public EventSourceId EventSourceId;
         public ObserverState ObserverState;
@@ -32,21 +35,31 @@ public class but_not_second_time(context context) : Given<context>(context)
 
         async Task Because()
         {
-            var waitTime = 5.Seconds();
-            await ReactorObserver.WaitTillActive();
+            var waitTime = 20.Seconds();
+            await ReactorObserver.WaitTillActive(waitTime);
             Observers[0].ShouldFail = true;
             Observers[1].ShouldFail = false;
+            Observers[1].HandleTime = 1.Seconds();
+            Observers[2].ShouldFail = false;
+            Observers[2].HandleTime = 1.Seconds();
             await EventStore.EventLog.Append(EventSourceId, Event);
 
             // Wait for the first event to have been handled
             await Tcs[0].Task.WaitAsync(waitTime);
 
             FailedPartitionsBeforeRetry = await EventStore.WaitForThereToBeFailedPartitions(ObserverId);
-            Jobs = await EventStore.WaitForThereToBeJobs();
+            Jobs = await EventStore.WaitForThereToBeJobs(waitTime);
 
             // Wait for the second event to have been handled
             await Tcs[1].Task.WaitAsync(waitTime);
-            await EventStore.WaitForThereToBeNoJobs();
+
+            // Append an event to be caught up
+            await EventStore.EventLog.Append(EventSourceId, Event);
+
+            // Wait for the third event to have been handled
+            await Tcs[2].Task.WaitAsync(waitTime);
+            JobsWithCatchUp = await EventStore.WaitForThereToBeJobs(waitTime);
+            JobsAfterCompleted = await EventStore.WaitForThereToBeNoJobs(waitTime);
 
             FailedPartitionsAfterRetry = await GetFailedPartitions();
             ObserverState = await ReactorObserver.GetState();
@@ -54,9 +67,11 @@ public class but_not_second_time(context context) : Given<context>(context)
     }
 
     [Fact] void should_fail_one_partition() => Context.FailedPartitionsBeforeRetry.Count().ShouldEqual(1);
-    [Fact] void should_start_replaying_job() => Context.Jobs.First().Type.ShouldContain("RetryFailedPartitionJob");
+    [Fact] void should_start_replaying_job() => Context.Jobs.First().Type.ShouldContain(nameof(RetryFailedPartitionJob));
     [Fact] void should_recover_failed_partition() => Context.FailedPartitionsAfterRetry.ShouldBeEmpty();
+    [Fact] void should_start_catchup_for_partition_job() => Context.JobsWithCatchUp.SingleOrDefault(_ => _.Type == nameof(CatchUpObserverPartition)).ShouldNotBeNull();
+    [Fact] void should_have_completed_both_jobs() => Context.JobsWithCatchUp.First().Type.ShouldContain(nameof(CatchUpObserverPartition));
     [Fact] void should_have_the_active_observer_running_state() => Context.ObserverState.RunningState.ShouldEqual(ObserverRunningState.Active);
-    [Fact] void should_have_correct_last_handled_event_sequence_number() => Context.ObserverState.LastHandledEventSequenceNumber.Value.ShouldEqual(0ul);
-    [Fact] void should_have_correct_next_event_sequence_number() => Context.ObserverState.NextEventSequenceNumber.Value.ShouldEqual(1ul);
+    [Fact] void should_have_correct_last_handled_event_sequence_number() => Context.ObserverState.LastHandledEventSequenceNumber.Value.ShouldEqual(1ul);
+    [Fact] void should_have_correct_next_event_sequence_number() => Context.ObserverState.NextEventSequenceNumber.Value.ShouldEqual(2ul);
 }

--- a/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
@@ -69,8 +69,8 @@ public class and_needs_to_catch_up(context context) : Given<context>(context)
     [Fact] void should_fail_one_partition() => Context.FailedPartitionsBeforeRetry.Count().ShouldEqual(1);
     [Fact] void should_start_replaying_job() => Context.Jobs.First().Type.ShouldContain(nameof(RetryFailedPartitionJob));
     [Fact] void should_recover_failed_partition() => Context.FailedPartitionsAfterRetry.ShouldBeEmpty();
-    [Fact] void should_start_catchup_for_partition_job() => Context.JobsWithCatchUp.SingleOrDefault(_ => _.Type == nameof(CatchUpObserverPartition)).ShouldNotBeNull();
-    [Fact] void should_have_completed_both_jobs() => Context.JobsWithCatchUp.First().Type.ShouldContain(nameof(CatchUpObserverPartition));
+    [Fact] void should_start_catchup_for_partition_job() => Context.JobsWithCatchUp.SingleOrDefault(_ => _.Name == nameof(CatchUpObserverPartition)).ShouldNotBeNull();
+    [Fact] void should_have_completed_all_jobs_at_the_end() => Context.JobsAfterCompleted.ShouldBeEmpty();
     [Fact] void should_have_the_active_observer_running_state() => Context.ObserverState.RunningState.ShouldEqual(ObserverRunningState.Active);
     [Fact] void should_have_correct_last_handled_event_sequence_number() => Context.ObserverState.LastHandledEventSequenceNumber.Value.ShouldEqual(1ul);
     [Fact] void should_have_correct_next_event_sequence_number() => Context.ObserverState.NextEventSequenceNumber.Value.ShouldEqual(2ul);

--- a/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/but_not_third_time.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_handling_event/and_it_fails/but_not_third_time.cs
@@ -5,8 +5,10 @@ using Cratis.Chronicle.Contracts.Jobs;
 using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Integration.Base;
+using Cratis.Chronicle.Storage.Observation;
 using Humanizer;
 using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_handling_event.and_it_fails.but_not_third_time.context;
+using ObserverRunningState = Cratis.Chronicle.Concepts.Observation.ObserverRunningState;
 
 namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_handling_event.and_it_fails;
 
@@ -20,6 +22,7 @@ public class but_not_third_time(context context) : Given<context>(context)
         public IEnumerable<Job> Jobs;
         public SomeEvent Event;
         public EventSourceId EventSourceId;
+        public ObserverState ObserverState;
 
         void Establish()
         {
@@ -54,10 +57,14 @@ public class but_not_third_time(context context) : Given<context>(context)
             await EventStore.WaitForThereToBeNoJobs(waitTime);
 
             FailedPartitionsAfterRetry = await GetFailedPartitions();
+            ObserverState = await ReactorObserver.GetState();
         }
     }
 
     [Fact] void should_fail_one_partition() => Context.FailedPartitionsBeforeRetry.Count().ShouldEqual(1);
     [Fact] void should_start_replaying_job() => Context.Jobs.First().Type.ShouldContain("RetryFailedPartitionJob");
     [Fact] void should_recover_failed_partition() => Context.FailedPartitionsAfterRetry.ShouldBeEmpty();
+    [Fact] void should_have_the_active_observer_running_state() => Context.ObserverState.RunningState.ShouldEqual(ObserverRunningState.Active);
+    [Fact] void should_have_correct_last_handled_event_sequence_number() => Context.ObserverState.LastHandledEventSequenceNumber.Value.ShouldEqual(0ul);
+    [Fact] void should_have_correct_next_event_sequence_number() => Context.ObserverState.NextEventSequenceNumber.Value.ShouldEqual(1ul);
 }

--- a/Source/Kernel/Grains.Specs/Jobs/for_Job/given/SomeJob.cs
+++ b/Source/Kernel/Grains.Specs/Jobs/for_Job/given/SomeJob.cs
@@ -15,7 +15,7 @@ public class SomeJob : Job<SomeRequest, SomeJobState>
     protected override Task<IImmutableList<JobStepDetails>> PrepareSteps(SomeRequest request) =>
         Task.FromResult<IImmutableList<JobStepDetails>>(StepsToPrepare.ToImmutableList());
 
-    protected override bool RemoveAfterCompleted => ShouldBeRemovedAfterCompleted;
+    protected override bool KeepAfterCompleted => !ShouldBeRemovedAfterCompleted;
     public override Task OnCompleted() => OnCompletedThrows
         ? Task.FromException(new Exception())
         : Task.CompletedTask;

--- a/Source/Kernel/Grains/Jobs/Job.cs
+++ b/Source/Kernel/Grains/Jobs/Job.cs
@@ -628,11 +628,14 @@ public abstract class Job<TRequest, TJobState> : Grain<TJobState>, IJob<TRequest
             {
                 return onCompletedError;
             }
-            StatusChanged(State.Progress.FailedSteps > 0 ? JobStatus.CompletedWithFailures : JobStatus.CompletedSuccessfully);
             if (RemoveAfterCompleted)
             {
                 await ClearStateAsync();
                 cleared = true;
+            }
+            else
+            {
+                StatusChanged(State.Progress.FailedSteps > 0 ? JobStatus.CompletedWithFailures : JobStatus.CompletedSuccessfully);
             }
 
             DeactivateOnIdle();

--- a/Source/Kernel/Grains/Jobs/Job.cs
+++ b/Source/Kernel/Grains/Jobs/Job.cs
@@ -59,9 +59,9 @@ public abstract class Job<TRequest, TJobState> : Grain<TJobState>, IJob<TRequest
     protected JobKey JobKey { get; private set; } = JobKey.NotSet;
 
     /// <summary>
-    /// Gets a value indicating whether to clean up data after the job has completed.
+    /// Gets a value indicating whether to keep the persisted data after the job has completed.
     /// </summary>
-    protected virtual bool RemoveAfterCompleted => false;
+    protected virtual bool KeepAfterCompleted => false;
 
     /// <summary>
     /// Gets the job as a Grain reference.
@@ -628,7 +628,7 @@ public abstract class Job<TRequest, TJobState> : Grain<TJobState>, IJob<TRequest
             {
                 return onCompletedError;
             }
-            if (RemoveAfterCompleted)
+            if (!KeepAfterCompleted)
             {
                 await ClearStateAsync();
                 cleared = true;

--- a/Source/Kernel/Grains/Observation/Jobs/CatchUpObserver.cs
+++ b/Source/Kernel/Grains/Observation/Jobs/CatchUpObserver.cs
@@ -22,9 +22,6 @@ namespace Cratis.Chronicle.Grains.Observation.Jobs;
 public class CatchUpObserver(IStorage storage, ILogger<CatchUpObserver> logger) : Job<CatchUpObserverRequest, JobStateWithLastHandledEvent>, ICatchUpObserver
 {
     /// <inheritdoc/>
-    protected override bool RemoveAfterCompleted => true;
-
-    /// <inheritdoc/>
     public override async Task OnCompleted()
     {
         using var scope = logger.BeginJobScope(JobId, JobKey);

--- a/Source/Kernel/Grains/Observation/Jobs/CatchUpObserverPartition.cs
+++ b/Source/Kernel/Grains/Observation/Jobs/CatchUpObserverPartition.cs
@@ -18,7 +18,7 @@ public class CatchUpObserverPartition(ILogger<CatchUpObserverPartition> logger) 
     public override async Task OnCompleted()
     {
         using var scope = logger.BeginJobScope(JobId, JobKey);
-        var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey.ObserverId, Request.ObserverKey);
+        var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey);
         if (State is { HandledAllEvents: false, LastHandledEventSequenceNumber.IsActualValue: true })
         {
             logger.NotAllEventsWereHandled(nameof(CatchUpObserverPartition), State.LastHandledEventSequenceNumber);

--- a/Source/Kernel/Grains/Observation/Jobs/ReplayObserverPartition.cs
+++ b/Source/Kernel/Grains/Observation/Jobs/ReplayObserverPartition.cs
@@ -19,7 +19,7 @@ public class ReplayObserverPartition(ILogger<ReplayObserverPartition> logger) : 
     public override async Task OnCompleted()
     {
         using var scope = logger.BeginJobScope(JobId, JobKey);
-        var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey.ObserverId, Request.ObserverKey);
+        var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey);
         if (State is { HandledAllEvents: false, LastHandledEventSequenceNumber.IsActualValue: true })
         {
             logger.NotAllEventsWereHandled(nameof(ReplayObserverPartition), State.LastHandledEventSequenceNumber);

--- a/Source/Kernel/Grains/Observation/Jobs/RetryFailedPartitionJob.cs
+++ b/Source/Kernel/Grains/Observation/Jobs/RetryFailedPartitionJob.cs
@@ -16,9 +16,6 @@ namespace Cratis.Chronicle.Grains.Observation.Jobs;
 public class RetryFailedPartitionJob(ILogger<RetryFailedPartitionJob> logger) : Job<RetryFailedPartitionRequest, JobStateWithLastHandledEvent>, IRetryFailedPartitionJob
 {
     /// <inheritdoc/>
-    protected override bool RemoveAfterCompleted => true;
-
-    /// <inheritdoc/>
     public override async Task OnCompleted()
     {
         using var scope = logger.BeginJobScope(JobId, JobKey);

--- a/Source/Kernel/Grains/Observation/Observer.cs
+++ b/Source/Kernel/Grains/Observation/Observer.cs
@@ -334,7 +334,7 @@ public class Observer(
         var exceptionStackTrace = string.Empty;
         var tailEventSequenceNumber = State.NextEventSequenceNumber;
 
-        var eventsToHandle = events.Where(_ => _.Metadata.SequenceNumber >= State.NextEventSequenceNumber).ToArray();
+        var eventsToHandle = events.Where(_ => _.Metadata.SequenceNumber >= tailEventSequenceNumber).ToArray();
         var numEventsSuccessfullyHandled = EventCount.Zero;
         var stateChanged = false;
         if (eventsToHandle.Length != 0)
@@ -464,7 +464,7 @@ public class Observer(
 
         var newLastHandledEvent = State.LastHandledEventSequenceNumber == EventSequenceNumber.Unavailable ||
                                   State.LastHandledEventSequenceNumber < lastHandledEvent ? lastHandledEvent : State.LastHandledEventSequenceNumber;
-        var nextEventSequenceNumber = State.NextEventSequenceNumber < lastHandledEvent ? lastHandledEvent.Next() : State.NextEventSequenceNumber;
+        var nextEventSequenceNumber = State.NextEventSequenceNumber <= lastHandledEvent ? lastHandledEvent.Next() : State.NextEventSequenceNumber;
         State = State with
         {
             LastHandledEventSequenceNumber = newLastHandledEvent,

--- a/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
@@ -390,7 +390,7 @@ public class EventSequenceStorage(
 
         var filter = Builders<Event>.Filter.And([.. filters]);
         var highest = await collection.Find(filter)
-                                      .SortByAscendingSequenceNumber()
+                                      .SortByDescendingSequenceNumber()
                                       .Limit(1)
                                       .SingleOrDefaultAsync()
                                       .ConfigureAwait(false);

--- a/Source/Kernel/Storage.MongoDB/Namespaces/NamespaceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Namespaces/NamespaceStorage.cs
@@ -23,7 +23,7 @@ public class NamespaceStorage(
     public async Task Ensure(EventStoreNamespaceName name)
     {
         var result = await GetCollection().FindAsync(Builders<MongoDBNamespace>.Filter.Eq(_ => _.Name, (string)name));
-        if (!result.Any())
+        if (!await result.AnyAsync())
         {
             await Create(name, DateTimeOffset.UtcNow);
         }


### PR DESCRIPTION
## Summary

This release fixes a few critical errors related to catching up events

### Added

- Integration tests around starting catchup partition jobs after retrying failed partitions

### Fixed

- Catching up events after a partition was caught up, recovered or replayed 
- `GetNextSequenceNumberGreaterOrEqualTo`
- Observation Jobs failed to get the Observer grain and thus could not be completed
