### PR TITLE
Fix/projection-ordering

### DIFF
--- a/Source/Kernel/Concepts/Configuration/Features.cs
+++ b/Source/Kernel/Concepts/Configuration/Features.cs
@@ -18,4 +18,9 @@ public class Features
     /// Whether the Workbench is enabled. Default true.
     /// </summary>
     public bool Workbench { get; init; } = true;
+
+    /// <summary>
+    /// Whether the Changeset Storage is enabled. Default false.
+    /// </summary>
+    public bool ChangesetStorage { get; init; }
 }

--- a/Source/Kernel/Projections/Pipelines/ChangesetExtensions.cs
+++ b/Source/Kernel/Projections/Pipelines/ChangesetExtensions.cs
@@ -5,6 +5,7 @@ using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage;
 
 namespace Cratis.Chronicle.Projections.Pipelines;
 
@@ -13,6 +14,21 @@ namespace Cratis.Chronicle.Projections.Pipelines;
 /// </summary>
 public static class ChangesetExtensions
 {
+    /// <summary>
+    /// Set the model instance as not initialized.
+    /// </summary>
+    /// <param name="changeset">Changeset to set to.</param>
+    /// <param name="isInitialized">Whether the model instance is initialized.</param>
+    public static void SetInitialized(this IChangeset<AppendedEvent, ExpandoObject> changeset, bool isInitialized)
+    {
+        changeset.Add(
+            new PropertiesChanged<ExpandoObject>(
+                changeset.CurrentState,
+                [
+                    new PropertyDifference(WellKnownProperties.ModelInstanceInitialized, null, isInitialized)
+                ]));
+    }
+
     /// <summary>
     /// Adds properties from a source type, any existing modifications to these properties will not be included.
     /// </summary>

--- a/Source/Kernel/Projections/Pipelines/ProjectionPipeline.cs
+++ b/Source/Kernel/Projections/Pipelines/ProjectionPipeline.cs
@@ -5,6 +5,7 @@ using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Projections.Pipelines.Steps;
+using Cratis.Chronicle.Storage.Changes;
 using Cratis.Chronicle.Storage.Sinks;
 using Microsoft.Extensions.Logging;
 using EngineProjection = Cratis.Chronicle.Projections.IProjection;
@@ -19,24 +20,34 @@ namespace Cratis.Chronicle.Projections.Pipelines;
 /// </remarks>
 /// <param name="projection">The <see cref="EngineProjection"/> the pipeline is for.</param>
 /// <param name="sink"><see cref="ISink"/> to use.</param>
+/// <param name="changesetStorage"><see cref="IChangesetStorage"/> for storing changesets as they occur.</param>
 /// <param name="objectComparer"><see cref="IObjectComparer"/> for comparing objects.</param>
 /// <param name="steps">Collection of <see cref="ICanPerformProjectionPipelineStep"/> to perform.</param>
 /// <param name="logger"><see cref="ILogger{T}"/> for logging.</param>
 public class ProjectionPipeline(
     EngineProjection projection,
     ISink sink,
+    IChangesetStorage changesetStorage,
     IObjectComparer objectComparer,
     IEnumerable<ICanPerformProjectionPipelineStep> steps,
     ILogger<ProjectionPipeline> logger) : IProjectionPipeline
 {
     /// <inheritdoc/>
-    public Task BeginReplay(ReplayContext context) => sink.BeginReplay(context);
+    public async Task BeginReplay(ReplayContext context)
+    {
+        await changesetStorage.BeginReplay(projection.Model.Name);
+        await sink.BeginReplay(context);
+    }
 
     /// <inheritdoc/>
     public Task ResumeReplay(ReplayContext context) => sink.ResumeReplay(context);
 
     /// <inheritdoc/>
-    public Task EndReplay(ReplayContext context) => sink.EndReplay(context);
+    public async Task EndReplay(ReplayContext context)
+    {
+        await sink.EndReplay(context);
+        await changesetStorage.EndReplay(projection.Model.Name);
+    }
 
     /// <inheritdoc/>
     public async Task<IChangeset<AppendedEvent, ExpandoObject>> Handle(AppendedEvent @event)
@@ -44,7 +55,8 @@ public class ProjectionPipeline(
         logger.StartingPipeline(@event.Metadata.SequenceNumber);
         var context = ProjectionEventContext.Empty(objectComparer, @event) with
         {
-            OperationType = projection.GetOperationTypeFor(@event.Metadata.Type)
+            OperationType = projection.GetOperationTypeFor(@event.Metadata.Type),
+
         };
 
         foreach (var step in steps)

--- a/Source/Kernel/Projections/Pipelines/ProjectionPipelineManager.cs
+++ b/Source/Kernel/Projections/Pipelines/ProjectionPipelineManager.cs
@@ -59,6 +59,7 @@ public class ProjectionPipelineManager(
         return _pipelines[key] = new ProjectionPipeline(
             projection,
             sink,
+            namespaceStorage.Changesets,
             objectComparer,
             steps,
             loggerFactory.CreateLogger<ProjectionPipeline>());

--- a/Source/Kernel/Projections/Pipelines/Steps/SaveChanges.cs
+++ b/Source/Kernel/Projections/Pipelines/Steps/SaveChanges.cs
@@ -29,9 +29,9 @@ public class SaveChanges(ISink sink, IChangesetStorage changesetStorage, ILogger
         // TODO: Return the number of affected records and pass this along to the changeset storage
         await sink.ApplyChanges(context.Key, context.Changeset, context.Event.Metadata.SequenceNumber);
         await changesetStorage.Save(
-            projection.Identifier,
+            projection.Model.Name,
             context.Key,
-            projection.Path,
+            context.Event.Metadata.Type,
             context.Event.Context.SequenceNumber,
             context.Event.Context.CorrelationId,
             context.Changeset);

--- a/Source/Kernel/Projections/Pipelines/Steps/SetInitialState.cs
+++ b/Source/Kernel/Projections/Pipelines/Steps/SetInitialState.cs
@@ -3,6 +3,7 @@
 
 using System.Dynamic;
 using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Sinks;
 using Microsoft.Extensions.Logging;
 using EngineProjection = Cratis.Chronicle.Projections.IProjection;
@@ -25,19 +26,51 @@ public class SetInitialState(ISink sink, ILogger<SetInitialState> logger) : ICan
         }
 
         logger.GettingInitialValues(context.Event.Metadata.SequenceNumber);
-        var initialState = await sink.FindOrDefault(context.Key);
 
+        // If we are joining, or adding a child - we do want to set initial state
+        // We can then set a property __initialized to false if its not already
+        // For other operations, when we get the object from the sink, if the object exists and __initialized is false, we can set the initial state
+        // for those properties that does not have a value. We then set the __initialized to true.
+        var initialState = await sink.FindOrDefault(context.Key);
         var needsInitialState = false;
         if (initialState is null)
         {
-            needsInitialState = true;
-            initialState = projection.InitialModelState;
+            if (context.ChildrenAffected || context.IsJoin)
+            {
+                context.Changeset.SetInitialized(false);
+                initialState = new ExpandoObject();
+            }
+            else
+            {
+                needsInitialState = true;
+                initialState = projection.InitialModelState;
+                context.Changeset.SetInitialized(true);
+            }
+
             SetKeyForInitialState(initialState, context.Key);
         }
+        else if (!HasBeenInitialized(initialState))
+        {
+            var initialStateAsDictionary = (IDictionary<string, object?>)initialState;
+            var initialModelStateAsDictionary = (IDictionary<string, object?>)projection.InitialModelState;
+
+            // TODO: Ideally we should do this recursively, as properties can be joined deep in the hierarchy and we want to
+            // initialize all properties that are not set. This is a simple implementation that only works for the first level.
+            foreach (var property in initialModelStateAsDictionary.Where((kvp) => !initialStateAsDictionary.ContainsKey(kvp.Key)))
+            {
+                initialStateAsDictionary[property.Key] = property.Value;
+            }
+
+            context.Changeset.SetInitialized(true);
+        }
+
         context.Changeset.InitialState = initialState;
 
         return context with { NeedsInitialState = needsInitialState };
     }
+
+    bool HasBeenInitialized(ExpandoObject initialState) =>
+        ((IDictionary<string, object?>)initialState).TryGetValue(WellKnownProperties.ModelInstanceInitialized, out var initialized) && initialized is bool initializedBool && initializedBool;
 
     void SetKeyForInitialState(ExpandoObject initialState, Key key)
     {

--- a/Source/Kernel/Projections/Projection.cs
+++ b/Source/Kernel/Projections/Projection.cs
@@ -144,7 +144,7 @@ public class Projection : IProjection, IDisposable
             var operation = child.GetOperationTypeFor(eventType);
             if (operation != ProjectionOperationType.None)
             {
-                return operation;
+                return operation | ProjectionOperationType.ChildrenAffected;
             }
         }
 

--- a/Source/Kernel/Projections/ProjectionEventContext.cs
+++ b/Source/Kernel/Projections/ProjectionEventContext.cs
@@ -44,6 +44,11 @@ public record ProjectionEventContext(
     public bool IsRemove => OperationType.HasFlag(ProjectionOperationType.Remove);
 
     /// <summary>
+    /// Whether the operation type affects children.
+    /// </summary>
+    public bool ChildrenAffected => OperationType.HasFlag(ProjectionOperationType.ChildrenAffected);
+
+    /// <summary>
     /// Creates a new empty <see cref="ProjectionEventContext"/> with the given <see cref="IObjectComparer"/> and
     /// <see cref="AppendedEvent"/>.
     /// </summary>

--- a/Source/Kernel/Projections/ProjectionOperationType.cs
+++ b/Source/Kernel/Projections/ProjectionOperationType.cs
@@ -27,5 +27,10 @@ public enum ProjectionOperationType
     /// <summary>
     /// Entity is removed.
     /// </summary>
-    Remove = 1 << 2
+    Remove = 1 << 2,
+
+    /// <summary>
+    /// Children are affected.
+    /// </summary>
+    ChildrenAffected = 1 << 3
 }

--- a/Source/Kernel/Storage.MongoDB/Changes/ChangesetStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Changes/ChangesetStorage.cs
@@ -5,9 +5,8 @@ using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
-using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Models;
 using Cratis.Chronicle.Storage.Changes;
-using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Changes;
@@ -16,23 +15,31 @@ namespace Cratis.Chronicle.Storage.MongoDB.Changes;
 /// Represents a <see cref="IChangesetStorage"/> for storing changesets in MongoDB.
 /// </summary>
 /// <param name="eventStoreDatabase"><see cref="IEventStoreNamespaceDatabase"/> for the changesets.</param>
-///
 public class ChangesetStorage(
     IEventStoreNamespaceDatabase eventStoreDatabase) : IChangesetStorage
 {
-#pragma warning disable IDE0051,RCS1213 // Remove unused private members
-    IMongoCollection<BsonDocument> Collection => eventStoreDatabase.GetCollection<BsonDocument>(WellKnownCollectionNames.Changesets);
-#pragma warning restore IDE0051,RCS1213 // Remove unused private members
+    /// <inheritdoc/>
+    public Task BeginReplay(ModelName model) =>
+        GetCollection(model).DeleteManyAsync(FilterDefinition<ModelChangeset>.Empty);
 
     /// <inheritdoc/>
-    public Task Save(
-        ProjectionId projectionIdentifier,
-        Key projectionObjectKey,
-        ProjectionPath projectionPath,
+    public Task EndReplay(ModelName model) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async Task Save(
+        ModelName model,
+        Key modelKey,
+        EventType eventType,
         EventSequenceNumber sequenceNumber,
         CorrelationId correlationId,
         IChangeset<AppendedEvent, ExpandoObject> changeset)
     {
-        return Task.CompletedTask;
+        var collection = GetCollection(model);
+        var key = new ModelChangeKey(modelKey.ToString(), sequenceNumber, correlationId);
+        var modelChangeset = new ModelChangeset(key, eventType, changeset.Changes);
+        await collection.InsertOneAsync(modelChangeset);
     }
+
+    IMongoCollection<ModelChangeset> GetCollection(ModelName model) =>
+        eventStoreDatabase.GetCollection<ModelChangeset>($"{model}-changes");
 }

--- a/Source/Kernel/Storage.MongoDB/Changes/ModelChangeKey.cs
+++ b/Source/Kernel/Storage.MongoDB/Changes/ModelChangeKey.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Changes;
+
+/// <summary>
+/// Represents the unique key for a model change.
+/// </summary>
+/// <param name="Key">The model key.</param>
+/// <param name="SequenceNumber">The sequence number of the event that caused the change.</param>
+/// <param name="CorrelationId">CorrelationId of the change.</param>
+public record ModelChangeKey(string Key, EventSequenceNumber SequenceNumber, CorrelationId CorrelationId);

--- a/Source/Kernel/Storage.MongoDB/Changes/ModelChangeset.cs
+++ b/Source/Kernel/Storage.MongoDB/Changes/ModelChangeset.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Changes;
+
+/// <summary>
+/// Represents a changeset for a model.
+/// </summary>
+/// <param name="Id">The unique identifier - composite key.</param>
+/// <param name="EventType">Type of event that caused the change.</param>
+/// <param name="Changes">The actual changes.</param>
+public record ModelChangeset(ModelChangeKey Id, EventType EventType, IEnumerable<Change> Changes);

--- a/Source/Kernel/Storage.MongoDB/EventStoreStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreStorage.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Configuration;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Concepts.Observation.Reactors.Json;
 using Cratis.Chronicle.Concepts.Observation.Reducers.Json;
@@ -24,6 +25,7 @@ using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Events.MongoDB.EventTypes;
 using Cratis.Types;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Storage.MongoDB;
 
@@ -43,6 +45,7 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// <param name="jsonSerializerOptions">The global <see cref="JsonSerializerOptions"/>.</param>
 /// <param name="sinkFactories"><see cref="IInstancesOf{T}"/> for getting all <see cref="ISinkFactory"/> instances.</param>
 /// <param name="jobTypes"><see cref="IJobTypes"/>.</param>
+/// <param name="options"><see cref="ChronicleOptions"/>.</param>
 /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
 public class EventStoreStorage(
     EventStoreName eventStore,
@@ -55,6 +58,7 @@ public class EventStoreStorage(
     JsonSerializerOptions jsonSerializerOptions,
     IInstancesOf<ISinkFactory> sinkFactories,
     IJobTypes jobTypes,
+    IOptions<ChronicleOptions> options,
     ILoggerFactory loggerFactory) : IEventStoreStorage
 {
     readonly ConcurrentDictionary<EventStoreNamespaceName, IEventStoreNamespaceStorage> _namespaces = new();
@@ -99,6 +103,7 @@ public class EventStoreStorage(
                 jsonSerializerOptions,
                 sinkFactories,
                 jobTypes,
+                options,
                 loggerFactory);
     }
 }

--- a/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
@@ -89,7 +89,8 @@ public class ChangesetConverter(
                     break;
 
                 case ResolvedJoin resolvedJoined:
-                    ApplyActualChanges(key, resolvedJoined.Changes, updateDefinitionBuilder, ref updateBuilder, ref hasChanges, arrayFiltersForDocument, eventSequenceNumber);
+                    var applyActualChangesTask = ApplyActualChanges(key, resolvedJoined.Changes, updateDefinitionBuilder, ref updateBuilder, ref hasChanges, arrayFiltersForDocument, eventSequenceNumber);
+                    joinTasks.Add(applyActualChangesTask);
                     break;
             }
         }

--- a/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
@@ -44,11 +44,20 @@ public class Sink(
     /// <inheritdoc/>
     public async Task<ExpandoObject?> FindOrDefault(Key key)
     {
-        using var result = await Collection.FindAsync(Builders<BsonDocument>.Filter.Eq("_id", converter.ToBsonValue(key)));
+        var collection = Collection;
+        var ns = collection.CollectionNamespace;
+
+        using var result = await collection.FindAsync(Builders<BsonDocument>.Filter.Eq("_id", converter.ToBsonValue(key)));
         var instance = result.SingleOrDefault();
         if (instance != default)
         {
             return expandoObjectConverter.ToExpandoObject(instance, model.Schema);
+        }
+        if (key.ToString() == "2a8e8ca6-4ca4-420e-8ec1-7a9d845f5704")
+        {
+            var all = collection.Find(_ => true).ToList();
+            Console.WriteLine(ns);
+            all = collection.Find(_ => true).ToList();
         }
 
         return default;

--- a/Source/Kernel/Storage.MongoDB/Storage.cs
+++ b/Source/Kernel/Storage.MongoDB/Storage.cs
@@ -6,6 +6,7 @@ using System.Reactive.Subjects;
 using System.Text.Json;
 using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Configuration;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Concepts.Observation.Reactors.Json;
 using Cratis.Chronicle.Concepts.Observation.Reducers.Json;
@@ -14,6 +15,7 @@ using Cratis.Chronicle.Reactive;
 using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Types;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB;
@@ -33,6 +35,7 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// <param name="jsonSerializerOptions">The global <see cref="JsonSerializerOptions"/>.</param>
 /// <param name="sinkFactories"><see cref="IInstancesOf{T}"/> for getting all <see cref="ISinkFactory"/> instances.</param>
 /// <param name="jobTypes"><see cref="IJobTypes"/>.</param>
+/// <param name="options"><see cref="ChronicleOptions"/>.</param>
 /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
 public class Storage(
     IDatabase database,
@@ -44,6 +47,7 @@ public class Storage(
     JsonSerializerOptions jsonSerializerOptions,
     IInstancesOf<ISinkFactory> sinkFactories,
     IJobTypes jobTypes,
+    IOptions<ChronicleOptions> options,
     ILoggerFactory loggerFactory) : IStorage
 {
     readonly ConcurrentDictionary<EventStoreName, IEventStoreStorage> _eventStores = [];
@@ -91,6 +95,7 @@ public class Storage(
             jsonSerializerOptions,
             sinkFactories,
             jobTypes,
+            options,
             loggerFactory);
 
         return _eventStores[eventStore] = eventStoreStorage;

--- a/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
+++ b/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
@@ -94,11 +94,6 @@ public static class WellKnownCollectionNames
     public const string ProjectionDefinitions = "projection-definitions";
 
     /// <summary>
-    /// The collection that holds projection definitions.
-    /// </summary>
-    public const string Changesets = "changesets";
-
-    /// <summary>
     /// The collection that holds the definitions of constraints.
     /// </summary>
     public const string Constraints = "constraints";

--- a/Source/Kernel/Storage/Changes/IChangesetStorage.cs
+++ b/Source/Kernel/Storage/Changes/IChangesetStorage.cs
@@ -5,7 +5,7 @@ using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
-using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Models;
 
 namespace Cratis.Chronicle.Storage.Changes;
 
@@ -15,19 +15,33 @@ namespace Cratis.Chronicle.Storage.Changes;
 public interface IChangesetStorage
 {
     /// <summary>
+    /// Begin replay of a specific <see cref="ModelName"/>.
+    /// </summary>
+    /// <param name="model">The <see cref="ModelName"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    Task BeginReplay(ModelName model);
+
+    /// <summary>
+    /// Begin replay of a specific <see cref="ModelName"/>.
+    /// </summary>
+    /// <param name="model">The <see cref="ModelName"/>.</param>
+    /// <returns>Awaitable task.</returns>
+    Task EndReplay(ModelName model);
+
+    /// <summary>
     /// Save changesets associated with a specific <see cref="CorrelationId"/>.
     /// </summary>
-    /// <param name="projectionIdentifier">The <see cref="ProjectionId"/>.</param>
-    /// <param name="projectionObjectKey">The <see cref="Key"/>.</param>
-    /// <param name="projectionPath">The <see cref="ProjectionPath"/>.</param>
+    /// <param name="model">The <see cref="ModelName"/>.</param>
+    /// <param name="modelKey">The <see cref="Key"/>.</param>
+    /// <param name="eventType">The <see cref="EventType"/> that was at the root.</param>
     /// <param name="sequenceNumber">The <see cref="EventSequenceNumber"/>.</param>
     /// <param name="correlationId">The <see cref="CorrelationId"/> to save for.</param>
     /// <param name="changeset">All the associated <see cref="IChangeset{Event, ExpandoObject}">changesets</see>.</param>
-    /// <returns>Async task.</returns>
+    /// <returns>Awaitable task.</returns>
     Task Save(
-        ProjectionId projectionIdentifier,
-        Key projectionObjectKey,
-        ProjectionPath projectionPath,
+        ModelName model,
+        Key modelKey,
+        EventType eventType,
         EventSequenceNumber sequenceNumber,
         CorrelationId correlationId,
         IChangeset<AppendedEvent, ExpandoObject> changeset);

--- a/Source/Kernel/Storage/Changes/NullChangesetStorage.cs
+++ b/Source/Kernel/Storage/Changes/NullChangesetStorage.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Models;
+
+namespace Cratis.Chronicle.Storage.Changes;
+
+/// <summary>
+/// Represents a null implementation of <see cref="IChangesetStorage"/>.
+/// </summary>
+public class NullChangesetStorage : IChangesetStorage
+{
+    /// <inheritdoc/>
+    public Task BeginReplay(ModelName model) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task EndReplay(ModelName model) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task Save(ModelName model, Key modelKey, EventType eventType, EventSequenceNumber sequenceNumber, CorrelationId correlationId, IChangeset<AppendedEvent, ExpandoObject> changeset) => Task.CompletedTask;
+}

--- a/Source/Kernel/Storage/WellKnownProperties.cs
+++ b/Source/Kernel/Storage/WellKnownProperties.cs
@@ -14,4 +14,9 @@ public static class WellKnownProperties
     /// The property name for the last handled sequence number.
     /// </summary>
     public const string LasHandledEventSequenceNumber = "__lastHandledEventSequenceNumber";
+
+    /// <summary>
+    /// The property name for whether an model instance is initialized.
+    /// </summary>
+    public const string ModelInstanceInitialized = "__initialized";
 }


### PR DESCRIPTION
### Fixed

- Fixing a problem with projection engine to make it able to handle partitions more in parallel. The problem we had was if a child was added and the root which would receive the child didn't exist, it would then fill it with initial state. This is not really the job for an event that only affects the children. Instead, we now will mark it that it is not initialized and if the model then exists as a result of asking the sink, we will see if its initialized. If not initialized, it will initialize the properties that does not have a value.
