### PR TITLE
Exposing Chronicle configuration options and setting the AspNetCore IdentityProvider as the default identity provider

### DIFF
--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -38,7 +38,9 @@ public static class ChronicleClientServiceCollectionExtensions
                 SoftwareVersion = options.SoftwareVersion,
                 SoftwareCommit = options.SoftwareCommit,
                 ProgramIdentifier = options.ProgramIdentifier,
-                IdentityProvider = new IdentityProvider(sp.GetRequiredService<IHttpContextAccessor>()),
+                IdentityProvider = new IdentityProvider(
+                    sp.GetRequiredService<IHttpContextAccessor>(),
+                    sp.GetRequiredService<ILogger<IdentityProvider>>()),
                 LoggerFactory = sp.GetRequiredService<ILoggerFactory>(),
             };
             configureChronicleOptions?.Invoke(chronicleOptions);

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ChronicleClientServiceCollectionExtensions
     /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
     /// <param name="configureChronicleOptions">Optional <see cref="Action{T}"/> for configuring Chronicle options.</param>
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
-    public static IServiceCollection AddChronicleClient(
+    public static IServiceCollection AddCratisChronicleClient(
         this IServiceCollection services,
         Action<ChronicleOptions>? configureChronicleOptions = default)
     {

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using Cratis.Chronicle;
+using Cratis.Chronicle.AspNetCore.Identities;
 using Cratis.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,9 +22,12 @@ public static class ChronicleClientServiceCollectionExtensions
     /// <summary>
     /// Add the <see cref="IChronicleClient"/> to the services.
     /// </summary>
-    /// /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="configureChronicleOptions">Optional <see cref="Action{T}"/> for configuring Chronicle options.</param>
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
-    public static IServiceCollection AddChronicleClient(this IServiceCollection services)
+    public static IServiceCollection AddChronicleClient(
+        this IServiceCollection services,
+        Action<ChronicleOptions>? configureChronicleOptions = default)
     {
         services.AddSingleton<IChronicleClient>(sp =>
         {
@@ -34,8 +38,10 @@ public static class ChronicleClientServiceCollectionExtensions
                 SoftwareVersion = options.SoftwareVersion,
                 SoftwareCommit = options.SoftwareCommit,
                 ProgramIdentifier = options.ProgramIdentifier,
+                IdentityProvider = new IdentityProvider(sp.GetRequiredService<IHttpContextAccessor>()),
                 LoggerFactory = sp.GetRequiredService<ILoggerFactory>(),
             };
+            configureChronicleOptions?.Invoke(chronicleOptions);
             return new ChronicleClient(chronicleOptions);
         });
 

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle;
 using Cratis.Chronicle.AspNetCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,12 +28,14 @@ public static class ChronicleClientWebApplicationBuilderExtensions
     /// <param name="configureOptions">Optional <see cref="Action{T}"/> for configuring options.</param>
     /// <param name="configSection">Optional config section.</param>
     /// <param name="loggerFactory">Optional <see cref="ILoggerFactory"/>.</param>
+    /// <param name="configureChronicleOptions">Optional <see cref="Action{T}"/> for configuring Chronicle options.</param>
     /// <returns><see cref="WebApplicationBuilder"/> for configuration continuation.</returns>
     public static WebApplicationBuilder AddCratisChronicle(
         this WebApplicationBuilder builder,
         Action<ChronicleAspNetCoreOptions>? configureOptions = default,
         string? configSection = default,
-        ILoggerFactory? loggerFactory = default)
+        ILoggerFactory? loggerFactory = default,
+        Action<ChronicleOptions>? configureChronicleOptions = default)
     {
         builder.Services.AddOptions(configureOptions);
         builder.Configuration.Bind(configSection ?? ConfigurationPath.Combine(DefaultSectionPaths));
@@ -43,7 +46,7 @@ public static class ChronicleClientWebApplicationBuilderExtensions
             .AddAggregates()
             .AddCompliance()
             .AddCausation()
-            .AddChronicleClient()
+            .AddChronicleClient(configureChronicleOptions)
             .AddHttpContextAccessor()
             .AddHostedService<ChronicleClientStartupTask>();
         builder.Host.AddCratisChronicle(loggerFactory);

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class ChronicleClientWebApplicationBuilderExtensions
             .AddAggregates()
             .AddCompliance()
             .AddCausation()
-            .AddChronicleClient(configureChronicleOptions)
+            .AddCratisChronicleClient(configureChronicleOptions)
             .AddHttpContextAccessor()
             .AddHostedService<ChronicleClientStartupTask>();
         builder.Host.AddCratisChronicle(loggerFactory);

--- a/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
+++ b/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
@@ -36,7 +36,7 @@ public class IdentityProvider(IHttpContextAccessor httpContextAccessor, ILogger<
             return Identity.NotSet;
         }
 
-        logger.IdentitySet(username);
+        logger.IdentitySet(subject, name, username);
         return new Identity(subject, name, username);
     }
 }

--- a/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
+++ b/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Chronicle.Identities;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.AspNetCore.Identities;
 
@@ -13,7 +14,8 @@ namespace Cratis.Chronicle.AspNetCore.Identities;
 /// Initializes a new instance of the <see cref="IdentityProvider"/> class.
 /// </remarks>
 /// <param name="httpContextAccessor"><see cref="IHttpContextAccessor"/> for accessing the current <see cref="HttpContext"/>.</param>
-public class IdentityProvider(IHttpContextAccessor httpContextAccessor) : BaseIdentityProvider
+/// <param name="logger"><see cref="ILogger"/> for logging.</param>
+public class IdentityProvider(IHttpContextAccessor httpContextAccessor, ILogger<IdentityProvider> logger) : BaseIdentityProvider
 {
     /// <inheritdoc/>
     protected override Identity GetCurrent()
@@ -30,9 +32,11 @@ public class IdentityProvider(IHttpContextAccessor httpContextAccessor) : BaseId
             string.IsNullOrEmpty(name) &&
             string.IsNullOrEmpty(username))
         {
+            logger.IdentityNotSet();
             return Identity.NotSet;
         }
 
