### PR TITLE
Fixing the path for themes that gets programatically set

### DIFF
--- a/Source/Workbench/Web/App.tsx
+++ b/Source/Workbench/Web/App.tsx
@@ -15,11 +15,10 @@ import { MVVM } from '@cratis/applications.react.mvvm';
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 function App() {
-    useTheme();
-
     const basePathElement = document.querySelector('meta[name="base-path"]') as HTMLMetaElement;
     const basePath = basePathElement?.content ?? '/';
 
+    useTheme(basePath);
     return (
         <ApplicationModel development={isDevelopment} apiBasePath={basePath} basePath={basePath}>
             <MVVM>

--- a/Source/Workbench/Web/Utils/useTheme.ts
+++ b/Source/Workbench/Web/Utils/useTheme.ts
@@ -4,13 +4,13 @@
 import { useDarkMode } from "usehooks-ts";
 import { useLayoutEffect } from "react";
 
-export const useTheme = () => {
+export const useTheme = (basePath: string) => {
     const { toggle, enable, disable } = useDarkMode();
     const isDarkMode = true;
 
     useLayoutEffect(() => {
         const theme = isDarkMode ? 'dark' : 'light';
-        document.getElementById('theme')?.setAttribute('href', `/themes/${theme}.css`);
+        document.getElementById('theme')?.setAttribute('href', `${basePath}/themes/${theme}.css`);
         document.body.classList.toggle('dark', isDarkMode);
         document.body.classList.toggle('light', !isDarkMode);
     }, [isDarkMode]);


### PR DESCRIPTION
### Fixed

- Themes in the workbench gets programatically set by `useTheme()` this didn't take into consideration the `basePath` when working in embedded mode.
