### PR TITLE
Main

### DIFF
--- a/Source/Kernel/Grains/Jobs/Job.cs
+++ b/Source/Kernel/Grains/Jobs/Job.cs
@@ -86,7 +86,7 @@ public abstract class Job<TRequest, TJobState> : Grain<TJobState>, IJob<TRequest
     {
         _logger = ServiceProvider.GetService<ILogger<Job<TRequest, TJobState>>>() ?? new NullLogger<Job<TRequest, TJobState>>();
         _observers = new(
-            TimeSpan.FromMinutes(1),
+            TimeSpan.MaxValue,
             ServiceProvider.GetService<ILogger<ObserverManager<IJobObserver>>>() ?? new NullLogger<ObserverManager<IJobObserver>>());
 
         JobId = this.GetPrimaryKey(out var keyExtension);

--- a/Source/Kernel/Grains/Projections/Projection.cs
+++ b/Source/Kernel/Grains/Projections/Projection.cs
@@ -29,7 +29,7 @@ public class Projection(
     IProjectionDefinitionComparer projectionDefinitionComparer,
     ILogger<Projection> logger) : Grain<ProjectionDefinition>, IProjection
 {
-    readonly ObserverManager<INotifyProjectionDefinitionsChanged> _definitionObservers = new(TimeSpan.FromMinutes(1), logger);
+    readonly ObserverManager<INotifyProjectionDefinitionsChanged> _definitionObservers = new(TimeSpan.MaxValue, logger);
 
     /// <inheritdoc/>
     public async Task SetDefinition(ProjectionDefinition definition)


### PR DESCRIPTION
### Fixed

- Fixing expiration for Grain observers for `Jobs` and `Projection` to be `TimeSpan.MaxValue`. The expiration is used for not notifying grain observers that might not be there anymore. For our usecases in these places, the observers are there and explicitly removed when they're not there. In fact, specifically for `Projection` this would mean that anyone interested in the change of definition would not get it after 1 minute the way it was today, which is wrong. (#1692)
