### PR TITLE
Making ResourceEmbedder a private reference. It is only used as a tool during build

### DIFF
--- a/Source/Api/Api.csproj
+++ b/Source/Api/Api.csproj
@@ -12,7 +12,9 @@
     <ItemGroup>
         <ProjectReference Include="../Clients/Connections/Connections.csproj" />
         <ProjectReference Include="../Kernel/Contracts/Contracts.csproj" />
-        <ProjectReference Include="../Tools/ResourceEmbedder/ResourceEmbedder.csproj" />
+        <ProjectReference Include="../Tools/ResourceEmbedder/ResourceEmbedder.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Fixed

- Fixing the reference to `ResourceEmbedder` to be a private reference and not to be propagated in package dependencies.
