### PR TITLE
Putting back the apiBasePath which was taken out during debugging

### DIFF
--- a/Source/Workbench/Web/App.tsx
+++ b/Source/Workbench/Web/App.tsx
@@ -21,7 +21,7 @@ function App() {
     const basePath = basePathElement?.content ?? '/';
 
     return (
-        <ApplicationModel development={isDevelopment} apiBasePath={''} microservice='Workbench'>
+        <ApplicationModel development={isDevelopment} apiBasePath={basePath}>
             <MVVM>
                 <LayoutProvider>
                     <DialogComponents confirmation={ConfirmationDialog}>


### PR DESCRIPTION
### Fixed

- Putting back the usage of `apiBasePath` this was taken out for debugging purposes and forgotten to put back  🤦🏼
