### PR TITLE
Fix NullReferenceException and Append failure in EventScenario

### DIFF
--- a/Chronicle.slnx
+++ b/Chronicle.slnx
@@ -11,6 +11,7 @@
         <Project Path="Source/Clients/DotNET.CodeAnalysis.Specs/DotNET.CodeAnalysis.Specs.csproj" />
         <Project Path="Source/Clients/DotNET.Specs/DotNET.Specs.csproj" />
         <Project Path="Source/Clients/Testing/Testing.csproj" />
+        <Project Path="Source/Clients/Testing.Specs/Testing.Specs.csproj" />
         <Project Path="Source/Clients/Workbench/Workbench.csproj" />
         <Project Path="Source/Clients/XUnit.Integration/XUnit.Integration.csproj" />
     </Folder>

--- a/Source/Clients/Testing.Specs/EventSequences/TestEvent.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/TestEvent.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// A test event used by the Testing.Specs project.
+/// </summary>
+/// <param name="Value">A test value.</param>
+[EventType]
+public record TestEvent(string Value);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_appending_event.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_appending_event.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_appending_event : Specification, IDisposable
+{
+    EventScenario _scenario;
+    AppendResult _result;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because() => _result = await _scenario.EventLog.Append(
+        EventSourceId.New(),
+        new TestEvent("hello"));
+
+    [Fact] void should_be_successful() => _result.ShouldBeSuccessful();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_appending_multiple_events.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_appending_multiple_events.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_appending_multiple_events : Specification, IDisposable
+{
+    EventScenario _scenario;
+    AppendManyResult _result;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because() => _result = await _scenario.EventLog.AppendMany(
+        EventSourceId.New(),
+        [new TestEvent("first"), new TestEvent("second")]);
+
+    [Fact] void should_be_successful() => _result.ShouldBeSuccessful();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_creating_scenario.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_creating_scenario.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_creating_scenario : Specification
+{
+    EventScenario _scenario;
+    Exception _error;
+
+    async Task Because() => _error = await Catch.Exception(() =>
+    {
+        _scenario = new EventScenario();
+
+        return Task.CompletedTask;
+    });
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_have_event_log() => _scenario.EventLog.ShouldNotBeNull();
+    [Fact] void should_have_event_sequence() => _scenario.EventSequence.ShouldNotBeNull();
+    [Fact] void should_have_given_builder() => _scenario.Given.ShouldNotBeNull();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_seeding_events_with_given.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_seeding_events_with_given.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_seeding_events_with_given : Specification, IDisposable
+{
+    EventScenario _scenario;
+    EventSourceId _eventSourceId;
+    AppendResult _result;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _eventSourceId = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_eventSourceId)
+            .Events(new TestEvent("seeded"));
+
+        _result = await _scenario.EventLog.Append(
+            _eventSourceId,
+            new TestEvent("appended after seed"));
+    }
+
+    [Fact] void should_be_successful() => _result.ShouldBeSuccessful();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/Testing.Specs.csproj
+++ b/Source/Clients/Testing.Specs/Testing.Specs.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Chronicle.Testing.Specs</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Testing</RootNamespace>
+        <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../Testing/Testing.csproj" />
+        <ProjectReference Include="../DotNET/DotNET.csproj" />
+        <ProjectReference Include="../Connections/Connections.csproj" />
+        <ProjectReference Include="../../Kernel/Contracts/Contracts.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" />
+        <PackageReference Include="Microsoft.Orleans.BroadcastChannel" />
+        <PackageReference Include="Microsoft.Orleans.Core.Abstractions" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" />
+        <PackageReference Include="Microsoft.Orleans.Serialization" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.SystemTextJson" />
+        <PackageReference Include="Microsoft.Orleans.Server" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" />
+        <PackageReference Include="Microsoft.Orleans.Reminders" />
+    </ItemGroup>
+</Project>

--- a/Source/Clients/Testing/EventSequences/InMemoryEventTypesStorage.cs
+++ b/Source/Clients/Testing/EventSequences/InMemoryEventTypesStorage.cs
@@ -43,7 +43,12 @@ internal sealed class InMemoryEventTypesStorage : IEventTypesStorage
 
     /// <inheritdoc/>
     public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) =>
-        Task.FromResult(new EventTypeDefinition(eventTypeId, EventTypeOwner.Client, false, [], []));
+        Task.FromResult(new EventTypeDefinition(
+            eventTypeId,
+            EventTypeOwner.Client,
+            false,
+            [new EventTypeGenerationDefinition(EventTypeGeneration.First, new JsonSchema())],
+            []));
 
     /// <inheritdoc/>
     public Task<IEnumerable<KernelEventTypes::EventTypeSchema>> GetAllGenerationsForEventType(EventType eventType) =>

--- a/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
+++ b/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
@@ -72,16 +72,38 @@ internal static class InProcessEventSequence
             expandoObjectConverter,
             global::Cratis.Json.Globals.JsonSerializerOptions ?? new global::System.Text.Json.JsonSerializerOptions());
 
