### PR TITLE
Fix event ordering in AppendedEventsQueue.HandlePartitioned

### DIFF
--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber_with_interleaved_events_across_two_partitions.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/a_single_subscriber_with_interleaved_events_across_two_partitions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_AppendedEventsQueue.given;
+
+/// <summary>
+/// Creates six events with a single event type across two partitions where sequence
+/// numbers interleave: partition A gets seq 0, 1, 4, 5 and partition B gets seq 2, 3.
+/// This reproduces the scenario where grouping by partition before delivering would
+/// cause an observer to advance past lower-numbered events from the other partition.
+/// </summary>
+public class a_single_subscriber_with_interleaved_events_across_two_partitions : a_single_subscriber
+{
+    protected EventType _eventType = new("Some event", 1);
+    protected EventSourceId _partitionA;
+    protected EventSourceId _partitionB;
+    protected List<AppendedEvent> _allEvents;
+
+    void Establish()
+    {
+        _partitionA = Guid.NewGuid();
+        _partitionB = Guid.NewGuid();
+
+        _allEvents =
+        [
+            CreateEvent(0, _partitionA),
+            CreateEvent(1, _partitionA),
+            CreateEvent(2, _partitionB),
+            CreateEvent(3, _partitionB),
+            CreateEvent(4, _partitionA),
+            CreateEvent(5, _partitionA),
+        ];
+    }
+
+    protected override IEnumerable<EventType> EventTypes => [_eventType];
+
+    static AppendedEvent CreateEvent(ulong sequenceNumber, EventSourceId eventSourceId) =>
+        new(
+            EventContext.Empty with
+            {
+                SequenceNumber = sequenceNumber,
+                EventType = new("Some event", 1),
+                EventSourceId = eventSourceId
+            },
+            new System.Dynamic.ExpandoObject());
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/interleaved_events_across_partitions_with_single_subscriber.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/interleaved_events_across_partitions_with_single_subscriber.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.EventSequences.for_AppendedEventsQueue.when_enqueuing;
+
+/// <summary>
+/// Regression spec for the race condition where HandlePartitioned grouped events by
+/// partition before delivering them. This caused the observer's NextEventSequenceNumber
+/// to advance past lower-numbered events from the other partition, dropping them.
+/// </summary>
+public class interleaved_events_across_partitions_with_single_subscriber : given.a_single_subscriber_with_interleaved_events_across_two_partitions
+{
+    async Task Because()
+    {
+        await _queue.Enqueue(_allEvents);
+        await _queue.AwaitQueueDepletion();
+    }
+
+    [Fact]
+    void should_deliver_events_to_both_partitions() =>
+        _handledEventsPerPartition.Count.ShouldEqual(2);
+
+    [Fact]
+    void should_deliver_all_four_events_for_partition_a() =>
+        _handledEventsPerPartition[_partitionA]
+            .SelectMany(h => h.Events)
+            .Count()
+            .ShouldEqual(4);
+
+    [Fact]
+    void should_deliver_all_two_events_for_partition_b() =>
+        _handledEventsPerPartition[_partitionB]
+            .SelectMany(h => h.Events)
+            .Count()
+            .ShouldEqual(2);
+
+    [Fact]
+    void should_deliver_all_six_events_in_total() =>
+        _handledEventsPerPartition
+            .SelectMany(p => p.Value)
+            .SelectMany(h => h.Events)
+            .Count()
+            .ShouldEqual(6);
+
+    [Fact]
+    void should_deliver_partition_a_events_in_sequence_order() =>
+        _handledEventsPerPartition[_partitionA]
+            .SelectMany(h => h.Events)
+            .Select(e => (ulong)e.Context.SequenceNumber)
+            .ShouldContainOnly([0UL, 1UL, 4UL, 5UL]);
+
+    [Fact]
+    void should_deliver_partition_b_events_in_sequence_order() =>
+        _handledEventsPerPartition[_partitionB]
+            .SelectMany(h => h.Events)
+            .Select(e => (ulong)e.Context.SequenceNumber)
+            .ShouldContainOnly([2UL, 3UL]);
+
+    [Fact]
+    void should_deliver_first_batch_of_partition_a_before_partition_b() =>
+        _handledEventsPerPartition[_partitionA][0]
+            .Events
+            .Select(e => (ulong)e.Context.SequenceNumber)
+            .ShouldContainOnly([0UL, 1UL]);
+
+    [Fact]
+    void should_deliver_second_batch_of_partition_a_after_partition_b() =>
+        _handledEventsPerPartition[_partitionA][^1]
+            .Events
+            .Select(e => (ulong)e.Context.SequenceNumber)
+            .ShouldContainOnly([4UL, 5UL]);
+}

--- a/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
@@ -241,18 +241,35 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
 
     async Task HandlePartitioned(IEnumerable<AppendedEvent> events)
     {
-        foreach (var group in events.GroupBy(@event => @event.Context.EventSourceId))
+        // Sort events by sequence number and deliver consecutive same-partition batches.
+        // This prevents a race condition where processing one partition's events first
+        // advances the observer's NextEventSequenceNumber past lower-numbered events
+        // from other partitions, causing those events to be incorrectly skipped.
+        var sorted = events.OrderBy(e => e.Context.SequenceNumber).ToList();
+
+        var index = 0;
+        while (index < sorted.Count)
         {
+            var partition = sorted[index].Context.EventSourceId;
+            var start = index;
+            while (index < sorted.Count && sorted[index].Context.EventSourceId == partition)
+            {
+                index++;
+            }
+
+            var partitionEvents = sorted.GetRange(start, index - start);
+
             var tasks = new List<Task>();
             foreach (var subscription in _subscriptions)
             {
-                var actualEvents = group.Where(@event => subscription.EventTypeIds.Contains(@event.Context.EventType.Id)).ToList();
+                var actualEvents = partitionEvents
+                    .Where(@event => subscription.EventTypeIds.Contains(@event.Context.EventType.Id))
+                    .ToList();
                 if (actualEvents.Count == 0)
                 {
                     continue;
                 }
                 var observer = _grainFactory.GetGrain<IObserver>(subscription.ObserverKey);
-                var partition = group.Key;
                 tasks.Add(observer.Handle(partition, actualEvents));
             }
 


### PR DESCRIPTION
## Summary

Fix a race condition in `AppendedEventsQueue.HandlePartitioned` that caused read models to miss events when a batch of seeded events spanned multiple partitions.

## Fixed

- Events delivered out of global sequence order when `HandlePartitioned` grouped by partition, causing observers to advance `NextEventSequenceNumber` past lower-numbered events from other partitions and silently dropping them
