### PR TITLE
Fix/test-issues

### DIFF
--- a/Integration/Api/for_EventStoreQueries/when_getting_event_stores.cs
+++ b/Integration/Api/for_EventStoreQueries/when_getting_event_stores.cs
@@ -10,7 +10,7 @@ namespace Cratis.Chronicle.Integration.Api.for_EventStoreQueries;
 [Collection(ChronicleCollection.Name)]
 public class when_getting_event_stores(context context) : Given<context>(context)
 {
-    public class context(ChronicleOutOfProcessFixtureWithLocalImage fixture) : given.a_configured_http_client(fixture)
+    public class context(ChronicleOutOfProcessFixtureWithLocalImage fixture) : given.an_http_client(fixture)
     {
         public QueryResult<IEnumerable<string>> Result;
 

--- a/Integration/Api/given/Specification.cs
+++ b/Integration/Api/given/Specification.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Api.given;
+
+public class Specification(ChronicleOutOfProcessFixtureWithLocalImage fixture) : Specification<ChronicleOutOfProcessFixtureWithLocalImage, ApiWebApplicationFactory, Program>(fixture);

--- a/Integration/Api/given/a_specification_context.cs
+++ b/Integration/Api/given/a_specification_context.cs
@@ -1,6 +1,0 @@
-// Copyright (c) Cratis. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-namespace Cratis.Chronicle.Integration.Api.given;
-
-public class a_specification_context(ChronicleOutOfProcessFixtureWithLocalImage fixture) : IntegrationSpecificationContext<ChronicleOutOfProcessFixtureWithLocalImage, ApiWebApplicationFactory, Program>(fixture);

--- a/Integration/Api/given/an_http_client.cs
+++ b/Integration/Api/given/an_http_client.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.Integration.Api.given;
 
-public class a_configured_http_client(ChronicleOutOfProcessFixtureWithLocalImage fixture) : a_specification_context(fixture)
+public class an_http_client(ChronicleOutOfProcessFixtureWithLocalImage fixture) : Specification(fixture)
 {
     protected HttpClient Client { get; private set; }
 

--- a/Integration/DotNET.InProcess/AggregateRoots/ActorBased/Scenarios/given/an_aggregate_root_with_state.cs
+++ b/Integration/DotNET.InProcess/AggregateRoots/ActorBased/Scenarios/given/an_aggregate_root_with_state.cs
@@ -9,7 +9,7 @@ using Cratis.Chronicle.Transactions;
 
 namespace Cratis.Chronicle.InProcess.Integration.AggregateRoots.ActorBased.Scenarios.given;
 
-public class an_aggregate_root_with_state<TAggregate, TInternalState>(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class an_aggregate_root_with_state<TAggregate, TInternalState>(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     where TAggregate : IIntegrationTestAggregateRoot<TInternalState>
     where TInternalState : class
 {

--- a/Integration/DotNET.InProcess/AggregateRoots/Scenarios/given/an_aggregate_root_with_state.cs
+++ b/Integration/DotNET.InProcess/AggregateRoots/Scenarios/given/an_aggregate_root_with_state.cs
@@ -9,7 +9,7 @@ using Cratis.Chronicle.Transactions;
 
 namespace Cratis.Chronicle.InProcess.Integration.AggregateRoots.Scenarios.given;
 
-public class an_aggregate_root_with_state<TAggregate, TInternalState>(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class an_aggregate_root_with_state<TAggregate, TInternalState>(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     where TAggregate : IAggregateRoot
     where TInternalState : class
 {

--- a/Integration/DotNET.InProcess/IntegrationSpecification.cs
+++ b/Integration/DotNET.InProcess/IntegrationSpecification.cs
@@ -3,4 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration;
 
-public class IntegrationSpecificationContext(ChronicleInProcessFixture fixture) : IntegrationSpecificationContext<ChronicleInProcessFixture>(fixture);
+public class IntegrationSpecification(ChronicleInProcessFixture fixture) : IntegrationSpecification<ChronicleInProcessFixture>(fixture)
+{
+    public override bool AutoDiscoverArtifacts => false;
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
@@ -7,7 +7,7 @@ using MongoDB.Driver;
 
 namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.given;
 
-public class a_projection_and_events_appended_to_it<TProjection, TReadModel>(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_projection_and_events_appended_to_it<TProjection, TReadModel>(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     where TProjection : class, IProjectionFor<TReadModel>, new()
     where TReadModel : class
 {

--- a/Integration/DotNET.InProcess/Specification.cs
+++ b/Integration/DotNET.InProcess/Specification.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration;
 
-public class IntegrationSpecification(ChronicleInProcessFixture fixture) : IntegrationSpecification<ChronicleInProcessFixture>(fixture)
+public class Specification(ChronicleInProcessFixture fixture) : Specification<ChronicleInProcessFixture>(fixture)
 {
     public override bool AutoDiscoverArtifacts => false;
 }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/an_event.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/an_event.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class an_event(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public EventSourceId EventSourceId { get; } = "source";
         public SomeEvent Event { get; private set; }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/existing_sequence_number.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/existing_sequence_number.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class existing_sequence_number(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public EventSourceId EventSourceId { get; } = "source";
         public SomeEvent FirstEvent;

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/many_events.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/many_events.cs
@@ -8,7 +8,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class many_events(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public Events.EventSourceId EventSourceId { get; } = "source";
         public IList<SomeEvent> Events { get; private set; }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/many_with_first_event_violating_unique_constraint.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/many_with_first_event_violating_unique_constraint.cs
@@ -10,7 +10,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class many_with_first_event_violating_unique_constraint(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
         public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_constraint_value_added_and_then_removed.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_constraint_value_added_and_then_removed.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class with_constraint_value_added_and_then_removed(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
         public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_unique_constraint_violation.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_unique_constraint_violation.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class with_unique_constraint_violation(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
         public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_unique_event_violation.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/with_unique_event_violation.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appendin
 [Collection(ChronicleCollection.Name)]
 public class with_unique_event_violation(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueEventConstraint)];
         public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted)];

--- a/Integration/DotNET.InProcess/for_EventSequence/when_getting_from_sequence_number/many_events.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_getting_from_sequence_number/many_events.cs
@@ -10,7 +10,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_getting_
 [Collection(ChronicleCollection.Name)]
 public class many_events(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public EventSourceId EventSourceId { get; } = "source";
         public IList<SomeEvent> Events { get; private set; }

--- a/Integration/DotNET.InProcess/for_JobsManager/given/all_dependencies.cs
+++ b/Integration/DotNET.InProcess/for_JobsManager/given/all_dependencies.cs
@@ -5,7 +5,7 @@ using Cratis.Chronicle.Storage.Jobs;
 
 namespace Cratis.Chronicle.InProcess.Integration.for_JobsManager.given;
 
-public class all_dependencies(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class all_dependencies(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TheJobStepProcessor JobStepProcessor;
     public IJobStorage JobStorage;

--- a/Integration/DotNET.InProcess/for_Reactors/given/a_disconnected_reactor_observing_an_event.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/given/a_disconnected_reactor_observing_an_event.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.given;
 
-public class a_disconnected_reactor_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_disconnected_reactor_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource Tcs;
     public ReactorWithoutDelay Reactor;

--- a/Integration/DotNET.InProcess/for_Reactors/given/a_disconnected_reactor_observing_no_event_types.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/given/a_disconnected_reactor_observing_no_event_types.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.given;
 
-public class a_disconnected_reactor_observing_no_event_types(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_disconnected_reactor_observing_no_event_types(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource Tcs;
     public ReactorWithoutHandlers Reactor;

--- a/Integration/DotNET.InProcess/for_Reactors/given/a_reactor_observing_an_event.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/given/a_reactor_observing_an_event.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.given;
 
-public class a_reactor_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_reactor_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource Tcs;
     public SomeReactor Reactor;

--- a/Integration/DotNET.InProcess/for_Reactors/given/a_reactor_observing_an_event_that_can_fail.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/given/a_reactor_observing_an_event_that_can_fail.cs
@@ -5,7 +5,7 @@ using Cratis.Chronicle.Observation;
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.given;
 
-public class a_reactor_observing_an_event_that_can_fail(ChronicleInProcessFixture chronicleInProcessFixture, int numberOfObservations) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_reactor_observing_an_event_that_can_fail(ChronicleInProcessFixture chronicleInProcessFixture, int numberOfObservations) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource[] Tcs;
     public ReactorThatCanFail[] Observers;

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event/and_not_waiting_for_observer_to_be_active.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event/and_not_waiting_for_observer_to_be_active.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.when_appending_eve
 [Collection(ChronicleCollection.Name)]
 public class and_not_waiting_for_observer_to_be_active(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public static TaskCompletionSource Tsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public EventSourceId EventSourceId;

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event/and_waiting_for_observer_to_be_active.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event/and_waiting_for_observer_to_be_active.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_Reactors.when_appending_eve
 [Collection(ChronicleCollection.Name)]
 public class and_waiting_for_observer_to_be_active(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public static TaskCompletionSource Tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public EventSourceId EventSourceId;

--- a/Integration/DotNET.InProcess/for_Reducers/given/a_disconnected_reducer_observing_an_event.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/given/a_disconnected_reducer_observing_an_event.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.given;
 
-public class a_disconnected_reducer_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_disconnected_reducer_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource Tcs;
     public ReducerWithoutDelay Reducer;

--- a/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_able_to_delete.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_able_to_delete.cs
@@ -6,7 +6,7 @@ using MongoDB.Driver;
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.given;
 
-public class a_reducer_able_to_delete<TReducer>(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_reducer_able_to_delete<TReducer>(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     where TReducer : class, IReducerFor<SomeReadModel>, new()
 {
     public TReducer Reducer;

--- a/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_observing_an_event.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_observing_an_event.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.given;
 
-public class a_reducer_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_reducer_observing_an_event(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource Tcs;
     public SomeReducer Reducer;

--- a/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_observing_an_event_that_can_fail.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_observing_an_event_that_can_fail.cs
@@ -3,7 +3,7 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.given;
 
-public class a_reducer_observing_an_event_that_can_fail(ChronicleInProcessFixture chronicleInProcessFixture, int numberOfObservations) : IntegrationSpecificationContext(chronicleInProcessFixture)
+public class a_reducer_observing_an_event_that_can_fail(ChronicleInProcessFixture chronicleInProcessFixture, int numberOfObservations) : Specification(chronicleInProcessFixture)
 {
     public TaskCompletionSource[] Tcs;
     public ReducerThatCanFail[] Observers;

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_not_waiting_for_observer_to_be_active.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_not_waiting_for_observer_to_be_active.cs
@@ -9,7 +9,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.when_appending_eve
 [Collection(ChronicleCollection.Name)]
 public class and_not_waiting_for_observer_to_be_active(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public static TaskCompletionSource Tsc = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public EventSourceId EventSourceId;

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_waiting_for_observer_to_be_active.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_waiting_for_observer_to_be_active.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_Reducers.when_appending_eve
 [Collection(ChronicleCollection.Name)]
 public class and_waiting_for_observer_to_be_active(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : IntegrationSpecificationContext(chronicleInProcessFixture)
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
     {
         public static TaskCompletionSource Tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public EventSourceId EventSourceId;

--- a/Source/Clients/Api/ApiServiceCollectionExtensions.cs
+++ b/Source/Clients/Api/ApiServiceCollectionExtensions.cs
@@ -61,8 +61,8 @@ public static class ApiServiceCollectionExtensions
         {
             services.AddCratisChronicleConnection(urlFactory: sp =>
             {
-                var options = sp.GetRequiredService<IOptions<ChronicleApiOptions>>();
-                return options.Value.ChronicleUrl;
+                var options = sp.GetRequiredService<IOptions<ChronicleOptions>>();
+                return options.Value.Url;
             });
         }
 

--- a/Source/Clients/Api/ChronicleApiOptions.cs
+++ b/Source/Clients/Api/ChronicleApiOptions.cs
@@ -14,14 +14,4 @@ public class ChronicleApiOptions
     /// Gets the port for the REST API.
     /// </summary>
     public int ApiPort { get; init; } = 8080;
-
-    /// <summary>
-    /// Gets the <see cref="ChronicleUrl"/> to use.
-    /// </summary>
-    public ChronicleUrl ChronicleUrl { get; init; } = ChronicleUrl.Default;
-
-    /// <summary>
-    /// Gets the timeout for connecting in seconds.
-    /// </summary>
-    public int ConnectTimeout { get; init; } = 5;
 }

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using Cratis.Chronicle;
 using Cratis.Chronicle.AspNetCore.Identities;
+using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Rules;
 using Cratis.Execution;
 using Microsoft.AspNetCore.Http;
@@ -37,12 +38,15 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddSingleton<IChronicleClient>(sp =>
         {
             var options = sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value;
+            var connection = sp.GetService<IChronicleConnection>();
             options.ServiceProvider = sp;
             options.IdentityProvider = new IdentityProvider(
                                 sp.GetRequiredService<IHttpContextAccessor>(),
                                 sp.GetRequiredService<ILogger<IdentityProvider>>());
             options.LoggerFactory = sp.GetRequiredService<ILoggerFactory>();
-            return new ChronicleClient(options);
+            return connection is null ?
+                new ChronicleClient(options) :
+                new ChronicleClient(connection, options);
         });
 
         services.AddScoped(sp =>

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
@@ -81,7 +81,7 @@ public static class ChronicleClientWebApplicationBuilderExtensions
             {
                 var aspNetCoreOptions = new ChronicleAspNetCoreOptions();
                 CopyValues(aspNetCoreOptions, options);
-                configure((ChronicleAspNetCoreOptions)options);
+                configure(aspNetCoreOptions);
                 CopyValues(options, aspNetCoreOptions);
             });
         }

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -216,12 +216,8 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
         }
 
         await ChronicleFixture.RemoveAllDatabases();
-        _ = Task.Run(async () =>
-        {
-            await (_webApplicationFactory?.DisposeAsync() ?? ValueTask.CompletedTask);
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-        });
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
     }
 
     /// <summary>

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -216,6 +216,12 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
         }
 
         await ChronicleFixture.RemoveAllDatabases();
+        _ = Task.Run(async () =>
+        {
+            await (_webApplicationFactory?.DisposeAsync() ?? ValueTask.CompletedTask);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        });
     }
 
     /// <summary>

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -59,7 +59,7 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
     /// <summary>
     /// Gets the value indicating whether to auto discover artifacts.
     /// </summary>
-    public virtual bool AutoDiscoverArtifacts { get; }
+    public virtual bool AutoDiscoverArtifacts { get; } = true;
 
     /// <summary>
     /// Gets the docker network.

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -216,12 +216,6 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
         }
 
         await ChronicleFixture.RemoveAllDatabases();
-        _ = Task.Run(async () =>
-        {
-            await (_webApplicationFactory?.DisposeAsync() ?? ValueTask.CompletedTask);
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-        });
     }
 
     /// <summary>

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -23,15 +23,14 @@ namespace Cratis.Chronicle.XUnit.Integration;
 public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, IAsyncLifetime, IChronicleSetupFixture
     where TChronicleFixture : IChronicleFixture
 {
+#pragma warning disable CA2213, SA1600, CA1051
+    protected IAsyncDisposable? _webApplicationFactory;
+#pragma warning restore CA2213, SA1600, CA1051
     static readonly DefaultClientArtifactsProvider _defaultClientArtifactsProvider = new(new CompositeAssemblyProvider(ProjectReferencedAssemblies.Instance, PackageReferencedAssemblies.Instance));
     static PropertyInfo _servicesProperty = null!;
     static MethodInfo _createClientMethod = null!;
     static MethodInfo _createClientWithOptionsMethod = null!;
     static bool _isInitialized;
-
-#pragma warning disable CA2213
-    IAsyncDisposable? _webApplicationFactory;
-#pragma warning restore CA2213
     bool _backupPerformed;
     string _name = string.Empty;
     IServiceProvider? _services;
@@ -207,7 +206,7 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
     }
 
     /// <inheritdoc/>
-    public async Task DisposeAsync()
+    public virtual async Task DisposeAsync()
     {
         if (!_backupPerformed)
         {
@@ -216,8 +215,6 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
         }
 
         await ChronicleFixture.RemoveAllDatabases();
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
     }
 
     /// <summary>

--- a/Source/Clients/XUnit.Integration/ChronicleOrleansFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOrleansFixture.cs
@@ -18,6 +18,19 @@ public class ChronicleOrleansFixture<TChronicleFixture>(TChronicleFixture chroni
     where TChronicleFixture : IChronicleFixture
 {
     /// <inheritdoc/>
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+
+        _ = Task.Run(async () =>
+        {
+            await (_webApplicationFactory?.DisposeAsync() ?? ValueTask.CompletedTask);
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        });
+    }
+
+    /// <inheritdoc/>
     protected override IAsyncDisposable CreateWebApplicationFactory()
     {
         var startupType = TestAssembly!.ExportedTypes.FirstOrDefault(type => type.Name == "Startup");

--- a/Source/Clients/XUnit.Integration/ChronicleOutOfProcessFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOutOfProcessFixture.cs
@@ -28,7 +28,7 @@ public class ChronicleOutOfProcessFixture : ChronicleFixture
             .WithEnvironment("Storage__ConnectionDetails", $"mongodb://localhost:{MongoDBPort}")
             .WithPortBinding(MongoDBPort, 27017)
             .WithPortBinding(8081, 8080)
-            .WithPortBinding(35000, 35000)
+            .WithPortBinding(35001, 35000)
             .WithHostname(HostName)
             .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(), "backups"), "/backups")
             .WithNetwork(network)

--- a/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,10 +22,10 @@ public abstract class ChronicleWebApplicationFactory<TStartup>(IChronicleSetupFi
     {
         builder
             .UseContentRoot(contentRoot)
-            .ConfigureServices(services => services.Configure<ChronicleOptions>(options =>
-            {
-                options.ArtifactsProvider = fixture;
-                options.Url = "chronicle://localhost:35001";
-            }));
+            .ConfigureServices(services => services.PostConfigure<ChronicleAspNetCoreOptions>(options =>
+                {
+                    options.ArtifactsProvider = fixture;
+                    options.Url = "chronicle://localhost:35001";
+                }));
     }
 }

--- a/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
@@ -22,10 +22,16 @@ public abstract class ChronicleWebApplicationFactory<TStartup>(IChronicleSetupFi
     {
         builder
             .UseContentRoot(contentRoot)
-            .ConfigureServices(services => services.PostConfigure<ChronicleAspNetCoreOptions>(options =>
+            .ConfigureServices(services =>
+            {
+                void OptionsConfigurator(ChronicleOptions options)
                 {
                     options.ArtifactsProvider = fixture;
                     options.Url = "chronicle://localhost:35001";
-                }));
+                }
+
+                services.Configure<ChronicleAspNetCoreOptions>(OptionsConfigurator);
+                services.Configure<ChronicleOptions>(OptionsConfigurator);
+            });
     }
 }

--- a/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleWebApplicationFactory.cs
@@ -21,6 +21,10 @@ public abstract class ChronicleWebApplicationFactory<TStartup>(IChronicleSetupFi
     {
         builder
             .UseContentRoot(contentRoot)
-            .ConfigureServices(services => services.Configure<ChronicleOptions>(options => options.ArtifactsProvider = fixture));
+            .ConfigureServices(services => services.Configure<ChronicleOptions>(options =>
+            {
+                options.ArtifactsProvider = fixture;
+                options.Url = "chronicle://localhost:35001";
+            }));
     }
 }

--- a/Source/Clients/XUnit.Integration/IChronicleFixture.cs
+++ b/Source/Clients/XUnit.Integration/IChronicleFixture.cs
@@ -7,7 +7,7 @@ using DotNet.Testcontainers.Networks;
 namespace Cratis.Chronicle.XUnit.Integration;
 
 /// <summary>
-/// Defines the chronicle fiture.
+/// Defines the chronicle fixture.
 /// </summary>
 public interface IChronicleFixture : IAsyncDisposable
 {

--- a/Source/Clients/XUnit.Integration/Specification.cs
+++ b/Source/Clients/XUnit.Integration/Specification.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.XUnit.Integration;
 /// </summary>
 /// <typeparam name="TChronicleFixture">The type of the chronicle fixture.</typeparam>
 /// <param name="fixture">The <see cref="ChronicleInProcessFixture"/>.</param>
-public abstract class IntegrationSpecificationContext<TChronicleFixture>(TChronicleFixture fixture) : ChronicleOrleansFixture<TChronicleFixture>(fixture)
+public abstract class Specification<TChronicleFixture>(TChronicleFixture fixture) : ChronicleOrleansFixture<TChronicleFixture>(fixture)
     where TChronicleFixture : IChronicleFixture
 {
     /// <inheritdoc/>
@@ -43,7 +43,7 @@ public abstract class IntegrationSpecificationContext<TChronicleFixture>(TChroni
 /// <typeparam name="TStartup">The startup class type.</typeparam>
 /// <param name="fixture">The <see cref="ChronicleInProcessFixture"/>.</param>
 #pragma warning disable SA1402
-public abstract class IntegrationSpecificationContext<TChronicleFixture, TFactory, TStartup>(TChronicleFixture fixture) : ChronicleClientFixture<TChronicleFixture, TFactory, TStartup>(fixture)
+public abstract class Specification<TChronicleFixture, TFactory, TStartup>(TChronicleFixture fixture) : ChronicleClientFixture<TChronicleFixture, TFactory, TStartup>(fixture)
 #pragma warning restore SA1402
     where TChronicleFixture : IChronicleFixture
     where TFactory : ChronicleWebApplicationFactory<TStartup>


### PR DESCRIPTION
> Warning: We changed the `IntegrationSpecificationContext` to just be called `Specification` - although this is a breaking change, we haven't bumped the major version number. This was supposed to be part of the 14.0.0 release and since we're not far along into the 14.0.0 cycles, we decided to just do it here.

### Fixed

- Defaulting to port 35001 for Chronicle out-of-process specifications - avoiding conflicts with running solutions of Chronicle.
- Removing explicit disposal of `WebApplicationFactory` as it is managed - enabling possible reuse if needed by the ASP.NET Core Testing library of the service provider.
- Fixing so that the configuration of Chronicle during specs / tests actually configures the `ChronicleAspNetCoreOptions`.
- Adding automatic configuration of `ChronicleOptions` when using ASP.NET Core as client - it will now configure this in addition to `ChronicleAspNetCoreOptions`.
- Defaulting auto discovery of artifacts to true for specs / tests. This is how it effectively was, due to incorrect configuration of `ChronicleAspNetCoreOptions`, although before it was more accidental.
- Fixing naming of base classes for specifications