### PR TITLE
Fixing project references so that we get correct dependencies in NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,12 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <Version Condition=" '$(Version)' == '' ">1.0.0</Version>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="Cratis.Chronicle" Version="$(Version)" />
-        <PackageVersion Include="Cratis.Chronicle.InProcess" Version="$(Version)" />
-
         <!-- System -->
         <PackageVersion Include="System.Reactive" Version="6.0.1" />
         <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />

--- a/Documentation/contributing/clients/internalization.md
+++ b/Documentation/contributing/clients/internalization.md
@@ -152,8 +152,8 @@ This guarantees that the repacked assembly is available for reference during the
 <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Web" />
 
 <Target Name="BuildDependencies">
-    <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
     <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+    <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
 </Target>
 
 <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Web" />
@@ -163,8 +163,8 @@ This guarantees that the repacked assembly is available for reference during the
 </PropertyGroup>
 
 <ItemGroup Condition="'$(Repack)' == 'true'">
+    <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
     <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
-    <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
 </ItemGroup>
 
 <ItemGroup Condition="'$(Repack)' != 'true'">
@@ -173,10 +173,9 @@ This guarantees that the repacked assembly is available for reference during the
 </ItemGroup>
 ```
 
-> Note: Notice the `<PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>`, its version is defined in the central package management (`Directory.Packages.props`)
-> with a variable `$(Version)`. If the `Version` property is not set, it will default to `1.0.0`.
-> During publishing (`Publish` property set to `true`), we use a build property setting this variable to the correct version number.
-> This package reference is needed for the generated `.nuspec` to be correct when packaging the package.
+> Note: When repacking, the `<ProjectReference/>` to a repacked project, like the `DotNET.csproj` will have to not reference the output assembly directly, which will
+> be the assembly before it has been repackaged. This is due to build optimization and parallelism. In conjunction with the `<Copy/>` statement we get the correct
+> assembly that it will create correct bindings to. Also notice that we include the `.pdb` file when copying, to get a correct reference.
 
 This configuration ensures that, when repacking is enabled, your project references the merged output assembly directly—guaranteeing runtime correctness and hiding internal APIs.
 During normal development (when repacking is not enabled), it falls back to standard project references, preserving fast incremental builds and IDE tooling support.

--- a/Source/Clients/Api/Api.csproj
+++ b/Source/Clients/Api/Api.csproj
@@ -17,7 +17,6 @@
     </ItemGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
         <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
         <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
     </Target>
@@ -29,10 +28,12 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" />
         <ProjectReference Include="../Connections/Connections.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>

--- a/Source/Clients/AspNetCore/AspNetCore.csproj
+++ b/Source/Clients/AspNetCore/AspNetCore.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFrameworks=$(TargetFrameworks);TargetFramework=$(TargetFramework);Repack=$(Repack)" />
         <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -26,8 +26,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">

--- a/Source/Clients/DotNET.InProcess/DotNET.InProcess.csproj
+++ b/Source/Clients/DotNET.InProcess/DotNET.InProcess.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
-        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)" />
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -36,8 +36,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll" />
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">

--- a/Source/Clients/Orleans.XUnit/Orleans.XUnit.csproj
+++ b/Source/Clients/Orleans.XUnit/Orleans.XUnit.csproj
@@ -12,9 +12,10 @@
     </ItemGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET.InProcess/DotNET.InProcess.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
-        <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
         <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -24,14 +25,15 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
+        <ProjectReference Include="../DotNET.InProcess/DotNET.InProcess.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.InProcess.dll"/>
-
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
-        <PackageReference Include="Cratis.Chronicle.InProcess" Condition="'$(Publish)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" />
+        <ProjectReference Include="../DotNET.InProcess/DotNET.InProcess.csproj" />
         <ProjectReference Include="../../Kernel/Concepts/Concepts.csproj">
             <PrivateAssets>all</PrivateAssets>
             <Aliases>Server</Aliases>

--- a/Source/Clients/Orleans/Orleans.csproj
+++ b/Source/Clients/Orleans/Orleans.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
         <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -23,12 +23,12 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">
-        <ProjectReference Include="../DotNET/DotNET.csproj"/>
+        <ProjectReference Include="../DotNET/DotNET.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
+++ b/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
@@ -12,9 +12,10 @@
     </ItemGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET.InProcess/DotNET.InProcess.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
-        <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
         <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET.InProcess/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.InProcess.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -24,24 +25,22 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET.InProcess/DotNET.InProcess.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.InProcess.dll"/>
-
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
-        <PackageReference Include="Cratis.Chronicle.InProcess" Condition="'$(Publish)' == 'true'"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="../AspNetCore/AspNetCore.csproj" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">
         <ProjectReference Include="../DotNET/DotNET.csproj" />
-        <ProjectReference Include="../DotNET.InProcess/DotNET.InProcess.csproj" />
         <ProjectReference Include="../../Kernel/Concepts/Concepts.csproj"/>
         <ProjectReference Include="../../Kernel/Grains/Grains.csproj"/>
         <ProjectReference Include="../../Kernel/Diagnostics/Diagnostics.csproj"/>
         <ProjectReference Include="../../Kernel/Storage.MongoDB/Storage.MongoDB.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../DotNET.InProcess/DotNET.InProcess.csproj" />
+        <ProjectReference Include="../AspNetCore/AspNetCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Clients/XUnit/XUnit.csproj
+++ b/Source/Clients/XUnit/XUnit.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <Target Name="BuildDependencies">
-        <MSBuild Projects="../DotNET/DotNET.csproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework);TargetFrameworks=$(TargetFrameworks);Repack=$(Repack)" />
         <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.dll" DestinationFolder="$(OutDir)"/>
+        <Copy SourceFiles="../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb" DestinationFolder="$(OutDir)" Condition="Exists('../DotNET/bin/$(Configuration)/$(TargetFramework)/Cratis.Chronicle.pdb')"/>
     </Target>
 
     <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
@@ -19,14 +19,13 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(Repack)' == 'true'">
+        <ProjectReference Include="../DotNET/DotNET.csproj" ReferenceOutputAssembly="false"/>
         <Reference Include="$(OutDir)/Cratis.Chronicle.dll"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Repack)' != 'true'">
-        <ProjectReference Include="../DotNET/DotNET.csproj" />
+        <ProjectReference Include="../DotNET/DotNET.csproj"/>
         <ProjectReference Include="../Connections/Connections.csproj" />
-
-        <PackageReference Include="Cratis.Chronicle" Condition="'$(Publish)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Fixed

- After a lot of back and forth, we finally figured out the correct **MSBuild** mechanisms for getting both correct assembly bindings for repacked assemblies and a proper correctly versioned dependency in the generated `.nuspec` file for published client packages.
