### PR TITLE
Upgrading 3rd parties

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,29 +9,29 @@
     <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.1" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.2.4" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.2.4" />
-    <PackageVersion Include="Cratis.Arc" Version="18.1.3" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="18.1.3" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="18.1.3" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="18.1.3" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.2.6" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.2.6" />
+    <PackageVersion Include="Cratis.Arc" Version="18.3.0" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="18.3.0" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="18.3.0" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="18.3.0" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.1.0" />
     <!-- Orleans -->
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="9.2.1" />
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.2.1" />


### PR DESCRIPTION
### Fixed

- Upgrading Cratis Arc with support for `TimeSpan` serializer for MongoDB.
