### PR TITLE
Fixing RemovedWith to support class level

### DIFF
--- a/Documentation/projections/model-bound/children.md
+++ b/Documentation/projections/model-bound/children.md
@@ -132,7 +132,9 @@ When a `QuantityIncreased` event occurs later:
 
 ## Removing Children
 
-Use `RemovedWith` to remove children from collections:
+Use `RemovedWith` to remove children from collections. You can apply it either on the collection property or on the child type class:
+
+### Property-Level Removal
 
 ```csharp
 public record Order(
@@ -148,9 +150,29 @@ public record OrderLine(
     string Description);
 ```
 
+### Class-Level Removal
+
+Apply `RemovedWith` directly on the child type for better separation of concerns:
+
+```csharp
+public record Order(
+    [Key]
+    Guid OrderId,
+
+    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
+    IEnumerable<OrderLine> Lines);
+
+[RemovedWith<LineItemRemoved>(
+    key: nameof(LineItemRemoved.ItemId),
+    parentKey: nameof(LineItemRemoved.OrderId))]
+public record OrderLine(
+    [Key] Guid Id,
+    string Description);
+```
+
 ### RemovedWithJoin
 
-For more complex removal scenarios using joins:
+For removal based on events from different streams (joins), use `RemovedWithJoin`:
 
 ```csharp
 public record Subscription(
@@ -161,6 +183,17 @@ public record Subscription(
     [RemovedWithJoin<FeatureDeactivated>(key: nameof(FeatureDeactivated.FeatureId))]
     IEnumerable<Feature> Features);
 ```
+
+Or at the class level:
+
+```csharp
+[RemovedWithJoin<FeatureDeactivated>(key: nameof(FeatureDeactivated.FeatureId))]
+public record Feature(
+    [Key] Guid FeatureId,
+    string Name);
+```
+
+> **Note**: For comprehensive documentation on removal options including removing root read models, see [Removal](./removal.md).
 
 ## Complete Example
 

--- a/Documentation/projections/model-bound/index.md
+++ b/Documentation/projections/model-bound/index.md
@@ -57,6 +57,7 @@ See the following pages for detailed information on each feature:
 - [FromEvery](./from-every.md) - Update properties from all events
 - [Counters](./counters.md) - Increment, Decrement, Count
 - [Children](./children.md) - Managing child collections
+- [Removal](./removal.md) - Removing read models and children with RemovedWith, RemovedWithJoin
 - [Joins](./joins.md) - Joining with other events
 - [Event Sequence Source](./event-sequence-source.md) - Reading from specific event sequences
 - [Not Rewindable](./not-rewindable.md) - Forward-only projections

