### PR TITLE
Add overloads to EventSequenceShouldExtensions

### DIFF
--- a/Documentation/testing/events/event-sequence-assertions.md
+++ b/Documentation/testing/events/event-sequence-assertions.md
@@ -12,9 +12,17 @@ These methods are available on any `IEventSequence` or `IEventLog` instance, inc
 | Method | Asserts |
 |--------|---------|
 | `ShouldHaveTailSequenceNumber(expected)` | Tail sequence number matches the expected value |
+| `ShouldHaveAppendedEvent<TEvent>()` | At least one event of the given type exists anywhere in the sequence |
+| `ShouldHaveAppendedEvent<TEvent>(validator)` | At least one event of the given type exists and passes the validator |
+| `ShouldHaveAppendedEvent<TEvent>(predicate)` | At least one event of the given type matches the predicate |
+| `ShouldHaveAppendedEvent<TEvent>(eventSourceId)` | At least one event of the given type exists for the event source |
+| `ShouldHaveAppendedEvent<TEvent>(eventSourceId, validator)` | At least one event of the given type exists for the event source and passes the validator |
+| `ShouldHaveAppendedEvent<TEvent>(eventSourceId, predicate)` | At least one event of the given type matches the predicate for the event source |
 | `ShouldHaveAppendedEvent<TEvent>(sequenceNumber)` | An event of the given type exists at the sequence number |
 | `ShouldHaveAppendedEvent<TEvent>(sequenceNumber, validator)` | An event of the given type exists at the sequence number and passes the validator |
+| `ShouldHaveAppendedEvent<TEvent>(sequenceNumber, predicate)` | An event of the given type at the sequence number matches the predicate |
 | `ShouldHaveAppendedEvent<TEvent>(sequenceNumber, eventSourceId, validator)` | An event of the given type exists at the sequence number for the given event source and passes the validator |
+| `ShouldHaveAppendedEvent<TEvent>(sequenceNumber, eventSourceId, predicate)` | An event of the given type at the sequence number for the given event source matches the predicate |
 
 All methods are async and return `Task`. They throw `EventSequenceAssertionException` on failure with a descriptive message.
 
@@ -35,7 +43,7 @@ Sequence numbers are zero-based, so the first event has sequence number `0` and 
 
 ## Verifying an appended event by type
 
-Use `ShouldHaveAppendedEvent<TEvent>` to verify that an event of the expected type was appended at a specific sequence number:
+Use `ShouldHaveAppendedEvent<TEvent>` without a sequence number to verify that at least one event of the expected type was appended anywhere in the sequence:
 
 ```csharp
 var scenario = new EventScenario();
@@ -43,6 +51,13 @@ var scenario = new EventScenario();
 await scenario.EventLog.Append(authorId, new AuthorRegistered("Jane Smith"));
 await scenario.EventLog.Append(authorId, new BookAdded("Clean Code"));
 
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>();
+await scenario.EventLog.ShouldHaveAppendedEvent<BookAdded>();
+```
+
+When you know the exact position, pass a sequence number to assert at a specific location:
+
+```csharp
 await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(0);
 await scenario.EventLog.ShouldHaveAppendedEvent<BookAdded>(1);
 ```
@@ -60,9 +75,34 @@ await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(0, author =>
     author.Name.ShouldEqual("Jane Smith"));
 ```
 
+Without a sequence number, the validator runs against the first event of the matching type:
+
+```csharp
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(author =>
+    author.Name.ShouldEqual("Jane Smith"));
+```
+
+## Verifying with a predicate
+
+Pass a `Func<TEvent, bool>` predicate when you only need to check whether the event satisfies a condition. The assertion fails if no event of the expected type returns `true` from the predicate:
+
+```csharp
+var scenario = new EventScenario();
+
+await scenario.EventLog.Append(authorId, new AuthorRegistered("Jane Smith"));
+
+// Without sequence number — finds any matching event
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(
+    author => author.Name == "Jane Smith");
+
+// At a specific sequence number
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(0,
+    author => author.Name == "Jane Smith");
+```
+
 ## Verifying event content for a specific event source
 
-When events for multiple event sources exist in the same sequence, filter by event source to avoid ambiguity:
+When events for multiple event sources exist in the same sequence, filter by event source to avoid ambiguity. All event source overloads support both `Action<TEvent>` validators and `Func<TEvent, bool>` predicates:
 
 ```csharp
 var scenario = new EventScenario();
