### PR TITLE
Fixing scope for IEventStoreNameSpaceResolver registration

### DIFF
--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -34,18 +34,16 @@ public static class ChronicleClientServiceCollectionExtensions
     public static IServiceCollection AddCratisChronicleClient(this IServiceCollection services)
     {
         services.AddHttpContextAccessor();
-        services.AddScoped(sp =>
+        services.AddSingleton(sp =>
         {
             var options = sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value;
 
-            // If an instance is configured and it's not the default, use it
             if (options.EventStoreNamespaceResolver is not null &&
                 options.EventStoreNamespaceResolver is not DefaultEventStoreNamespaceResolver)
             {
                 return options.EventStoreNamespaceResolver;
             }
 
-            // Otherwise, use the configured type (which defaults to HttpHeaderEventStoreNamespaceResolver)
             var resolverType = options.EventStoreNamespaceResolverType ?? throw new InvalidOperationException("EventStoreNamespaceResolverType cannot be null");
 
             if (!typeof(IEventStoreNamespaceResolver).IsAssignableFrom(resolverType))
@@ -106,7 +104,6 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddScoped<IRules, Rules>();
         services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.ArtifactsProvider);
         services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.NamingPolicy);
-        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.EventStoreNamespaceResolver);
         services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.CorrelationIdAccessor);
 
         return services;


### PR DESCRIPTION
### Fixed

- Scoping for `IEventStoreNamespaceResolver` was wrong - it should be a singleton, not scoped.
