### PR TITLE
Mounting /data/db to Tmpfs - in memory

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -50,6 +50,7 @@ jobs:
 
   specs:
     runs-on: ubuntu-latest
+    needs: [dotnet-build]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,6 +72,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
+    needs: [dotnet-build]
     strategy:
       matrix:
         namespace:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -3,6 +3,7 @@ name: .NET Build
 env:
   DOTNET8_VERSION: "8.0.407"
   DOTNET_VERSION: "9.0.x"
+  DOTNET_CACHE: "dotnet-cache-${{ github.sha }}"
 
 on:
   workflow_dispatch:
@@ -38,8 +39,32 @@ jobs:
             ${{ env.DOTNET8_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
+      - uses: actions/cache@v3
+        id: dotnet-x64-output
+        with:
+          path: ./**/bin
+          key: ${{ env.DOTNET_CACHE }}
+
       - name: Build
         run: dotnet build --configuration Release --framework net9.0
+
+  specs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .Net
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            ${{ env.DOTNET_VERSION }}
+
+      - uses: actions/cache@v3
+        id: dotnet-x64-output
+        with:
+          path: ./**/bin
+          key: ${{ env.DOTNET_CACHE }}
 
       - name: Run tests
         run: dotnet test --no-build --configuration Release --framework net9.0 --settings specs.runsettings
@@ -67,5 +92,12 @@ jobs:
           dotnet-version: |
             ${{ env.DOTNET_VERSION }}
 
+      - uses: actions/cache@v3
+        id: dotnet-x64-output
+        with:
+          path: ./**/bin
+          key: ${{ env.DOTNET_CACHE }}
+
+
       - name: Run integration tests for .Net 9
-        run: dotnet test --filter FullyQualifiedName~${{ env.NAMESPACE }} --logger "console;verbosity=normal" --configuration Release --framework net9.0
+        run: dotnet test --no-build --filter FullyQualifiedName~${{ env.NAMESPACE }} --logger "console;verbosity=normal" --configuration Release --framework net9.0

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,7 +1,6 @@
 name: .NET Build
 
 env:
-  DOTNET8_VERSION: "8.0.407"
   DOTNET_VERSION: "9.0.x"
   DOTNET_CACHE: "dotnet-cache-${{ github.sha }}"
 
@@ -36,7 +35,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            ${{ env.DOTNET8_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
       - uses: actions/cache@v3
@@ -99,7 +97,6 @@ jobs:
         with:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
-
 
       - name: Run integration tests for .Net 9
         run: dotnet test --no-build --filter FullyQualifiedName~${{ env.NAMESPACE }} --logger "console;verbosity=normal" --configuration Release --framework net9.0

--- a/Integration/Base/GlobalFixture.cs
+++ b/Integration/Base/GlobalFixture.cs
@@ -3,6 +3,7 @@
 
 using Docker.DotNet;
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using MongoDB.Driver;
@@ -27,7 +28,8 @@ public class GlobalFixture : IAsyncDisposable
             .Build();
 
         MongoDBContainer = new ContainerBuilder()
-            .WithImage("cratis/mongodb")
+            .WithImage("mongo")
+            .WithTmpfsMount("/data/db", AccessMode.ReadWrite)
             .WithPortBinding(27018, 27017)
             .WithHostname(HostName)
             .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(), "backups"), "/backups")


### PR DESCRIPTION
### Fixed

- Switches to tmpfs for in-memory storage for MongoDB database when running integration specs (#1811)
- Separating out build from running specs and integration specs and using caching of binaries, optimizing builds.