--- a/Documentation/projections/model-bound/removal.md
+++ b/Documentation/projections/model-bound/removal.md
@@ -1,0 +1,222 @@
+# Removing Read Models
+
+Model-bound projections support removing read models and child items through the `RemovedWith` and `RemovedWithJoin` attributes. These can be applied at both the class level (for root read models and child types) and on properties/parameters (for child collections).
+
+## Removing Root Read Models
+
+Use `RemovedWith` at the class level to specify which event removes the entire read model instance:
+
+```csharp
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+
+[RemovedWith<AccountClosed>]
+public record Account(
+    [Key]
+    Guid Id,
+
+    [SetFrom<AccountOpened>(nameof(AccountOpened.Name))]
+    string Name,
+
+    [SetFrom<AccountOpened>(nameof(AccountOpened.Balance))]
+    decimal Balance);
+```
+
+When an `AccountClosed` event occurs, the corresponding `Account` read model is removed from the store.
+
+### With Custom Key
+
+You can specify which property on the event identifies the read model to remove:
+
+```csharp
+[RemovedWith<AccountClosed>(key: nameof(AccountClosed.AccountId))]
+public record Account(
+    [Key]
+    Guid Id,
+
+    [SetFrom<AccountOpened>(nameof(AccountOpened.Name))]
+    string Name);
+```
+
+## Multiple Removal Options
+
+A read model can be removed by multiple different events:
+
+```csharp
+[RemovedWith<AccountClosed>]
+[RemovedWith<AccountMerged>(key: nameof(AccountMerged.SourceAccountId))]
+[RemovedWithJoin<OrganizationClosed>]
+public record Account(
+    [Key]
+    Guid Id,
+
+    [SetFrom<AccountOpened>(nameof(AccountOpened.Name))]
+    string Name);
+```
+
+In this example, an account can be removed by:
+
+- An `AccountClosed` event (direct removal)
+- An `AccountMerged` event when it's the source account
+- An `OrganizationClosed` event through a join relationship
+
+## RemovedWithJoin
+
+Use `RemovedWithJoin` when the removal event comes from a different stream (join relationship):
+
+```csharp
+[RemovedWithJoin<CompanyDissolved>]
+public record Employee(
+    [Key]
+    Guid Id,
+
+    [SetFrom<EmployeeHired>(nameof(EmployeeHired.Name))]
+    string Name,
+
+    [Join<CompanyRegistered>]
+    string CompanyName);
+```
+
+When the company is dissolved, all employees associated with that company are removed.
+
+## Removing Children
+
+Children can be removed in two ways:
+
+### Property-Level Removal
+
+Apply `RemovedWith` on the collection property alongside `ChildrenFrom`:
+
+```csharp
+public record Order(
+    [Key]
+    Guid OrderId,
+
+    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
+    [RemovedWith<LineItemRemoved>(key: nameof(LineItemRemoved.ItemId))]
+    IEnumerable<OrderLine> Lines);
+
+public record OrderLine(
+    [Key] Guid Id,
+    string Description);
+```
+
+### Class-Level Removal on Child Types
+
+Apply `RemovedWith` directly on the child type. This is particularly useful when the same child model is used in multiple parents or when you want to keep removal logic with the child definition:
+
+```csharp
+public record Order(
+    [Key]
+    Guid OrderId,
+
+    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
+    IEnumerable<OrderLine> Lines);
+
+[RemovedWith<LineItemRemoved>(
+    key: nameof(LineItemRemoved.ItemId),
+    parentKey: nameof(LineItemRemoved.OrderId))]
+public record OrderLine(
+    [Key] Guid Id,
+    string Description);
+```
+
+Both approaches produce the same result. The class-level approach keeps the removal definition with the child type, while the property-level approach keeps it with the parent.
+
+### Parameters
+
+For child removal, you can specify:
+
+- **key**: Property on the event that identifies which child to remove
+- **parentKey**: Property on the event that identifies the parent (defaults to EventSourceId)
+
+## Children with RemovedWithJoin
+
+For children that should be removed based on join events:
+
+```csharp
+public record UserProfile(
+    [Key]
+    Guid UserId,
+
+    [ChildrenFrom<UserJoinedGroup>(key: nameof(UserJoinedGroup.GroupId))]
+    [RemovedWithJoin<GroupDeleted>]
+    IEnumerable<GroupMembership> Groups);
+```
+
+Or at the class level:
+
+```csharp
+public record UserProfile(
+    [Key]
+    Guid UserId,
+
+    [ChildrenFrom<UserJoinedGroup>(key: nameof(UserJoinedGroup.GroupId))]
+    IEnumerable<GroupMembership> Groups);
+
+[RemovedWithJoin<GroupDeleted>(key: nameof(GroupDeleted.GroupId))]
+public record GroupMembership(
+    [Key] Guid GroupId,
+    string GroupName);
+```
+
+## Complete Example
+
+Here's a comprehensive example showing both root and child removal:
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+
+// Events
+[EventType]
+public record ShoppingCartCreated(string CustomerName);
+
+[EventType]
+public record ItemAddedToCart(Guid ItemId, string ProductName, decimal Price);
+
+[EventType]
+public record ItemRemovedFromCart(Guid CartId, Guid ItemId);
+
+[EventType]
+public record CartCheckedOut();
+
+[EventType]
+public record CartAbandoned();
+
+// Read Models
+[RemovedWith<CartCheckedOut>]
+[RemovedWith<CartAbandoned>]
+public record ShoppingCart(
+    [Key]
+    Guid Id,
+
+    [SetFrom<ShoppingCartCreated>(nameof(ShoppingCartCreated.CustomerName))]
+    string Customer,
+
+    [ChildrenFrom<ItemAddedToCart>(key: nameof(ItemAddedToCart.ItemId))]
+    IEnumerable<CartItem> Items);
+
+[RemovedWith<ItemRemovedFromCart>(
+    key: nameof(ItemRemovedFromCart.ItemId),
+    parentKey: nameof(ItemRemovedFromCart.CartId))]
+public record CartItem(
+    [Key] Guid Id,
+
+    [SetFrom<ItemAddedToCart>(nameof(ItemAddedToCart.ProductName))]
+    string Product,
+
+    [SetFrom<ItemAddedToCart>(nameof(ItemAddedToCart.Price))]
+    decimal Price);
+```
+
+## Best Practices
+
+1. **Use class-level removal** for root read models to keep the removal logic with the model definition
+2. **Choose property vs class-level removal for children** based on where the logic fits best:
+   - Property-level if the removal is specific to how the child is used in that parent
+   - Class-level if the removal logic applies universally to that child type
+3. **Always specify keys explicitly** when the default EventSourceId doesn't apply
+4. **Use RemovedWithJoin** for removal events from different streams (e.g., when a parent entity in another aggregate is deleted)
+5. **Combine multiple removal attributes** when a model can be removed by different events

--- a/Documentation/projections/model-bound/toc.yml
+++ b/Documentation/projections/model-bound/toc.yml
@@ -10,6 +10,8 @@
   href: counters.md
 - name: Children
   href: children.md
+- name: Removal
+  href: removal.md
 - name: Joins
   href: joins.md
 - name: Event Sequence Source

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/TestEvents.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/TestEvents.cs
@@ -37,5 +37,17 @@ public record ItemsRemovedFromInventory(int Quantity, DateTimeOffset OccurredAt)
 [EventType]
 public record UserRegisteredWithCustomId(Guid UserId, string Email, string Name);
 
+[EventType]
+public record ReadModelRemoved(Guid Id);
+
+[EventType]
+public record ReadModelRemovedJoin(Guid Id);
+
+[EventType]
+public record ChildItemRemoved(Guid ParentId, Guid ItemId);
+
+[EventType]
+public record ChildItemRemovedJoin(Guid ItemId);
+
 #pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore SA1649 // File name should match first type name

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/TestModels.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/TestModels.cs
@@ -127,5 +127,44 @@ public record UserProfile(
 
     string Name);
 
+[RemovedWith<ReadModelRemoved>]
+public record RemovableReadModel(
+    [Key]
+    Guid Id,
+
+    [SetFrom<DebitAccountOpened>(nameof(DebitAccountOpened.Name))]
+    string Name);
+
+[RemovedWith<ReadModelRemoved>]
+[RemovedWithJoin<ReadModelRemovedJoin>]
+public record ReadModelWithMultipleRemovalOptions(
+    [Key]
+    Guid Id,
+
+    [SetFrom<DebitAccountOpened>(nameof(DebitAccountOpened.Name))]
+    string Name);
+
+[RemovedWith<ReadModelRemoved>(key: nameof(ReadModelRemoved.Id))]
+public record RemovableReadModelWithKey(
+    [Key]
+    Guid Id,
+
+    [SetFrom<DebitAccountOpened>(nameof(DebitAccountOpened.Name))]
+    string Name);
+
+[RemovedWith<ChildItemRemoved>(key: nameof(ChildItemRemoved.ItemId), parentKey: nameof(ChildItemRemoved.ParentId))]
+public record RemovableChildItem(
+    [Key]
+    Guid Id,
+
+    string Name);
+
+public record ParentWithRemovableChildren(
+    [Key]
+    Guid Id,
+
+    [ChildrenFrom<ItemAddedToCart>(key: nameof(ItemAddedToCart.ItemId), identifiedBy: nameof(RemovableChildItem.Id))]
+    IEnumerable<RemovableChildItem> Items);
+
 #pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore SA1649 // File name should match first type name

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/given/a_model_bound_projection_builder.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/given/a_model_bound_projection_builder.cs
@@ -19,7 +19,11 @@ public class a_model_bound_projection_builder : Specification
             typeof(DebitAccountOpened),
             typeof(DepositToDebitAccountPerformed),
             typeof(WithdrawalFromDebitAccountPerformed),
-            typeof(ItemAddedToCart)
+            typeof(ItemAddedToCart),
+            typeof(ReadModelRemoved),
+            typeof(ReadModelRemovedJoin),
+            typeof(ChildItemRemoved),
+            typeof(ChildItemRemovedJoin)
         ]);
 
         builder = new ModelBoundProjectionBuilder(naming_policy, event_types);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_children_having_class_level_removed_with.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_children_having_class_level_removed_with.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building;
+
+public class with_children_having_class_level_removed_with : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Because() => _result = builder.Build(typeof(ParentWithRemovableChildren));
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_one_child_definition() => _result.Children.Count.ShouldEqual(1);
+    [Fact] void should_have_child_with_correct_name() => _result.Children.ContainsKey(nameof(ParentWithRemovableChildren.Items)).ShouldBeTrue();
+    [Fact] void should_have_removed_with_on_children() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Count.ShouldEqual(1);
+    [Fact] void should_have_removed_with_for_correct_event_type() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ChildItemRemoved)).Id.ToString());
+    [Fact] void should_use_specified_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().Key.ShouldEqual(nameof(ChildItemRemoved.ItemId));
+    [Fact] void should_use_specified_parent_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().ParentKey.ShouldEqual(nameof(ChildItemRemoved.ParentId));
+}

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building;
+
+public class with_class_level_removed_with : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Because() => _result = builder.Build(typeof(RemovableReadModel));
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_one_removed_with_entry() => _result.RemovedWith.Count.ShouldEqual(1);
+    [Fact] void should_have_removed_with_for_correct_event_type() => _result.RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ReadModelRemoved)).Id.ToString());
+    [Fact] void should_use_default_key_expression() => _result.RemovedWith.Values.First().Key.ShouldEqual(WellKnownExpressions.EventSourceId);
+}

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_and_removed_with_join.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_and_removed_with_join.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building;
+
+public class with_class_level_removed_with_and_removed_with_join : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Because() => _result = builder.Build(typeof(ReadModelWithMultipleRemovalOptions));
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_one_removed_with_entry() => _result.RemovedWith.Count.ShouldEqual(1);
+    [Fact] void should_have_one_removed_with_join_entry() => _result.RemovedWithJoin.Count.ShouldEqual(1);
+    [Fact] void should_have_removed_with_for_correct_event_type() => _result.RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ReadModelRemoved)).Id.ToString());
+    [Fact] void should_have_removed_with_join_for_correct_event_type() => _result.RemovedWithJoin.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ReadModelRemovedJoin)).Id.ToString());
+}

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_with_custom_key.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_with_custom_key.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building;
+
+public class with_class_level_removed_with_with_custom_key : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Because() => _result = builder.Build(typeof(RemovableReadModelWithKey));
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_one_removed_with_entry() => _result.RemovedWith.Count.ShouldEqual(1);
+    [Fact] void should_have_removed_with_for_correct_event_type() => _result.RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ReadModelRemoved)).Id.ToString());
+    [Fact] void should_use_specified_key_expression() => _result.RemovedWith.Values.First().Key.ShouldEqual(nameof(ReadModelRemoved.Id));
+}

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -156,11 +156,30 @@ static class ChildrenDefinitionExtensions
                 }
             }
 
+            // Process class-level RemovedWith attributes on the child type
+            ProcessChildTypeLevelRemovedWith(childType, getOrCreateEventType, childrenDef);
+
             // Process properties for attributes (this handles SetFromContext and other attributes on properties)
             foreach (var childProperty in childType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
                 processMember(childProperty, definition, [], false, null, childrenDef);
             }
+        }
+    }
+
+    static void ProcessChildTypeLevelRemovedWith(
+        Type childType,
+        Func<Type, EventType> getOrCreateEventType,
+        ChildrenDefinition childrenDef)
+    {
+        foreach (var (attr, eventType) in childType.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
+        {
+            childrenDef.RemovedWith.ProcessRemovedWithAttribute(getOrCreateEventType, attr, eventType);
+        }
+
+        foreach (var (attr, eventType) in childType.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
+        {
+            childrenDef.RemovedWithJoin.ProcessRemovedWithJoinAttribute(getOrCreateEventType, attr, eventType);
         }
     }
 

--- a/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
@@ -72,6 +72,7 @@ internal class ModelBoundProjectionBuilder(
                           attr.GetType().GetGenericTypeDefinition() == typeof(FromEventAttribute<>))
             .ToList();
 
+        ProcessClassLevelRemovedWith(modelType, definition);
         var primaryConstructor = ProcessRecord(modelType, definition, classLevelFromEvents);
         ProcessProperties(modelType, definition, classLevelFromEvents, primaryConstructor);
         BuildFromEveryDefinition(definition);
@@ -130,6 +131,19 @@ internal class ModelBoundProjectionBuilder(
             Properties = properties,
             IncludeChildren = true
         };
+    }
+
+    void ProcessClassLevelRemovedWith(Type modelType, ProjectionDefinition definition)
+    {
+        foreach (var (attr, eventType) in modelType.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
+        {
+            definition.RemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, attr, eventType);
+        }
+
+        foreach (var (attr, eventType) in modelType.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
+        {
+            definition.RemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, attr, eventType);
+        }
     }
 
     void ProcessProperties(Type modelType, ProjectionDefinition definition, List<Attribute> classLevelFromEvents, ConstructorInfo? primaryConstructor)

--- a/Source/Clients/DotNET/Projections/ModelBound/RemovedWithAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/RemovedWithAttribute.cs
@@ -4,24 +4,26 @@
 namespace Cratis.Chronicle.Projections.ModelBound;
 
 /// <summary>
-/// Attribute used to indicate what event removes a child from a collection.
+/// Attribute used to indicate what event removes a read model or a child from a collection.
+/// When used on a class, it indicates the event that removes the read model instance.
+/// When used on a property or parameter, it indicates the event that removes a child from a collection.
 /// </summary>
 /// <typeparam name="TEvent">The type of event that removes the child.</typeparam>
-/// <param name="key">Optional property name on the event that identifies the child to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
-/// <param name="parentKey">Optional property name that identifies the parent. Defaults to WellKnownExpressions.EventSourceId.</param>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
+/// <param name="key">Optional property name on the event that identifies the instance to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
+/// <param name="parentKey">Optional property name that identifies the parent (only used for children). Defaults to WellKnownExpressions.EventSourceId.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class RemovedWithAttribute<TEvent>(string? key = default, string? parentKey = default) : Attribute, IProjectionAnnotation, IRemovedWithAttribute
 {
     /// <inheritdoc/>
     public Type EventType => typeof(TEvent);
 
     /// <summary>
-    /// Gets the property name on the event that identifies the child to remove.
+    /// Gets the property name on the event that identifies the instance to remove.
     /// </summary>
     public string Key { get; } = key ?? WellKnownExpressions.EventSourceId;
 
     /// <summary>
-    /// Gets the property name that identifies the parent.
+    /// Gets the property name that identifies the parent (only used for children).
     /// </summary>
     public string ParentKey { get; } = parentKey ?? WellKnownExpressions.EventSourceId;
 }

--- a/Source/Clients/DotNET/Projections/ModelBound/RemovedWithJoinAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/RemovedWithJoinAttribute.cs
@@ -4,18 +4,20 @@
 namespace Cratis.Chronicle.Projections.ModelBound;
 
 /// <summary>
-/// Attribute used to indicate what event removes a child from a collection through a join.
+/// Attribute used to indicate what event removes a read model or a child from a collection through a join.
+/// When used on a class, it indicates the event that removes the read model instance through a join.
+/// When used on a property or parameter, it indicates the event that removes a child from a collection through a join.
 /// </summary>
 /// <typeparam name="TEvent">The type of event that removes the child.</typeparam>
-/// <param name="key">Optional property name on the event that identifies the child to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
+/// <param name="key">Optional property name on the event that identifies the instance to remove. Defaults to WellKnownExpressions.EventSourceId.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class RemovedWithJoinAttribute<TEvent>(string? key = default) : Attribute, IProjectionAnnotation, IRemovedWithJoinAttribute
 {
     /// <inheritdoc/>
     public Type EventType => typeof(TEvent);
 
     /// <summary>
-    /// Gets the property name on the event that identifies the child to remove.
+    /// Gets the property name on the event that identifies the instance to remove.
     /// </summary>
     public string Key { get; } = key ?? WellKnownExpressions.EventSourceId;
 }


### PR DESCRIPTION
### Fixed

- Removal using `RemovedWith` was missing support for class/record level, which was the original intent. This is now fixed.
