### PR TITLE
Fixing instantiation of namespaces query - rely on the container

### DIFF
--- a/Source/Workbench/Web/State/Namespaces/Namespaces.ts
+++ b/Source/Workbench/Web/State/Namespaces/Namespaces.ts
@@ -21,9 +21,8 @@ export class Namespaces implements INamespaces {
     constructor(
         private readonly _localStorage: ILocalStorage,
         private readonly _messenger: IMessenger,
-        @inject('params') private readonly _params: EventStoreAndNamespaceParams) {
-
-        const namespacesQuery: AllNamespaces = new AllNamespaces();
+        @inject('params') private readonly _params: EventStoreAndNamespaceParams,
+        namespacesQuery: AllNamespaces) {
 
         namespacesQuery.subscribe(result => {
             this._namespaces.next(result.data);


### PR DESCRIPTION
### Fixed

- Fixing Workbench namespace selector to use dependency injection for the queries, so that they are initialized correctly.