+        logger.IdentitySet(username);
         return new Identity(subject, name, username);
     }
 }

--- a/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
+++ b/Source/Clients/AspNetCore/Identities/IdentityProvider.cs
@@ -25,8 +25,8 @@ public class IdentityProvider(IHttpContextAccessor httpContextAccessor, ILogger<
         if (context?.Request.Path.StartsWithSegments("/.cratis") ?? true) return base.GetCurrent();
 
         var subject = context.User.Claims.FirstOrDefault(_ => _.Type == "sub")?.Value ?? string.Empty;
-        var name = context.User.Claims.FirstOrDefault(_ => _.Type == "name")?.Value ?? string.Empty;
-        var username = context.User.Claims.FirstOrDefault(_ => _.Type == "preferred_username")?.Value ?? string.Empty;
+        var name = context.User.Claims.FirstOrDefault(_ => _.Type == "name")?.Value ?? context.User.Identity?.Name ?? string.Empty;
+        var username = context.User.Claims.FirstOrDefault(_ => _.Type == "preferred_username")?.Value ?? context.User.Identity?.Name ?? string.Empty;
 
         if (string.IsNullOrEmpty(subject) &&
             string.IsNullOrEmpty(name) &&

--- a/Source/Clients/AspNetCore/Identities/IdentityProviderLogging.cs
+++ b/Source/Clients/AspNetCore/Identities/IdentityProviderLogging.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.AspNetCore.Identities;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class IdentityProviderLogging
+{
+    [LoggerMessage(LogLevel.Trace, "Identity not set")]
+    internal static partial void IdentityNotSet(this ILogger<IdentityProvider> logger);
+
+    [LoggerMessage(LogLevel.Trace, "Identity set to {Identity}")]
+    internal static partial void IdentitySet(this ILogger<IdentityProvider> logger, string identity);
+}

--- a/Source/Clients/AspNetCore/Identities/IdentityProviderLogging.cs
+++ b/Source/Clients/AspNetCore/Identities/IdentityProviderLogging.cs
@@ -14,6 +14,6 @@ internal static partial class IdentityProviderLogging
     [LoggerMessage(LogLevel.Trace, "Identity not set")]
     internal static partial void IdentityNotSet(this ILogger<IdentityProvider> logger);
 
-    [LoggerMessage(LogLevel.Trace, "Identity set to {Identity}")]
-    internal static partial void IdentitySet(this ILogger<IdentityProvider> logger, string identity);
+    [LoggerMessage(LogLevel.Trace, "Identity set to (Subject:'{subject}', Name:'{name}', Username:'{username}')")]
+    internal static partial void IdentitySet(this ILogger<IdentityProvider> logger, string subject, string name, string username);
 }

--- a/Source/Clients/DotNET/ChronicleOptions.cs
+++ b/Source/Clients/DotNET/ChronicleOptions.cs
@@ -67,7 +67,7 @@ public class ChronicleOptions(
     /// <summary>
     /// Gets the <see cref="IIdentityProvider"/> to use.
     /// </summary>
-    public IIdentityProvider IdentityProvider { get; init; } = identityProvider ?? new BaseIdentityProvider();
+    public IIdentityProvider IdentityProvider { get; set; } = identityProvider ?? new BaseIdentityProvider();
 
     /// <summary>
     /// Gets the <see cref="JsonSerializerOptions"/> to use.

--- a/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
+++ b/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
@@ -4,6 +4,7 @@
 extern alias Server;
 
 using Cratis.Chronicle;
+using Cratis.Chronicle.AspNetCore.Identities;
 using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Grains.Observation.Reactors.Clients;
 using Cratis.Chronicle.Grains.Observation.Reducers.Clients;
@@ -13,6 +14,7 @@ using Cratis.Chronicle.Rules;
 using Cratis.Chronicle.Setup;
 using Cratis.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -114,6 +116,9 @@ public static class ChronicleClientSiloBuilderExtensions
                 var options = sp.GetRequiredService<IOptions<ChronicleOptions>>().Value;
                 options.ServiceProvider = sp;
                 options.ArtifactsProvider = sp.GetRequiredService<IClientArtifactsProvider>();
+                options.IdentityProvider = new IdentityProvider(
+                    sp.GetRequiredService<IHttpContextAccessor>(),
+                    sp.GetRequiredService<ILogger<IdentityProvider>>()),
 
                 var grainFactory = sp.GetRequiredService<IGrainFactory>();
                 var services = sp.GetRequiredService<IServices>();

--- a/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
+++ b/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
@@ -118,7 +118,7 @@ public static class ChronicleClientSiloBuilderExtensions
                 options.ArtifactsProvider = sp.GetRequiredService<IClientArtifactsProvider>();
                 options.IdentityProvider = new IdentityProvider(
                     sp.GetRequiredService<IHttpContextAccessor>(),
-                    sp.GetRequiredService<ILogger<IdentityProvider>>()),
+                    sp.GetRequiredService<ILogger<IdentityProvider>>());
 
                 var grainFactory = sp.GetRequiredService<IGrainFactory>();
                 var services = sp.GetRequiredService<IServices>();


### PR DESCRIPTION
### Added

- Adding the posibility to configure `ChronicleOptions` when adding Chronicle to your `WebApplication`.

### Fixed

- The ASP.NET Core `IdentityProvider` is now hooked up by default, as was expected when using ASP.NET Core and the Orleans InProcess client.
