### PR TITLE
Making the MongoDB database default to the chronicle one, which is what is expected

### DIFF
--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -60,7 +60,7 @@ builder.Host
    .UseOrleans(_ => _
         .UseLocalhostClustering()
         .AddChronicleToSilo(_ => _
-           .WithMongoDB(chronicleOptions.Storage.ConnectionDetails, WellKnownDatabaseNames.Chronicle))
+           .WithMongoDB(chronicleOptions))
         .UseDashboard(options =>
         {
             options.Host = "*";

--- a/Source/Kernel/Storage.MongoDB/MongoDBChronicleBuilderExtensions.cs
+++ b/Source/Kernel/Storage.MongoDB/MongoDBChronicleBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Configuration;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Compliance;
 using Cratis.Chronicle.Storage.MongoDB;
@@ -19,13 +20,22 @@ public static class MongoDBChronicleBuilderExtensions
     static bool _mongoDBArtifactsInitialized;
 
     /// <summary>
+    /// Configure Chronicle to use MongoDB, based on the <see cref="ChronicleOptions"/>.
+    /// </summary>
+    /// <param name="builder"><see cref="IChronicleBuilder"/> to configure.</param>
+    /// <param name="options"><see cref="ChronicleOptions"/> to use.</param>
+    /// <returns><see cref="IChronicleBuilder"/> for continuation.</returns>
+    public static IChronicleBuilder WithMongoDB(this IChronicleBuilder builder, ChronicleOptions options) =>
+        builder.WithMongoDB(options.Storage.ConnectionDetails, WellKnownDatabaseNames.Chronicle);
+
+    /// <summary>
     /// Configure Chronicle to use MongoDB.
     /// </summary>
     /// <param name="builder"><see cref="IChronicleBuilder"/> to configure.</param>
     /// <param name="server">Connection string for the MongoDB server.</param>
-    /// <param name="database">Name of the database to use.</param>
+    /// <param name="database">Name of the database to use. Defaults to the <see cref="WellKnownDatabaseNames.Chronicle"/>.</param>
     /// <returns><see cref="IChronicleBuilder"/> for continuation.</returns>
-    public static IChronicleBuilder WithMongoDB(this IChronicleBuilder builder, string server, string database)
+    public static IChronicleBuilder WithMongoDB(this IChronicleBuilder builder, string server, string database = WellKnownDatabaseNames.Chronicle)
     {
         builder.SiloBuilder
             .UseMongoDBClient(server)


### PR DESCRIPTION
### Fixed

- Defaulting the database for MongoDB to the `chronicle+main` database. This means you don't have to specify database when running Orleans InProcess. This will also then be compatible if moving from in-process to out-of-process as it will default to this.
- Adding an overload to `.WithMongoDB()` that takes the `ChronicleOptions` which is then passed along from the Kernel Server program.