@@ -72,10 +112,17 @@ var author2 = AuthorId.New();
 await scenario.EventLog.Append(author1, new AuthorRegistered("Jane Smith"));
 await scenario.EventLog.Append(author2, new AuthorRegistered("John Doe"));
 
+// With sequence number and validator
 await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(0, author1, author =>
     author.Name.ShouldEqual("Jane Smith"));
-await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(1, author2, author =>
+
+// Without sequence number — finds any matching event for the event source
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(author2, author =>
     author.Name.ShouldEqual("John Doe"));
+
+// With a predicate instead of a validator
+await scenario.EventLog.ShouldHaveAppendedEvent<AuthorRegistered>(
+    author1, author => author.Name == "Jane Smith");
 ```
 
 ## AppendedEventWithResult assertions

--- a/Source/Clients/Testing/EventSequences/EventSequenceShouldExtensions.cs
+++ b/Source/Clients/Testing/EventSequences/EventSequenceShouldExtensions.cs
@@ -30,6 +30,97 @@ public static class EventSequenceShouldExtensions
     }
 
     /// <summary>
+    /// Asserts that at least one event of the specified type was appended to the event sequence.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no event of the expected type is found.</exception>
+    public static Task ShouldHaveAppendedEvent<TEvent>(this IEventSequence eventSequence) =>
+        eventSequence.ShouldHaveAppendedEvent<TEvent>(_ => { });
+
+    /// <summary>
+    /// Asserts that at least one event of the specified type was appended and validates its content.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="validator">An action that validates the first matching event instance.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no event of the expected type is found or the validator throws.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        Action<TEvent> validator)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(EventSequenceNumber.First);
+        AssertAnyEventInList(events, validator);
+    }
+
+    /// <summary>
+    /// Asserts that at least one event of the specified type was appended and matches the predicate.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="predicate">A function that returns true if the event matches expectations.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no matching event is found.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        Func<TEvent, bool> predicate)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(EventSequenceNumber.First);
+        AssertAnyEventInList(events, predicate);
+    }
+
+    /// <summary>
+    /// Asserts that at least one event of the specified type was appended for the given event source.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> to filter by.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no event of the expected type is found.</exception>
+    public static Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        EventSourceId eventSourceId) =>
+        eventSequence.ShouldHaveAppendedEvent<TEvent>(eventSourceId, _ => { });
+
+    /// <summary>
+    /// Asserts that at least one event of the specified type was appended for the given event source and validates its content.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> to filter by.</param>
+    /// <param name="validator">An action that validates the first matching event instance.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no event of the expected type is found or the validator throws.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        EventSourceId eventSourceId,
+        Action<TEvent> validator)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(EventSequenceNumber.First, eventSourceId);
+        AssertAnyEventInList(events, validator);
+    }
+
+    /// <summary>
+    /// Asserts that at least one event of the specified type was appended for the given event source and matches the predicate.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> to filter by.</param>
+    /// <param name="predicate">A function that returns true if the event matches expectations.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when no matching event is found.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        EventSourceId eventSourceId,
+        Func<TEvent, bool> predicate)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(EventSequenceNumber.First, eventSourceId);
+        AssertAnyEventInList(events, predicate);
+    }
+
+    /// <summary>
     /// Asserts that a specific event type was appended at the given sequence number.
     /// </summary>
     /// <typeparam name="TEvent">The expected event type.</typeparam>
@@ -57,7 +148,25 @@ public static class EventSequenceShouldExtensions
         Action<TEvent> validator)
     {
         var events = await eventSequence.GetFromSequenceNumber(sequenceNumber);
-        AssertEventInList(events, sequenceNumber, validator);
+        AssertEventAtSequenceNumber(events, sequenceNumber, validator);
+    }
+
+    /// <summary>
+    /// Asserts that a specific event type was appended at the given sequence number and matches the predicate.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="sequenceNumber">The <see cref="EventSequenceNumber"/> at which the event is expected.</param>
+    /// <param name="predicate">A function that returns true if the event matches expectations.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when the event is not found, has the wrong type, or the predicate returns false.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        EventSequenceNumber sequenceNumber,
+        Func<TEvent, bool> predicate)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(sequenceNumber);
+        AssertEventAtSequenceNumber(events, sequenceNumber, predicate);
     }
 
     /// <summary>
@@ -77,10 +186,60 @@ public static class EventSequenceShouldExtensions
         Action<TEvent> validator)
     {
         var events = await eventSequence.GetFromSequenceNumber(sequenceNumber, eventSourceId);
-        AssertEventInList(events, sequenceNumber, validator);
+        AssertEventAtSequenceNumber(events, sequenceNumber, validator);
     }
 
-    static void AssertEventInList<TEvent>(
+    /// <summary>
+    /// Asserts that a specific event type was appended for the given event source at the given sequence number and matches the predicate.
+    /// </summary>
+    /// <typeparam name="TEvent">The expected event type.</typeparam>
+    /// <param name="eventSequence">The <see cref="IEventSequence"/> to assert on.</param>
+    /// <param name="sequenceNumber">The <see cref="EventSequenceNumber"/> at which the event is expected.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> the event belongs to.</param>
+    /// <param name="predicate">A function that returns true if the event matches expectations.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous assertion.</returns>
+    /// <exception cref="EventSequenceAssertionException">Thrown when the event is not found, has the wrong type, or the predicate returns false.</exception>
+    public static async Task ShouldHaveAppendedEvent<TEvent>(
+        this IEventSequence eventSequence,
+        EventSequenceNumber sequenceNumber,
+        EventSourceId eventSourceId,
+        Func<TEvent, bool> predicate)
+    {
+        var events = await eventSequence.GetFromSequenceNumber(sequenceNumber, eventSourceId);
+        AssertEventAtSequenceNumber(events, sequenceNumber, predicate);
+    }
+
+    static void AssertAnyEventInList<TEvent>(
+        IEnumerable<AppendedEvent> events,
+        Action<TEvent> validator)
+    {
+        var envelope = events.FirstOrDefault(e => e.Content is TEvent)
+            ?? throw new EventSequenceAssertionException(
+                $"Expected at least one event of type '{typeof(TEvent).Name}', but none was found.");
+
+        validator((TEvent)envelope.Content);
+    }
+
+    static void AssertAnyEventInList<TEvent>(
+        IEnumerable<AppendedEvent> events,
+        Func<TEvent, bool> predicate)
+    {
+        var matchingEvents = events.Where(e => e.Content is TEvent).ToList();
+
+        if (matchingEvents.Count == 0)
+        {
+            throw new EventSequenceAssertionException(
+                $"Expected at least one event of type '{typeof(TEvent).Name}', but none was found.");
+        }
+
+        if (!matchingEvents.Exists(e => predicate((TEvent)e.Content)))
+        {
+            throw new EventSequenceAssertionException(
+                $"Expected at least one event of type '{typeof(TEvent).Name}' matching the predicate, but none matched.");
+        }
+    }
+
+    static void AssertEventAtSequenceNumber<TEvent>(
         IEnumerable<AppendedEvent> events,
         EventSequenceNumber sequenceNumber,
         Action<TEvent> validator)
@@ -96,5 +255,27 @@ public static class EventSequenceShouldExtensions
         }
 
         validator(typedEvent);
+    }
+
+    static void AssertEventAtSequenceNumber<TEvent>(
+        IEnumerable<AppendedEvent> events,
+        EventSequenceNumber sequenceNumber,
+        Func<TEvent, bool> predicate)
+    {
+        var envelope = events.FirstOrDefault(e => e.Context.SequenceNumber == sequenceNumber)
+            ?? throw new EventSequenceAssertionException(
+                $"Expected event of type '{typeof(TEvent).Name}' at sequence number {sequenceNumber}, but no event was found.");
+
+        if (envelope.Content is not TEvent typedEvent)
+        {
+            throw new EventSequenceAssertionException(
+                $"Expected event of type '{typeof(TEvent).Name}' at sequence number {sequenceNumber}, but found '{envelope.Content?.GetType().Name}'.");
+        }
+
+        if (!predicate(typedEvent))
+        {
+            throw new EventSequenceAssertionException(
+                $"Event of type '{typeof(TEvent).Name}' at sequence number {sequenceNumber} did not match the predicate.");
+        }
     }
 }


### PR DESCRIPTION
## Added
- Overloads of `ShouldHaveAppendedEvent` without sequence number that search for any event of the given type in the sequence
- `Func<TEvent, bool>` predicate overloads as an alternative to `Action<TEvent>` validators for all `ShouldHaveAppendedEvent` variants
- `EventSourceId`-only overloads without sequence number for filtering by event source
- Documentation for all new assertion overloads