### PR TITLE
Fix MongoDB initialization not to fail if trying to reinitialize single node cluster

### DIFF
--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -13,9 +13,14 @@ if [ ! -f "$FLAG_FILE" ]; then
     mkdir -p /data/db /data/configdb
     chown -R mongodb:mongodb /data/db /data/configdb
 
-    mongod --logpath /var/log/mongodb/initdb.log --replSet "rs0" --bind_ip 0.0.0.0 --fork
-    mongosh --eval 'rs.initiate({_id: "rs0", members: [{ _id: 0, host: "localhost:27017"}]})'
-    mongod --shutdown
+    echo "Starting MongoDB for initialization..."
+    mongod --logpath /var/log/mongodb/initdb.log --replSet "rs0" --bind_ip 0.0.0.0 --fork || true
+
+    echo "Initializing replica set..."
+    mongosh --eval 'rs.initiate({_id: "rs0", members: [{ _id: 0, host: "localhost:27017"}]}' || true
+
+    echo "Shutting down MongoDB after initialization..."
+    mongod --shutdown || true
     touch "$FLAG_FILE"
 fi
 


### PR DESCRIPTION
### Fixed

- Fixing the initialization of replica set for MongoDB - if it fails because it has already been initialized, don't fail the entire container.
