### PR TITLE
Add missing ProjectReference for Kernel Storage in XUnit Integration project

### DIFF
--- a/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
+++ b/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
@@ -24,6 +24,9 @@
             <Aliases>KernelCore</Aliases>
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
+        <ProjectReference Include="../../Kernel/Storage/Storage.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
         <ProjectReference Include="../../Kernel/Storage.MongoDB/Storage.MongoDB.csproj">
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>


### PR DESCRIPTION
## Summary

Adds a missing ProjectReference for the Kernel Storage project in the XUnit Integration project.

### Fixed

- Added ProjectReference for Kernel Storage.
