### PR TITLE
Moving away from embedded workbench due to ReadToRun issues with embedded manifests

### DIFF
--- a/Source/Kernel/Server/Server.csproj
+++ b/Source/Kernel/Server/Server.csproj
@@ -30,7 +30,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../../Workbench/Embedded/Embedded.csproj" />
+        <ProjectReference Include="../../Api/Api.csproj" />
         <ProjectReference Include="../Compliance/Compliance.csproj" />
         <ProjectReference Include="../Projections/Projections.csproj" />
         <ProjectReference Include="../Grains/Grains.csproj" />


### PR DESCRIPTION
### Fixed

- Due to problems with ReadyToRun compiled version of the server when part of the Docker images, we decided to let the Workbench frontend be within the `wwwroot` folder and served as static files from the root Web server rather than use the Embedded option we provide.
