### PR TITLE
Refactor AddCratisChronicleClient to accept optional IClientArtifactsProvider

### DIFF
--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_custom_type.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_custom_type.cs
@@ -24,7 +24,7 @@ public class when_adding_chronicle_client_with_custom_type : Specification
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _resolver = _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>();
     }

--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_default_configuration.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_default_configuration.cs
@@ -21,7 +21,7 @@ public class when_adding_chronicle_client_with_default_configuration : Specifica
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _resolver = _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>();
     }

--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_default_instance.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_default_instance.cs
@@ -25,7 +25,7 @@ public class when_adding_chronicle_client_with_default_instance : Specification
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _resolver = _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>();
     }

--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_instance.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_instance.cs
@@ -26,7 +26,7 @@ public class when_adding_chronicle_client_with_instance : Specification
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _resolver = _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>();
     }

--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_invalid_type.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_invalid_type.cs
@@ -24,7 +24,7 @@ public class when_adding_chronicle_client_with_invalid_type : Specification
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _exception = Catch.Exception(() => _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>());
     }

--- a/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_null_type.cs
+++ b/Source/Clients/AspNetCore.Specs/for_ChronicleClientServiceCollectionExtensions/when_adding_chronicle_client_with_null_type.cs
@@ -24,7 +24,7 @@ public class when_adding_chronicle_client_with_null_type : Specification
 
     void Because()
     {
-        _services.AddCratisChronicleClient();
+        _services.AddCratisChronicleClient(DefaultClientArtifactsProvider.Default);
         _serviceProvider = _services.BuildServiceProvider();
         _exception = Catch.Exception(() => _serviceProvider.GetRequiredService<IEventStoreNamespaceResolver>());
     }

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -29,9 +29,12 @@ public static class ChronicleClientServiceCollectionExtensions
     /// Add the <see cref="IChronicleClient"/> to the services.
     /// </summary>
     /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="artifactsProvider">Optional <see cref="IClientArtifactsProvider"/> instance to register.
+    /// When not provided, falls back to <see cref="DefaultClientArtifactsProvider.Default"/>.</param>
     /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
-    public static IServiceCollection AddCratisChronicleClient(this IServiceCollection services)
+    public static IServiceCollection AddCratisChronicleClient(this IServiceCollection services, IClientArtifactsProvider? artifactsProvider = null)
     {
+        artifactsProvider ??= DefaultClientArtifactsProvider.Default;
         services.AddHttpContextAccessor();
         services.AddSingleton(sp =>
         {
@@ -102,7 +105,7 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Projections);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().ReadModels);
 
-        services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.ArtifactsProvider);
+        services.AddSingleton(artifactsProvider);
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.NamingPolicy);
         services.AddSingleton(sp => sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value.CorrelationIdAccessor);
 

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
@@ -57,7 +57,7 @@ public static class ChronicleClientWebApplicationBuilderExtensions
             .AddUnitOfWork()
             .AddCompliance()
             .AddCausation()
-            .AddCratisChronicleClient();
+            .AddCratisChronicleClient(artifactsProvider);
 
         var chronicleBuilder = new ChronicleBuilder(builder.Services, builder.Configuration, artifactsProvider);
         configure?.Invoke(chronicleBuilder);


### PR DESCRIPTION
## Summary

Enhance the `AddCratisChronicleClient` method to accept an optional `IClientArtifactsProvider` parameter, allowing for more flexible client configuration.

### Changed

- Updated `AddCratisChronicleClient` to accept an optional `IClientArtifactsProvider`, defaulting to `DefaultClientArtifactsProvider.Default` if not provided.

