### PR TITLE
Registering missing service registrations

### DIFF
--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -106,6 +106,8 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddScoped<IRules, Rules>();
         services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.ArtifactsProvider);
         services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.NamingPolicy);
+        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.EventStoreNamespaceResolver);
+        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.CorrelationIdAccessor);
 
         return services;
     }


### PR DESCRIPTION
### Fixed

- Adding service registration for `IEventStoreNamespaceResolver` when using ASP.NET Core
- Adding service registration for `ICorrelationIdAccessor` when using ASP.NET Core
