### PR TITLE
Fix/stabilizing-observers

### DIFF
--- a/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
+++ b/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
@@ -118,8 +118,10 @@ public static class ChronicleClientSiloBuilderExtensions
                 var grainFactory = sp.GetRequiredService<IGrainFactory>();
                 var services = sp.GetRequiredService<IServices>();
 
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+
                 var connectionLifecycle = new ConnectionLifecycle(options.LoggerFactory.CreateLogger<ConnectionLifecycle>());
-                var connection = new Cratis.Chronicle.Orleans.InProcess.ChronicleConnection(connectionLifecycle, services, grainFactory);
+                var connection = new Cratis.Chronicle.Orleans.InProcess.ChronicleConnection(connectionLifecycle, services, grainFactory, loggerFactory);
                 return new ChronicleClient(connection, options);
             });
 

--- a/Source/Clients/Orleans.InProcess/ChronicleConnection.cs
+++ b/Source/Clients/Orleans.InProcess/ChronicleConnection.cs
@@ -6,6 +6,7 @@ extern alias Server;
 using System.Diagnostics;
 using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Contracts.Clients;
+using Microsoft.Extensions.Logging;
 using Server::Cratis.Chronicle.Services.Clients;
 
 namespace Cratis.Chronicle.Orleans.InProcess;
