### PR TITLE
Fixing dependency to be towards Arc.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Cratis.Fundamentals" Version="7.2.6" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.2.6" />
     <PackageVersion Include="Cratis.Arc" Version="18.3.0" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="18.3.0" />
     <PackageVersion Include="Cratis.Arc.MongoDB" Version="18.3.0" />
     <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="18.3.0" />
     <PackageVersion Include="Cratis.Arc.Swagger" Version="18.3.0" />

--- a/Source/Clients/ApplicationModel/ApplicationModel.csproj
+++ b/Source/Clients/ApplicationModel/ApplicationModel.csproj
@@ -6,14 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="../AspNetCore/AspNetCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cratis.Arc" />
+        <PackageReference Include="Cratis.Arc.Core" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Fixed

- Fixing dependency from AppModel package to be towards Arc.Core instead of Arc.
