### PR TITLE
Instead of binding via chronicle client, bind to options

### DIFF
--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -102,9 +102,9 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Reducers);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Projections);
         services.AddScoped<IRules, Rules>();
-        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.ArtifactsProvider);
-        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.NamingPolicy);
-        services.AddSingleton(sp => sp.GetRequiredService<IChronicleClient>().Options.CorrelationIdAccessor);
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.ArtifactsProvider);
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.NamingPolicy);
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.CorrelationIdAccessor);
 
         return services;
     }


### PR DESCRIPTION
### Fixed

- Fixing service collection bindings to not bind as factory via the `IChronicleClient`, but rather directly to the definitions in the actual options. This should avoid circular resolutions that we're seeing in some scenarios.