@@ -19,10 +20,12 @@ namespace Cratis.Chronicle.Orleans.InProcess;
 /// <param name="lifecycle"><see cref="IConnectionLifecycle"/> for managing lifecycle.</param>
 /// <param name="services"><see cref="IServices"/> to use.</param>
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for working with grains.</param>
+/// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
 public class ChronicleConnection(
     IConnectionLifecycle lifecycle,
     IServices services,
-    IGrainFactory grainFactory) : IChronicleConnection
+    IGrainFactory grainFactory,
+    ILoggerFactory loggerFactory) : IChronicleConnection
 {
     ConnectionService? _connectionService;
 
@@ -54,7 +57,7 @@ public class ChronicleConnection(
 
     void Connect()
     {
-        _connectionService = new ConnectionService(grainFactory);
+        _connectionService = new ConnectionService(grainFactory, loggerFactory.CreateLogger<ConnectionService>());
         _connectionService.Connect(new()
         {
             ConnectionId = Lifecycle.ConnectionId,

--- a/Source/Kernel/Grains.Interfaces/Projections/IProjection.cs
+++ b/Source/Kernel/Grains.Interfaces/Projections/IProjection.cs
@@ -23,4 +23,11 @@ public interface IProjection : IGrainWithStringKey
     /// <param name="subscriber"><see cref="INotifyProjectionDefinitionsChanged"/> to subscribe.</param>
     /// <returns>Awaitable task.</returns>
     Task SubscribeDefinitionsChanged(INotifyProjectionDefinitionsChanged subscriber);
+
+    /// <summary>
+    /// Unsubscribe to changes in projection or pipeline definition changes.
+    /// </summary>
+    /// <param name="subscriber"><see cref="INotifyProjectionDefinitionsChanged"/> to subscribe.</param>
+    /// <returns>Awaitable task.</returns>
+    Task UnsubscribeDefinitionsChanged(INotifyProjectionDefinitionsChanged subscriber);
 }

--- a/Source/Kernel/Grains.Specs/Observation/for_Observer/given/an_observer_with_subscription.cs
+++ b/Source/Kernel/Grains.Specs/Observation/for_Observer/given/an_observer_with_subscription.cs
@@ -1,7 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Grains.Observation.States;
 
 namespace Cratis.Chronicle.Grains.Observation.for_Observer.given;
 
@@ -14,6 +18,7 @@ public class an_observer_with_subscription : an_observer
     {
         subscription = new ObserverSubscription(_observerId, _observerKey, [], typeof(ObserverSubscriber), SiloAddress.Zero, null);
         _observer.SetSubscription(subscription);
+        _observer.TransitionTo<Routing>();
 
         _storageStats.ResetCounts();
     }

--- a/Source/Kernel/Grains.Specs/Observation/for_Observer/given/an_observer_with_subscription_for_specific_event_type.cs
+++ b/Source/Kernel/Grains.Specs/Observation/for_Observer/given/an_observer_with_subscription_for_specific_event_type.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Grains.Observation.States;
 
 namespace Cratis.Chronicle.Grains.Observation.for_Observer.given;
 
@@ -16,6 +19,7 @@ public class an_observer_with_subscription_for_specific_event_type : an_observer
     {
         subscription = new ObserverSubscription(_observerId, _observerKey, [event_type], typeof(IObserverSubscriber), SiloAddress.Zero, null);
         _observer.SetSubscription(subscription);
+        _observer.TransitionTo<Routing>();
 
         _storageStats.ResetCounts();
     }

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
@@ -63,6 +63,13 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     }
 
     /// <inheritdoc/>
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
     public Task Enqueue(IEnumerable<AppendedEvent> appendedEvents)
     {
         _queue.Enqueue(appendedEvents);

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueueLogging.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueueLogging.cs
@@ -13,4 +13,7 @@ internal static partial class AppendedEventsQueueLogMessages
 {
     [LoggerMessage(LogLevel.Error, "Failed notifying observers")]
     internal static partial void NotifyingObserversFailed(this ILogger<AppendedEventsQueue> logger, Exception exception);
+
+    [LoggerMessage(LogLevel.Error, "An error occurred while handling appended events in queue. Keep on processing.")]
+    internal static partial void QueueHandlerFailed(this ILogger<AppendedEventsQueue> logger, Exception exception);
 }

--- a/Source/Kernel/Grains/Observation/Observer.cs
+++ b/Source/Kernel/Grains/Observation/Observer.cs
@@ -374,25 +374,8 @@ public class Observer(
     {
         using var scope = logger.BeginObserverScope(_observerId, _observerKey);
 
-        if (!_subscription.IsSubscribed || Failures.IsFailed(partition))
+        if (!ShouldHandleEvent(partition))
         {
-            return;
-        }
-
-        if (_isPreparingCatchup)
-        {
-            return;
-        }
-
-        if (State.ReplayingPartitions.Contains(partition))
-        {
-            logger.PartitionReplayingCannotHandleNewEvents(partition);
-            return;
-        }
-
-        if (State.CatchingUpPartitions.Contains(partition))
-        {
-            logger.PartitionCatchingUpCannotHandleNewEvents(partition);
             return;
         }
 
@@ -547,6 +530,47 @@ public class Observer(
         }
 
         return time;
+    }
+
+    bool ShouldHandleEvent(Key partition)
+    {
+        if (!_subscription.IsSubscribed)
+        {
+            logger.ObserverIsNotSubscribed();
+            return false;
+        }
+
+        if (Failures.IsFailed(partition))
+        {
+            logger.PartitionIsFailed(partition);
+            return false;
+        }
+
+        if (State.RunningState != ObserverRunningState.Active)
+        {
+            logger.ObserverIsNotActive();
+            return false;
+        }
+
+        if (_isPreparingCatchup)
+        {
+            logger.ObserverIsPreparingCatchup();
+            return false;
+        }
+
+        if (State.ReplayingPartitions.Contains(partition))
+        {
+            logger.PartitionReplayingCannotHandleNewEvents(partition);
+            return false;
+        }
+
+        if (State.CatchingUpPartitions.Contains(partition))
+        {
+            logger.PartitionCatchingUpCannotHandleNewEvents(partition);
+            return false;
+        }
+
+        return true;
     }
 
     async Task ResumeJobs()

--- a/Source/Kernel/Grains/Observation/Observer.cs
+++ b/Source/Kernel/Grains/Observation/Observer.cs
@@ -455,18 +455,26 @@ public class Observer(
                     exceptionStackTrace = ex.StackTrace ?? string.Empty;
                 }
             }
-            if (failed)
-            {
-                await PartitionFailed(partition, tailEventSequenceNumber, exceptionMessages, exceptionStackTrace);
-            }
-            else
-            {
-                _metrics?.SuccessfulObservation();
-            }
 
-            if (stateChanged)
+            try
             {
-                await WriteStateAsync();
+                if (failed)
+                {
+                    await PartitionFailed(partition, tailEventSequenceNumber, exceptionMessages, exceptionStackTrace);
+                }
+                else
+                {
+                    _metrics?.SuccessfulObservation();
+                }
+
+                if (stateChanged)
+                {
+                    await WriteStateAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.ObserverFailedForUnknownReasonsAfterHandlingEvents(ex);
             }
         }
     }

--- a/Source/Kernel/Grains/Observation/ObserverLogging.cs
+++ b/Source/Kernel/Grains/Observation/ObserverLogging.cs
@@ -85,6 +85,9 @@ internal static partial class ObserverLogMessages
 
     [LoggerMessage(LogLevel.Trace, "Registering partitions that are catching up")]
     internal static partial void RegisteringCatchingUpPartitions(this ILogger<Observer> logger);
+
+    [LoggerMessage(LogLevel.Critical, "Observer failed for unknown reasons after handling events")]
+    internal static partial void ObserverFailedForUnknownReasonsAfterHandlingEvents(this ILogger<Observer> logger, Exception exception);
 }
 
 internal static class ObserverScopes

--- a/Source/Kernel/Grains/Observation/ObserverLogging.cs
+++ b/Source/Kernel/Grains/Observation/ObserverLogging.cs
@@ -44,6 +44,18 @@ internal static partial class ObserverLogMessages
     [LoggerMessage(LogLevel.Debug, "Resuming catchup for partition {Partition} starting from event sequence number {EventSequenceNumber}")]
     internal static partial void StartingCatchUpForPartition(this ILogger<Observer> logger, Key partition, EventSequenceNumber eventSequenceNumber);
 
+    [LoggerMessage(LogLevel.Debug, "Observer is not subscribed, ignoring handling of event")]
+    internal static partial void ObserverIsNotSubscribed(this ILogger<Observer> logger);
+
+    [LoggerMessage(LogLevel.Debug, "Observer is not active, ignoring handling of event")]
+    internal static partial void ObserverIsNotActive(this ILogger<Observer> logger);
+
+    [LoggerMessage(LogLevel.Debug, "Partition '{Partition}' is in a failed state, ignoring handling of event")]
+    internal static partial void PartitionIsFailed(this ILogger<Observer> logger, Key partition);
+
+    [LoggerMessage(LogLevel.Debug, "Observer is preparing catchup, ignoring handling of event")]
+    internal static partial void ObserverIsPreparingCatchup(this ILogger<Observer> logger);
+
     [LoggerMessage(LogLevel.Debug, "Partition {Partition} is replaying events and cannot accept new events to handle")]
     internal static partial void PartitionReplayingCannotHandleNewEvents(this ILogger<Observer> logger, Key partition);
 

--- a/Source/Kernel/Grains/Projections/Projection.cs
+++ b/Source/Kernel/Grains/Projections/Projection.cs
@@ -86,6 +86,13 @@ public class Projection(
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
+    public Task UnsubscribeDefinitionsChanged(INotifyProjectionDefinitionsChanged subscriber)
+    {
+        _definitionObservers.Unsubscribe(subscriber);
+        return Task.CompletedTask;
+    }
+
     async Task AddReplayRecommendationForAllNamespaces(ProjectionKey key, IEnumerable<EventStoreNamespaceName> namespaces)
     {
         foreach (var @namespace in namespaces)

--- a/Source/Kernel/Services/Clients/ConnectionServiceLogging.cs
+++ b/Source/Kernel/Services/Clients/ConnectionServiceLogging.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Services.Clients;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class ConnectionServiceLogMessages
+{
+    [LoggerMessage(LogLevel.Error, "Failure during keep alive for connection {ConnectionId}")]
+    internal static partial void FailureDuringKeepAlive(this ILogger<ConnectionService> logger, string connectionId, Exception exception);
+}


### PR DESCRIPTION
### Fixed

- Adding fail safe error handling for `ConnectionService` during keep alive. If it fails within the keep alive loop, it will keep on going and not just die. Added logging if this occurs.
- Added more error handling for `AppendedEventsQueue` to ensure the queue task is always alive, and if it stops it will be recreated. Logging the errors if they occur.
- If a call to `Handle()` on the `Observer` fails, the `AppendedEventsQueue` will catch this and retry indefinitely. Any failures happening within the Observer should be handled by itself and rais failed partitions. But not being able to reach the `Observer` should not mean we move on to the next event. This might need a circuit breaker. For now we consider this scenario as a transient failure.
- Observers will now not handle any events unless it is in the `Active` state. This is to prevent handling happening while transitioning between states.
- Projections clean up after themselves by unregistering for definition changes.
