### PR TITLE
Marking Infrastructure project reference as private - it shouldn't be a NuGet package dependency

### DIFF
--- a/Source/Clients/Api/Api.csproj
+++ b/Source/Clients/Api/Api.csproj
@@ -22,7 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../../Infrastructure/Infrastructure.csproj" />
+        <ProjectReference Include="../../Infrastructure/Infrastructure.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
         <ProjectReference Include="../../Tools/ResourceEmbedder/ResourceEmbedder.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>

--- a/Source/Clients/Testing/Testing.csproj
+++ b/Source/Clients/Testing/Testing.csproj
@@ -8,7 +8,9 @@
     <ItemGroup>
         <ProjectReference Include="../DotNET/DotNET.csproj"/>
         <ProjectReference Include="../Connections/Connections.csproj" />
-        <ProjectReference Include="../../Infrastructure/Infrastructure.csproj" />
+        <ProjectReference Include="../../Infrastructure/Infrastructure.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
         <ProjectReference Include="../../Kernel/Contracts/Contracts.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>


### PR DESCRIPTION
### Fixed

- Fixing Client projects (Api, Testing) to have private project reference to internal project called Infrastructure, resulting in the assemblies being private and not relying on a public package.
