### PR TITLE
Sync Copilot Instructions from Cratis/Templates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,40 @@ When these instructions don't explicitly cover a situation, apply these values t
 - Always reuse the active terminal for commands.
 - Do not create new terminals unless current one is busy or fails.
 
+## Formatting
+
+- Honor the existing code style and conventions in the project.
+- Apply code-formatting style defined in .editorconfig.
+- Prefer file-scoped namespace declarations and single-line using directives.
+- Insert a new line before the opening curly brace of any code block (e.g., after `if`, `for`, `while`, `foreach`, `using`, `try`, etc.).
+- Ensure that the final return statement of a method is on its own line.
+- Use pattern matching and switch expressions wherever possible.
+- Use `nameof` instead of string literals when referring to member names.
+- Place private class declarations at the bottom of the file.
+
+## C# Instructions
+
+- Prefer `var` over explicit types when declaring variables.
+- Do not add unnecessary comments or documentation.
+- Use `using` directives for namespaces at the top of the file.
+- Sort the `using` directives alphabetically.
+- Use namespaces that match the folder structure.
+- Remove unused `using` directives.
+- Use file-scoped namespace declarations.
+- Use single-line using directives.
+- For types that do not have an implementation, don't add a body (e.g., `public interface IMyInterface;`).
+- Prefer using `record` types for immutable data structures (events, commands, read models, concepts).
+- Use expression-bodied members for simple methods and properties.
+- Use `async` and `await` for asynchronous programming.
+- Use `Task` and `Task<T>` for asynchronous methods.
+- Use `IEnumerable<T>` for collections that are not modified.
+- Never return mutable collections from public APIs.
+- Don't use regions in the code.
+- Never add postfixes like Async, Impl, etc. to class or method names.
+- Favor collection initializers and object initializers.
+- Use string interpolation instead of string.Format or concatenation.
+- Favor primary constructors for all types.
+
 ## Chronicle & Arc Key Conventions
 
 These conventions exist because the frameworks rely on convention-based discovery. Breaking them doesn't just violate style — it breaks runtime behavior.
@@ -59,6 +93,20 @@ Commands and Queries generate TypeScript proxies at build time via `dotnet build
 
 **When running parallel agents or sub-agents:** backend and frontend work for the same slice **cannot** run in parallel. The backend agent must finish and `dotnet build` must succeed before the frontend agent starts. Independent slices (no shared events) can have their backends worked on in parallel, but each slice's frontend still depends on its own backend build completing first.
 
+## TypeScript / Frontend Instructions
+
+- Prefer `const` over `let` over `var` when declaring variables.
+- Never use shortened or abbreviated names for variables, parameters, or properties.
+  - Use full descriptive names: `deltaX` not `dx`, `index` not `idx`, `event` not `e`, `previous` not `prev`, `direction` not `dir`, `position` not `pos`, `contextMenu` not `ctx`/`ctxMenu`.
+  - The only acceptable short names are well-established domain terms (e.g. `id`, `url`, `min`, `max`).
+- Never leave unused import statements in the code.
+- Always ensure that the code compiles without warnings.
+  - Use `yarn compile` to verify (if successful it doesn't output anything).
+- Do not prefix a file, component, type, or symbol with the name of its containing folder or the concept it belongs to. Instead, use folder structure to provide that context.
+- Favor functional folder structure over technical folder structure.
+  - Group files by the feature or concept they belong to, not by their technical role.
+  - Avoid folders like `components/`, `hooks/`, `utils/`, `types/` at the feature level.
+
 ## Development Workflow
 
 - After creating each new file, run `dotnet build` (C#) or `yarn compile` (TypeScript) immediately before proceeding to the next file. Fix all errors as they appear — never accumulate technical debt.
@@ -68,9 +116,95 @@ Commands and Queries generate TypeScript proxies at build time via `dotnet build
 - Review each file for lint compliance before moving on.
 - The user may keep Storybook running — do not try to stop it, suggest stopping it, or start your own instance.
 
+## XML Documentation
+
+- All **public** types, methods, properties, and operators **must** have XML doc comments.
+- Always use **multiline** `<summary>` tags — opening and closing tags on their own lines. Never single-line.
+- Every method or operator with parameters must include `<param name="...">` for each parameter.
+- Every non-void method or operator must include `<returns>`.
+- Every method that throws must document the exception with `<exception cref="...">` tags.
+- Use `<see cref="..."/>` and `<paramref name="..."/>` to cross-reference types and parameters.
+
+## Exceptions
+
+- Use exceptions for exceptional situations only.
+- Don't use exceptions for control flow.
+- Always provide a meaningful message when throwing an exception.
+- Always create a custom exception type that derives from Exception.
+- Never use any built-in exception types like InvalidOperationException, ArgumentException, etc.
+- Add XML documentation for exceptions being thrown.
+- XML documentation for exception should start with "The exception that is thrown when ...".
+- Never suffix exception class names with "Exception".
+
+## Nullable Reference Types
+
+- Always use is null or is not null instead of == null or != null.
+- Trust the C# null annotations and don't add null checks when the type system says a value cannot be null.
+- Add `!` operator where nullability warnings occur.
+- Use `is not null` checks before dereferencing potentially null values.
+
+## Naming Conventions
+
+- Follow PascalCase for component names, method names, and public members.
+- Use camelCase for private fields and local variables.
+- Prefix private fields with an underscore (e.g., `_privateField`).
+- Prefix interface names with "I" (e.g., IUserService).
+
+## Logging
+
+- Use structured logging with named parameters.
+- Use appropriate log levels (Information, Warning, Error, Debug).
+- Always use a generic ILogger<T> where T is the class name.
+- Keep logging in separate partial methods for better readability. Call the file `<SystemName>Logging.cs`. Make this class partial and static and internal and all methods should be internal.
+- Use the `[LoggerMessage]` attribute to define log messages.
+- Don't include `eventId` in the `[LoggerMessage]` attribute.
+
+## Dependency Injection
+
+- Systems that have a convention of IFoo to Foo does not need to be registered explicitly.
+- Prefer constructor injection over method injection.
+- Avoid service locator pattern (i.e., avoid using IServiceProvider directly).
+- For implementations that should be singletons, use the `[Singleton]` attribute on the class.
+
 ## TypeScript Type Safety
 
