### PR TITLE
FIxing a problem with projection join that joins on the Id of the model

### DIFF
--- a/Integration/Orleans.InProcess/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
@@ -8,6 +8,7 @@ using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.given;
 
+
 public class a_projection_and_events_appended_to_it<TProjection, TModel>(GlobalFixture globalFixture) : IntegrationSpecificationContext(globalFixture)
     where TProjection : class, IProjectionFor<TModel>, new()
 {
@@ -69,12 +70,12 @@ public class a_projection_and_events_appended_to_it<TProjection, TModel>(GlobalF
         }
     }
 
+    protected virtual Task<TModel> GetModelResult() => GetModel(ModelId);
+
     protected async Task WaitForProjectionAndSetResult(EventSequenceNumber eventSequenceNumber)
     {
         await Observer.WaitTillReachesEventSequenceNumber(eventSequenceNumber);
-        var filter = Builders<TModel>.Filter.Eq(new StringFieldDefinition<TModel, string>("_id"), ModelId);
-        var result = await _globalFixture.ReadModels.Database.GetCollection<TModel>().FindAsync(filter);
-        Result = result.FirstOrDefault();
+        Result = await GetModelResult();
     }
 
     protected async Task<TModel> GetModel(EventSourceId eventSourceId)

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BookAddedToInventory.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BookAddedToInventory.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+[EventType]
+public record BookAddedToInventory(string Title, string Author, string ISBN);

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BookBorrowed.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BookBorrowed.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+[EventType]
+public record BookBorrowed(Guid UserId);

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BorrowedBook.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BorrowedBook.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+public record BorrowedBook(
+    Guid Id,
+    Guid UserId,
+    string Title,
+    string User,
+    DateTimeOffset Borrowed,
+    DateTimeOffset Returned,
+    EventSequenceNumber __lastHandledEventSequenceNumber);

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BorrowedBooksProjection.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/BorrowedBooksProjection.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+public class BorrowedBooksProjection : IProjectionFor<BorrowedBook>
+{
+    public void Define(IProjectionBuilderFor<BorrowedBook> builder) => builder
+        .From<BookBorrowed>(from => from
+            .Set(m => m.UserId).To(e => e.UserId)
+            .Set(m => m.Borrowed).ToEventContextProperty(c => c.Occurred))
+        .Join<BookAddedToInventory>(bookBuilder => bookBuilder
+            .On(m => m.Id)
+            .Set(m => m.Title).To(e => e.Title))
+        .Join<UserOnboarded>(userBuilder => userBuilder
+            .On(m => m.UserId)
+            .Set(m => m.User).To(e => e.Name));
+}

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/UserOnboarded.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/UserOnboarded.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+[EventType]
+public record UserOnboarded(string Name, string Email);

--- a/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/and_event_joined_has_happened_first.cs
+++ b/Integration/Orleans.InProcess/Projections/Scenarios/when_projecting_with_join_on_id/and_event_joined_has_happened_first.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Integration.Base;
+using Cratis.Chronicle.Integration.Orleans.InProcess.AggregateRoots.Concepts;
+using Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Events;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id.and_event_joined_has_happened_first.context;
+
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.Projections.Scenarios.when_projecting_with_join_on_id;
+
+[Collection(GlobalCollection.Name)]
+public class and_event_joined_has_happened_first(context context) : Given<context>(context)
+{
+    const string BootTitle = "MyBook";
+    const string UserName = "User";
+
+    public class context(GlobalFixture globalFixture) : given.a_projection_and_events_appended_to_it<BorrowedBooksProjection, BorrowedBook>(globalFixture)
+    {
+        public Guid UserId;
+        public Guid BookId;
+        public override IEnumerable<Type> EventTypes => [typeof(BookAddedToInventory), typeof(UserOnboarded), typeof(BookBorrowed)];
+
+        void Establish()
+        {
+            UserId = Guid.Parse("3c760aaf-2119-4336-8721-3f4c97e86a1b");
+            EventSourceId = UserId.ToString();
+            BookId = Guid.Parse("462ec4f6-fd9e-4549-92b9-00b769636468");
+
+            EventsWithEventSourceIdToAppend.Add(new(BookId, new BookAddedToInventory(BootTitle, string.Empty, string.Empty)));
+            EventsWithEventSourceIdToAppend.Add(new(UserId.ToString(), new UserOnboarded(UserName, string.Empty)));
+            EventsWithEventSourceIdToAppend.Add(new(BookId, new BookBorrowed(UserId)));
+        }
+
+        protected override Task<BorrowedBook> GetModelResult()
+        {
+            var result = GlobalFixture.ReadModels.Database.GetCollection<BorrowedBook>().Find(_ => _.Id == BookId);
+            return result.FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_user_name() => Context.Result.User.ShouldEqual(UserName);
+    [Fact] void should_have_book_id() => Context.Result.Id.ShouldEqual(Context.BookId);
+    [Fact] void should_have_book_title() => Context.Result.Title.ShouldEqual(BootTitle);
+    [Fact] void should_set_the_event_sequence_number_to_last_event() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Source/Kernel/Projections/Pipelines/Steps/SetInitialState.cs
+++ b/Source/Kernel/Projections/Pipelines/Steps/SetInitialState.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Storage.Sinks;
 using Microsoft.Extensions.Logging;
 using EngineProjection = Cratis.Chronicle.Projections.IProjection;
@@ -30,9 +32,18 @@ public class SetInitialState(ISink sink, ILogger<SetInitialState> logger) : ICan
         {
             needsInitialState = true;
             initialState = projection.InitialModelState;
+            SetKeyForInitialState(initialState, context.Key);
         }
         context.Changeset.InitialState = initialState;
 
         return context with { NeedsInitialState = needsInitialState };
+    }
+
+    void SetKeyForInitialState(ExpandoObject initialState, Key key)
+    {
+        // TODO: We should improve how we work with Keys and not just "magic strings" like id or _id (MongoDB):
+        // https://github.com/Cratis/Chronicle/issues/1387
+        // https://github.com/Cratis/Chronicle/issues/1630
+        ((IDictionary<string, object?>)initialState)["id"] = key.Value;
     }
 }

--- a/Source/Kernel/Projections/ProjectionFactory.cs
+++ b/Source/Kernel/Projections/ProjectionFactory.cs
@@ -290,6 +290,9 @@ public class ProjectionFactory(
             ? projectionDefinition.Join.Where(join => join.Value.On == actualIdentifiedByProperty).ToArray()
             : projectionDefinition.Join.Where(join => fromDefinition.Properties.Any(from => join.Value.On == from.Key)).ToArray();
 
+        // Include join expressions that join on the id property
+        joinExpressions = [.. joinExpressions, .. projectionDefinition.Join.Where(join => join.Value.On == "id")];
+
         if (joinExpressions.Length == 0)
         {
             return;


### PR DESCRIPTION
### Fixed

- When using `.Join<>` and then using `.On(m => m.Id)`- the Key/Id of the model, it never resolved the join. This fixes that and considers a join expression on the primary key to be a join expression to use for `ResolveJoin` operation which runs after events have been projected to catch any past events it should resolve properties from.
