### PR TITLE
Changing internal payload for projection changes to be JsonObject

### DIFF
--- a/Source/Kernel/Grains.Interfaces/Projections/ProjectionChangeset.cs
+++ b/Source/Kernel/Grains.Interfaces/Projections/ProjectionChangeset.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Dynamic;
+using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Models;
 
@@ -13,4 +13,4 @@ namespace Cratis.Chronicle.Grains.Projections;
 /// <param name="Namespace">The namespace for the event store.</param>
 /// <param name="ModelKey">The <see cref="ModelKey"/> for the model.</param>
 /// <param name="Model">The instance of the model.</param>
-public record ProjectionChangeset(EventStoreNamespaceName Namespace, ModelKey ModelKey, ExpandoObject Model);
+public record ProjectionChangeset(EventStoreNamespaceName Namespace, ModelKey ModelKey, JsonObject Model);

--- a/Source/Kernel/Services/Projections/Projections.cs
+++ b/Source/Kernel/Services/Projections/Projections.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Dynamic;
 using System.Reactive.Linq;
 using System.Text.Json;
 using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Grains;
-using Cratis.Chronicle.Json;
-using NJsonSchema;
 using Orleans.Streams;
 using ProtoBuf.Grpc;
 
@@ -20,12 +17,10 @@ namespace Cratis.Chronicle.Services.Projections;
 /// </summary>
 /// <param name="clusterClient"><see cref="IClusterClient"/> for interacting with the cluster.</param>
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
-/// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting to and from <see cref="ExpandoObject"/>.</param>
 /// <param name="jsonSerializerOptions"><see cref="JsonSerializerOptions"/> for serialization.</param>
 public class Projections(
     IClusterClient clusterClient,
     IGrainFactory grainFactory,
-    IExpandoObjectConverter expandoObjectConverter,
     JsonSerializerOptions jsonSerializerOptions) : IProjections
 {
     /// <inheritdoc/>
@@ -95,24 +90,18 @@ public class Projections(
         var streamProvider = clusterClient.GetStreamProvider(WellKnownStreamProviders.ProjectionChangesets);
         var streamId = StreamId.Create(new StreamIdentity(Guid.Empty, request.ProjectionId));
 
-        var projection = grainFactory.GetGrain<Grains.Projections.IProjection>(new ProjectionKey(request.ProjectionId, request.EventStore));
-
         var stream = streamProvider.GetStream<Grains.Projections.ProjectionChangeset>(streamId);
         StreamSubscriptionHandle<Grains.Projections.ProjectionChangeset>? subscription = null;
 
         var observable = Observable.Create<ProjectionChangeset>(async (observer, cancellationToken) =>
         {
-            var definition = await projection.GetDefinition();
-            var modelSchema = await JsonSchema.FromJsonAsync(definition.Model.Schema);
-
             subscription = await stream.SubscribeAsync((changeset, _) =>
             {
-                var jsonInstance = expandoObjectConverter.ToJsonObject(changeset.Model, modelSchema);
                 observer.OnNext(new ProjectionChangeset
                 {
                     Namespace = changeset.Namespace,
                     ModelKey = changeset.ModelKey,
-                    Model = jsonInstance.ToJsonString(jsonSerializerOptions)
+                    Model = changeset.Model.ToJsonString(jsonSerializerOptions)
                 });
 
                 return Task.CompletedTask;

--- a/Source/Kernel/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -88,7 +88,7 @@ public static class ChronicleServerSiloBuilderExtensions
                 new FailedPartitions(storage),
                 new Cratis.Chronicle.Services.Observation.Reactors.Reactors(grainFactory, sp.GetRequiredService<IReactorMediator>(), sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Observation.Reactors.Reactors>>()),
                 new Cratis.Chronicle.Services.Observation.Reducers.Reducers(grainFactory, sp.GetRequiredService<IReducerMediator>(), expandoObjectConverter, sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Observation.Reducers.Reducers>>()),
-                new Cratis.Chronicle.Services.Projections.Projections(clusterClient, grainFactory, expandoObjectConverter, jsonSerializerOptions),
+                new Cratis.Chronicle.Services.Projections.Projections(clusterClient, grainFactory, jsonSerializerOptions),
                 new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage),
                 new Cratis.Chronicle.Services.Host.Server(clusterClient));
         });


### PR DESCRIPTION
### Fixed

- Internal serialization issue when using `ExpandoObject` in `ProjectionChangeset`. The way we serialize things for Orleans right now, this got basically serialized into Json and deserialized back as ExpandoObject with all properties being `System.Text.Json` node types. Trying to convert from `ExpandoObject` using our converter then messed up everything, especially for objects with arrays - these properties were lost. This should now be fixed.
