### PR TITLE
Fix/immediate projection grain

### DIFF
--- a/Source/Kernel/Grains/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Grains/Projections/ImmediateProjection.cs
@@ -79,7 +79,6 @@ public class ImmediateProjection(
             var fromSequenceNumber = _lastHandledEventSequenceNumber == EventSequenceNumber.Unavailable ? EventSequenceNumber.First : _lastHandledEventSequenceNumber.Next();
             projectionChanged = State.LastUpdated > _lastUpdated;
             _lastUpdated = State.LastUpdated ?? DateTimeOffset.UtcNow;
-            fromSequenceNumber = EventSequenceNumber.First;
 
             var eventSequenceKey = new EventSequenceKey(_projectionKey!.EventSequenceId, _projectionKey!.EventStore, _projectionKey!.Namespace);
             var eventSequence = GrainFactory.GetGrain<IEventSequence>(eventSequenceKey);


### PR DESCRIPTION
### Fixed

- ImmediateProjection Grain would accumulate projections to the cached state in the grain because from event sequence number was always set to 0 
