### PR TITLE
Fix/client-simplification

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,12 +19,12 @@
         <!-- Cratis -->
         <PackageVersion Include="Cratis.Fundamentals" Version="6.5.1" />
         <PackageVersion Include="Cratis.Metrics.Roslyn" Version="6.5.1" />
-        <PackageVersion Include="Cratis.Applications" Version="16.0.1" />
-        <PackageVersion Include="Cratis.Applications.MongoDB" Version="16.0.1" />
-        <PackageVersion Include="Cratis.Applications.Orleans" Version="16.0.1" />
-        <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="16.0.1" />
-        <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="16.0.1" />
-        <PackageVersion Include="Cratis.Applications.Swagger" Version="16.0.1" />
+        <PackageVersion Include="Cratis.Applications" Version="16.0.2" />
+        <PackageVersion Include="Cratis.Applications.MongoDB" Version="16.0.2" />
+        <PackageVersion Include="Cratis.Applications.Orleans" Version="16.0.2" />
+        <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="16.0.2" />
+        <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="16.0.2" />
+        <PackageVersion Include="Cratis.Applications.Swagger" Version="16.0.2" />
         <!-- Orleans -->
         <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="9.1.2" />
         <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.1.2" />

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -18,7 +18,12 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class ChronicleClientServiceCollectionExtensions
 {
+#if NET9_0
     static readonly Lock _eventStoreInitLock = new();
+#else
+    static readonly object _eventStoreInitLock = new();
+#endif
+
     static readonly ConcurrentDictionary<EventStoreNamespaceName, IEventStore> _eventStores = new();
 
     /// <summary>

--- a/Source/Clients/AspNetCore/ChronicleClientStartupTask.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientStartupTask.cs
@@ -27,7 +27,7 @@ public class ChronicleClientStartupTask(IChronicleClient chronicleClient, IOptio
             return;
         }
 
-        var eventStore = chronicleClient.GetEventStore(options.Value.EventStore);
+        var eventStore = await chronicleClient.GetEventStore(options.Value.EventStore);
         await eventStore.DiscoverAll();
         await eventStore.RegisterAll();
     }

--- a/Source/Clients/DotNET.InProcess/ChronicleClientSiloBuilderExtensions.cs
+++ b/Source/Clients/DotNET.InProcess/ChronicleClientSiloBuilderExtensions.cs
@@ -32,7 +32,11 @@ public static class ChronicleClientSiloBuilderExtensions
     /// </summary>
     public static readonly string[] DefaultSectionPaths = ["Cratis", "Chronicle"];
 
+#if NET9_0
     static readonly Lock _eventStoreInitLock = new();
+#else
+    static readonly object _eventStoreInitLock = new();
+#endif
 
     /// <summary>
     /// Add Chronicle to the silo. This enables running Chronicle in process in the same process as the silo.

--- a/Source/Clients/DotNET/ChronicleOptions.cs
+++ b/Source/Clients/DotNET/ChronicleOptions.cs
@@ -21,6 +21,7 @@ namespace Cratis.Chronicle;
 /// <param name="serviceProvider">Optional <see cref="IServiceProvider"/> for resolving instances of things like event types, Reactors, reducers, projections and other artifacts. Will revert to <see cref="DefaultServiceProvider"/> if not configured.</param>
 /// <param name="artifactsProvider">Optional <see cref="IClientArtifactsProvider"/>. If not specified, it will use the <see cref="DefaultClientArtifactsProvider"/> with both project and package referenced assemblies.</param>
 /// <param name="correlationIdAccessor">Optional <see cref="ICorrelationIdAccessor"/> to use. Will revert to default if not configured.</param>
+/// <param name="autoDiscoverAndRegister">Optional disable automatic discovery of artifacts and registering these.</param>
 /// <param name="connectTimeout">Optional timeout when connecting in seconds. Defaults to 5.</param>
 /// <param name="loggerFactory">Optional <see cref="ILoggerFactory"/> to use internally in client for logging.</param>
 public class ChronicleOptions(
@@ -31,6 +32,7 @@ public class ChronicleOptions(
     IServiceProvider? serviceProvider = null,
     IClientArtifactsProvider? artifactsProvider = null,
     ICorrelationIdAccessor? correlationIdAccessor = null,
+    bool autoDiscoverAndRegister = true,
     int connectTimeout = 5,
     ILoggerFactory? loggerFactory = null)
 {
@@ -90,6 +92,11 @@ public class ChronicleOptions(
     /// Gets the <see cref="IModelNameConvention"/> to use.
     /// </summary>
     public IModelNameConvention ModelNameConvention { get; set; } = modelNameConvention ?? new DefaultModelNameConvention();
+
+    /// <summary>
+    /// Gets a value indicating whether to automatically discover and register artifacts.
+    /// </summary>
+    public bool AutoDiscoverAndRegister { get; set; } = autoDiscoverAndRegister;
 
     /// <summary>
     /// Gets the timeout when connecting in seconds.

--- a/Source/Clients/DotNET/IChronicleClient.cs
+++ b/Source/Clients/DotNET/IChronicleClient.cs
@@ -25,11 +25,12 @@ public interface IChronicleClient
     /// </summary>
     /// <param name="name">Name of the event store to get.</param>
     /// <param name="namespace">Optional namespace.</param>
+    /// <param name="skipDiscovery">Whether to skip discovery.</param>
     /// <returns><see cref="IEventStore"/>.</returns>
     /// <remarks>
     /// If no namespace is specified, the default namespace will be used.
     /// </remarks>
-    IEventStore GetEventStore(EventStoreName name, EventStoreNamespaceName? @namespace = default);
+    Task<IEventStore> GetEventStore(EventStoreName name, EventStoreNamespaceName? @namespace = default, bool skipDiscovery = false);
 
     /// <summary>
     /// List all the event stores.

--- a/Source/Clients/DotNET/Reactors/Reactors.cs
+++ b/Source/Clients/DotNET/Reactors/Reactors.cs
@@ -22,8 +22,7 @@ public class Reactors : IReactors
 {
 #if NET9_0
     static readonly Lock _registerLock = new();
-#endif
-#if NET8_0
+#else
     static readonly object _registerLock = new();
 #endif
     readonly IEventStore _eventStore;


### PR DESCRIPTION
### Changed

- Changing the `GetEventStore()` method on `ChronicleClient` to be async - optimizing the API by automatically calling the `DiscoverAll()` and `RegisterAll()` methods. It is possible to override this by either setting the `AutoDiscoverAndRegister` in the `ChronicleOptions` to `false` or use the `skipDiscovery` argument on `GetEventStore()`.
