### PR TITLE
Adding support for specifying custom key for FromEvent attribute

### DIFF
--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/TestEvents.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/TestEvents.cs
@@ -34,5 +34,8 @@ public record ItemsAddedToInventory(int Quantity, DateTimeOffset OccurredAt);
 [EventType]
 public record ItemsRemovedFromInventory(int Quantity, DateTimeOffset OccurredAt);
 
+[EventType]
+public record UserRegisteredWithCustomId(Guid UserId, string Email, string Name);
+
 #pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore SA1649 // File name should match first type name

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/TestModels.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/TestModels.cs
@@ -118,5 +118,14 @@ public record InventoryStatus(
     [FromEvery(contextProperty: nameof(EventContext.Occurred))]
     DateTimeOffset LastUpdated);
 
+[FromEvent<UserRegisteredWithCustomId>(key: nameof(UserRegisteredWithCustomId.UserId))]
+public record UserProfile(
+    [Key]
+    Guid Id,
+
+    string Email,
+
+    string Name);
+
 #pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore SA1649 // File name should match first type name

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model_with_from_event_with_custom_key.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model_with_from_event_with_custom_key.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder;
+
+public class when_building_model_with_from_event_with_custom_key : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(UserRegisteredWithCustomId)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(UserProfile));
+
+    [Fact] void should_have_from_definition_for_event()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(UserRegisteredWithCustomId)).ToContract();
+        _result.From.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact] void should_map_email_property()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(UserRegisteredWithCustomId)).ToContract();
+        var properties = _result.From.Single(kvp => kvp.Key.IsEqual(eventType)).Value.Properties;
+        properties.Keys.ShouldContain(nameof(UserProfile.Email));
+    }
+
+    [Fact] void should_map_name_property()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(UserRegisteredWithCustomId)).ToContract();
+        var properties = _result.From.Single(kvp => kvp.Key.IsEqual(eventType)).Value.Properties;
+        properties.Keys.ShouldContain(nameof(UserProfile.Name));
+    }
+
+    [Fact] void should_use_custom_key_from_event()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(UserRegisteredWithCustomId)).ToContract();
+        var fromDefinition = _result.From.Single(kvp => kvp.Key.IsEqual(eventType)).Value;
+        fromDefinition.Key.ShouldEqual(nameof(UserRegisteredWithCustomId.UserId));
+    }
+}

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model_with_from_event_with_invalid_key.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model_with_from_event_with_invalid_key.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder;
+
+public class when_building_model_with_from_event_with_invalid_key : given.a_model_bound_projection_builder
+{
+    Exception _exception;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(UserRegisteredWithCustomId)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _exception = Catch.Exception(() => builder.Build(typeof(UserProfileWithInvalidKey)));
+
+    [Fact] void should_throw_invalid_property_for_type() => _exception.ShouldBeOfExactType<InvalidPropertyForType>();
+
+    [Fact] void should_indicate_property_name_in_exception_message()
+    {
+        _exception.Message.ShouldContain("NonExistentProperty");
+    }
+
+    [Fact] void should_indicate_event_type_in_exception_message()
+    {
+        _exception.Message.ShouldContain(nameof(UserRegisteredWithCustomId));
+    }
+}
+
+#pragma warning disable SA1402 // File may only contain a single type
+[FromEvent<UserRegisteredWithCustomId>(key: "NonExistentProperty")]
+record UserProfileWithInvalidKey(
+    [Key]
+    Guid Id,
+
+    string Email,
+
+    string Name);
+#pragma warning restore SA1402 // File may only contain a single type

--- a/Source/Clients/DotNET/Projections/ModelBound/FromDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/FromDefinitionExtensions.cs
@@ -31,6 +31,30 @@ static class FromDefinitionExtensions
     }
 
     /// <summary>
+    /// Adds a set mapping to the From definition for a given event type with an optional key.
+    /// </summary>
+    /// <param name="targetFrom">The target From dictionary to add the mapping to.</param>
+    /// <param name="getOrCreateEventType">Function to get or create a cached EventType instance.</param>
+    /// <param name="namingPolicy">The naming policy for converting property names.</param>
+    /// <param name="eventType">The event type to map from.</param>
+    /// <param name="propertyName">The property name on the projection model.</param>
+    /// <param name="eventPropertyName">The property name on the event.</param>
+    /// <param name="key">Optional key expression to use for identifying the model instance.</param>
+    internal static void AddSetMappingWithKey(this IDictionary<EventType, FromDefinition> targetFrom, Func<Type, EventType> getOrCreateEventType, INamingPolicy namingPolicy, Type eventType, string propertyName, string eventPropertyName, string? key)
+    {
+        var eventTypeId = getOrCreateEventType(eventType);
+        var fromDefinition = targetFrom.GetOrCreateFromDefinition(eventTypeId);
+        var eventPropertyPath = new PropertyPath(eventPropertyName);
+        fromDefinition.Properties[propertyName] = namingPolicy.GetPropertyName(eventPropertyPath);
+
+        if (!string.IsNullOrEmpty(key))
+        {
+            var keyPropertyPath = new PropertyPath(key);
+            fromDefinition.Key = namingPolicy.GetPropertyName(keyPropertyPath);
+        }
+    }
+
+    /// <summary>
     /// Adds an add mapping to the From definition for a given event type.
     /// </summary>
     /// <param name="targetFrom">The target From dictionary to add the mapping to.</param>

--- a/Source/Clients/DotNET/Projections/ModelBound/FromEventAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/FromEventAttribute.cs
@@ -7,11 +7,17 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// Attribute used at class level to indicate that properties should be set from an event by convention.
 /// </summary>
 /// <typeparam name="TEvent">The type of event to set from.</typeparam>
+/// <param name="key">Optional property name on the event that identifies the read model instance. Defaults to using the event source identifier.</param>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = true)]
-public sealed class FromEventAttribute<TEvent> : Attribute, IProjectionAnnotation, IFromEventAttribute
+public sealed class FromEventAttribute<TEvent>(string? key = default) : Attribute, IProjectionAnnotation, IFromEventAttribute
 {
     /// <summary>
     /// Gets the type of event this attribute projects from.
     /// </summary>
     public Type EventType => typeof(TEvent);
+
+    /// <summary>
+    /// Gets the property name on the event that identifies the read model instance.
+    /// </summary>
+    public string? Key { get; } = key;
 }

--- a/Source/Clients/DotNET/Projections/ModelBound/PropertyValidator.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/PropertyValidator.cs
@@ -13,6 +13,24 @@ public static class PropertyValidator
     /// <summary>
     /// Validates that a property name exists on a given type.
     /// </summary>
+    /// <typeparam name="T">The type to validate against.</typeparam>
+    /// <param name="propertyName">The property name to validate.</param>
+    /// <exception cref="InvalidPropertyForType">Thrown when the property does not exist on the type.</exception>
+    /// <returns>The validated property name.</returns>
+    public static string ValidatePropertyExists<T>(string propertyName)
+    {
+        var type = typeof(T);
+        if (type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase) is null)
+        {
+            throw new InvalidPropertyForType(type, propertyName);
+        }
+
+        return propertyName;
+    }
+
+    /// <summary>
+    /// Validates that a property name exists on a given type.
+    /// </summary>
     /// <param name="type">The type to validate against.</param>
     /// <param name="propertyName">The property name to validate.</param>
     /// <exception cref="InvalidPropertyForType">Thrown when the property does not exist on the type.</exception>


### PR DESCRIPTION
### Added

- Added support for specifying custom key when using the `[FromEvent]` attribute for model bound projections, as one can with the declarative approach.
