### PR TITLE
Fix/catchup-reset

### DIFF
--- a/Source/Kernel/Grains.Specs/Observation/for_Observer/when_observer_is_caught_up.cs
+++ b/Source/Kernel/Grains.Specs/Observation/for_Observer/when_observer_is_caught_up.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Properties;
+namespace Cratis.Chronicle.Grains.Observation.for_Observer;
+
+public class when_observer_is_caught_up : given.an_observer_with_subscription
+{
+    async Task Establish()
+    {
+        await _observer.Subscribe<NullObserverSubscriber>(ObserverType.Reactor, [], SiloAddress.Zero);
+        _stateStorage.State.CatchingUpPartitions.Add(new Key("partition1", ArrayIndexers.NoIndexers));
+        _stateStorage.State.CatchingUpPartitions.Add(new Key("partition2", ArrayIndexers.NoIndexers));
+        _storageStats.ResetCounts();
+    }
+
+    Task Because() => _observer.CaughtUp(42L);
+
+    [Fact] void should_clear_catching_up_observers() => _stateStorage.State.CatchingUpPartitions.ShouldBeEmpty();
+    [Fact] void should_write_state() => _storageStats.Writes.ShouldBeGreaterThan(0);
+}

--- a/Source/Kernel/Grains.Specs/Observation/for_Observer/when_replaying.cs
+++ b/Source/Kernel/Grains.Specs/Observation/for_Observer/when_replaying.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Observation;
+
 namespace Cratis.Chronicle.Grains.Observation.for_Observer;
 
 public class when_replaying : given.an_observer_with_subscription

--- a/Source/Kernel/Grains/Observation/Observer.cs
+++ b/Source/Kernel/Grains/Observation/Observer.cs
@@ -332,6 +332,8 @@ public class Observer(
     {
         using var scope = logger.BeginObserverScope(_observerId, _observerKey);
         HandleNewLastHandledEvent(lastHandledEventSequenceNumber);
+
+        State.CatchingUpPartitions.Clear();
         await WriteStateAsync();
         await TransitionTo<Routing>();
     }

--- a/Source/Kernel/Grains/Observation/States/Routing.cs
+++ b/Source/Kernel/Grains/Observation/States/Routing.cs
@@ -53,6 +53,10 @@ public class Routing(
 
         logger.TailEventSequenceNumbers(_tailEventSequenceNumber, _nextUnhandledEventSequenceNumber);
 
+        // We should not be having any partitions to catch up or replay at this point, routing will figure out if we need to catch up the observer
+        state.CatchingUpPartitions.Clear();
+        state.ReplayingPartitions.Clear();
+
         return await EvaluateState(state);
     }
 


### PR DESCRIPTION
### Fixed

- Fixing so that we actually clear out `CatchingUpPartitions` in the `Observer` state when it has caught up.
- Making observer "self-heal" on routing by clearing `CatchingUpPartitions` and `ReplayingPartitions`. (#1688)