### PR TITLE
Allow case ignoring in constraints

### DIFF
--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintDefinition/when_converting_to_contract.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintDefinition/when_converting_to_contract.cs
@@ -28,7 +28,8 @@ public class when_converting_to_contract : Specification
                 new(_firstEventType.Id, ["First event, first Property", "First event, second Property"]),
                 new(_secondEventType.Id, ["Second event, first Property", "Second event, second Property"])
             ],
-            _removedWithEventType);
+            _removedWithEventType,
+            false);
     }
 
     void Because()

--- a/Source/Clients/DotNET/Events/Constraints/IUniqueConstraintBuilder.cs
+++ b/Source/Clients/DotNET/Events/Constraints/IUniqueConstraintBuilder.cs
@@ -37,6 +37,12 @@ public interface IUniqueConstraintBuilder
     IUniqueConstraintBuilder On(EventType eventType, string[] properties);
 
     /// <summary>
+    /// Ignore casing during comparison.
+    /// </summary>
+    /// <returns>Builder for continuation.</returns>
+    IUniqueConstraintBuilder IgnoreCasing();
+
+    /// <summary>
     /// Indicate an event that will remove the unique constraint.
     /// </summary>
     /// <typeparam name="TEventType">The <see cref="EventType"/> that removes the constraint.</typeparam>

--- a/Source/Clients/DotNET/Events/Constraints/UniqueConstraintBuilder.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UniqueConstraintBuilder.cs
@@ -21,6 +21,7 @@ public class UniqueConstraintBuilder(IEventTypes eventTypes, Type? owner = defau
     ConstraintName? _name;
     ConstraintViolationMessageProvider? _messageProvider;
     EventTypeId? _removedWith;
+    bool _ignoreCasing;
 
     /// <inheritdoc/>
     public IUniqueConstraintBuilder On<TEventType>(params Expression<Func<TEventType, object>>[] properties)
@@ -40,6 +41,13 @@ public class UniqueConstraintBuilder(IEventTypes eventTypes, Type? owner = defau
 
         _eventTypesAndProperties.Add(new UniqueConstraintEventDefinition(eventType.Id, properties));
         _eventTypeSchemas[eventType.Id] = schema;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IUniqueConstraintBuilder IgnoreCasing()
+    {
+        _ignoreCasing = true;
         return this;
     }
 
@@ -85,7 +93,8 @@ public class UniqueConstraintBuilder(IEventTypes eventTypes, Type? owner = defau
             name,
             messageProvider,
             [.. _eventTypesAndProperties],
-            _removedWith);
+            _removedWith,
+            _ignoreCasing);
     }
 
     void ThrowIfNoEventTypesAdded()

--- a/Source/Clients/DotNET/Events/Constraints/UniqueConstraintDefinition.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UniqueConstraintDefinition.cs
@@ -13,6 +13,7 @@ namespace Cratis.Chronicle.Events.Constraints;
 /// <param name="MessageCallback">the callback that provides the <see cref="ConstraintViolationMessage"/> of the constraint.</param>
 /// <param name="EventsWithProperties">The <see cref="EventType"/> and properties the constraint is for.</param>
 /// <param name="RemovedWith">The <see cref="EventTypeId"/> of the event that removes the constraint.</param>
