### PR TITLE
Use valid timespan when debugging in TimeSpanFactory

### DIFF
--- a/Integration/Orleans.InProcess/TimeSpanFactory.cs
+++ b/Integration/Orleans.InProcess/TimeSpanFactory.cs
@@ -15,7 +15,7 @@ public static class TimeSpanFactory
     {
         if (Debugger.IsAttached)
         {
-            return TimeSpan.MaxValue;
+            return Timeout.InfiniteTimeSpan;
         }
         return TimeSpan.FromSeconds(5);
     }
@@ -29,7 +29,7 @@ public static class TimeSpanFactory
     {
         if (Debugger.IsAttached)
         {
-            return TimeSpan.MaxValue;
+            return Timeout.InfiniteTimeSpan;
         }
         return TimeSpan.FromSeconds(seconds);
     }


### PR DESCRIPTION
### Fixed

- TimeSpanFactory when debugger is attached