-- Never use `any` — use `unknown`, `Record<string, unknown>`, or proper generic constraints instead. See [TypeScript Conventions](./instructions/typescript.instructions.md) for detailed patterns.
+- Never use `any` type - always use proper type annotations:
+  - Use `unknown` for values of unknown type that need runtime checking.
+  - Use `Record<string, unknown>` for objects with unknown properties.
+  - Use proper generic constraints like `<TCommand extends object = object>` instead of `= any`.
+  - Use `React.ComponentType<Props>` for React component types.
+- When type assertions are necessary, use `unknown` as an intermediate type:
+  - Prefer `value as unknown as TargetType` over `value as any`.
+  - For objects with dynamic properties: `(obj as unknown as { prop: Type }).prop`.
+- For generic React components:
+  - Use `unknown` as default generic parameter instead of `any`.
+  - Example: `<TCommand = unknown>` not `<TCommand = any>`.
+- For Storybook files:
+  - Use `React.ComponentType<Record<string, never>>` for components with no props.
+  - Always use `as unknown as` when converting component imports to avoid type mismatch errors.
+  - Properly type story args instead of using `any`.
+- For event handlers:
+  - Be careful with React.MouseEvent vs DOM MouseEvent - they are different types.
+  - React synthetic events: `React.MouseEvent<Element, MouseEvent>`.
+  - DOM native events: `MouseEvent`.
+  - Convert between them using: `nativeEvent as unknown as React.MouseEvent`.
+  - Use `e.preventDefault?.()` instead of `(e as any).preventDefault?.()`.
+- For library objects (PIXI, etc.):
+  - Use proper library types when available.
+  - Use specific property types: `{ canvas?: HTMLCanvasElement }` instead of `any`.
+- When working with external libraries that have strict generic constraints:
+  - Import necessary types (e.g., `Command` from `@cratis/arc/commands`).
+  - Use type assertions through `unknown` to satisfy constraints: `props.command as unknown as Constructor<Command<...>>`.
+  - Extract tuple results explicitly rather than destructuring when type assertions are needed.
+- For function parameter types that may be unknown:
+  - Add type guards: `if (typeof accessor !== 'function') return ''`.
+  - Type parameters with fallbacks: `function<T = unknown>(accessor: ((obj: T) => unknown) | unknown)`.
+- For arrays and collections accessed from `unknown` types:
+  - Cast to proper array type: `((obj as Record<string, unknown>).items || []) as string[]`.
+  - Type array elements when iterating: `array.forEach((item: string) => ...)`.
+- For generic type parameters:
+  - Ensure proper type conversions: `String(value)` when string operations are needed.
+  - Use explicit Date parameter types: `new Date(value as string | number | Date)`.
 
 ## Detailed Guides
 
@@ -90,3 +224,12 @@ These guides contain the full rules, examples, and rationale for each topic. The
    - [Dialogs](./instructions/dialogs.instructions.md)
    - [Reactors](./instructions/reactors.instructions.md)
    - [Orleans](./instructions/orleans.instructions.md)
+
+## Header
+
+All files should start with the following header:
+
+```csharp
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+```

--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -131,21 +131,6 @@ The framework discovers and wires dependencies by convention. Explicit registrat
 - Use `async`/`await` for asynchronous programming.
 - Use `Task` and `Task<T>` for asynchronous methods.
 
-## File Header
-
-Every C# file must start with:
-
-```csharp
-// Copyright (c) Cratis. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-```
-
-## Generated Files
-
-**Never edit generated files.** Files produced by code generators, scaffolding tools, or any other automated tool must not be modified by hand — in any language. Generated files are overwritten on the next build, so hand-edits are silently lost and create false confidence that a fix is in place.
-
-- If the generated output is wrong, fix the **source** (the template, the generator configuration, or the source type) and rebuild.
-
 ## Chronicle & Arc — Key API Types
 
 These are the building blocks. Each type has a specific role in the vertical slice architecture — using the right type in the right place means the framework handles discovery, wiring, and proxy generation automatically.

--- a/.github/instructions/efcore.instructions.md
+++ b/.github/instructions/efcore.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "**/*Context*.cs, **/Database/**/*.cs, **/Migrations/**/*.cs"
+applyTo: "**/*.cs"
 ---
 
 # Entity Framework Core Instructions

--- a/.github/instructions/pull-requests.instructions.md
+++ b/.github/instructions/pull-requests.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: ".github/**"
+applyTo: "**/*"
 ---
 
 # How to Do Pull Requests

--- a/.github/instructions/specs.csharp.instructions.md
+++ b/.github/instructions/specs.csharp.instructions.md
@@ -239,4 +239,11 @@ public class and_name_already_exists(context context) : Given<context>(context)
 
 - Don't break long `should_` method lines — prefer one-line lambda assertions.
 - Don't add blank lines between multiple `should_` methods.
+
+## Entity Framework Core Specs
+
+- Use SQLite in-memory database for specs involving `DbContext`.
+- `SaveChanges` / `SaveChangesAsync` are virtual and can be mocked with NSubstitute.
+- `DbSet` methods are virtual — mock as needed.
+- Pass options when substituting: `Substitute.For<YourDbContext>(options)`.
 - Simulate failures by mocking `SaveChanges` to throw exceptions.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,26 +1,10 @@
 ---
-applyTo: "**/*.ts, **/*.tsx"
+applyTo: "**/*.ts,**/*.tsx"
 ---
 
 # TypeScript Conventions
 
 TypeScript's type system is the primary tool for catching bugs before they reach production. Every rule here pushes toward maximum compiler coverage and self-documenting code. If the types are right, the code almost writes itself.
-
-## Variables and Naming
-
-- Prefer `const` over `let` over `var`.
-- Never use shortened or abbreviated names for variables, parameters, or properties.
-  - Use full descriptive names: `deltaX` not `dx`, `index` not `idx`, `event` not `e`, `previous` not `prev`, `direction` not `dir`, `position` not `pos`, `contextMenu` not `ctx`/`ctxMenu`.
-  - The only acceptable short names are well-established domain terms (e.g. `id`, `url`, `min`, `max`).
-- Never leave unused import statements in the code.
-- Always ensure the code compiles without warnings — run `yarn compile` to verify (no output means success).
-
-## Folder Structure and Naming
-
-- Do not prefix a file, component, type, or symbol with the name of its containing folder or concept — use folder structure to provide that context instead.
-- Favor functional folder structure over technical folder structure.
-  - Group files by the feature or concept they belong to, not by their technical role.
-  - Avoid folders like `components/`, `hooks/`, `utils/`, `types/` at the feature level.
 
 ## Enums over Magic Strings
 
