### PR TITLE
Exposing FailedPartition API as an Idiomatic C# API

### DIFF
--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Identities;
+using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reducers;
@@ -139,6 +140,7 @@ public class EventStore : IEventStore
             _eventSerializer,
             serviceProvider,
             jsonSerializerOptions);
+        FailedPartitions = new FailedPartitions(this);
 
         AggregateRootFactory = new AggregateRootFactory(
             this,
@@ -184,6 +186,9 @@ public class EventStore : IEventStore
 
     /// <inheritdoc/>
     public IProjections Projections { get; }
+
+    /// <inheritdoc/>
+    public IFailedPartitions FailedPartitions { get; }
 
     /// <inheritdoc/>
     public async Task DiscoverAll()

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Aggregates;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reducers;
@@ -71,6 +72,11 @@ public interface IEventStore
     /// Gets the <see cref="IProjections"/> for the event store.
     /// </summary>
     IProjections Projections { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IFailedPartitions"/> for the event store.
+    /// </summary>
+    IFailedPartitions FailedPartitions { get; }
 
     /// <summary>
     /// Discover all artifacts for the event store.

--- a/Source/Clients/DotNET/Observation/FailedPartition.cs
+++ b/Source/Clients/DotNET/Observation/FailedPartition.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents a failed partition.
+/// </summary>
+/// <param name="Id">Unique identifier of the failed partition registration.</param>
+/// <param name="ObserverId">The identifier of the observer (Reactor, Reducer).</param>
+/// <param name="Partition">Partition that has failed.</param>
+/// <param name="Attempts">Collection of <see cref="FailedPartitionAttempt"/>.</param>
+public record FailedPartition(FailedPartitionId Id, ObserverId ObserverId, Partition Partition, IEnumerable<FailedPartitionAttempt> Attempts);

--- a/Source/Clients/DotNET/Observation/FailedPartitionAttempt.cs
+++ b/Source/Clients/DotNET/Observation/FailedPartitionAttempt.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents a failed partition attempt.
+/// </summary>
+/// <param name="Occurred">When it occurred.</param>
+/// <param name="SequenceNumber">Event sequence number it occured at.</param>
+/// <param name="Messages">Collection of messages associated.</param>
+/// <param name="StackTrace">Associated stack trace.</param>
+public record FailedPartitionAttempt(DateTimeOffset Occurred, EventSequenceNumber SequenceNumber, IEnumerable<string> Messages, string StackTrace);

--- a/Source/Clients/DotNET/Observation/FailedPartitionConverters.cs
+++ b/Source/Clients/DotNET/Observation/FailedPartitionConverters.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Converter methods for <see cref="FailedPartition"/>.
+/// </summary>
+internal static class FailedPartitionConverters
+{
+    /// <summary>
+    /// Convert from a <see cref="Contracts.Observation.FailedPartition"/> to a <see cref="FailedPartition"/>.
+    /// </summary>
+    /// <param name="failedPartition">The <see cref="Contracts.Observation.FailedPartition"/> to convert from.</param>
+    /// <returns>Converted <see cref="FailedPartition"/>.</returns>
+    internal static FailedPartition ToClient(this Contracts.Observation.FailedPartition failedPartition)
+    {
+        return new FailedPartition(
+            failedPartition.Id,
+            failedPartition.ObserverId,
+            failedPartition.Partition,
+            failedPartition.Attempts.Select(_ => _.ToClient()));
+    }
+
+    /// <summary>
+    /// Convert from a collection of <see cref="Contracts.Observation.FailedPartition"/> to a collection of <see cref="FailedPartition"/>.
+    /// </summary>
+    /// <param name="failedPartitions">Collection of <see cref="Contracts.Observation.FailedPartition"/>.</param>
+    /// <returns>A collection of <see cref="FailedPartition"/>.</returns>
+    internal static IEnumerable<FailedPartition> ToClient(this IEnumerable<Contracts.Observation.FailedPartition> failedPartitions) =>
+        failedPartitions.Select(_ => _.ToClient()).ToArray();
+
+    /// <summary>
+    /// Convert from a <see cref="Contracts.Observation.FailedPartitionAttempt"/> to a <see cref="FailedPartitionAttempt"/>.
+    /// </summary>
+    /// <param name="failedPartitionAttempt">The <see cref="Contracts.Observation.FailedPartitionAttempt"/> to convert from.</param>
+    /// <returns>Converted <see cref="FailedPartitionAttempt"/>.</returns>
+    internal static FailedPartitionAttempt ToClient(this Contracts.Observation.FailedPartitionAttempt failedPartitionAttempt)
+    {
+        return new FailedPartitionAttempt(
+            failedPartitionAttempt.Occurred,
+            failedPartitionAttempt.SequenceNumber,
+            failedPartitionAttempt.Messages,
+            failedPartitionAttempt.StackTrace);
+    }
+}

--- a/Source/Clients/DotNET/Observation/FailedPartitionId.cs
+++ b/Source/Clients/DotNET/Observation/FailedPartitionId.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents the unique identifier of a failed partition.
+/// </summary>
+/// <param name="value">The inner value.</param>
+public record FailedPartitionId(Guid value) : ConceptAs<Guid>(value)
+{
+    public static implicit operator FailedPartitionId(Guid value) => new(value);
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="FailedPartitionId"/> class with a new unique value.
+    /// </summary>
+    /// <returns><see cref="FailedPartitionId"/> instance.</returns>
+    public static FailedPartitionId New() => new(Guid.NewGuid());
+}

--- a/Source/Clients/DotNET/Observation/FailedPartitions.cs
+++ b/Source/Clients/DotNET/Observation/FailedPartitions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents an implementation of <see cref="IFailedPartitions"/>.
+/// </summary>
+/// <param name="eventStore"><see cref="IEventStore"/> to use for getting failed partitions.</param>
+public class FailedPartitions(IEventStore eventStore) : IFailedPartitions
+{
+    /// <inheritdoc/>
+    public async Task<IEnumerable<FailedPartition>> GetAllFailedPartitions()
+    {
+        var failedPartitions = await eventStore.Connection.Services.FailedPartitions.GetFailedPartitions(new()
+        {
+            EventStore = eventStore.Name,
+            Namespace = eventStore.Namespace,
+        });
+
+        return failedPartitions.ToClient();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<FailedPartition>> GetFailedPartitionsFor(ObserverId observerId)
+    {
+        var failedPartitions = await eventStore.Connection.Services.FailedPartitions.GetFailedPartitions(new()
+        {
+            EventStore = eventStore.Name,
+            Namespace = eventStore.Namespace,
+            ObserverId = observerId
+        });
+
+        return failedPartitions.ToClient();
+    }
+}

--- a/Source/Clients/DotNET/Observation/IFailedPartitions.cs
+++ b/Source/Clients/DotNET/Observation/IFailedPartitions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Defines a system that can work with failed partitions.
+/// </summary>
+public interface IFailedPartitions
+{
+    /// <summary>
+    /// Get any failed partitions for any observer (Reactor, Reducer ++).
+    /// </summary>
+    /// <returns>A collection of any <see cref="FailedPartition"/>.</returns>
+    Task<IEnumerable<FailedPartition>> GetAllFailedPartitions();
+
+    /// <summary>
+    /// Get any failed partitions for a specific observer (Reactor, Reducer ++).
+    /// </summary>
+    /// <param name="observerId"><see cref="ObserverId"/> to get for.</param>
+    /// <returns>A collection of any <see cref="FailedPartition"/>.</returns>
+    Task<IEnumerable<FailedPartition>> GetFailedPartitionsFor(ObserverId observerId);
+}

--- a/Source/Clients/DotNET/Observation/ObserverId.cs
+++ b/Source/Clients/DotNET/Observation/ObserverId.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Concept that represents the unique identifier of an observer.
+/// </summary>
+/// <param name="Value">Actual value.</param>
+public record ObserverId(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Gets the representation of an unspecified <see cref="ObserverId"/>.
+    /// </summary>
+    public static readonly ObserverId Unspecified = new("[unspecified]");
+
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="ObserverId"/>.
+    /// </summary>
+    /// <param name="id">String to convert from.</param>
+    public static implicit operator ObserverId(string id) => new(id);
+}

--- a/Source/Clients/DotNET/Observation/Partition.cs
+++ b/Source/Clients/DotNET/Observation/Partition.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Concept that represents a partition.
+/// </summary>
+/// <param name="Value">Actual value.</param>
+public record Partition(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="Partition"/>.
+    /// </summary>
+    /// <param name="value">String to convert from.</param>
+    public static implicit operator Partition(string value) => new(value);
+}

--- a/Source/Clients/DotNET/Reactors/IReactors.cs
+++ b/Source/Clients/DotNET/Reactors/IReactors.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Observation;
+
 namespace Cratis.Chronicle.Reactors;
 
 /// <summary>
@@ -34,4 +36,18 @@ public interface IReactors
     /// <param name="id"><see cref="ReactorId"/> to get for.</param>
     /// <returns><see cref="ReactorHandler"/> instance.</returns>
     ReactorHandler GetHandlerById(ReactorId id);
+
+    /// <summary>
+    /// Get any failed partitions for a specific reactor.
+    /// </summary>
+    /// <typeparam name="TReactor">Type of reducer.</typeparam>
+    /// <returns>Collection of <see cref="FailedPartition"/>, if any.</returns>
+    Task<IEnumerable<FailedPartition>> GetFailedPartitions<TReactor>();
+
+    /// <summary>
+    /// Get any failed partitions for a specific reactor.
+    /// </summary>
+    /// <param name="reactorType">Type of reducer.</param>
+    /// <returns>Collection of <see cref="FailedPartition"/>, if any.</returns>
+    Task<IEnumerable<FailedPartition>> GetFailedPartitions(Type reactorType);
 }

--- a/Source/Clients/DotNET/Reactors/ReactorId.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorId.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Observation;
+
 namespace Cratis.Chronicle.Reactors;
 
 /// <summary>
@@ -19,4 +21,10 @@ public record ReactorId(string Value) : ConceptAs<string>(Value)
     /// </summary>
     /// <param name="id">String to convert from.</param>
     public static implicit operator ReactorId(string id) => new(id);
+
+    /// <summary>
+    /// Implicitly convert from <see cref="ReactorId"/> to <see cref="ObserverId"/>.
+    /// </summary>
+    /// <param name="id"><see cref="ReactorId"/> to convert from.</param>
+    public static implicit operator ObserverId(ReactorId id) => new(id.Value);
 }

--- a/Source/Clients/DotNET/Reactors/Reactors.cs
+++ b/Source/Clients/DotNET/Reactors/Reactors.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Auditing;
 using Cratis.Chronicle.Contracts.Observation;
 using Cratis.Chronicle.Contracts.Observation.Reactors;
 using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Observation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -134,6 +135,17 @@ public class Reactors : IReactors
         var reactorHandler = _handlers.Values.SingleOrDefault(_ => _.Id == id);
         ThrowIfUnknownReactorId(reactorHandler, id);
         return reactorHandler!;
+    }
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<Observation.FailedPartition>> GetFailedPartitions<TReactor>() =>
+        GetFailedPartitions(typeof(TReactor));
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<Observation.FailedPartition>> GetFailedPartitions(Type reactorType)
+    {
+        var handler = _handlers[reactorType];
+        return _eventStore.FailedPartitions.GetFailedPartitionsFor(handler.Id);
     }
 
     static void ThrowIfUnknownReactorId(ReactorHandler? handler, ReactorId reactorId)

