### PR TITLE
Fix/kestrel-embedded

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <ApplicationModel>15.4.5</ApplicationModel>
+        <ApplicationModel>15.4.6</ApplicationModel>
         <Fundamentals>6.3.1</Fundamentals>
         <Orleans>9.1.2</Orleans>
     </PropertyGroup>

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -44,6 +44,7 @@ public class WebServer(
                     });
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
+
                 builder.WebHost
                     .UseKestrel()
                     .UseUrls($"http://*:{workbenchOptions.Value.Port}");

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Connections;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -50,7 +50,7 @@ public class WebServer(
                     .UseKestrel(options =>
                     {
                         options.ConfigureEndpointDefaults(_ => { });
-                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
+                        options.ListenAnyIP(workbenchOptions.Value.Port);
                     });
 
                 _webApplication = builder.Build();

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -6,6 +6,7 @@ using Cratis.Chronicle.Connections;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -44,9 +45,9 @@ public class WebServer(
                     });
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
-
                 builder.WebHost
-                    .UseKestrel()
+                    .UseKestrel(options =>
+                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2))
                     .UseUrls($"http://*:{workbenchOptions.Value.Port}");
 
                 _webApplication = builder.Build();

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -33,6 +33,7 @@ public class WebServer(
             async () =>
             {
                 var builder = WebApplication.CreateBuilder();
+                builder.Configuration.Sources.Clear();
                 var chronicleServices = serviceProvider.GetService<IServices>();
 
                 builder.Host
@@ -44,10 +45,12 @@ public class WebServer(
                     });
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
-
                 builder.WebHost
-                    .UseKestrel()
-                    .UseUrls($"http://*:{workbenchOptions.Value.Port}");
+                    .UseKestrel(options =>
+                    {
+                        options.ConfigureEndpointDefaults(_ => { });
+                        options.ListenAnyIP(workbenchOptions.Value.Port);
+                    });
 
                 _webApplication = builder.Build();
 

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -34,7 +34,6 @@ public class WebServer(
             async () =>
             {
                 var builder = WebApplication.CreateBuilder();
-                builder.Configuration.Sources.Clear();
                 var chronicleServices = serviceProvider.GetService<IServices>();
 
                 builder.Host
@@ -51,7 +50,8 @@ public class WebServer(
                     {
                         options.ConfigureEndpointDefaults(_ => { });
                         options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
-                    });
+                    })
+                    .UseUrls($"http://*:{workbenchOptions.Value.Port}");
 
                 _webApplication = builder.Build();
 

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -46,7 +46,7 @@ public class WebServer(
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
                 builder.WebHost
-                    .UseKestrel(options =>
+                    .ConfigureKestrel(options =>
                         options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2))
                     .UseUrls($"http://*:{workbenchOptions.Value.Port}");
 

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -46,8 +46,11 @@ public class WebServer(
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
                 builder.WebHost
-                    .ConfigureKestrel(options =>
-                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2))
+                    .UseKestrel(options =>
+                    {
+                        options.ConfigureEndpointDefaults(_ => { });
+                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
+                    })
                     .UseUrls($"http://*:{workbenchOptions.Value.Port}");
 
                 _webApplication = builder.Build();

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -6,6 +6,7 @@ using Cratis.Chronicle.Connections;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -49,7 +50,7 @@ public class WebServer(
                     .UseKestrel(options =>
                     {
                         options.ConfigureEndpointDefaults(_ => { });
-                        options.ListenAnyIP(workbenchOptions.Value.Port);
+                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
                     });
 
                 _webApplication = builder.Build();

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -33,7 +33,6 @@ public class WebServer(
             async () =>
             {
                 var builder = WebApplication.CreateBuilder();
-                builder.Configuration.Sources.Clear();
                 var chronicleServices = serviceProvider.GetService<IServices>();
 
                 builder.Host

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Connections;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -34,6 +33,7 @@ public class WebServer(
             async () =>
             {
                 var builder = WebApplication.CreateBuilder();
+                builder.Configuration.Sources.Clear();
                 var chronicleServices = serviceProvider.GetService<IServices>();
 
                 builder.Host
@@ -46,11 +46,7 @@ public class WebServer(
 
                 builder.Services.AddCratisChronicleApi(chronicleServices);
                 builder.WebHost
-                    .UseKestrel(options =>
-                    {
-                        options.ConfigureEndpointDefaults(_ => { });
-                        options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
-                    })
+                    .UseKestrel()
                     .UseUrls($"http://*:{workbenchOptions.Value.Port}");
 
                 _webApplication = builder.Build();

--- a/Source/Workbench/Embedded/WebServer.cs
+++ b/Source/Workbench/Embedded/WebServer.cs
@@ -34,6 +34,7 @@ public class WebServer(
             async () =>
             {
                 var builder = WebApplication.CreateBuilder();
+                builder.Configuration.Sources.Clear();
                 var chronicleServices = serviceProvider.GetService<IServices>();
 
                 builder.Host
@@ -50,8 +51,7 @@ public class WebServer(
                     {
                         options.ConfigureEndpointDefaults(_ => { });
                         options.ListenAnyIP(workbenchOptions.Value.Port, listenOptions => listenOptions.Protocols = HttpProtocols.Http1AndHttp2);
-                    })
-                    .UseUrls($"http://*:{workbenchOptions.Value.Port}");
+                    });
 
                 _webApplication = builder.Build();
 


### PR DESCRIPTION
### Fixed

- Making the WebServer in the Embedded workbench more autonomous, ignoring default configuration sources.
