### PR TITLE
Always interleave observer state + fix one off catchup

### DIFF
--- a/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind.cs
@@ -50,6 +50,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind(contex
             await EventStore.Reactors.Register<ReactorWithoutDelay>();
             await ReactorObserver.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reactor.WaitTillHandledEventReaches(FirstEvents.Count + CatchupEvents.Count);
+            await ReactorObserver.WaitTillActive();
             ReactorObserverState = await ReactorObserver.GetState();
         }
     }

--- a/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
@@ -1,22 +1,17 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Contracts.Jobs;
-using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences;
-using Cratis.Chronicle.Grains.Observation;
-using Cratis.Chronicle.Grains.Observation.Jobs;
 using Cratis.Chronicle.Integration.Base;
 using Cratis.Chronicle.Storage.Observation;
-using Humanizer;
-using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_single_partition.and_reactor_has_observed_events_previously_but_is_now_behind.context;
+using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_multiple_partitions.and_reactor_has_observed_events_previously_but_is_now_behind_by_one.context;
 using ObserverRunningState = Cratis.Chronicle.Concepts.Observation.ObserverRunningState;
 
-namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_single_partition;
+namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_multiple_partitions;
 
 [Collection(GlobalCollection.Name)]
-public class and_reactor_has_observed_events_previously_but_is_now_behind(context context) : Given<context>(context)
+public class and_reactor_has_observed_events_previously_but_is_now_behind_by_one(context context) : Given<context>(context)
 {
     public class context(GlobalFixture globalFixture) : given.a_disconnected_reactor_observing_an_event(globalFixture)
     {
@@ -33,14 +28,14 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind(contex
             ReactorObserver = GetObserverForReactor<ReactorWithoutDelay>();
             await ReactorObserver.WaitTillActive();
 
-            FirstEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 10, "Partition").ToList();
+            FirstEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 10).ToList();
             var result = await EventStore.EventLog.AppendMany(FirstEvents);
             var lastHandled = result.SequenceNumbers.Last();
 
             await ReactorObserver.WaitTillReachesEventSequenceNumber(lastHandled);
             reactor.Disconnect();
 
-            CatchupEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 10, "Partition").ToList();
+            CatchupEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 1).ToList();
             result = await EventStore.EventLog.AppendMany(CatchupEvents);
             LastEventSequenceNumberAfterDisconnect = result.SequenceNumbers.Last();
         }

--- a/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
+++ b/Integration/Orleans.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
@@ -1,22 +1,17 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Contracts.Jobs;
-using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences;
-using Cratis.Chronicle.Grains.Observation;
-using Cratis.Chronicle.Grains.Observation.Jobs;
 using Cratis.Chronicle.Integration.Base;
 using Cratis.Chronicle.Storage.Observation;
-using Humanizer;
-using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_single_partition.and_reactor_has_observed_events_previously_but_is_now_behind.context;
+using context = Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_single_partition.and_reactor_has_observed_events_previously_but_is_now_behind_by_one.context;
 using ObserverRunningState = Cratis.Chronicle.Concepts.Observation.ObserverRunningState;
 
 namespace Cratis.Chronicle.Integration.Orleans.InProcess.for_Reactors.when_connecting.existing.with_single_partition;
 
 [Collection(GlobalCollection.Name)]
-public class and_reactor_has_observed_events_previously_but_is_now_behind(context context) : Given<context>(context)
+public class and_reactor_has_observed_events_previously_but_is_now_behind_by_one(context context) : Given<context>(context)
 {
     public class context(GlobalFixture globalFixture) : given.a_disconnected_reactor_observing_an_event(globalFixture)
     {
@@ -40,7 +35,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind(contex
             await ReactorObserver.WaitTillReachesEventSequenceNumber(lastHandled);
             reactor.Disconnect();
 
-            CatchupEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 10, "Partition").ToList();
+            CatchupEvents = EventForEventSourceIdHelpers.CreateMultiple(i => new SomeEvent(42), 1, "Partition").ToList();
             result = await EventStore.EventLog.AppendMany(CatchupEvents);
             LastEventSequenceNumberAfterDisconnect = result.SequenceNumbers.Last();
         }

--- a/Source/Kernel/Grains.Interfaces/Observation/IObserver.cs
+++ b/Source/Kernel/Grains.Interfaces/Observation/IObserver.cs
@@ -25,6 +25,7 @@ public interface IObserver : IStateMachine<ObserverState>, IGrainWithStringKey
     /// Get the state from the observer.
     /// </summary>
     /// <returns>The <see cref="ObserverState"/>.</returns>
+    [AlwaysInterleave]
     Task<ObserverState> GetState();
 
     /// <summary>
@@ -38,18 +39,21 @@ public interface IObserver : IStateMachine<ObserverState>, IGrainWithStringKey
     /// Get the subscription for the observer.
     /// </summary>
     /// <returns>Tbe <see cref="ObserverSubscription"/>.</returns>
+    [AlwaysInterleave]
     Task<ObserverSubscription> GetSubscription();
 
     /// <summary>
     /// Check if the observer has a subscription subscribed.
     /// </summary>
     /// <returns>True if it has, false if not.</returns>
+    [AlwaysInterleave]
     Task<bool> IsSubscribed();
 
     /// <summary>
     /// Get the event types that the observer is observing.
     /// </summary>
     /// <returns>Collection of <see cref="EventType"/>.</returns>
+    [AlwaysInterleave]
     Task<IEnumerable<EventType>> GetEventTypes();
 
     /// <summary>

--- a/Source/Kernel/Grains/Observation/States/Routing.cs
+++ b/Source/Kernel/Grains/Observation/States/Routing.cs
@@ -128,5 +128,5 @@ public class Routing(
     bool IsFallingBehind(ObserverState state) =>
         state.NextEventSequenceNumber.IsActualValue &&
         _tailEventSequenceNumber.IsActualValue &&
-        state.NextEventSequenceNumber < _tailEventSequenceNumber;
+        state.NextEventSequenceNumber <= _tailEventSequenceNumber;
 }


### PR DESCRIPTION
### Fixed

- An issue where during connecting of an Observer it would skip and event if it had to catchup only a single event
- Make getting state from Observer always interleave
