### PR TITLE
Fix/reducers

### DIFF
--- a/Source/Clients/DotNET/DefaultServiceProvider.cs
+++ b/Source/Clients/DotNET/DefaultServiceProvider.cs
@@ -8,12 +8,24 @@ namespace Cratis.Chronicle;
 /// <summary>
 /// Represents a default <see cref="IServiceProvider"/> that will create instances of services using the default constructor.
 /// </summary>
-public class DefaultServiceProvider : IServiceProvider, IServiceProviderIsService
+public class DefaultServiceProvider : IServiceProvider, IServiceProviderIsService, IServiceScopeFactory, IServiceScope
 {
+    /// <inheritdoc/>
+    public IServiceProvider ServiceProvider => this;
+
+    /// <inheritdoc/>
+    public IServiceScope CreateScope() => this;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+    }
+
     /// <inheritdoc/>
     public object? GetService(Type serviceType)
     {
         if (serviceType == typeof(IServiceProviderIsService)) return this;
+        if (serviceType == typeof(IServiceScopeFactory)) return this;
         return Activator.CreateInstance(serviceType);
     }
 

--- a/Source/Clients/XUnit/Defaults.cs
+++ b/Source/Clients/XUnit/Defaults.cs
@@ -42,11 +42,13 @@ public class Defaults
 
         EventTypes.Discover().Wait();
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
         EventSerializer = new EventSerializer(
             ClientArtifactsProvider,
             new DefaultServiceProvider(),
             EventTypes,
             Globals.JsonSerializerOptions);
+#pragma warning restore CA2000 // Dispose objects before losing scope
     }
 
     /// <summary>

--- a/Source/Kernel/Grains/Observation/Reducers/Clients/ReducerObserverSubscriber.cs
+++ b/Source/Kernel/Grains/Observation/Reducers/Clients/ReducerObserverSubscriber.cs
@@ -90,7 +90,7 @@ public class ReducerObserverSubscriber(
                 await reducerSubscriberResultTCS.Task.WaitAsync(TimeSpan.FromSeconds(5));
                 var result = await reducerSubscriberResultTCS.Task;
                 tcs.SetResult(result.ObserverResult);
-                return result.ModelState;
+                return result;
             }) ?? Task.CompletedTask);
 
             await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/Source/Kernel/Grains/Observation/Reducers/ReducerDelegate.cs
+++ b/Source/Kernel/Grains/Observation/Reducers/ReducerDelegate.cs
@@ -3,6 +3,7 @@
 
 using System.Dynamic;
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Grains.Observation.Reducers.Clients;
 
 namespace Cratis.Chronicle.Grains.Observation.Reducers;
 
@@ -12,4 +13,4 @@ namespace Cratis.Chronicle.Grains.Observation.Reducers;
 /// <param name="events">Collection of <see cref="AppendedEvent"/> to reduce from.</param>
 /// <param name="initialState">The initial state.</param>
 /// <returns>The reduced state.</returns>
-public delegate Task<ExpandoObject> ReducerDelegate(IEnumerable<AppendedEvent> events, ExpandoObject? initialState);
+public delegate Task<ReducerSubscriberResult> ReducerDelegate(IEnumerable<AppendedEvent> events, ExpandoObject? initialState);

--- a/Source/Kernel/Grains/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Grains/Observation/Reducers/ReducerPipeline.cs
@@ -40,10 +40,11 @@ public class ReducerPipeline(
     {
         var initial = await Sink.FindOrDefault(context.Key);
 
-        var reduced = await reducer(context.Events, initial);
+        var result = await reducer(context.Events, initial);
+        if (result.ObserverResult.State != ObserverSubscriberState.Ok) return;
 
         var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, context.Events.First(), initial ?? new ExpandoObject());
-        if (!objectComparer.Compare(initial, reduced, out var differences))
+        if (!objectComparer.Compare(initial, result.ModelState, out var differences))
         {
             changeset.Add(new PropertiesChanged<ExpandoObject>(null!, differences));
         }


### PR DESCRIPTION
### Fixed

- Fixing so that Reducers will not create an empty model instance if it fails.
- the `DefaultServiceProvider` used when no service provider is configured is now supporting scope creations. There will be no scoping, since it doesn't have any service collection and binding registration support. But will support the scenario of bare bone console apps.