-        var grain = new KernelEventSequences::EventSequence(
-            storage,
-            new KernelConstraints::ConstraintValidationFactory(storage),
-            eventTypeMigrations,
-            null!,
-            jsonComplianceManager,
-            expandoObjectConverter,
-            eventSerializer,
-            new KernelEventSequences::EventHashCalculator(),
-            NullLogger<KernelEventSequences::EventSequence>.Instance);
+        // The Grain base class constructor accesses RuntimeContext.Current!.ObservableLifecycle,
+        // which requires a valid IGrainContext to be set as the current execution context.
+        // Following the same approach as OrleansTestKit, we set a test context with a lifecycle
+        // before constructing the grain, then reset it afterward.
+        // The Grain constructor also resolves IGrainRuntime from ActivationServices, so we
+        // must provide a service provider with IGrainRuntime registered.
+        var grainLifecycle = new TestGrainLifecycle();
+        var testServiceProvider = new TestServiceProvider();
+        var grainRuntime = new TestGrainRuntime(testServiceProvider);
+        testServiceProvider.AddService<IGrainRuntime>(grainRuntime);
+
+        var grainContext = new TestGrainContext
+        {
+            ObservableLifecycle = grainLifecycle,
+            ActivationServices = testServiceProvider
+        };
+
+        KernelEventSequences::EventSequence grain;
+
+        using (RuntimeContextScope.SetContext(grainContext))
+        {
+            grain = new KernelEventSequences::EventSequence(
+                storage,
+                new KernelConstraints::ConstraintValidationFactory(storage),
+                eventTypeMigrations,
+                null!,
+                jsonComplianceManager,
+                expandoObjectConverter,
+                eventSerializer,
+                new KernelEventSequences::EventHashCalculator(),
+                NullLogger<KernelEventSequences::EventSequence>.Instance);
+        }
 
         var grainStorage = new InMemoryGrainStorage<Cratis.Chronicle.Storage.EventSequences.EventSequenceState>();
         _storageField.SetValue(grain, grainStorage);

--- a/Source/Clients/Testing/RuntimeContextScope.cs
+++ b/Source/Clients/Testing/RuntimeContextScope.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Chronicle.Testing;
+
+/// <summary>
+/// Manages the Orleans <c>RuntimeContext</c> for in-process grain construction without a silo.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="Grain"/> base class constructor accesses <c>RuntimeContext.Current!.ObservableLifecycle</c>,
+/// which requires a valid <see cref="IGrainContext"/> to be set as the current execution context. This class
+/// uses reflection to call the internal <c>RuntimeContext.SetExecutionContext</c> method, following the same
+/// approach used by the OrleansTestKit project.
+/// </para>
+/// <para>
+/// Usage: wrap grain construction in a <see langword="using"/> block to ensure the context is properly cleaned up:
+/// <code>
+/// using (RuntimeContextScope.SetExecutionContext(testGrainContext))
+/// {
+///     var grain = new MyGrain(dependencies...);
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+internal static class RuntimeContextScope
+{
+    static readonly Action<IGrainContext?> _setContext = CreateSetContextAction();
+
+    /// <summary>
+    /// Sets the given <see cref="IGrainContext"/> as the current Orleans runtime context and returns
+    /// an <see cref="IDisposable"/> that clears the context on disposal.
+    /// </summary>
+    /// <param name="context">The <see cref="IGrainContext"/> to set as current.</param>
+    /// <returns>An <see cref="IDisposable"/> that resets the runtime context when disposed.</returns>
+    internal static IDisposable SetContext(IGrainContext context) => new Scope(context);
+
+    static Action<IGrainContext?> CreateSetContextAction()
+    {
+        var assembly = typeof(GrainId).Assembly;
+        var contextType = assembly.GetType("Orleans.Runtime.RuntimeContext")
+            ?? throw new InvalidOperationException(
+                "Could not find Orleans.Runtime.RuntimeContext in Orleans.Core.Abstractions. " +
+                "This may indicate an incompatible Orleans version.");
+
+        var method = contextType.GetMethod("SetExecutionContext", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "Could not find RuntimeContext.SetExecutionContext method. " +
+                "This may indicate an incompatible Orleans version.");
+
+        // SetExecutionContext has an out parameter for the previous context — wrap it
+        // in a simple Action since we don't need the previous value.
+        return ctx =>
+        {
+            var args = new object?[] { ctx, null };
+            method.Invoke(null, args);
+        };
+    }
+
+    sealed class Scope : IDisposable
+    {
+        internal Scope(IGrainContext context)
+        {
+            _setContext(context);
+        }
+
+        public void Dispose()
+        {
+            _setContext(null);
+        }
+    }
+}

