### PR TITLE
Keeping grains alive forever + fixing disposal only if Task is completed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <ApplicationModel>15.0.12</ApplicationModel>
-        <Fundamentals>6.1.2</Fundamentals>
+        <Fundamentals>6.1.3</Fundamentals>
         <Orleans>9.0.1</Orleans>
     </PropertyGroup>
     <ItemGroup>
@@ -97,7 +97,7 @@
         <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="8.10.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
         <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
         <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
@@ -24,7 +24,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     readonly ConcurrentQueue<IEnumerable<AppendedEvent>> _queue = new();
     readonly AsyncManualResetEvent _queueEvent = new();
     readonly AsyncManualResetEvent _queueEmptyEvent = new();
-    readonly TaskCompletionSource _queueTaskCompletionSource = new();
+    readonly TaskCompletionSource _queueTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
     readonly Task _queueTask;
     ConcurrentBag<AppendedEventsQueueObserverSubscription> _subscriptions = [];
     IMeterScope<AppendedEventsQueue>? _metrics;

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
@@ -51,6 +51,9 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     /// <inheritdoc/>
     public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
+        // Keep the Grain alive forever: Confirmed here: https://github.com/dotnet/orleans/issues/1721#issuecomment-216566448
+        DelayDeactivation(TimeSpan.MaxValue);
+
         var queueId = (int)this.GetPrimaryKeyLong(out var key);
         _metrics = _meter.BeginScope(key, queueId);
         return base.OnActivateAsync(cancellationToken);
@@ -88,7 +91,18 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     public void Dispose()
     {
         _queueTaskCompletionSource.SetCanceled();
+
+        if (!_queueTask.IsCompleted)
+        {
+            try
+            {
+                _queueTask.Wait(1000);
+            }
+            catch { }
+        }
+
         _queueTask.Dispose();
+
         _metrics?.Dispose();
     }
 

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueues.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueues.cs
@@ -11,16 +11,18 @@ namespace Cratis.Chronicle.Grains.EventSequences;
 /// </summary>
 public class AppendedEventsQueues : Grain, IAppendedEventsQueues
 {
-    readonly IAppendedEventsQueue[] _queues;
+    IAppendedEventsQueue[] _queues = [];
     int _nextQueue;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppendedEventsQueues"/> class.
-    /// </summary>
-    /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
-    public AppendedEventsQueues(IGrainFactory grainFactory)
+    /// <inheritdoc/>
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
     {
-        _queues = Enumerable.Range(0, 8).Select(_ => grainFactory.GetGrain<IAppendedEventsQueue>(_, this.GetPrimaryKeyString())).ToArray();
+        // Keep the Grain alive forever: Confirmed here: https://github.com/dotnet/orleans/issues/1721#issuecomment-216566448
+        DelayDeactivation(TimeSpan.MaxValue);
+
+        _queues = Enumerable.Range(0, 8).Select(_ => GrainFactory.GetGrain<IAppendedEventsQueue>(_, this.GetPrimaryKeyString())).ToArray();
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Fixed

- Making the AppendedEventsQueues and specific Queue grains live forever, which is the intended behavior as they are there to scale out handling of events.
- Fixing disposal of Queue task in `AppendedEventsQueue` to only dispose if task is completed and will now wait for its completion on disposal.
- FIxing `TaskCompletionSource` for `AppendedEventsQueue` to run continuations asynchronously.
