### PR TITLE
Making gRPC message size configurable and defaulting to 100MB

### DIFF
--- a/Documentation/clients/aspnetcore/index.md
+++ b/Documentation/clients/aspnetcore/index.md
@@ -36,7 +36,9 @@ You can configure Chronicle using your `appsettings.json` file. The configuratio
     "SoftwareCommit": "abc123",
     "ProgramIdentifier": "my-service",
     "AutoDiscoverAndRegister": true,
-    "ConnectTimeout": 5
+    "ConnectTimeout": 5,
+    "MaxReceiveMessageSize": 104857600,
+    "MaxSendMessageSize": 104857600
   }
 }
 ```
@@ -68,6 +70,10 @@ Chronicle__ProgramIdentifier=my-service
 # Connection settings
 Chronicle__ConnectTimeout=10
 Chronicle__AutoDiscoverAndRegister=true
+
+# gRPC message size limits (in bytes, defaults to 100 MB)
+Chronicle__MaxReceiveMessageSize=104857600
+Chronicle__MaxSendMessageSize=104857600
 ```
 
 Environment variables take precedence over `appsettings.json`, making them ideal for environment-specific configuration.

--- a/Documentation/recipes/configuration/grpc-message-size.md
+++ b/Documentation/recipes/configuration/grpc-message-size.md
@@ -1,0 +1,74 @@
+# gRPC Message Size Configuration
+
+When working with large event batches or queries that return many events, you may encounter gRPC message size limits. Chronicle provides configuration options to adjust the maximum send and receive message sizes.
+
+## Default Settings
+
+By default, Chronicle sets both `MaxReceiveMessageSize` and `MaxSendMessageSize` to **100 MB** (104,857,600 bytes). This is significantly higher than the default gRPC limit of 4 MB, making it suitable for most scenarios involving large event collections.
+
+## Configuring Message Sizes
+
+You can configure the message sizes when creating a `ChronicleClient` or through options:
+
+```csharp
+var options = new ChronicleOptions
+{
+    Url = new ChronicleUrl("chronicle://localhost:35000"),
+    MaxReceiveMessageSize = 200 * 1024 * 1024, // 200 MB
+    MaxSendMessageSize = 200 * 1024 * 1024      // 200 MB
+};
+
+var client = new ChronicleClient(options);
+```
+
+## Configuration via appsettings.json
+
+For ASP.NET Core applications, you can configure message sizes in your `appsettings.json`:
+
+```json
+{
+  "Chronicle": {
+    "Url": "chronicle://localhost:35000",
+    "MaxReceiveMessageSize": 209715200,
+    "MaxSendMessageSize": 209715200
+  }
+}
+```
+
+## Configuration via Environment Variables
+
+Message sizes can also be set using environment variables:
+
+```bash
+Chronicle__MaxReceiveMessageSize=209715200
+Chronicle__MaxSendMessageSize=209715200
+```
+
+## Understanding the Error
+
+If you encounter an error like:
+
+```
+Status(StatusCode="ResourceExhausted", Detail="Received message exceeds the maximum configured message size.")
+```
+
+This indicates that the response from the server exceeds the `MaxReceiveMessageSize`. You should increase this value to accommodate larger responses.
+
+## Recommendations
+
+- **Default (100 MB)**: Suitable for most applications with moderate event batch sizes
+- **200+ MB**: Consider for applications that frequently query large event ranges or work with many events
+- **Performance Considerations**: Larger message sizes consume more memory. Balance your needs with available resources
+- **Server Configuration**: Ensure the Chronicle Kernel server is also configured to handle the message sizes you need
+
+## Null Values
+
+Setting either property to `null` will use the gRPC default (4 MB), which is generally **not recommended** for Chronicle applications:
+
+```csharp
+var options = new ChronicleOptions
+{
+    MaxReceiveMessageSize = null, // Uses gRPC default of 4 MB - not recommended
+    MaxSendMessageSize = null     // Uses gRPC default of 4 MB - not recommended
+};
+```

--- a/Documentation/recipes/configuration/index.md
+++ b/Documentation/recipes/configuration/index.md
@@ -5,3 +5,4 @@ This section contains recipes for configuring Chronicle in various scenarios and
 ## Topics
 
 - [Camel Casing](camel-casing.md) - Configure camel case naming policy for JSON serialization
+- [gRPC Message Size](grpc-message-size.md) - Configure maximum message sizes for large event collections

