### PR TITLE
Adding interfaces for easier discoverability for all the model bound attributes

### DIFF
--- a/Source/Clients/DotNET/Projections/ModelBound/AddFromAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/AddFromAttribute.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </remarks>
 /// <param name="eventPropertyName">Optional name of the property on the event. If not specified, uses the model property name.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class AddFromAttribute<TEvent>(string? eventPropertyName = default) : Attribute, IProjectionAnnotation
+public sealed class AddFromAttribute<TEvent>(string? eventPropertyName = default) : Attribute, IProjectionAnnotation, IAddFromAttribute
 {
     /// <summary>
     /// Gets the name of the property on the event.

--- a/Source/Clients/DotNET/Projections/ModelBound/CountAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/CountAttribute.cs
@@ -8,4 +8,4 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </summary>
 /// <typeparam name="TEvent">The type of event to count.</typeparam>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class CountAttribute<TEvent> : Attribute, IProjectionAnnotation;
+public sealed class CountAttribute<TEvent> : Attribute, IProjectionAnnotation, ICountAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/DecrementAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/DecrementAttribute.cs
@@ -8,4 +8,4 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </summary>
 /// <typeparam name="TEvent">The type of event that triggers the decrement.</typeparam>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class DecrementAttribute<TEvent> : Attribute, IProjectionAnnotation;
+public sealed class DecrementAttribute<TEvent> : Attribute, IProjectionAnnotation, IDecrementAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/IAddFromAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IAddFromAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates that a property value should be added from an event property.
+/// </summary>
+public interface IAddFromAttribute
+{
+    /// <summary>
+    /// Gets the name of the property on the event.
+    /// </summary>
+    string? EventPropertyName { get; }
+}

--- a/Source/Clients/DotNET/Projections/ModelBound/ICountAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ICountAttribute.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates that a property value should count occurrences of an event.
+/// </summary>
+public interface ICountAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/IDecrementAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IDecrementAttribute.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates that a property value should be decremented when an event occurs.
+/// </summary>
+public interface IDecrementAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/IIncrementAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IIncrementAttribute.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates that a property value should be incremented when an event occurs.
+/// </summary>
+public interface IIncrementAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/IJoinAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IJoinAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates a property should be populated through a join with an event.
+/// </summary>
+public interface IJoinAttribute
+{
+    /// <summary>
+    /// Gets the property name on the model to join on.
+    /// </summary>
+    string? On { get; }
+
+    /// <summary>
+    /// Gets the name of the property on the event.
+    /// </summary>
+    string? EventPropertyName { get; }
+}

--- a/Source/Clients/DotNET/Projections/ModelBound/IRemovedWithAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IRemovedWithAttribute.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates what event removes a child from a collection.
+/// </summary>
+public interface IRemovedWithAttribute : IKeyedAttribute;
+

--- a/Source/Clients/DotNET/Projections/ModelBound/IRemovedWithJoinAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IRemovedWithJoinAttribute.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates what event removes a child from a collection through a join.
+/// </summary>
+public interface IRemovedWithJoinAttribute : IKeyedAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/ISetFromAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ISetFromAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound;
+
+/// <summary>
+/// Defines an attribute that indicates that a property value should be set from an event property.
+/// </summary>
+public interface ISetFromAttribute
+{
+    /// <summary>
+    /// Gets the name of the property on the event.
+    /// </summary>
+    string? EventPropertyName { get; }
+}

--- a/Source/Clients/DotNET/Projections/ModelBound/IncrementAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/IncrementAttribute.cs
@@ -8,4 +8,4 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </summary>
 /// <typeparam name="TEvent">The type of event that triggers the increment.</typeparam>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class IncrementAttribute<TEvent> : Attribute, IProjectionAnnotation;
+public sealed class IncrementAttribute<TEvent> : Attribute, IProjectionAnnotation, IIncrementAttribute;

--- a/Source/Clients/DotNET/Projections/ModelBound/JoinAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/JoinAttribute.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// <param name="on">Optional property name on the model to join on. If not specified for root projections, must be specified.</param>
 /// <param name="eventPropertyName">Optional name of the property on the event. If not specified, uses the model property name.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class JoinAttribute<TEvent>(string? on = default, string? eventPropertyName = default) : Attribute, IProjectionAnnotation
+public sealed class JoinAttribute<TEvent>(string? on = default, string? eventPropertyName = default) : Attribute, IProjectionAnnotation, IJoinAttribute
 {
     /// <summary>
     /// Gets the property name on the model to join on.

--- a/Source/Clients/DotNET/Projections/ModelBound/RemovedWithAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/RemovedWithAttribute.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// <param name="key">Optional property name on the event that identifies the child to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
 /// <param name="parentKey">Optional property name that identifies the parent. Defaults to WellKnownExpressions.EventSourceId.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class RemovedWithAttribute<TEvent>(string? key = default, string? parentKey = default) : Attribute, IProjectionAnnotation, IKeyedAttribute
+public sealed class RemovedWithAttribute<TEvent>(string? key = default, string? parentKey = default) : Attribute, IProjectionAnnotation, IRemovedWithAttribute
 {
     /// <summary>
     /// Gets the property name on the event that identifies the child to remove.
@@ -25,3 +25,4 @@ public sealed class RemovedWithAttribute<TEvent>(string? key = default, string? 
     /// </summary>
     public string ParentKey { get; } = parentKey ?? WellKnownExpressions.EventSourceId;
 }
+

--- a/Source/Clients/DotNET/Projections/ModelBound/RemovedWithJoinAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/RemovedWithJoinAttribute.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </remarks>
 /// <param name="key">Optional property name on the event that identifies the child to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class RemovedWithJoinAttribute<TEvent>(string? key = default) : Attribute, IProjectionAnnotation
+public sealed class RemovedWithJoinAttribute<TEvent>(string? key = default) : Attribute, IProjectionAnnotation, IRemovedWithJoinAttribute
 {
     /// <summary>
     /// Gets the property name on the event that identifies the child to remove.

--- a/Source/Clients/DotNET/Projections/ModelBound/SetFromAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/SetFromAttribute.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </remarks>
 /// <param name="eventPropertyName">Optional name of the property on the event. If not specified, uses the model property name.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
-public sealed class SetFromAttribute<TEvent>(string? eventPropertyName = default) : Attribute, IProjectionAnnotation
+public sealed class SetFromAttribute<TEvent>(string? eventPropertyName = default) : Attribute, IProjectionAnnotation, ISetFromAttribute
 {
     /// <summary>
     /// Gets the name of the property on the event.


### PR DESCRIPTION
### Fixed

- Only some of the model bound projection attributes had interface representations for discoverability and type checking, this was an oversight .  The missing interfaces had no impact on runtime as of now.
