### PR TITLE
Return the builder continuation

### DIFF
--- a/Source/Clients/XUnit.Integration/ChronicleOutOfProcessFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOutOfProcessFixture.cs
@@ -42,9 +42,6 @@ public class ChronicleOutOfProcessFixture : ChronicleFixture
     /// </summary>
     /// <param name="builder"><see cref="ContainerBuilder"/> to configure.</param>
     /// <returns>The configured <see cref="ContainerBuilder"/>.</returns>
-    protected virtual ContainerBuilder ConfigureImage(ContainerBuilder builder)
-    {
+    protected virtual ContainerBuilder ConfigureImage(ContainerBuilder builder) =>
         builder.WithImage("cratis/chronicle:latest-development");
-        return builder;
-    }
 }


### PR DESCRIPTION
### Fixed

- Fixing the default `ConfigureImage` of the `ChronicleOutOfProcessFixture` to return the created container builder, not the original coming as input. In TestContainer this type is immutable and cloned for every operation you perform on it.
