### PR TITLE
Appended events queue issue and broken specs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,6 @@
         <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
         <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
-        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.11.0" />
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.11.1" />
     </ItemGroup>
 </Project>

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber.cs
@@ -30,7 +30,7 @@ public abstract class a_single_subscriber : all_dependencies
                 var events = callInfo.Arg<IEnumerable<AppendedEvent>>();
                 if (!_handledEventsPerPartition.TryGetValue(key, out var handledEvents))
                 {
-                    handledEvents = new();
+                    handledEvents = [];
                     _handledEventsPerPartition.TryAdd(key, handledEvents);
                 }
                 handledEvents.Add(new(key, events));

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
@@ -14,7 +15,7 @@ public abstract class a_single_subscriber : all_dependencies
 {
     protected ObserverKey _observerKey;
     protected IObserver _observer;
-    protected List<HandledEvents> _handledEvents = [];
+    protected ConcurrentDictionary<Key, List<HandledEvents>> _handledEventsPerPartition = [];
     protected AppendedEventsQueue _queue;
 
     async Task Establish()
@@ -27,7 +28,12 @@ public abstract class a_single_subscriber : all_dependencies
             {
                 var key = callInfo.Arg<Key>();
                 var events = callInfo.Arg<IEnumerable<AppendedEvent>>();
-                _handledEvents.Add(new(key, events));
+                if (!_handledEventsPerPartition.TryGetValue(key, out var handledEvents))
+                {
+                    handledEvents = new();
+                    _handledEventsPerPartition.TryAdd(key, handledEvents);
+                }
+                handledEvents.Add(new(key, events));
             });
         _grainFactory.GetGrain<IObserver>(_observerKey).Returns(_observer);
 

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/two_subscribers.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/given/two_subscribers.cs
@@ -38,7 +38,7 @@ public class two_subscribers : all_dependencies
                 var events = callInfo.Arg<IEnumerable<AppendedEvent>>();
                 if (!_firstObserverHandledEventsPerPartition.TryGetValue(key, out var handledEvents))
                 {
-                    handledEvents = new();
+                    handledEvents = [];
                     _firstObserverHandledEventsPerPartition.TryAdd(key, handledEvents);
                 }
                 handledEvents.Add(new(key, events));