--- a/Source/Clients/DotNET/Reducers/IReducers.cs
+++ b/Source/Clients/DotNET/Reducers/IReducers.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Observation;
+
 namespace Cratis.Chronicle.Reducers;
 
 /// <summary>
@@ -69,4 +71,18 @@ public interface IReducers
     /// <param name="reducerId"><see cref="ReducerId"/> to get for.</param>
     /// <returns>The type.</returns>
     Type GetClrType(ReducerId reducerId);
+
+    /// <summary>
+    /// Get any failed partitions for a specific reducer.
+    /// </summary>
+    /// <typeparam name="TReducer">Type of reducer.</typeparam>
+    /// <returns>Collection of <see cref="FailedPartition"/>, if any.</returns>
+    Task<IEnumerable<FailedPartition>> GetFailedPartitions<TReducer>();
+
+    /// <summary>
+    /// Get any failed partitions for a specific reducer.
+    /// </summary>
+    /// <param name="reducerType">Type of reducer.</param>
+    /// <returns>Collection of <see cref="FailedPartition"/>, if any.</returns>
+    Task<IEnumerable<FailedPartition>> GetFailedPartitions(Type reducerType);
 }

--- a/Source/Clients/DotNET/Reducers/ReducerId.cs
+++ b/Source/Clients/DotNET/Reducers/ReducerId.cs
@@ -1,13 +1,15 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Observation;
+
 namespace Cratis.Chronicle.Reducers;
 
 /// <summary>
 /// Represents the unique identifier of a reducer.
 /// </summary>
