### PR TITLE
Fix CreateClient in OrleansFixture integrationt test package

### DIFF
--- a/Source/Clients/XUnit.Integration/OrleansFixture.cs
+++ b/Source/Clients/XUnit.Integration/OrleansFixture.cs
@@ -191,7 +191,7 @@ public class OrleansFixture : IClientArtifactsProvider, IDisposable, IAsyncLifet
     /// </summary>
     /// <param name="options">The <see cref="WebApplicationFactoryClientOptions"/>.</param>
     /// <returns>A new <see cref="HttpClient"/> instance.</returns>
-    public HttpClient CreateClient(WebApplicationFactoryClientOptions options) => (_createClientMethod.Invoke(_webApplicationFactory, [options]) as HttpClient)!;
+    public HttpClient CreateClient(WebApplicationFactoryClientOptions options) => (_createClientWithOptionsMethod.Invoke(_webApplicationFactory, [options]) as HttpClient)!;
 
     /// <inheritdoc/>
     public virtual void Dispose()


### PR DESCRIPTION
### Fixed

- An issue with `OrleansFixture.CreateClient` method that would throw an exception when called with `WebApplicationFactoryClientOptions`