--- a/Source/Clients/Connections/ChronicleConnection.cs
+++ b/Source/Clients/Connections/ChronicleConnection.cs
@@ -35,6 +35,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
 {
     readonly ChronicleUrl _url;
     readonly int _connectTimeout;
+    readonly int? _maxReceiveMessageSize;
+    readonly int? _maxSendMessageSize;
     readonly ITaskFactory _tasks;
     readonly ICorrelationIdAccessor _correlationIdAccessor;
     readonly CancellationToken _cancellationToken;
@@ -51,6 +53,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     /// </summary>
     /// <param name="url"><see cref="ChronicleUrl"/> to connect with.</param>
     /// <param name="connectTimeout">Timeout when connecting in seconds.</param>
+    /// <param name="maxReceiveMessageSize">Maximum receive message size in bytes.</param>
+    /// <param name="maxSendMessageSize">Maximum send message size in bytes.</param>
     /// <param name="connectionLifecycle"><see cref="IConnectionLifecycle"/> for when connection state changes.</param>
     /// <param name="tasks"><see cref="ITaskFactory"/> to create tasks with.</param>
     /// <param name="correlationIdAccessor"><see cref="ICorrelationIdAccessor"/> to access the correlation ID.</param>
@@ -60,6 +64,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     public ChronicleConnection(
         ChronicleUrl url,
         int connectTimeout,
+        int? maxReceiveMessageSize,
+        int? maxSendMessageSize,
         IConnectionLifecycle connectionLifecycle,
         ITaskFactory tasks,
         ICorrelationIdAccessor correlationIdAccessor,
@@ -69,6 +75,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
         GrpcClientFactory.AllowUnencryptedHttp2 = true;
         _url = url;
         _connectTimeout = connectTimeout;
+        _maxReceiveMessageSize = maxReceiveMessageSize;
+        _maxSendMessageSize = maxSendMessageSize;
         Lifecycle = connectionLifecycle;
         _tasks = tasks;
         _correlationIdAccessor = correlationIdAccessor;
@@ -191,6 +199,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
             new GrpcChannelOptions
             {
                 HttpHandler = httpHandler,
+                MaxReceiveMessageSize = _maxReceiveMessageSize,
+                MaxSendMessageSize = _maxSendMessageSize,
                 ServiceConfig = new ServiceConfig
                 {
                     MethodConfigs =

--- a/Source/Clients/Connections/ServiceCollectionExtensions.cs
+++ b/Source/Clients/Connections/ServiceCollectionExtensions.cs
@@ -42,6 +42,8 @@ public static class ServiceCollectionExtensions
             return new ChronicleConnection(
                 url,
                 5,
+                null,
+                null,
                 connectionLifecycle,
                 new Cratis.Tasks.TaskFactory(),
                 correlationIdAccessor,

--- a/Source/Clients/DotNET/ChronicleClient.cs
+++ b/Source/Clients/DotNET/ChronicleClient.cs
@@ -66,6 +66,8 @@ public class ChronicleClient : IChronicleClient, IDisposable
         _connection = new ChronicleConnection(
             options.Url,
             options.ConnectTimeout,
+            options.MaxReceiveMessageSize,
+            options.MaxSendMessageSize,
             connectionLifecycle,
             new Tasks.TaskFactory(),
             options.CorrelationIdAccessor,

--- a/Source/Clients/DotNET/ChronicleOptions.cs
+++ b/Source/Clients/DotNET/ChronicleOptions.cs
@@ -118,6 +118,16 @@ public class ChronicleOptions(
     public int ConnectTimeout { get; set; } = connectTimeout;
 
     /// <summary>
+    /// Gets or sets the maximum receive message size in bytes for gRPC messages. Defaults to 100 MB.
+    /// </summary>
+    public int? MaxReceiveMessageSize { get; set; } = 100 * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum send message size in bytes for gRPC messages. Defaults to 100 MB.
+    /// </summary>
+    public int? MaxSendMessageSize { get; set; } = 100 * 1024 * 1024;
+
+    /// <summary>
     /// Gets the <see cref="ILoggerFactory"/> to use internally in the client.
     /// </summary>
     public ILoggerFactory LoggerFactory { get; set; } = loggerFactory ?? new LoggerFactory();


### PR DESCRIPTION
### Fixed

- Exposing configurable gRPC messages sizes in the .NET Client and also defaulting it to 100MB, a little bit more than the default of 4MB :) 