-/// <param name="value">The actual value.</param>
-public record ReducerId(string value) : ConceptAs<string>(value)
+/// <param name="Value">The actual value.</param>
+public record ReducerId(string Value) : ConceptAs<string>(Value)
 {
     /// <summary>
     /// Gets the representation of an unspecified <see cref="ReducerId"/>.
@@ -19,4 +21,10 @@ public record ReducerId(string value) : ConceptAs<string>(value)
     /// </summary>
     /// <param name="id">String to convert from.</param>
     public static implicit operator ReducerId(string id) => new(id);
+
+    /// <summary>
+    /// Implicitly convert from <see cref="ReducerId"/> to <see cref="ObserverId"/>.
+    /// </summary>
+    /// <param name="id"><see cref="ReducerId"/> to convert from.</param>
+    public static implicit operator ObserverId(ReducerId id) => new(id.Value);
 }

--- a/Source/Clients/DotNET/Reducers/Reducers.cs
+++ b/Source/Clients/DotNET/Reducers/Reducers.cs
@@ -10,6 +10,7 @@ using Cratis.Chronicle.Contracts.Observation.Reducers;
 using Cratis.Chronicle.Contracts.Sinks;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Identities;
+using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Sinks;
 using Cratis.Models;
@@ -121,6 +122,17 @@ public class Reducers(
 
     /// <inheritdoc/>
     public bool HasReducerFor(Type modelType) => _handlers.ContainsKey(modelType);
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<Observation.FailedPartition>> GetFailedPartitions<TReducer>() =>
+        GetFailedPartitions(typeof(TReducer));
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<Observation.FailedPartition>> GetFailedPartitions(Type reducerType)
+    {
+        var handler = GetByType(reducerType);
+        return eventStore.FailedPartitions.GetFailedPartitionsFor(handler.Id);
+    }
 
     ReducerHandler CreateHandlerFor(Type reducerType, Type modelType)
     {

--- a/Source/Clients/XUnit/Events/EventStoreForTesting.cs
+++ b/Source/Clients/XUnit/Events/EventStoreForTesting.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reducers;
@@ -58,6 +59,9 @@ public class EventStoreForTesting : IEventStore
 
     /// <inheritdoc/>
     public IUnitOfWorkManager UnitOfWorkManager => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public IFailedPartitions FailedPartitions => throw new NotImplementedException();
 
     /// <inheritdoc/>
     public Task DiscoverAll() => Task.CompletedTask;


### PR DESCRIPTION
### Added

- Addiing an idiomatic C# API for working with failed partitions of observers (Reactors, Reducers, Projections). (#1599)