@@ -57,37 +41,9 @@ Each type gets its own file because it makes the codebase navigable — finding 
 `any` disables the compiler — the one tool that catches bugs for free. Every `any` is a hole in the safety net. Use `unknown` and narrow with type guards instead.
 
 - Never use `any` — use `unknown`, `Record<string, unknown>`, or proper generic constraints.
-- Use proper generic constraints: `<TCommand extends object = object>` not `= any`.
-- Use `unknown` as the default generic parameter: `<T = unknown>` not `<T = any>`.
 - Prefer `value as unknown as TargetType` over `value as any`.
-- For objects with dynamic properties: `(obj as unknown as { prop: Type }).prop`.
-
-### Event Handlers
-
+- Use `unknown` as default generic parameter instead of `any`.
 - React synthetic events (`React.MouseEvent<Element, MouseEvent>`) and DOM events (`MouseEvent`) are different types — don't mix them.
-- Convert between them: `nativeEvent as unknown as React.MouseEvent`.
-- Use `e.preventDefault?.()` instead of `(e as any).preventDefault?.()`.
-
-### Generic React Components
-
-- Use `React.ComponentType<Props>` for React component types.
-- For Storybook components with no props: `React.ComponentType<Record<string, never>>`.
-- When converting component imports in Storybook: always `as unknown as` to avoid type mismatch errors.
-- Properly type story args — never use `any`.
-
-### External Libraries
-
-- Use proper library types when available (e.g. PIXI types, not `any`).
-- Use specific property types: `{ canvas?: HTMLCanvasElement }` instead of `any`.
-- When library generics have strict constraints, thread types through `unknown`: `props.command as unknown as Constructor<Command<...>>`.
-- Extract tuple results explicitly rather than destructuring when type assertions are needed.
-
-### Unknown Values
-
-- Add type guards before using function parameters of unknown type: `if (typeof accessor !== 'function') return ''`.
-- Type parameters with fallbacks: `function<T = unknown>(accessor: ((obj: T) => unknown) | unknown)`.
-- Cast unknown objects to record before property access: `(obj as Record<string, unknown>).items`.
-- Use `String(value)` for string conversions; `new Date(value as string | number | Date)` for dates.
 
 ## Localised Strings
 
@@ -145,22 +101,6 @@ For attribute strings (e.g. `title`, `placeholder`, `aria-label`):
 
 - **Never** use plain string literals for user-visible text in JSX or attribute props. This includes `label`, `header`, `placeholder`, `title`, `aria-label`, `emptyMessage`, and any visible text nodes.
 - Only constant, non-localised values are allowed as raw strings (CSS class names, `key` props, internal identifiers).
