### PR TITLE
Upgrading AppModel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
         <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     </PropertyGroup>
     <ItemGroup>
-
         <!-- System -->
         <PackageVersion Include="System.Reactive" Version="6.1.0" />
         <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
@@ -13,12 +12,12 @@
         <!-- Cratis -->
         <PackageVersion Include="Cratis.Fundamentals" Version="7.2.3" />
         <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.2.3" />
-        <PackageVersion Include="Cratis.Applications" Version="17.24.6" />
-        <PackageVersion Include="Cratis.Applications.MongoDB" Version="17.24.6" />
-        <PackageVersion Include="Cratis.Applications.Orleans" Version="17.24.6" />
-        <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="17.24.6" />
-        <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="17.24.6" />
-        <PackageVersion Include="Cratis.Applications.Swagger" Version="17.24.6" />
+        <PackageVersion Include="Cratis.Applications" Version="17.24.9" />
+        <PackageVersion Include="Cratis.Applications.MongoDB" Version="17.24.9" />
+        <PackageVersion Include="Cratis.Applications.Orleans" Version="17.24.9" />
+        <PackageVersion Include="Cratis.Applications.Orleans.MongoDB" Version="17.24.9" />
+        <PackageVersion Include="Cratis.Applications.ProxyGenerator.Build" Version="17.24.9" />
+        <PackageVersion Include="Cratis.Applications.Swagger" Version="17.24.9" />
         <!-- Microsoft -->
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />


### PR DESCRIPTION
### Fixed

- Upgrading to the latest version of Cratis Application Model with a fix for Azure CosmosDB - MongoDB RU bases instances and its `Collection not found` errors when working with Change Stream. It will now reciliently handle this and try to reconnect to the collection on regular interval (every second) and once the collection is there, it should be fine. Some of the APIs for the Workbench sits on top of collections and they might not be there, causing the workbench to misbehave. This should fix that issue.
