### PR TITLE
Binding configuration properly for Workbench options

### DIFF
--- a/Source/Workbench/Embedded/WorkbenchWebApplicationBuilderExtensions.cs
+++ b/Source/Workbench/Embedded/WorkbenchWebApplicationBuilderExtensions.cs
@@ -32,8 +32,9 @@ public static class WorkbenchWebApplicationBuilderExtensions
     {
         configSection ??= ConfigurationPath.Combine(DefaultSectionPaths);
 
-        builder.Services.AddOptions(configureOptions);
-        builder.Configuration.Bind(configSection);
+        builder.Services
+            .AddOptions(configureOptions)
+            .BindConfiguration(configSection);
         builder.Services.AddHostedService<WebServer>();
 
         return builder;


### PR DESCRIPTION
### Fixed

- Fixing how we bind the Workbench options configuration, switching from `.Bind()` to `.BindConfiguration()` which is what we want.´for it to be available properly.
