### PR TITLE
Feature/correlation and tracing

### DIFF
--- a/Source/Clients/DotNET/EventSequences/IEventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/IEventSequence.cs
@@ -73,8 +73,15 @@ public interface IEventSequence
     /// <param name="eventStreamType">Optional <see cref="EventStreamType"/> to append to. Defaults to <see cref="EventStreamType.All"/>.</param>
     /// <param name="eventStreamId">Optional <see cref="EventStreamId"/> to append to. Defaults to <see cref="EventStreamId.Default"/>.</param>
     /// <param name="eventSourceType">Optional <see cref="EventSourceType"/> to append to. Defaults to <see cref="EventSourceType.Default"/>.</param>
+    /// <param name="correlationId">Optional <see cref="CorrelationId"/> of the event. Defaults to <see cref="ICorrelationIdAccessor.Current"/>.</param>
     /// <returns>Awaitable <see cref="Task"/>.</returns>
-    Task<AppendResult> Append(EventSourceId eventSourceId, object @event, EventStreamType? eventStreamType = default, EventStreamId? eventStreamId = default, EventSourceType? eventSourceType = default);
+    Task<AppendResult> Append(
+        EventSourceId eventSourceId,
+        object @event,
+        EventStreamType? eventStreamType = default,
+        EventStreamId? eventStreamId = default,
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default);
 
     /// <summary>
     /// Append a collection of events to the event store.
@@ -84,21 +91,29 @@ public interface IEventSequence
     /// <param name="eventStreamType">Optional <see cref="EventStreamType"/> to append to. Defaults to <see cref="EventStreamType.All"/>.</param>
     /// <param name="eventStreamId">Optional <see cref="EventStreamId"/> to append to. Defaults to <see cref="EventStreamId.Default"/>.</param>
     /// <param name="eventSourceType">Optional <see cref="EventSourceType"/> to append to. Defaults to <see cref="EventSourceType.Default"/>.</param>
+    /// <param name="correlationId">Optional <see cref="CorrelationId"/> of the event. Defaults to <see cref="ICorrelationIdAccessor.Current"/>.</param>
     /// <returns>Awaitable <see cref="Task"/>.</returns>
     /// <remarks>
     /// All events will be committed as one operation for the underlying data store.
     /// </remarks>
-    Task<AppendManyResult> AppendMany(EventSourceId eventSourceId, IEnumerable<object> events, EventStreamType? eventStreamType = default, EventStreamId? eventStreamId = default, EventSourceType? eventSourceType = default);
+    Task<AppendManyResult> AppendMany(
+        EventSourceId eventSourceId,
+        IEnumerable<object> events,
+        EventStreamType? eventStreamType = default,
+        EventStreamId? eventStreamId = default,
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default);
 
     /// <summary>
     /// Append a collection of events to the event store as a transaction.
     /// </summary>
     /// <param name="events">Collection of <see cref="EventForEventSourceId"/> to append.</param>
+    /// <param name="correlationId">Optional <see cref="CorrelationId"/> of the event. Defaults to <see cref="ICorrelationIdAccessor.Current"/>.</param>
     /// <returns>Awaitable <see cref="Task"/>.</returns>
     /// <remarks>
     /// All events will be committed as one operation for the underlying data store.
     /// </remarks>
-    Task<AppendManyResult> AppendMany(IEnumerable<EventForEventSourceId> events);
+    Task<AppendManyResult> AppendMany(IEnumerable<EventForEventSourceId> events, CorrelationId? correlationId = default);
 
     /// <summary>
     /// Redact an event at a specific sequence number.

--- a/Source/Clients/DotNET/Transactions/UnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWork.cs
@@ -78,7 +78,7 @@ public class UnitOfWork(
                             .Select(e => new EventForEventSourceId(e.EventSourceId, e.Event, e.Causation))
                             .ToArray();
             var eventSequence = eventStore.GetEventSequence(eventSequenceId);
-            var result = await eventSequence.AppendMany(sorted);
+            var result = await eventSequence.AppendMany(sorted, correlationId);
             result.ConstraintViolations.ForEach(_constraintViolations.Add);
             result.Errors.ForEach(_appendErrors.Add);
             _lastCommittedEventSequenceNumber = result.SequenceNumbers.OrderBy(_ => _.Value).LastOrDefault();

--- a/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
+++ b/Source/Clients/Orleans.InProcess/ChronicleClientSiloBuilderExtensions.cs
@@ -92,6 +92,7 @@ public static class ChronicleClientSiloBuilderExtensions
 
     static void ConfigureChronicle(this ISiloBuilder builder, Action<IChronicleBuilder>? configureChronicle = default)
     {
+        builder.AddActivityPropagation();
         builder.AddIncomingGrainCallFilter<UnitOfWorkIncomingCallFilter>();
         builder.AddOutgoingGrainCallFilter<UnitOfWorkOutgoingCallFilter>();
         builder.AddChronicleToSilo(configureChronicle);

--- a/Source/Clients/XUnit/Events/EventSequenceForTesting.cs
+++ b/Source/Clients/XUnit/Events/EventSequenceForTesting.cs
@@ -33,7 +33,8 @@ public class EventSequenceForTesting(IEventTypes eventTypes, params EventForEven
         object @event,
         EventStreamType? eventStreamType = default,
         EventStreamId? eventStreamId = default,
-        EventSourceType? eventSourceType = default) => Task.FromResult(AppendResult.Success(CorrelationId.New(), EventSequenceNumber.Unavailable));
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default) => Task.FromResult(AppendResult.Success(correlationId ?? CorrelationId.New(), EventSequenceNumber.Unavailable));
 
     /// <inheritdoc/>
     public Task<AppendManyResult> AppendMany(
@@ -41,10 +42,11 @@ public class EventSequenceForTesting(IEventTypes eventTypes, params EventForEven
         IEnumerable<object> events,
         EventStreamType? eventStreamType = default,
         EventStreamId? eventStreamId = default,
-        EventSourceType? eventSourceType = default) => Task.FromResult(AppendManyResult.Success(CorrelationId.New(), []));
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default) => Task.FromResult(AppendManyResult.Success(correlationId ?? CorrelationId.New(), []));
 
     /// <inheritdoc/>
-    public Task<AppendManyResult> AppendMany(IEnumerable<EventForEventSourceId> events) => Task.FromResult(AppendManyResult.Success(CorrelationId.New(), []));
+    public Task<AppendManyResult> AppendMany(IEnumerable<EventForEventSourceId> events, CorrelationId? correlationId = default) => Task.FromResult(AppendManyResult.Success(correlationId ?? CorrelationId.New(), []));
 
     /// <inheritdoc/>
     public Task<IImmutableList<AppendedEvent>> GetForEventSourceIdAndEventTypes(


### PR DESCRIPTION
## Summary

When using an Orleans based client the CorrelationId of the appended events would always be the empty Guid due to the nature of Orleans message call contexts not cooperating with AsyncLocal which ICorrelationIdAccessor used.

### Added

- Optional parameter for `CorrelationId` in `IEventSequence` append methods

### Fixed

- `UnitOfWork` uses its own `CorrelationId` when appending events when committing
