### PR TITLE
Exposing ApplicationModelOptions to the Workbench and passing it along to the application model

### DIFF
--- a/Source/Workbench/Embedded/ChronicleWorkbenchOptions.cs
+++ b/Source/Workbench/Embedded/ChronicleWorkbenchOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Applications;
+
 namespace Cratis.Chronicle.Workbench.Embedded;
 
 /// <summary>
@@ -17,4 +19,9 @@ public class ChronicleWorkbenchOptions
     /// Gets or sets the port to expose the Workbench on.
     /// </summary>
     public int Port { get; set; } = DefaultPort;
+
+    /// <summary>
+    /// Gets or sets the <see cref="ApplicationModelOptions"/> for the Workbench.
+    /// </summary>
+    public ApplicationModelOptions ApplicationModel { get; set; } = new();
 }

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -24,7 +24,12 @@ public class WebServer(IOptions<ChronicleWorkbenchOptions> workbenchOptions) : I
         var builder = WebApplication.CreateBuilder();
 
         builder.Host
-            .UseCratisApplicationModel();
+            .UseCratisApplicationModel(options =>
+            {
+                options.CorrelationId = workbenchOptions.Value.ApplicationModel.CorrelationId;
+                options.Tenancy = workbenchOptions.Value.ApplicationModel.Tenancy;
+                options.IdentityDetailsProvider = workbenchOptions.Value.ApplicationModel.IdentityDetailsProvider;
+            });
 
         builder.Services.AddCratisChronicleApi();
 


### PR DESCRIPTION
### Fixed

- Exposing the ApplicationModel options in the Workbench options.
