### PR TITLE
Fix/relative-path

### DIFF
--- a/Source/Workbench/Web/App.tsx
+++ b/Source/Workbench/Web/App.tsx
@@ -21,7 +21,7 @@ function App() {
     const basePath = basePathElement?.content ?? '/';
 
     return (
-        <ApplicationModel development={isDevelopment} apiBasePath={basePath}>
+        <ApplicationModel development={isDevelopment} apiBasePath={basePath} basePath={basePath}>
             <MVVM>
                 <LayoutProvider>
                     <DialogComponents confirmation={ConfirmationDialog}>

--- a/Source/Workbench/Web/Utils/useRelativePath.ts
+++ b/Source/Workbench/Web/Utils/useRelativePath.ts
@@ -1,14 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { useMatch } from 'react-router-dom';
+import { useContext } from 'react';
+import { ApplicationModelContext } from '@cratis/applications.react';
 
 export const useRelativePath = (path: string) => {
-    const resolvedPath = useMatch('/:basePath/*');
-    if (!resolvedPath) {
-        return path;
-    }
-
-    const basePath = resolvedPath.params.basePath;
-    return `/${basePath}/${path}`.replace(/\/+/g, '/');
+    const applicationModel = useContext(ApplicationModelContext);
+    return `/${applicationModel.basePath}/${path}`.replace(/\/+/g, '/');
 };

--- a/Source/Workbench/Web/package.json
+++ b/Source/Workbench/Web/package.json
@@ -15,10 +15,10 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@cratis/applications": "15.5.4",
-        "@cratis/applications.react": "15.5.4",
-        "@cratis/applications.react.mvvm": "15.5.4",
-        "@cratis/applications.vite": "15.5.4",
+        "@cratis/applications": "15.6.0",
+        "@cratis/applications.react": "15.6.0",
+        "@cratis/applications.react.mvvm": "15.6.0",
+        "@cratis/applications.vite": "15.6.0",
         "allotment": "1.20.3",
         "echarts": "5.6.0",
         "mobx": "6.13.7",


### PR DESCRIPTION
### Fixed

- Switching to a more reliable way of getting the configured `basePath` for the embedded workbench. This leverages the `basePath` property in the ApplicationModel context instead. That gives us the path without having to try to resolve it through the router, which doesn't give us all the details anyways.