@@ -55,7 +55,7 @@ public class two_subscribers : all_dependencies
                 var events = callInfo.Arg<IEnumerable<AppendedEvent>>();
                 if (!_secondObserverHandledEventsPerPartition.TryGetValue(key, out var handledEvents))
                 {
-                    handledEvents = new();
+                    handledEvents = [];
                     _secondObserverHandledEventsPerPartition.TryAdd(key, handledEvents);
                 }
                 handledEvents.Add(new(key, events));

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_multiple_subscribers_that_subscribes_to_all_event_types.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_multiple_subscribers_that_subscribes_to_all_event_types.cs
@@ -33,14 +33,14 @@ public class multiple_events_with_different_partitions_with_multiple_subscribers
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_call_handle_on_first_observer_twice() => _firstObserverHandledEvents.Count.ShouldEqual(2);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_first_event() => _firstObserverHandledEvents[0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_second_event() => _firstObserverHandledEvents[1].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_first_event() => _firstObserverHandledEvents[0].Events.ShouldContainOnly(_firstAppendedEvent);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_second_event() => _firstObserverHandledEvents[1].Events.ShouldContainOnly(_secondAppendedEvent);
-    [Fact] void should_call_handle_on_second_observer_twice() => _secondObserverHandledEvents.Count.ShouldEqual(2);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_first_event() => _secondObserverHandledEvents[0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_second_event() => _secondObserverHandledEvents[1].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_first_event() => _secondObserverHandledEvents[0].Events.ShouldContainOnly(_firstAppendedEvent);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_second_event() => _secondObserverHandledEvents[1].Events.ShouldContainOnly(_secondAppendedEvent);
+    [Fact] void should_call_handle_on_first_observer_twice() => _firstObserverHandledEventsPerPartition.Count.ShouldEqual(2);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_first_event() => _firstObserverHandledEventsPerPartition[_firstEventSourceId][0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_second_event() => _firstObserverHandledEventsPerPartition[_secondEventSourceId][0].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_first_event() => _firstObserverHandledEventsPerPartition[_firstEventSourceId][0].Events.ShouldContainOnly(_firstAppendedEvent);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_second_event() => _firstObserverHandledEventsPerPartition[_secondEventSourceId][0].Events.ShouldContainOnly(_secondAppendedEvent);
+    [Fact] void should_call_handle_on_second_observer_twice() => _secondObserverHandledEventsPerPartition.Sum(_ => _.Value.Count).ShouldEqual(2);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_first_event() => _secondObserverHandledEventsPerPartition[_firstEventSourceId][0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_second_event() => _secondObserverHandledEventsPerPartition[_secondEventSourceId][0].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_first_event() => _secondObserverHandledEventsPerPartition[_firstEventSourceId][0].Events.ShouldContainOnly(_firstAppendedEvent);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_second_event() => _secondObserverHandledEventsPerPartition[_secondEventSourceId][0].Events.ShouldContainOnly(_secondAppendedEvent);
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_multiple_subscribers_that_subscribes_to_one_event_type_each.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_multiple_subscribers_that_subscribes_to_one_event_type_each.cs
@@ -34,10 +34,10 @@ public class multiple_events_with_different_partitions_with_multiple_subscribers
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_call_handle_on_first_observer_once() => _firstObserverHandledEvents.Count.ShouldEqual(1);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_first_event() => _firstObserverHandledEvents[0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
-    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_first_event() => _firstObserverHandledEvents[0].Events.ShouldContainOnly(_firstAppendedEvent);
-    [Fact] void should_call_handle_on_second_observer_once() => _secondObserverHandledEvents.Count.ShouldEqual(1);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_second_event() => _secondObserverHandledEvents[0].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
-    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_second_event() => _secondObserverHandledEvents[0].Events.ShouldContainOnly(_secondAppendedEvent);
+    [Fact] void should_call_handle_on_first_observer_once() => _firstObserverHandledEventsPerPartition.Sum(_ => _.Value.Count).ShouldEqual(1);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_source_id_for_first_event() => _firstObserverHandledEventsPerPartition[_firstEventSourceId][0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
+    [Fact] void should_call_handle_on_first_observer_with_correct_event_for_first_event() => _firstObserverHandledEventsPerPartition[_firstEventSourceId][0].Events.ShouldContainOnly(_firstAppendedEvent);
+    [Fact] void should_call_handle_on_second_observer_once() => _secondObserverHandledEventsPerPartition.Sum(_ => _.Value.Count).ShouldEqual(1);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_source_id_for_second_event() => _secondObserverHandledEventsPerPartition[_secondEventSourceId][0].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
+    [Fact] void should_call_handle_on_second_observer_with_correct_event_for_second_event() => _secondObserverHandledEventsPerPartition[_secondEventSourceId][0].Events.ShouldContainOnly(_secondAppendedEvent);
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_single_subscriber.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_single_subscriber.cs
@@ -36,8 +36,8 @@ public class multiple_events_with_different_partitions_with_single_subscriber : 
 
     [Fact] void should_call_handle_on_observer_for_two_different_partitions() => _handledEventsPerPartition.Count.ShouldEqual(2);
     [Fact] void should_call_handle_on_observer_for_two_events() => _handledEventsPerPartition.Sum(_ => _.Value.Count).ShouldEqual(2);
-    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Partition.Value == _firstEventSourceId.Value).ShouldNotBeNull();
-    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Partition.Value == _secondEventSourceId.Value).ShouldNotBeNull();
-    [Fact] void should_call_handle_on_observer_with_correct_event_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault( e => e == _firstAppendedEvent) is not null).ShouldNotBeNull();
-    [Fact] void should_call_handle_on_observer_with_correct_event_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault( e => e == _secondAppendedEvent) is not null).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Partition == _firstEventSourceId.Value).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Partition == _secondEventSourceId.Value).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault(e => e == _firstAppendedEvent) is not null).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault(e => e == _secondAppendedEvent) is not null).ShouldNotBeNull();
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_single_subscriber.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/multiple_events_with_different_partitions_with_single_subscriber.cs
@@ -34,9 +34,10 @@ public class multiple_events_with_different_partitions_with_single_subscriber : 
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_call_handle_on_observer_twice() => _handledEvents.Count.ShouldEqual(2);
-    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_first_event() => _handledEvents[0].Partition.Value.ShouldEqual(_firstEventSourceId.Value);
-    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_second_event() => _handledEvents[1].Partition.Value.ShouldEqual(_secondEventSourceId.Value);
-    [Fact] void should_call_handle_on_observer_with_correct_event_for_first_event() => _handledEvents[0].Events.ShouldContainOnly(_firstAppendedEvent);
-    [Fact] void should_call_handle_on_observer_with_correct_event_for_second_event() => _handledEvents[1].Events.ShouldContainOnly(_secondAppendedEvent);
+    [Fact] void should_call_handle_on_observer_for_two_different_partitions() => _handledEventsPerPartition.Count.ShouldEqual(2);
+    [Fact] void should_call_handle_on_observer_for_two_events() => _handledEventsPerPartition.Sum(_ => _.Value.Count).ShouldEqual(2);
+    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Partition.Value == _firstEventSourceId.Value).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_source_id_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Partition.Value == _secondEventSourceId.Value).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_for_first_event() => _handledEventsPerPartition[_firstEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault( e => e == _firstAppendedEvent) is not null).ShouldNotBeNull();
+    [Fact] void should_call_handle_on_observer_with_correct_event_for_second_event() => _handledEventsPerPartition[_secondEventSourceId].SingleOrDefault(e => e.Events.SingleOrDefault( e => e == _secondAppendedEvent) is not null).ShouldNotBeNull();
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/single_event_with_single_subscriber.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/single_event_with_single_subscriber.cs
@@ -24,7 +24,7 @@ public class single_event_with_single_subscriber : given.a_single_subscriber_wit
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_call_handle_on_observer_once() => _handledEvents.Count.ShouldEqual(1);
-    [Fact] void should_call_handle_on_observer_with_correct_event_source_id() => _handledEvents[0].Partition.Value.ShouldEqual(_eventSourceId.Value);
-    [Fact] void should_call_handle_on_observer_with_correct_event() => _handledEvents[0].Events.ShouldContainOnly(_appendedEvent);
+    [Fact] void should_call_handle_on_observer_once() => _handledEventsPerPartition[_eventSourceId].Count.ShouldEqual(1);
+    [Fact] void should_call_handle_on_observer_with_correct_event_source_id() => _handledEventsPerPartition[_eventSourceId][0].Partition.Value.ShouldEqual(_eventSourceId.Value);
+    [Fact] void should_call_handle_on_observer_with_correct_event() => _handledEventsPerPartition[_eventSourceId][0].Events.ShouldContainOnly(_appendedEvent);
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_subscriber_that_has_unsubscribed.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_subscriber_that_has_unsubscribed.cs
@@ -25,5 +25,5 @@ public class with_subscriber_that_has_unsubscribed : given.a_single_subscriber_w
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_not_call_handle_on_observer_twice() => _handledEvents.Count.ShouldEqual(0);
+    [Fact] void should_not_handle_any_events() => _handledEventsPerPartition.Count.ShouldEqual(0);
 }

