### PR TITLE
Making constraint updater ignore events that are not in the definition

### DIFF
--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_not_part_of_definition.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_not_part_of_definition.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Storage.Events.Constraints;
+
+namespace Cratis.Chronicle.Grains.Events.Constraints.for_UniqueConstraintIndexUpdater.when_updating;
+
+public class and_event_in_context_is_not_part_of_definition : Specification
+{
+    UniqueConstraintIndexUpdater _updater;
+    UniqueConstraintDefinition _definition;
+    IUniqueConstraintsStorage _storage;
+    ConstraintValidationContext _context;
+
+    void Establish()
+    {
+        _storage = Substitute.For<IUniqueConstraintsStorage>();
+        _definition = new("SomeConstraint", [new("SomeEvent", [])]);
+
+        _context = new([], EventSourceId.New(), "SomeOtherEvent", new ExpandoObject());
+        _updater = new(_definition, _context, _storage);
+    }
+
+    async Task Because() => await _updater.Update(EventSequenceNumber.First);
+
+    [Fact] void should_not_save_to_storage() => _storage.DidNotReceive().Save(Arg.Any<EventSourceId>(), Arg.Any<ConstraintName>(), Arg.Any<EventSequenceNumber>(), Arg.Any<UniqueConstraintValue>());
+}

--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_part_of_definition.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_part_of_definition.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Storage.Events.Constraints;
+
+namespace Cratis.Chronicle.Grains.Events.Constraints.for_UniqueConstraintIndexUpdater.when_updating;
+
+public class and_event_in_context_is_part_of_definition : Specification
+{
+    UniqueConstraintIndexUpdater _updater;
+    UniqueConstraintDefinition _definition;
+    IUniqueConstraintsStorage _storage;
+    ConstraintValidationContext _context;
+    EventSequenceNumber _eventSequenceNumber;
+    UniqueConstraintValue _value;
+
+    void Establish()
+    {
+        _storage = Substitute.For<IUniqueConstraintsStorage>();
+        _definition = new("SomeConstraint", [new("SomeEvent", ["SomeProperty"])]);
+
+        var contentAsExpando = new ExpandoObject();
+        dynamic content = contentAsExpando;
+        content.SomeProperty = "SomeValue";
+        _value = (UniqueConstraintValue)content.SomeProperty;
+
+        _context = new([], EventSourceId.New(), "SomeEvent", contentAsExpando);
+        _updater = new(_definition, _context, _storage);
+
+        _eventSequenceNumber = 42L;
+    }
+
+    async Task Because() => await _updater.Update(_eventSequenceNumber);
+
+    [Fact] void should_not_save_to_storage() => _storage.Received(1).Save(_context.EventSourceId, _definition.Name, Arg.Any<EventSequenceNumber>(), _value);
+}
+
+

--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_remove_event.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintIndexUpdater/when_updating/and_event_in_context_is_remove_event.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Storage.Events.Constraints;
+
+namespace Cratis.Chronicle.Grains.Events.Constraints.for_UniqueConstraintIndexUpdater.when_updating;
+
+public class and_event_in_context_is_remove_event : Specification
+{
+    UniqueConstraintIndexUpdater _updater;
+    UniqueConstraintDefinition _definition;
+    IUniqueConstraintsStorage _storage;
+    ConstraintValidationContext _context;
+
+    void Establish()
+    {
+        _storage = Substitute.For<IUniqueConstraintsStorage>();
+        _definition = new("SomeConstraint", [new("SomeEvent", [])], "SomeRemoveEvent");
+
+        _context = new([], EventSourceId.New(), "SomeRemoveEvent", new ExpandoObject());
+        _updater = new(_definition, _context, _storage);
+    }
+
+    async Task Because() => await _updater.Update(EventSequenceNumber.First);
+
+    [Fact] void should_not_save_to_storage() => _storage.Received(1).Remove(_context.EventSourceId, _definition.Name);
+}
+
+

--- a/Source/Kernel/Grains/Events/Constraints/UniqueConstraintDefinitionExtensions.cs
+++ b/Source/Kernel/Grains/Events/Constraints/UniqueConstraintDefinitionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Events.Constraints;
 
 namespace Cratis.Chronicle.Grains.Events.Constraints;
@@ -10,6 +11,15 @@ namespace Cratis.Chronicle.Grains.Events.Constraints;
 /// </summary>
 public static class UniqueConstraintDefinitionExtensions
 {
+    /// <summary>
+    /// Check if the <see cref="UniqueConstraintDefinition"/> supports a given event type.
+    /// </summary>
+    /// <param name="definition"><see cref="UniqueConstraintDefinition"/> to check.</param>
+    /// <param name="eventTypeId"><see cref="EventTypeId"/> to check for.</param>
+    /// <returns>True if it does, false if not.</returns>
+    public static bool SupportsEventType(this UniqueConstraintDefinition definition, EventTypeId eventTypeId) =>
+        definition.EventDefinitions.Any(_ => _.EventTypeId == eventTypeId);
+
     /// <summary>
     /// Get the property and value for the <see cref="UniqueConstraintDefinition"/> based on the <see cref="ConstraintValidationContext"/>.
     /// </summary>

--- a/Source/Kernel/Grains/Events/Constraints/UniqueConstraintIndexUpdater.cs
+++ b/Source/Kernel/Grains/Events/Constraints/UniqueConstraintIndexUpdater.cs
@@ -27,6 +27,11 @@ public class UniqueConstraintIndexUpdater(
         }
         else
         {
+            if (!definition.SupportsEventType(context.EventTypeId))
+            {
+                return;
+            }
+
             var value = definition.GetPropertiesAndValues(context).GetValue();
             if (value is not null)
             {


### PR DESCRIPTION
### Fixed

- An exception that occurred when trying to update unique constraint index for events a constraint wasn't defined to handle. This is now fixed by not trying to update the index if the event type is not supported.