-
-## File Header
-
-Every TypeScript file must start with:
-
-```typescript
-// Copyright (c) Cratis. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-```
-
-## Generated Files
-
-**Never edit generated files.** Files produced by the proxy generator (`dotnet build`), code scaffolding tools, or any other automated tool must not be modified by hand — in any language. Generated files are overwritten on the next build, so hand-edits are silently lost and create false confidence that a fix is in place.
-
-- If the generated output is wrong, fix the **source** (the C# record, the template, or the generator configuration) and rebuild.
-- Generated TypeScript proxy files (commands, queries, observable queries) are always regenerated from C# sources. Never edit them directly.
 
 ## Arc Frontend Patterns
 

--- a/.github/instructions/vertical-slices.instructions.md
+++ b/.github/instructions/vertical-slices.instructions.md
@@ -2,31 +2,513 @@
 applyTo: "**/Features/**/*.*"
 ---
 
-# Vertical Slice Architecture — Critical Rules
+# Vertical Slice Architecture
 
-These rules are enforced by the framework via convention-based discovery. Breaking them causes silent runtime failures, not compile errors.
+A vertical slice contains *everything* for a single behavior: the command or query, the events it produces, the projections that build read models, the React component that renders the UI, and the specs that verify it all works. Everything lives together in one folder because everything changes together.
 
-## Non-negotiable
+This is the opposite of layered architecture. In a layered project, adding "author registration" means touching `Commands/`, `Handlers/`, `Events/`, `Projections/`, `Models/`, and `Components/` — six folders across two tech stacks. In a vertical slice, it's one folder with one `.cs` file and one `.tsx` file. A developer working on a feature sees its entire scope without navigating elsewhere.
 
-- **All backend artifacts for a slice go in a single `<SliceName>.cs` file** — command, event, validator, constraint, read model, projection, all together.
-- **Commands define `Handle()` directly on the `[Command]` record** — never create a separate handler class. Arc discovers `Handle()` by convention.
-- **`[EventType]` takes NO arguments** — the type name is the identifier. `[EventType("name")]` and `[EventType("guid")]` are both wrong.
-- **Projections join EVENTS, never read models** — a projection that reads another read model breaks replay and creates hidden dependencies.
-- **Event properties are never nullable** — if a property is optional, you need a second event.
-- **Namespace drops the `.Features.` segment** — `MyApp.Authors.Registration`, not `MyApp.Features.Authors.Registration`.
-- **Never import `Dialog` from `primereact/dialog`** — use `CommandDialog` from `@cratis/components/CommandDialog` or `Dialog` from `@cratis/components/Dialogs`.
+## Technical Stack
 
-## Folder structure
+- .NET with C# 13 (ASP.NET Core)
+- React + TypeScript (Vite)
+- PrimeReact UI component library
+- Cratis Arc for CQRS application model
+- Cratis Chronicle for event sourcing
+- MongoDB for read models
+- Vitest + Mocha/Chai/Sinon for TypeScript specs
+- xUnit + Cratis.Specifications + NSubstitute for C# specs
+
+## Core Rules
+
+These are non-negotiable because the frameworks rely on them for convention-based discovery and proxy generation:
+
+- **Each vertical slice has its own folder with a single `.cs` file containing ALL backend artifacts.** This keeps cohesion high — you never wonder which file has the event or the validator. It's all in one place.
+- **Commands define `Handle()` directly on the record — never create separate handler classes.** Arc discovers `Handle()` by convention; a separate handler class breaks that discovery.
+- **`[EventType]` must have NO arguments — the type name is used automatically.** Adding a GUID or string argument is a mistake from other frameworks.
+- Complete one slice end-to-end before starting the next. Half-finished slices create confusion and merge conflicts.
+- Drop the `.Features` segment from namespaces (e.g. `MyApp.Projects.Registration` not `MyApp.Features.Projects.Registration`).
+
+---
+
+## Slice Types
+
+| Type | Purpose | What It Contains |
+|---|---|---|
+| **State Change** | Mutates system state | Command + events + validators/constraints |
+| **State View** | Projects events into queryable read models | Read model + projection + queries |
+| **Automation** | Reacts to read models, makes decisions | Reactor + local read models |
+| **Translation** | Adapts events across slices/systems | Reactor → triggers commands in own slice |
+
+---
+
+## Folder Structure
 
 ```
-Features/<Feature>/<Slice>/<Slice>.cs        <- all backend
-Features/<Feature>/<Slice>/<Component>.tsx   <- React component
-Features/<Feature>/<Slice>/when_<behavior>/  <- integration specs
+Features/
+├── <Feature>/
+│   ├── <Feature>.tsx              ← composition page (layout + menu)
+│   ├── <Concept>.cs               ← shared concepts for this feature
+│   ├── <SliceName>/
+│   │   ├── <SliceName>.cs         ← ALL backend artifacts in ONE file
+│   │   ├── <Component>.tsx        ← React component(s) for this slice
+│   │   └── when_<behavior>/       ← integration specs (state-change slices)
+│   │       ├── and_<scenario>.cs
+│   │       └── ...
+│   └── ...
 ```
 
-For step-by-step implementation guidance, use the `new-vertical-slice` skill.
-For architecture explanations and slice type selection, use the `cratis-vertical-slice` skill.
+**✅ CORRECT:**
+```
+Features/Authors/
+├── Authors.tsx
+├── AuthorId.cs
+├── AuthorName.cs
+├── Registration/
+│   ├── Registration.cs            ← command + event + constraint
+│   ├── AddAuthor.tsx
+│   └── when_registering/
+│       ├── and_there_are_no_authors.cs
+│       └── and_name_already_exists.cs
+└── Listing/
+    ├── Listing.cs                 ← read model + projection + query
+    └── Listing.tsx
+```
 
-## Sub-agent coordination
+**❌ WRONG — Never split by artifact type:**
+```
+Features/Authors/
+├── Commands/RegisterAuthor.cs
+├── Handlers/RegisterAuthorHandler.cs
+├── Events/AuthorRegistered.cs
+```
 
-Backend and frontend for the **same slice cannot run in parallel** — the frontend agent must wait for `dotnet build` to complete. Steps 1–3 (backend) are a hard prerequisite for step 4 (frontend). Independent slices with no shared events can have their backends worked on in parallel, but each slice's frontend still depends on its own build completing first.
+---
+
+## What Goes in a Single Slice File
+
+A single `<SliceName>.cs` file contains ALL of:
+
+- `[Command]` records with `Handle()` method
+- `CommandValidator<T>` (if needed)
+- `IConstraint` implementations (if needed)
+- `[EventType]` records
+- `[ReadModel]` records with static query methods (State View slices)
+- `IProjectionFor<T>` or model-bound projection attributes (State View slices)
+- `IReducerFor<T>` implementations (if needed)
+- `IReactor` implementations (Translation/Automation slices)
+- Slice-specific `ConceptAs<T>` types
+
+---
+
+## Events
+
+Events are **facts** — immutable records of things that have already happened. They are the write-side of the system and form a perfect audit trail. Once appended, an event is never modified or deleted; if something needs to be "undone," append a compensating event.
+
+Immutable records decorated with `[EventType]` from `Cratis.Chronicle.Events`.
+
+```csharp
+[EventType]
+public record AuthorRegistered(AuthorName Name);
+```
+
+**Rules:**
+- `[EventType]` takes **no arguments** — the type name is the event identifier.
+- Use past tense: `ItemAddedToCart`, `UserRegistered`, `AddressChangedForPerson`. Past tense reinforces that events describe what *happened*, not what *should happen*.
+- Events are facts — never nullable properties. Nullable properties mean the event's meaning is ambiguous, forcing every observer to add logic to interpret it. If a property is genuinely optional, you need a second event.
+- One purpose per event — never multipurpose events. A `UserUpdated` event with 10 nullable fields is a design smell; use `EmailChanged`, `NameChanged`, `AddressChanged` instead.
+
+**❌ WRONG:**
+```csharp
+[EventType("ce956ea9-...")]              // ❌ No GUID argument
+[EventType("AuthorRegistered")]          // ❌ No string argument
+```
+
+---
+
+## Commands
+
+Records decorated with `[Command]` from `Cratis.Arc.Commands.ModelBound`.
+
+```csharp
+[Command]
+public record RegisterAuthor(AuthorName Name)
+{
+    public (AuthorId, AuthorRegistered) Handle()
+    {
+        var authorId = AuthorId.New();
+        return (authorId, new(Name));
+    }
+}
+```
+
+**`Handle()` return types:**
+- Single event: `public AuthorRegistered Handle() => new(Name);`
+- Tuple (event + result): `public (AuthorId, AuthorRegistered) Handle() => ...`
+- `Result<TSuccess, TError>`: `public Result<BookReserved, ValidationResult> Handle(Book book) => ...`
+- `void` / `Task` for commands without events
+
+**Event source resolution (in priority order):**
+1. Parameter marked with `[Key]` from `Cratis.Chronicle.Keys`
+2. Parameter whose type has implicit conversion to `EventSourceId`
+3. Implement `ICanProvideEventSourceId`
+
+**DI in Handle():** Extra parameters (beyond the command and read model arguments) are resolved from DI automatically.
+
+---
+
+## Business Rules via DCB (Dynamic Consistency Boundary)
+
+Express business rules by accepting a **read model parameter** in `Handle()`. The framework injects the current projected state before invoking the method.
+
+```csharp
+[Command]
+public record ReserveBook(ISBN Isbn, MemberId MemberId)
+{
+    public Result<BookReserved, ValidationResult> Handle(Book book)
+    {
+        if (book.Available <= 0)
+            return ValidationResult.Error($"No available copies for {Isbn}");
+
+        return new BookReserved(Isbn, MemberId);
+    }
+}
+```
+
+Throw a **custom exception** (never built-in) to signal a violation — the framework converts it to a failed `CommandResult`.
+
+---
+
+## Command Validation
+
+Use `CommandValidator<T>` from `Cratis.Arc.Commands` (extends FluentValidation):
+
+```csharp
+public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
+{
+    public RegisterAuthorValidator()
+    {
+        RuleFor(c => c.Name).NotEmpty().WithMessage("Author name is required");
+    }
+}
+```
+
+Validators with DI dependencies:
+```csharp
+public class MyValidator : CommandValidator<MyCommand>
+{
+    public MyValidator(IMyService service)
+    {
+        RuleFor(x => x).MustAsync(async (cmd, ct) => await service.IsValid(cmd));
+    }
+}
+```
+
+---
+
+## Constraints
+
+Server-side rules enforced by Chronicle at event-append time.
+
+**Unique property across events:**
+```csharp
+public class UniqueAuthorName : IConstraint
+{
+    public void Define(IConstraintBuilder builder) => builder
+        .Unique(_ => _
+            .On<AuthorRegistered>(e => e.Name)
+            .On<AuthorNameChanged>(e => e.Name)
+            .RemovedWith<AuthorRemoved>()
+            .WithMessage("Author name must be unique"));
+}
+```
+
+**Unique event type per event source:**
+```csharp
+public class UniqueUser : IConstraint
+{
+    public void Define(IConstraintBuilder builder) =>
+        builder.Unique<UserRegistered>();
+}
+```
+
+---
+
+## Read Models & Projections
+
+Read models are the *read side* of the system — purpose-built views optimized for specific queries. A single events stream can feed many projections, each building a different view of the same data. This is by design: specialized projections are easier to maintain, perform better, and never break unrelated features when one query's needs change.
+
+### Model-Bound (Preferred — Attributes)
+
+```csharp
+[ReadModel]
+[FromEvent<Registration.AuthorRegistered>]
+public record Author(
+    [Key] AuthorId Id,
+    AuthorName Name)
+{
+    public static ISubject<IEnumerable<Author>> AllAuthors(IMongoCollection<Author> collection) =>
+        collection.Observe();
+}
+```
+
+**Key attributes:**
+| Attribute | Purpose |
+|---|---|
+| `[Key]` | Read model primary key |
+| `[FromEvent<T>]` | Convention-based auto-mapping from event |
+| `[FromEvent<T>(key: nameof(...))]` | Custom key from event property |
+| `[SetFrom<T>]` | Explicit property mapping from event |
+| `[AddFrom<T>]` / `[SubtractFrom<T>]` | Arithmetic operations |
+| `[Increment<T>]` / `[Decrement<T>]` | ±1 counters |
+| `[Count<T>]` | Absolute count |
+| `[ChildrenFrom<T>]` | Child collection from event |
+| `[Join<T>]` | Join data from another event stream |
+| `[RemovedWith<T>]` | Remove entry when event occurs |
+| `[Passive]` | On-demand projection, not actively observed |
+| `[NotRewindable]` | Forward-only, cannot be replayed |
+
+### Fluent Projection (Alternative — for complex cases)
+
+```csharp
+public class AuthorProjection : IProjectionFor<Author>
+{
+    public void Define(IProjectionBuilderFor<Author> builder) => builder
+        .From<AuthorRegistered>();
+}
+```
+
+AutoMap is **on by default** — you only need `.AutoMap()` if you previously called `.NoAutoMap()`. Most projections just call `.From<>()` directly.
+
+**Complex projection with joins:**
+```csharp
+public class BorrowedBooksProjection : IProjectionFor<BorrowedBook>
+{
+    public void Define(IProjectionBuilderFor<BorrowedBook> builder) => builder
+        .From<BookBorrowed>(from => from
+            .Set(m => m.UserId).To(e => e.UserId)
+            .Set(m => m.Borrowed).ToEventContextProperty(c => c.Occurred))
+        .Join<BookAddedToInventory>(j => j
+            .On(m => m.Id)
+            .Set(m => m.Title).To(e => e.Title))
+        .RemovedWith<BookReturned>();
+}
+```
+
+**Projections join EVENTS, never read models.** This is fundamental to event sourcing — projections rebuild state from the event stream, not from other projections. A projection that reads from another read model creates a hidden dependency and breaks replay.
+
+### Passive Projections
+
+For read models used only in DCB business rules (not for queries):
+```csharp
+public class BookProjection : IProjectionFor<Book>
+{
+    public void Define(IProjectionBuilderFor<Book> builder) => builder
+        .Passive()
+        .From<BookAddedToInventory>(e => e.Increment(book => book.Available))
+        .From<BookReserved>(e => e.Decrement(book => book.Available));
+}
+```
+
+---
+
+## Queries
+
+Static methods on `[ReadModel]` records. Favor reactive queries (`ISubject<T>`) for real-time updates.
+
+```csharp
+public static ISubject<IEnumerable<Author>> AllAuthors(IMongoCollection<Author> collection) =>
+    collection.Observe();
+
+public static Author? ById(IMongoCollection<Author> collection, AuthorId id) =>
+    collection.Find(a => a.Id == id).FirstOrDefault();
+```
+
+Method parameters are DI-resolved. `IMongoCollection<T>` is automatically available for `[ReadModel]` types.
+
+---
+
+## Reducers
+
+Reducers are the imperative counterpart to projections. Where projections are declarative mappings, reducers give you full control: receive the current state and an event, return the new state. Use them when mapping alone can't express the logic — aggregations, conditional updates, or complex transformations.
+
+```csharp
+public class AccountBalanceReducer : IReducerFor<AccountBalance>
+{
+    public AccountBalance OnDepositMade(DepositMade @event, AccountBalance? current, EventContext context)
+    {
+        var balance = current?.Balance ?? 0m;
+        return new AccountBalance(balance + @event.Amount, context.Occurred);
+    }
+}
+```
+
+- `current` is `null` for the first event — always handle initialization gracefully.
+- Keep reducers pure — no side effects, no database calls, no I/O. They must be safe to replay.
+- Use immutable state with `with` expressions on records.
+
+---
+
+## Reactors
+
+Reactors are the "if this then that" of event sourcing — they observe events and produce side effects. Unlike projections (which build state) and reducers (which transform state), reactors *do things*: send emails, trigger commands in other slices, call external APIs.
+
+Side-effect observers for Translation and Automation slices.
+
+```csharp
+public class StockKeeping(ICommandPipeline commandPipeline) : IReactor
+{
+    public async Task HandleBookReserved(BookReserved @event) =>
+        await commandPipeline.Execute(new DecreaseStock(@event.Isbn));
+}
+```
+
+- `IReactor` is a marker interface — method dispatch is by first-parameter type.
+- Method name can be anything descriptive.
+- `EventContext` parameter is optional.
+- `[OnceOnly]` — method executes only on first processing, skipped during replay.
+- If a reactor throws, the failing event source partition pauses until resolved.
+
+---
+
+## Event Seeding
+
+Provide predefined events at startup. Chronicle deduplicates automatically.
+
+```csharp
+public class EmployeeSeeding : ICanSeedEvents
+{
+    public void Seed(IEventSeedingBuilder builder)
+    {
+        builder.ForEventSource("employee-1", [
+            new PersonHired("John", "Doe", "Engineer"),
+            new EmployeeAddressSet("123 Main St", "Springfield", "62701", "US")
+        ]);
+    }
+}
+```
+
+Use `#if DEBUG` to prevent seeding in production.
+
+---
+
+## Concepts
+
+- Prefer `ConceptAs<T>` over raw primitives everywhere.
+- Concepts shared between slices → feature folder.
+- Concepts shared between features → `Features/` root.
+- One file per concept.
+
+See [Concepts Instructions](./concepts.instructions.md) for full details.
+
+---
+
+## Development Workflow
+
+Work **slice-by-slice** in this exact order. The sequence matters — TypeScript proxies are generated from C# during `dotnet build`, so frontend work cannot begin until the backend compiles.
+
+1. **Backend** — Implement the C# slice file (command/query/projection + events, validators, constraints)
+2. **Specs** — Write integration specs for state-change slices
+3. **Build** — Run `dotnet build` to generate TypeScript proxies (this step creates the `.ts` files the frontend imports)
+4. **Frontend** — Implement React component(s) using the auto-generated proxies
+5. **Composition** — Register in the feature's composition page
+6. **Routes** — Add/update routing if needed
+
+### Sub-agent coordination
+
+When parallel agents or sub-agents are used, steps 1–3 are a **hard prerequisite** for step 4. Backend and frontend for the same slice cannot run in parallel — the frontend agent must wait for `dotnet build` to complete. Independent slices (no shared event types) can have their backend phases worked on in parallel, but each slice's frontend still depends on its own build completing first.
+
+---
+
+## Integration Specs
+
+Specs live under `when_<behavior>/` folders directly inside the slice folder — no `for_` prefix.
+
+```csharp
+using context = MyApp.Authors.Registration.when_registering.and_there_are_no_authors.context;
+
+namespace MyApp.Authors.Registration.when_registering;
+
+[Collection(ChronicleCollection.Name)]
+public class and_there_are_no_authors(context context) : Given<context>(context)
+{
+    public class context(ChronicleOutOfProcessFixture fixture) : given.an_http_client(fixture)
+    {
+        public CommandResult<Guid>? Result;
+
+        async Task Because()
+        {
+            Result = await Client.ExecuteCommand<RegisterAuthor, Guid>(
+                "/api/authors/register",
+                new RegisterAuthor("John Doe"));
+        }
+    }
+
+    [Fact] void should_be_successful() => Context.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_have_appended_only_one_event() => Context.ShouldHaveTailSequenceNumber(EventSequenceNumber.First);
+    [Fact] void should_append_author_registered_event() => Context.ShouldHaveAppendedEvent<AuthorRegistered>(
+        EventSequenceNumber.First, Context.Result.Response,
+        evt => evt.Name.Value.ShouldEqual("John Doe"));
+}
+```
+
+---
+
+## Frontend
+
+### Listing View
+
+```tsx
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { AllAuthors } from './AllAuthors';
+
+export const Listing = () => {
+    const [result] = AllAuthors.use();
+
+    return (
+        <DataTable value={result.data} scrollable scrollHeight="flex" emptyMessage="No authors found.">
+            <Column field="name" header="Name" />
+        </DataTable>
+    );
+};
+```
+
+### Composition Page
+
+```tsx
+import { Page } from '../../Components/Common';
+import { AddAuthor } from './Registration/AddAuthor';
+import { Listing } from './Listing/Listing';
+import { useDialog } from '@cratis/arc.react/dialogs';
+import { Menubar } from 'primereact/menubar';
+import { MenuItem } from 'primereact/menuitem';
+import * as mdIcons from 'react-icons/md';
+
+export const Authors = () => {
+    const [AddAuthorDialog, showAddAuthorDialog] = useDialog(AddAuthor);
+
+    const menuItems: MenuItem[] = [
+        {
+            label: 'Add Author',
+            icon: mdIcons.MdAdd,
+            command: async () => { await showAddAuthorDialog(); }
+        }
+    ];
+
+    return (
+        <Page title="Authors">
+            <Menubar model={menuItems} />
+            <Listing />
+            <AddAuthorDialog />
+        </Page>
+    );
+};
+```
+
+### Dialogs
+
+- **Never** import `Dialog` from `primereact/dialog` — use Cratis wrappers.
+- `CommandDialog` from `@cratis/components/CommandDialog` — for dialogs that execute commands.
+- `Dialog` from `@cratis/components/Dialogs` — for data collection without commands.
+- Do not render manual `<Button>` for dialog actions.

--- a/.github/skills/add-business-rule/SKILL.md
+++ b/.github/skills/add-business-rule/SKILL.md
@@ -99,23 +99,6 @@ public class UniqueProjectName : IConstraint
 
 Constraints are discovered and enforced automatically — no registration or attribute on the command needed.
 
-## Simple validators (`CommandValidator<T>`)
-
-For format, range, and required-field rules that do not need event-sourced state — evaluated before `Handle()` runs:
-
-```csharp
-public class RegisterAuthorValidator : CommandValidator<RegisterAuthor>
-{
-    public RegisterAuthorValidator()
-    {
-        RuleFor(c => c.Name).NotEmpty().WithMessage("Name is required.");
-        RuleFor(c => c.Name).MaximumLength(100).WithMessage("Name must be 100 characters or fewer.");
-    }
-}
-```
-
-Validators are discovered automatically — no registration needed. If any rule fails, Chronicle returns an error result and `Handle()` is never called.
-
 ## After adding
 
 1. Add a spec for the failure case — see `write-specs` skill

--- a/.github/skills/add-projection/SKILL.md
+++ b/.github/skills/add-projection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-projection
-description: Use this skill when asked to add a Chronicle projection to a Cratis-based project. Covers model-bound projection attributes ([FromEvent<T>], [Key], [SetFrom<T>], etc.) and fluent IProjectionFor<T>. Enforces the AutoMap-first rule and Chronicle-specific join semantics. For creating a brand-new read model from scratch (events + projection + queries + TypeScript proxy), use cratis-readmodel instead. For reactors, use add-reactor instead.
+description: Use this skill when asked to add a Chronicle projection to a Cratis-based project. Enforces the AutoMap-first rule and Chronicle-specific join semantics.
 ---
 
 Add a Chronicle **projection** that populates a read model from events.

--- a/.github/skills/new-vertical-slice/SKILL.md
+++ b/.github/skills/new-vertical-slice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-vertical-slice
-description: Use this skill when asked to implement (build, create, add) a new feature, command, query, slice, or screen in a Cratis-based project. Provides the hands-on step-by-step execution workflow: C# backend → specs → dotnet build → React frontend → quality gates. For questions about how vertical slices are structured or which slice type to choose, see cratis-vertical-slice.
+description: Use this skill when asked to implement a new feature, command, query, slice, or screen in a Cratis-based project. Guides the full end-to-end workflow: C# backend → specs → dotnet build → React frontend → quality gates.
 ---
 
 Implement a complete vertical slice following this EXACT order. Never skip steps or work on multiple slices in parallel.
@@ -26,8 +26,8 @@ File creation order within the slice:
 2. Command `record` with `Handle()` method and optional validation attributes
    - If a business rule depends on Chronicle event-sourced state, add the relevant read model as a parameter to `Handle()` — see `add-business-rule` skill (DCB pattern)
 3. Constraint class `<Name>Constraint` (if needed)
-4. Event `record` with `[EventType]` (no arguments, no mutable properties)
-5. Read model `record` with `[ReadModel]` and model-bound projection attributes (`[FromEvent<T>]`, `[Key]`, etc.)
+5. Event `record` with `[EventType]` (no arguments, no mutable properties)
+6. Read model `record` with `[ReadModel]` and model-bound projection attributes (`[FromEvent<T>]`, `[Key]`, etc.)
    - Use fluent `IProjectionFor<T>` only when model-bound attributes don't fit
 
 **Critical rules:**

--- a/.github/skills/review-performance/SKILL.md
+++ b/.github/skills/review-performance/SKILL.md
@@ -8,7 +8,7 @@ Perform a focused performance review of changed code.
 ## Chronicle / Event Sourcing
 
 - [ ] Projections use AutoMap (on by default) — avoids manual mapping cost
-- [ ] Projections do NOT join on the read model (forces full re-read on every event replay)
+- [ ] Projections do NOT join on the read model (forces full re-read)
 - [ ] Reactors do NOT re-query the event log inside `On()` — use event data directly
 - [ ] No eager loading of entire event sequences without paging/filtering
 - [ ] New projections can replay all historical events without crashing
@@ -42,18 +42,6 @@ Perform a focused performance review of changed code.
 - [ ] `IEnumerable<T>` not enumerated multiple times — materialise once if needed
 - [ ] Large object logging uses `{@obj}` only at `Debug` level
 
----
-
-## Why the Chronicle items matter
-
-**Projection join semantics** — projections join events to events, never read models. Joining on a read model forces the framework to reload that model on every event during replay, turning O(1) projections into O(n) reads. At scale (millions of events) this is catastrophic.
-
-**Reactor I/O** — reactors receive the event as a parameter; all data for decisions is already there. Re-querying the event log inside `On()` creates redundant I/O and couples the reactor to current state instead of the event stream.
-
-**Historical replay safety** — new projections are replayed over all historical events the first time they are deployed. A crash on any historical event means the read model can never be built.
-
----
-
 ## Risk classification
 
 - 🔴 High — measurable degradation at moderate load — must fix before merge
@@ -64,12 +52,4 @@ Perform a focused performance review of changed code.
 
 Start with: **Performance Review: ✅ No issues / ⚠️ Minor findings / ❌ Blocking issues found**
 
-Group findings by category. For each finding include:
-- The specific file/line
-- What the issue is and why it matters
-- A concrete suggestion for fixing it
-
-End with a summary table showing ✅/⚠️/❌ per category.
-
-**Example finding:**
-> 🔴 **Chronicle / Event Sourcing** — `AuthorProjection.cs:14`: projection calls `.Join<AuthorUpdated>(u => u.AuthorId, r => r.Id)` where the right side `r` is a read model. This forces a full read-model reload on every `AuthorUpdated` event during replay. Fix: join on the event itself using a second `.From<AuthorUpdated>()` call.
+Group findings by category. End with a summary table showing ✅/⚠️/❌ per category.

--- a/.github/skills/review-security/SKILL.md
+++ b/.github/skills/review-security/SKILL.md
@@ -35,7 +35,7 @@ Perform a structured security review of changed code.
 - [ ] Events are immutable records — no mutable state in the event store
 - [ ] Aggregate/event-store IDs generated server-side, never accepted from untrusted clients
 - [ ] Event upcasting logic does not allow injection of unexpected properties
-- [ ] Uniqueness constraints use `IConstraint`, not read-model checks in `Handle()` (race-condition-safe)
+- [ ] Uniqueness constraints cannot be bypassed by concurrent multi-tenant writes
 
 ## Frontend
 
@@ -43,16 +43,6 @@ Perform a structured security review of changed code.
 - [ ] No tokens or secrets in `localStorage` — use `httpOnly` cookies or in-memory state
 - [ ] Command DTOs contain only the minimum required fields
 - [ ] No client-side access control not also enforced server-side
-
----
-
-## Why the event-sourcing items matter
-
-**Server-side IDs** — client-supplied aggregate IDs allow a malicious actor to overwrite another user’s data by guessing or supplying a known ID. Always generate IDs with `Guid.NewGuid()` in `Handle()` and never accept them from command properties.
-
-**Concurrent constraint bypass** — checking uniqueness via a read model in `Handle()` is vulnerable to race conditions: two requests can both pass the check before either event is projected. Use `IConstraint` with Chronicle’s built-in constraint mechanism which evaluates at append time.
-
----
 
 ## Risk classification
 
@@ -64,12 +54,4 @@ Perform a structured security review of changed code.
 
 Start with: **Security Review: ✅ No issues / ⚠️ Low-risk findings / ❌ Blocking issues found**
 
-Group findings by category. For each finding include:
-- The specific file/line
-- What the vulnerability is and the attack scenario
-- A concrete fix
-
-End with a summary table showing ✅/⚠️/❌ per category.
-
-**Example finding:**
-> 🔴 **Event Sourcing Specifics** — `RegisterAuthor.cs:12`: `Handle()` receives `authorId` from the command record and uses it directly as the event-source ID. An attacker can supply any GUID and overwrite an existing author’s event stream. Fix: generate `var authorId = AuthorId.New();` inside `Handle()` and remove it from the command record.
+Group findings by category. End with a summary table showing ✅/⚠️/❌ per category.

--- a/.github/skills/scaffold-feature/SKILL.md
+++ b/.github/skills/scaffold-feature/SKILL.md
@@ -22,7 +22,7 @@ Features/<Feature>/
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Page } from '../../Core/Page';  // Verify this path by searching: find src -name 'Page.tsx'
+import { Page } from '../../Core/Page';
 
 export const <Feature> = () => {
     return (

--- a/.github/skills/write-documentation/SKILL.md
+++ b/.github/skills/write-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-documentation
-description: Diátaxis Documentation Expert for Cratis projects. Writes high-quality DocFX documentation guided by the Diátaxis framework — classifying every page as a Tutorial, How-to Guide, Reference, or Explanation.
+description: "Diátaxis Documentation Expert for Cratis projects. Writes high-quality DocFX documentation guided by the Diátaxis framework — classifying every page as a Tutorial, How-to Guide, Reference, or Explanation."
 ---
 
 # Diátaxis Documentation Expert
@@ -80,24 +80,6 @@ With sub-topics:
       items:
         - name: Sub-topic
           href: subtopic/toc.yml
-
-## Updating the parent `toc.yml`
-
-Every new topic must also be linked from the **parent section's** `toc.yml`. Find it with:
-
-```bash
-find Documentation -name "toc.yml" | head -20
-```
-
-Add an entry in the parent file:
-
-```yaml
-# parent toc.yml — add the new topic alongside existing entries
-- name: Existing Topic
-  href: existing-topic/index.md
-- name: <New Topic Title>     # ← add this
-  href: <new-topic>/index.md  # ← relative to the parent toc.yml location
-```
 
 ## Writing Style
 

--- a/.github/skills/write-specs/SKILL.md
+++ b/.github/skills/write-specs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-specs
-description: Use this skill when asked to write integration specs for a vertical slice in a Cratis-based project. Produces BDD-style Chronicle integration specs using ChronicleOutOfProcessFixture, Given<context>, and xUnit. Covers State Change commands (happy path, validation, business rules, constraints) and State View queries. For unit specs, standalone class specs, or the general BDD spec pattern (Establish/Because/should_), see cratis-specs-csharp.
+description: Use this skill when asked to write tests, specs, or test coverage for a command, query, or slice in a Cratis-based project. Produces BDD-style integration specs using xUnit and Cratis.Specifications.
 ---
 
 Write comprehensive BDD integration specs for a vertical slice command or query.
@@ -25,38 +25,6 @@ Write one spec class for **each** of:
 2. **Each validation failure** — one `and_` class per `[Required]`, `[MaxLength]`, etc. rule
 3. **Each business rule violation** — one `and_` class per DCB condition in `Handle()` that inspects a read model
 4. **Each constraint violation** — one `and_` class per `IConstraint`
-
-## What to cover for State View queries
-
-State View queries project events into read models — they have no command to execute, so specs validate the projection logic by appending events first:
-
-```csharp
-// Listing/when_listing_authors/and_authors_have_been_registered.cs
-using context = MyApp.Authors.Listing.when_listing_authors.and_authors_have_been_registered.context;
-
-namespace MyApp.Authors.Listing.when_listing_authors;
-
-[Collection(ChronicleCollection.Name)]
-public class and_authors_have_been_registered(context context) : Given<context>(context)
-{
-    public class context(ChronicleOutOfProcessFixture fixture) : given.an_http_client(fixture)
-    {
-        public IEnumerable<AuthorSummary>? Result;
-        static readonly AuthorId _authorId = AuthorId.New();
-
-        async Task Establish() =>
-            await EventStore.EventLog.Append(_authorId, new AuthorRegistered(new AuthorName("John Doe")));
-
-        async Task Because() =>
-            Result = await Client.GetFromJsonAsync<IEnumerable<AuthorSummary>>("/api/authors");
-    }
-
-    [Fact] void should_include_the_registered_author() =>
-        Context.Result!.ShouldContain(a => a.Name == "John Doe");
-    [Fact] void should_return_one_author() =>
-        Context.Result!.Count().ShouldEqual(1);
-}
-```
 
 ## C# spec structure
 


### PR DESCRIPTION
Propagates Copilot instruction files from [Cratis/Templates](https://github.com/Cratis/Templates).

### Changes include:
- Updated `.github/copilot-instructions.md` (if present in source)
- Updated `.github/instructions/` folder (if present in source)
- Updated `.github/agents/` folder (if present in source)
- Updated `.github/skills/` folder (if present in source)
- Updated `.github/prompts/` folder (if present in source)

**Source repository:** Cratis/Templates