--- a/Source/Clients/Testing/TestGrainContext.cs
+++ b/Source/Clients/Testing/TestGrainContext.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing;
+
+/// <summary>
+/// Represents a minimal <see cref="IGrainContext"/> for constructing grains outside an Orleans silo.
+/// </summary>
+/// <remarks>
+/// The <see cref="Grain"/> base class constructor accesses <c>RuntimeContext.Current!.ObservableLifecycle</c>
+/// during construction. By setting this context as the current runtime context before creating the grain,
+/// the constructor receives a valid <see cref="IGrainLifecycle"/> without requiring a full Orleans silo.
+/// </remarks>
+#pragma warning disable SA1648 // inheritdoc should be used with inheriting class — IGrainContext is an interface, not a base class
+internal sealed class TestGrainContext : IGrainContext
+{
+    /// <inheritdoc/>
+    public ActivationId ActivationId { get; set; }
+
+    /// <inheritdoc/>
+    public IServiceProvider ActivationServices { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public GrainAddress Address { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public Task Deactivated { get; set; } = Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public GrainId GrainId { get; set; }
+
+    /// <inheritdoc/>
+    public object GrainInstance { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public GrainReference GrainReference { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public IGrainLifecycle ObservableLifecycle { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public IWorkItemScheduler Scheduler { get; set; } = default!;
+
+    /// <inheritdoc/>
+    public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Grain activation is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Grain deactivation is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);
+
+    /// <inheritdoc/>
+    public TComponent GetComponent<TComponent>()
+        where TComponent : class =>
+        throw new NotSupportedException($"GetComponent<{typeof(TComponent).Name}> is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public object? GetComponent(Type componentType) =>
+        throw new NotSupportedException($"GetComponent({componentType.Name}) is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public TTarget GetTarget<TTarget>()
+        where TTarget : class =>
+        throw new NotSupportedException($"GetTarget<{typeof(TTarget).Name}> is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public object? GetTarget() =>
+        throw new NotSupportedException("GetTarget is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Grain migration is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public void ReceiveMessage(object message) =>
+        throw new NotSupportedException("ReceiveMessage is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public void Rehydrate(IRehydrationContext context) =>
+        throw new NotSupportedException("Grain rehydration is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public void SetComponent<TComponent>(TComponent? value)
+        where TComponent : class =>
+        throw new NotSupportedException($"SetComponent<{typeof(TComponent).Name}> is not supported in test scenarios.");
+}

--- a/Source/Clients/Testing/TestGrainLifecycle.cs
+++ b/Source/Clients/Testing/TestGrainLifecycle.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.ObjectModel;
+
+namespace Cratis.Chronicle.Testing;
+
+/// <summary>
+/// Represents a test implementation of <see cref="IGrainLifecycle"/> that collects lifecycle
+/// observers so that grains can be constructed outside an Orleans silo.
+/// </summary>
+internal sealed class TestGrainLifecycle : IGrainLifecycle
+{
+    readonly Collection<(int Stage, ILifecycleObserver Observer)> _observers = [];
+
+    /// <inheritdoc/>
+    public void AddMigrationParticipant(IGrainMigrationParticipant participant)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void RemoveMigrationParticipant(IGrainMigrationParticipant participant)
+    {
+    }
+
+    /// <inheritdoc/>
+    public IDisposable Subscribe(string observerName, int stage, ILifecycleObserver observer)
+    {
+        var item = (Stage: stage, Observer: observer);
+        _observers.Add(item);
+
+        return new RemoveObserverDisposable(_observers, item);
+    }
+
+    /// <summary>
+    /// Triggers the start phase for all registered lifecycle observers in stage order.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal Task TriggerStartAsync()
+    {
+        var tasks = _observers.OrderBy(x => x.Stage).Select(x => x.Observer.OnStart(CancellationToken.None));
+
+        return Task.WhenAll(tasks.ToArray());
+    }
+
+    /// <summary>
+    /// Triggers the stop phase for all registered lifecycle observers.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    internal Task TriggerStopAsync()
+    {
+        var tasks = _observers.Select(x => x.Observer.OnStop(CancellationToken.None));
+
+        return Task.WhenAll(tasks.ToArray());
+    }
+
+    sealed class RemoveObserverDisposable(
+        Collection<(int Stage, ILifecycleObserver Observer)> observers,
+        (int Stage, ILifecycleObserver Observer) item) : IDisposable
+    {
+        public void Dispose() => observers.Remove(item);
+    }
+}

--- a/Source/Clients/Testing/TestGrainRuntime.cs
+++ b/Source/Clients/Testing/TestGrainRuntime.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans.Core;
+using Orleans.Timers;
+
+namespace Cratis.Chronicle.Testing;
+
+/// <summary>
+/// Represents a minimal <see cref="IGrainRuntime"/> for constructing grains outside an Orleans silo.
+/// </summary>
+/// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use.</param>
+internal sealed class TestGrainRuntime(IServiceProvider serviceProvider) : IGrainRuntime
+{
+    /// <inheritdoc/>
+    public IGrainFactory GrainFactory => throw new NotSupportedException("GrainFactory is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public ITimerRegistry TimerRegistry => throw new NotSupportedException("TimerRegistry is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public IServiceProvider ServiceProvider { get; } = serviceProvider;
+
+    /// <inheritdoc/>
+    public SiloAddress SiloAddress => SiloAddress.Zero;
+
+    /// <inheritdoc/>
+    public string SiloIdentity => "TestSilo";
+
+    /// <inheritdoc/>
+    public void DeactivateOnIdle(IGrainContext grainContext)
+    {
+    }
+
+    /// <inheritdoc/>
+    public void DelayDeactivation(IGrainContext grainContext, TimeSpan timeSpan)
+    {
+    }
+
+    /// <inheritdoc/>
+    public IStorage<TGrainState> GetStorage<TGrainState>(IGrainContext grainContext) =>
+        throw new NotSupportedException("GetStorage is not supported in test scenarios.");
+}

--- a/Source/Clients/Testing/TestServiceProvider.cs
+++ b/Source/Clients/Testing/TestServiceProvider.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing;
+
+/// <summary>
+/// Represents a minimal dictionary-backed <see cref="IServiceProvider"/> for grain construction in test scenarios.
+/// </summary>
+internal sealed class TestServiceProvider : IServiceProvider
+{
+    readonly Dictionary<Type, object> _services = [];
+
+    /// <inheritdoc/>
+    public object? GetService(Type serviceType) =>
+        _services.GetValueOrDefault(serviceType);
+
+    /// <summary>
+    /// Registers a service instance for the specified type.
+    /// </summary>
+    /// <typeparam name="T">The service type.</typeparam>
+    /// <param name="instance">The service instance.</param>
+    internal void AddService<T>(T instance)
+        where T : class =>
+        _services[typeof(T)] = instance;
+}


### PR DESCRIPTION
## Fixed
- `NullReferenceException` in `EventScenario` when constructing the kernel `EventSequence` grain outside a running Orleans silo — the grain constructor accessed `RuntimeContext.Current` and resolved `IGrainRuntime` from `ActivationServices`, both requiring a live silo. Construction is now wrapped in a minimal test context that satisfies both requirements.
- `AppendResult` returned "Sequence contains no elements" error on single `Append` calls — `InMemoryEventTypesStorage.GetDefinition` returned an `EventTypeDefinition` with empty `Generations`, causing `EventTypeMigrations.MigrateToAllGenerations` to crash on `.First()`. Now returns a single first-generation entry with an empty schema.

## Added
- `Testing.Specs` project with BDD specs covering `EventScenario` construction, single append, batch append, and seeded-event scenarios.