--- a/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_subscriber_that_throws_exception_on_first_handle.cs
+++ b/Source/Kernel/Grains.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_subscriber_that_throws_exception_on_first_handle.cs
@@ -38,5 +38,5 @@ public class with_subscriber_that_throws_exception_on_first_handle : given.a_sin
         await _queue.AwaitQueueDepletion();
     }
 
-    [Fact] void should_call_handle_on_observer_twice() => _handledEvents.Count.ShouldEqual(2);
+    [Fact] void should_call_handle_on_observer_twice() => _handledEventsPerPartition[_eventSourceId].Count.ShouldEqual(2);
 }

--- a/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Grains/EventSequences/AppendedEventsQueue.cs
@@ -25,7 +25,6 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     readonly ConcurrentQueue<IEnumerable<AppendedEvent>> _queue = new();
     readonly AsyncManualResetEvent _queueEvent = new();
     readonly AsyncManualResetEvent _queueEmptyEvent = new();
-    readonly TaskCompletionSource _queueTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
     Task _queueTask = Task.CompletedTask;
     bool _isDisposed;
     ConcurrentBag<AppendedEventsQueueObserverSubscription> _subscriptions = [];
@@ -101,7 +100,6 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     public void Dispose()
     {
         _isDisposed = true;
-        _queueTaskCompletionSource.SetCanceled();
 
         if (!_queueTask.IsCompleted)
         {
@@ -126,12 +124,14 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     /// <summary>
     /// Await the queue to be depleted.
     /// </summary>
+    /// <param name="periodNum">Optional amount of times it will check the queue.</param>
+    /// <param name="periodDelay">Optional time in ms it will wait after each check.</param>
     /// <returns>Awaitable task.</returns>
     /// <remarks>
     /// This method will block until the queue is depleted. This is useful for testing purposes.
     /// It is not exposed on the interface as it is not intended for production use.
     /// </remarks>
-    public async Task AwaitQueueDepletion()
+    public async Task AwaitQueueDepletion(int periodNum = 10, int periodDelay = 10)
     {
         await Task.Run(async () =>
         {
@@ -139,16 +139,16 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
             {
                 while (!_queue.IsEmpty)
                 {
-                    await Task.Delay(10);
+                    await Task.Delay(periodDelay);
                 }
                 await _queueEmptyEvent.WaitAsync();
             }
             else
             {
-                var count = 10;
+                var count = periodNum;
                 while (!_queue.IsEmpty)
                 {
-                    await Task.Delay(10);
+                    await Task.Delay(periodDelay);
                     if (--count == 0)
                     {
                         break;
@@ -168,20 +168,17 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         }
 
         _queueTask = _taskFactory.Run(QueueHandler);
-
-        // The queue task should never stop, then the queue will be stopped. We restart it if it stops. A sort of "watch dog".
-        _queueTask.ContinueWith(_ => StartQueueHandler(), TaskScheduler.Default);
     }
 
     async Task QueueHandler()
     {
-        while (!_queueTaskCompletionSource.Task.IsCanceled)
+        while (!_isDisposed)
         {
             try
             {
                 await _queueEvent.WaitAsync();
                 _queueEmptyEvent.Reset();
-                if (_queueTaskCompletionSource.Task.IsCanceled)
+                if (_isDisposed)
                 {
                     return;
                 }
@@ -220,6 +217,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
                 _logger.QueueHandlerFailed(exception);
             }
         }
+        StartQueueHandler();
     }
 
     async Task HandleSingle(IEnumerable<AppendedEvent> events)
@@ -227,12 +225,13 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         var @event = events.First();
         foreach (var subscription in _subscriptions)
         {
-            if (subscription.EventTypeIds.Contains(@event.Metadata.Type.Id))
+            if (!subscription.EventTypeIds.Contains(@event.Metadata.Type.Id))
             {
-                var observer = _grainFactory.GetGrain<IObserver>(subscription.ObserverKey);
-                var eventToHandle = new List<AppendedEvent> { @event };
-                await observer.Handle(@event.Context.EventSourceId, eventToHandle);
+                continue;
             }
+            var observer = _grainFactory.GetGrain<IObserver>(subscription.ObserverKey);
+            var eventToHandle = new List<AppendedEvent> { @event };
+            await observer.Handle(@event.Context.EventSourceId, eventToHandle);
         }
     }
 

--- a/Source/Kernel/Grains/Observation/Observer.cs
+++ b/Source/Kernel/Grains/Observation/Observer.cs
@@ -374,6 +374,11 @@ public class Observer(
     {
         using var scope = logger.BeginObserverScope(_observerId, _observerKey);
 
+        if (!events.Any())
+        {
+            return;
+        }
+
         if (!ShouldHandleEvent(partition))
         {
             return;


### PR DESCRIPTION
## Summary

Several specs occatioanly failed for appended events queue because it did not take into account parallelism of event sources. However that uncovered other issues in the appended events queue

### Fixed

- Appended events queue issues related to starting too many queue handlers due to incorrect usage of Task.ContinueWith
