### PR TITLE
Using PathBase to be able to rewrite all input requests

### DIFF
--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -51,6 +51,15 @@ public class WebServer(
 
                 _webApplication = builder.Build();
 
+                var basePath = workbenchOptions.Value.BaseUrl;
+                _webApplication.UsePathBase(basePath);
+
+                _webApplication.Use(async (context, next) =>
+                {
+                    context.Request.PathBase = context.Request.Path.Value!.Replace(basePath, string.Empty);
+                    await next();
+                });
+
                 _webApplication.UseCratisChronicleApi();
 
                 var rootType = typeof(WorkbenchWebApplicationBuilderExtensions);


### PR DESCRIPTION
### Fixed

- Fixing the Embedded Workbench by adding the use of `PathBase` and a middleware for rewriting the Path at the beginning of the pipeline for APIs and all other requests to recognize the base url but be redirected to correct resources which are not necessarily on the base path.
