### PR TITLE
New version of fundamentals with a fix for the CorrelationId concept

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <ApplicationModel>15.0.12</ApplicationModel>
-        <Fundamentals>6.1.0</Fundamentals>
+        <Fundamentals>6.1.2</Fundamentals>
         <Orleans>9.0.1</Orleans>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
### Fixed

- Upgrading to latest Fundamentals that has a fix that caused issues when serializing anything with `CorrelationId` on it. (https://github.com/Cratis/Fundamentals/pull/269)