+/// <param name="IgnoreCasing">Whether this constraint should ignore casing.</param>
 public record UniqueConstraintDefinition(
     ConstraintName Name,
     ConstraintViolationMessageProvider MessageCallback,

--- a/Source/Clients/DotNET/Events/Constraints/UniqueConstraintDefinition.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UniqueConstraintDefinition.cs
@@ -17,7 +17,8 @@ public record UniqueConstraintDefinition(
     ConstraintName Name,
     ConstraintViolationMessageProvider MessageCallback,
     IEnumerable<UniqueConstraintEventDefinition> EventsWithProperties,
-    EventTypeId? RemovedWith) : IConstraintDefinition
+    EventTypeId? RemovedWith,
+    bool IgnoreCasing) : IConstraintDefinition
 {
     /// <inheritdoc/>
     public Constraint ToContract() => new()
@@ -27,6 +28,7 @@ public record UniqueConstraintDefinition(
         RemovedWith = RemovedWith?.Value,
         Definition = new(new UniqueConstraintDefinitionContract
         {
+            IgnoreCasing = IgnoreCasing,
             EventDefinitions = EventsWithProperties.Select(_ => new Contracts.Events.Constraints.UniqueConstraintEventDefinition
             {
                 EventTypeId = _.EventTypeId,

--- a/Source/Kernel/Concepts/Events/Constraints/UniqueConstraintDefinition.cs
+++ b/Source/Kernel/Concepts/Events/Constraints/UniqueConstraintDefinition.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.Concepts.Events.Constraints;
 /// <param name="Name">Name of the constraint.</param>
 /// /// <param name="EventDefinitions">Collection of <see cref="UniqueConstraintEventDefinition"/>.</param>
 /// <param name="RemovedWith">The <see cref="EventTypeId"/> of the event that removes the constraint.</param>
-public record UniqueConstraintDefinition(ConstraintName Name, IEnumerable<UniqueConstraintEventDefinition> EventDefinitions, EventTypeId? RemovedWith = default) : IConstraintDefinition
+public record UniqueConstraintDefinition(ConstraintName Name, IEnumerable<UniqueConstraintEventDefinition> EventDefinitions, EventTypeId? RemovedWith = default, bool IgnoreCasing = false) : IConstraintDefinition
 {
     /// <inheritdoc/>
     public bool Equals(IConstraintDefinition? other) => base.Equals(other);

--- a/Source/Kernel/Concepts/Events/Constraints/UniqueConstraintDefinition.cs
+++ b/Source/Kernel/Concepts/Events/Constraints/UniqueConstraintDefinition.cs
@@ -7,8 +7,9 @@ namespace Cratis.Chronicle.Concepts.Events.Constraints;
 /// Represents a definition of a unique event type constraint.
 /// </summary>
 /// <param name="Name">Name of the constraint.</param>
-/// /// <param name="EventDefinitions">Collection of <see cref="UniqueConstraintEventDefinition"/>.</param>
+/// <param name="EventDefinitions">Collection of <see cref="UniqueConstraintEventDefinition"/>.</param>
 /// <param name="RemovedWith">The <see cref="EventTypeId"/> of the event that removes the constraint.</param>
+/// <param name="IgnoreCasing">Whether this constraint should ignore casing.</param>
 public record UniqueConstraintDefinition(ConstraintName Name, IEnumerable<UniqueConstraintEventDefinition> EventDefinitions, EventTypeId? RemovedWith = default, bool IgnoreCasing = false) : IConstraintDefinition
 {
     /// <inheritdoc/>

--- a/Source/Kernel/Contracts/Events/Constraints/UniqueConstraintDefinition.cs
+++ b/Source/Kernel/Contracts/Events/Constraints/UniqueConstraintDefinition.cs
@@ -16,4 +16,10 @@ public class UniqueConstraintDefinition
     /// </summary>
     [ProtoMember(1, IsRequired = true)]
     public IList<UniqueConstraintEventDefinition> EventDefinitions { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets whether to ignore casing.
+    /// </summary>
+    [ProtoMember(2)]
+    public bool IgnoreCasing { get; set; }
 }

--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_is_allowed.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_is_allowed.cs
@@ -13,7 +13,7 @@ public class and_value_is_allowed : given.a_unique_constraint_validator_with_val
     void Establish()
     {
         SetPropertyValue(42);
-        _storage.IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<ConstraintName>(), Arg.Any<UniqueConstraintValue>()).Returns((true, EventSequenceNumber.First));
+        _storage.IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<UniqueConstraintDefinition>(), Arg.Any<UniqueConstraintValue>()).Returns((true, EventSequenceNumber.First));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_is_not_allowed.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_is_not_allowed.cs
@@ -13,7 +13,7 @@ public class and_value_is_not_allowed : given.a_unique_constraint_validator_with
     void Establish()
     {
         SetPropertyValue(42);
-        _storage.IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<ConstraintName>(), Arg.Any<UniqueConstraintValue>()).Returns((false, 43U));
+        _storage.IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<UniqueConstraintDefinition>(), Arg.Any<UniqueConstraintValue>()).Returns((false, 43U));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_returned_for_property_is_null.cs
+++ b/Source/Kernel/Grains.Specs/Events/Constraints/for_UniqueConstraintValidator/when_validating/and_value_returned_for_property_is_null.cs
@@ -15,5 +15,5 @@ public class and_value_returned_for_property_is_null : given.a_unique_constraint
     async Task Because() => _result = await _validator.Validate(_context);
 
     [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
-    [Fact] void should_not_ask_storage_if_allowed() => _storage.DidNotReceive().IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<ConstraintName>(), Arg.Any<UniqueConstraintValue>());
+    [Fact] void should_not_ask_storage_if_allowed() => _storage.DidNotReceive().IsAllowed(Arg.Any<EventSourceId>(), Arg.Any<UniqueConstraintDefinition>(), Arg.Any<UniqueConstraintValue>());
 }

--- a/Source/Kernel/Grains/Events/Constraints/UniqueConstraintValidator.cs
+++ b/Source/Kernel/Grains/Events/Constraints/UniqueConstraintValidator.cs
@@ -36,7 +36,7 @@ public class UniqueConstraintValidator(
         }
 
         var value = propertiesWithValues.GetValue();
-        var (isAllowed, sequenceNumber) = await storage.IsAllowed(context.EventSourceId, definition.Name, value);
+        var (isAllowed, sequenceNumber) = await storage.IsAllowed(context.EventSourceId, definition, value);
         return isAllowed ?
             ConstraintValidationResult.Success :
             new()

--- a/Source/Kernel/Services/Events/Constraints/ConstraintConverters.cs
+++ b/Source/Kernel/Services/Events/Constraints/ConstraintConverters.cs
@@ -24,7 +24,8 @@ public static class ConstraintConverters
                 new UniqueConstraintDefinition(
                     constraint.Name,
                     constraint.Definition.Value0!.EventDefinitions.Select(e => e.ToChronicle()),
-                    constraint.RemovedWith is null ? null : (EventTypeId)constraint.RemovedWith),
+                    constraint.RemovedWith is null ? null : (EventTypeId)constraint.RemovedWith,
+                    constraint.Definition.Value0!.IgnoreCasing),
 
             Contracts.Events.Constraints.ConstraintType.UniqueEventType =>
                 new UniqueEventTypeConstraintDefinition(

--- a/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueConstraintsStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueConstraintsStorage.cs
@@ -17,10 +17,17 @@ namespace Cratis.Chronicle.Storage.MongoDB.Events.Constraints;
 public class UniqueConstraintsStorage(IEventStoreNamespaceDatabase eventStoreNamespaceDatabase, EventSequenceId eventSequenceId) : IUniqueConstraintsStorage
 {
     /// <inheritdoc/>
-    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventSourceId eventSourceId, ConstraintName name, UniqueConstraintValue value)
+    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventSourceId eventSourceId, UniqueConstraintDefinition definition, UniqueConstraintValue value)
     {
-        var collection = GetCollectionFor(name);
-        using var result = await collection.FindAsync(_ => _.Value == value);
+        var collection = GetCollectionFor(definition.Name);
+        var options = new FindOptions<UniqueConstraintIndex, UniqueConstraintIndex>();
+
+        if (definition.IgnoreCasing)
+        {
+            options.Collation = new Collation("en", strength: CollationStrength.Secondary, caseLevel: false);
+        }
+
+        using var result = await collection.FindAsync(_ => _.Value == value, options);
         var existing = result.FirstOrDefault();
         if (existing is not null)
         {

--- a/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueConstraintsStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueConstraintsStorage.cs
@@ -24,7 +24,7 @@ public class UniqueConstraintsStorage(IEventStoreNamespaceDatabase eventStoreNam
 
         if (definition.IgnoreCasing)
         {
-            options.Collation = new Collation("en", strength: CollationStrength.Secondary, caseLevel: false);
+            options.Collation = new Collation("en", caseLevel: false, strength: CollationStrength.Secondary);
         }
 
         using var result = await collection.FindAsync(_ => _.Value == value, options);

--- a/Source/Kernel/Storage/Events/Constraints/IUniqueConstraintsStorage.cs
+++ b/Source/Kernel/Storage/Events/Constraints/IUniqueConstraintsStorage.cs
@@ -15,13 +15,13 @@ public interface IUniqueConstraintsStorage
     /// Check if a constraint value exists.
     /// </summary>
     /// <param name="eventSourceId"><see cref="EventSourceId"/> to check for.</param>
-    /// <param name="name"><see cref="ConstraintName"/> to check for.</param>
+    /// <param name="definition"><see cref="UniqueConstraintDefinition"/> to check for.</param>
     /// <param name="value"><see cref="UniqueConstraintValue"/>to check.</param>
     /// <returns>
     /// Tuple containing a boolean saying whether or not its allowed to perform and the <see cref="EventSequenceNumber"/> for the item it violates.
     /// Returns <see cref="EventSequenceNumber.Unavailable"/> if it doesn't exist.
     /// </returns>
-    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventSourceId eventSourceId, ConstraintName name, UniqueConstraintValue value);
+    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventSourceId eventSourceId, UniqueConstraintDefinition definition, UniqueConstraintValue value);
 
     /// <summary>
     /// Save a constraint value.

--- a/Source/Workbench/Web/Api/EventSequences/AppendedEvents.ts
+++ b/Source/Workbench/Web/Api/EventSequences/AppendedEvents.ts
@@ -9,7 +9,7 @@ import { useQuery, useQueryWithPaging, PerformQuery, SetSorting, SetPage, SetPag
 import { AppendedEvent } from '../Events/AppendedEvent';
 import Handlebars from 'handlebars';
 
-const routeTemplate = Handlebars.compile('/api/event-store/{{eventStore}}/{{namespace}}/sequence/{{eventSequenceId}}');
+const routeTemplate = Handlebars.compile('/api/event-store/{{eventStore}}/{{namespace}}/sequence/{{eventSequenceId}}?eventSourceId={{eventSourceId}}');
 
 class AppendedEventsSortBy {
     private _metadata: SortingActionsForQuery<AppendedEvent[]>;
@@ -57,7 +57,7 @@ export interface AppendedEventsArguments {
 }
 
 export class AppendedEvents extends QueryFor<AppendedEvent[], AppendedEventsArguments> {
-    readonly route: string = '/api/event-store/{eventStore}/{namespace}/sequence/{eventSequenceId}';
+    readonly route: string = '/api/event-store/{eventStore}/{namespace}/sequence/{eventSequenceId}?eventSourceId={eventSourceId}';
     readonly routeTemplate: Handlebars.TemplateDelegate = routeTemplate;
     readonly defaultValue: AppendedEvent[] = [];
     private readonly _sortBy: AppendedEventsSortBy;


### PR DESCRIPTION
### Added

- `.IgnoreCasing()` method for IUniqueConstraintBuilder consumers that allows the user to specify whether or not he cares about case when validating the constraint's uniqueness. (#1723)