### PR TITLE
Disabling observer subscription for passive projections, they are not observing any stream

### DIFF
--- a/Source/Kernel/Grains/Projections/ProjectionsManager.cs
+++ b/Source/Kernel/Grains/Projections/ProjectionsManager.cs
@@ -94,6 +94,11 @@ public class ProjectionsManager(
         var projection = GrainFactory.GetGrain<IProjection>(key);
         await projection.SetDefinition(definition);
 
+        if (!definition.IsActive)
+        {
+            return;
+        }
+
         foreach (var namespaceName in namespaces)
         {
             await SubscribeIfNotSubscribed(definition, namespaceName);


### PR DESCRIPTION
### Fixed

- Passive Projections are no longer registering subscribers, causing an observer to be allocated (#1766(
