### PR TITLE
Fix slow waits in DotNET.InProcess specs

### DIFF
--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_deferred_parent_resolution/and_resolves_through_second_event_type.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_deferred_parent_resolution/and_resolves_through_second_event_type.cs
@@ -71,16 +71,29 @@ public class and_resolves_through_second_event_type(context context) : Given<con
             LastEventSequenceNumber = appendResult.SequenceNumber;
             await projection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
 
-            // Give it some time to process
-            await Task.Delay(1000);
-
             // Get failures if any
             FailedPartitions = await projection.GetFailedPartitions();
 
-            // Get the result
+            Result = await WaitForUpdatedRoot();
+        }
+
+        async Task<Root> WaitForUpdatedRoot(TimeSpan? timeout = null)
+        {
+            timeout ??= TimeSpanFactory.DefaultTimeout();
+
+            using var cts = new CancellationTokenSource(timeout.Value);
             var collection = ChronicleFixture.ReadModels.Database.GetCollection<Root>();
-            var queryResult = await collection.FindAsync(filter => filter.Name == UpdatedRootName);
-            Result = await queryResult.FirstOrDefaultAsync();
+            while (true)
+            {
+                var queryResult = await collection.FindAsync(filter => filter.Name == UpdatedRootName, cancellationToken: cts.Token);
+                var result = await queryResult.FirstOrDefaultAsync(cts.Token);
+                if (result is not null && result.__lastHandledEventSequenceNumber == LastEventSequenceNumber)
+                {
+                    return result;
+                }
+
+                await Task.Delay(50, cts.Token);
+            }
         }
     }
 

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending_events_with_multiple_generation_migrations/and_observers_consume_second_generation.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending_events_with_multiple_generation_migrations/and_observers_consume_second_generation.cs
@@ -69,16 +69,42 @@ public class and_observers_consume_second_generation(context context) : Given<co
 
             await EventStore.EventLog.Append(EventSourceId, Event);
 
-            await Reactor.WaitTillHandledEventReaches(1);
-            await Reducer.WaitTillHandledEventReaches(1);
-            await projectionHandler.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
-
             var collection = EventStoreForNamespaceDatabase.Database.GetCollection<BsonDocument>("event-log");
-            StoredEvent = await collection.Find(FilterDefinition<BsonDocument>.Empty).FirstOrDefaultAsync();
-
+            var readModels = _fixture.ReadModels.Database.GetCollection<UserReadModel>();
             var filter = Builders<UserReadModel>.Filter.Eq(new StringFieldDefinition<UserReadModel, string>("_id"), EventSourceId.Value);
-            var result = await _fixture.ReadModels.Database.GetCollection<UserReadModel>().FindAsync(filter);
-            ProjectionResult = await result.FirstOrDefaultAsync();
+
+            await WaitForObservedState(collection, readModels, filter);
+        }
+
+        async Task WaitForObservedState(
+            IMongoCollection<BsonDocument> eventLog,
+            IMongoCollection<UserReadModel> readModels,
+            FilterDefinition<UserReadModel> filter,
+            TimeSpan? timeout = default)
+        {
+            timeout ??= TimeSpanFactory.DefaultTimeout();
+            using var cts = new CancellationTokenSource(timeout.Value);
+
+            while (true)
+            {
+                StoredEvent = await eventLog.Find(FilterDefinition<BsonDocument>.Empty).FirstOrDefaultAsync(cts.Token);
+                var result = await readModels.FindAsync(filter, cancellationToken: cts.Token);
+                ProjectionResult = await result.FirstOrDefaultAsync(cts.Token);
+
+                if (StoredEvent is not null &&
+                    ProjectionResult is not null &&
+                    Reactor.ReceivedGeneration == 2u &&
+                    Reactor.ReceivedFirstName == "Jane" &&
+                    Reactor.ReceivedLastName == "Doe" &&
+                    Reducer.ReceivedGeneration == 2u &&
+                    Reducer.ReceivedFirstName == "Jane" &&
+                    Reducer.ReceivedLastName == "Doe")
+                {
+                    return;
+                }
+
+                await Task.Delay(50, cts.Token);
+            }
         }
     }
 

--- a/Integration/DotNET.InProcess/for_EventSequence/when_migrating_existing_events_after_new_generation/and_generation_2_content_is_backfilled.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_migrating_existing_events_after_new_generation/and_generation_2_content_is_backfilled.cs
@@ -53,18 +53,7 @@ public class and_generation_2_content_is_backfilled(context context) : Given<con
             // 4. Wait for the migration job to complete.
             if (result.IsSuccess)
             {
-                var timeout = DateTime.UtcNow.AddSeconds(30);
-                while (DateTime.UtcNow < timeout)
-                {
-                    var jobs = await jobsManager.GetAllJobs();
-                    var migrationJob = jobs.FirstOrDefault(j => j.Id == result.AsT0);
-                    if (migrationJob?.Status is KernelConcepts.Jobs.JobStatus.CompletedSuccessfully or KernelConcepts.Jobs.JobStatus.CompletedWithFailures)
-                    {
-                        break;
-                    }
-
-                    await Task.Delay(100);
-                }
+                _ = await EventStore.Jobs.WaitTillJobCompletesOrIsDeleted(result.AsT0.Value, TimeSpanFactory.FromSeconds(30));
             }
 
             // 5. Read the stored event after migration.

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/EventSequenceRedactionViaSequenceWaitHelpers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/EventSequenceRedactionViaSequenceWaitHelpers.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using KernelAppendedEvent = Cratis.Chronicle.Concepts.Events.AppendedEvent;
+using KernelGlobalEventTypes = Cratis.Chronicle.Concepts.Events.GlobalEventTypes;
+
+namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_redacting;
+
+static class EventSequenceRedactionViaSequenceWaitHelpers
+{
+    public static async Task<KernelAppendedEvent> WaitForRedactedEvent(this Cratis.Chronicle.XUnit.Integration.IChronicleSetupFixture fixture, Cratis.Chronicle.Events.EventSequenceNumber sequenceNumber, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.FromSeconds(30);
+        using var cts = new CancellationTokenSource(timeout.Value);
+        var storage = fixture.GetEventLogStorage();
+
+        while (true)
+        {
+            var storedEvent = await storage.GetEventAt(sequenceNumber.Value);
+            if (storedEvent.Context.EventType.Id == KernelGlobalEventTypes.Redaction)
+            {
+                return storedEvent;
+            }
+
+            await Task.Delay(50, cts.Token);
+        }
+    }
+
+    public static async Task<KernelAppendedEvent> WaitForSystemEvent(this Cratis.Chronicle.XUnit.Integration.IChronicleSetupFixture fixture, string eventTypeId, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.FromSeconds(30);
+        using var cts = new CancellationTokenSource(timeout.Value);
+        var systemStorage = fixture.GetSystemEventLogStorage();
+
+        while (true)
+        {
+            var tailSequenceNumber = await systemStorage.GetTailSequenceNumber();
+            var storedEvent = await systemStorage.GetEventAt(tailSequenceNumber);
+            if (storedEvent.Context.EventType.Id.Value == eventTypeId)
+            {
+                return storedEvent;
+            }
+
+            await Task.Delay(50, cts.Token);
+        }
+    }
+}

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_via_event_sequence.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_via_event_sequence.cs
@@ -30,22 +30,8 @@ public class a_single_event_via_event_sequence(context context) : Given<context>
             await EventStore.EventLog.Append(EventSourceId, Event);
             await EventStore.EventLog.Redact(EventSequenceNumber.First, "test reason");
 
-            // The redaction is performed asynchronously by EventSequencesReactor — poll until it completes.
-            var storage = GetEventLogStorage();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            do
-            {
-                StoredEvent = await storage.GetEventAt(EventSequenceNumber.First.Value);
-                if (StoredEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction)
-                {
-                    await Task.Delay(50, cts.Token);
-                }
-            }
-            while (StoredEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction);
-
-            var systemStorage = GetSystemEventLogStorage();
-            var tailSequenceNumber = await systemStorage.GetTailSequenceNumber();
-            SystemStoredEvent = await systemStorage.GetEventAt(tailSequenceNumber);
+            StoredEvent = await this.WaitForRedactedEvent(EventSequenceNumber.First);
+            SystemStoredEvent = await this.WaitForSystemEvent("EventRedactionRequested");
         }
     }
 

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
@@ -24,6 +24,8 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
         public SomeReducer Reducer { get; private set; }
         public NonReplayableReactor NonReplayableReactorInstance { get; private set; }
         public NonReplayableReducer NonReplayableReducerInstance { get; private set; }
+        public ReactorState NonReplayableReactorState { get; private set; }
+        public ReducerState NonReplayableReducerState { get; private set; }
 
         public override IEnumerable<Type> EventTypes => [typeof(SomeEvent), typeof(AnotherEvent)];
         public override IEnumerable<Type> Reactors => [typeof(SomeReactor), typeof(NonReplayableReactor)];
@@ -90,11 +92,10 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
             await Reactor.WaitTillHandledEventReaches(2);
             await Reducer.WaitTillHandledEventReaches(2);
 
-            // Give a brief window for non-replayable observers in case they would incorrectly be replayed.
-            await Task.Delay(500);
-
             ReactorState = await reactorHandler.GetState();
             ReducerState = await reducerHandler.GetState();
+            NonReplayableReactorState = await nonReplayableReactorHandler.GetState();
+            NonReplayableReducerState = await nonReplayableReducerHandler.GetState();
         }
 
         async Task MarkObserverAsNonReplayable(string observerId)
@@ -123,4 +124,10 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
 
     [Fact]
     void should_have_reducer_in_active_state() => Context.ReducerState.RunningState.ShouldEqual(ObserverRunningState.Active);
+
+    [Fact]
+    void should_keep_non_replayable_reactor_in_active_state() => Context.NonReplayableReactorState.RunningState.ShouldEqual(ObserverRunningState.Active);
+
+    [Fact]
+    void should_keep_non_replayable_reducer_in_active_state() => Context.NonReplayableReducerState.RunningState.ShouldEqual(ObserverRunningState.Active);
 }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
@@ -66,11 +66,13 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
             await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            // Wait for all observers to process the 3 events.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
-            await NonReplayableReactorInstance.WaitTillHandledEventReaches(3);
-            await NonReplayableReducerInstance.WaitTillHandledEventReaches(3);
+            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+
+            // Wait for all observers to process the appended events.
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
 
             // Mark the non-replayable observers as non-replayable in storage.
             await MarkObserverAsNonReplayable(typeof(NonReplayableReactor).GetReactorId());

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_observers.cs
@@ -62,10 +62,12 @@ public class a_single_event_with_observers(context context) : Given<context>(con
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
             await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            // Wait for all observers to process the 3 events.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
-            await projectionHandler.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First + 2);
+            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+
+            // Wait for all observers to process the appended events.
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
 
             // Reset counters before redaction to measure replay.
             Reactor.HandledEvents = 0;

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/all_events_for_an_event_source_via_event_sequence.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/all_events_for_an_event_source_via_event_sequence.cs
@@ -34,25 +34,9 @@ public class all_events_for_an_event_source_via_event_sequence(context context) 
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
             await EventStore.EventLog.Redact(EventSourceId, "test reason");
 
-            // The redaction is performed asynchronously by EventSequencesReactor — poll until it completes.
-            var storage = GetEventLogStorage();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            do
-            {
-                StoredFirstEvent = await storage.GetEventAt(EventSequenceNumber.First.Value);
-                StoredSecondEvent = await storage.GetEventAt((EventSequenceNumber.First + 1).Value);
-                if (StoredFirstEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction ||
-                    StoredSecondEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction)
-                {
-                    await Task.Delay(50, cts.Token);
-                }
-            }
-            while (StoredFirstEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction ||
-                    StoredSecondEvent.Context.EventType.Id != KernelGlobalEventTypes.Redaction);
-
-            var systemStorage = GetSystemEventLogStorage();
-            var tailSequenceNumber = await systemStorage.GetTailSequenceNumber();
-            SystemStoredEvent = await systemStorage.GetEventAt(tailSequenceNumber);
+            StoredFirstEvent = await this.WaitForRedactedEvent(EventSequenceNumber.First);
+            StoredSecondEvent = await this.WaitForRedactedEvent(EventSequenceNumber.First + 1);
+            SystemStoredEvent = await this.WaitForSystemEvent("EventsRedactedForEventSource");
         }
     }
 

--- a/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
@@ -68,11 +68,13 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
             await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            // Wait for all observers to process the 3 events.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
-            await NonReplayableReactorInstance.WaitTillHandledEventReaches(3);
-            await NonReplayableReducerInstance.WaitTillHandledEventReaches(3);
+            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+
+            // Wait for all observers to process the appended events.
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
 
             // Mark the non-replayable observers as non-replayable in storage.
             await MarkObserverAsNonReplayable(typeof(NonReplayableReactor).GetReactorId());

--- a/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
@@ -25,6 +25,8 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
         public SomeReducer Reducer { get; private set; }
         public NonReplayableReactor NonReplayableReactorInstance { get; private set; }
         public NonReplayableReducer NonReplayableReducerInstance { get; private set; }
+        public ReactorState NonReplayableReactorState { get; private set; }
+        public ReducerState NonReplayableReducerState { get; private set; }
 
         public override IEnumerable<Type> EventTypes => [typeof(SomeEvent), typeof(AnotherEvent)];
         public override IEnumerable<Type> Reactors => [typeof(SomeReactor), typeof(NonReplayableReactor)];
@@ -92,11 +94,10 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
             await Reactor.WaitTillHandledEventReaches(3);
             await Reducer.WaitTillHandledEventReaches(3);
 
-            // Give a brief window for non-replayable observers in case they would incorrectly be replayed.
-            await Task.Delay(500);
-
             ReactorState = await reactorHandler.GetState();
             ReducerState = await reducerHandler.GetState();
+            NonReplayableReactorState = await nonReplayableReactorHandler.GetState();
+            NonReplayableReducerState = await nonReplayableReducerHandler.GetState();
         }
 
         async Task MarkObserverAsNonReplayable(string observerId)
@@ -125,4 +126,10 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
 
     [Fact]
     void should_have_reducer_in_active_state() => Context.ReducerState.RunningState.ShouldEqual(ObserverRunningState.Active);
+
+    [Fact]
+    void should_keep_non_replayable_reactor_in_active_state() => Context.NonReplayableReactorState.RunningState.ShouldEqual(ObserverRunningState.Active);
+
+    [Fact]
+    void should_keep_non_replayable_reducer_in_active_state() => Context.NonReplayableReducerState.RunningState.ShouldEqual(ObserverRunningState.Active);
 }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_observers.cs
@@ -64,10 +64,12 @@ public class an_event_with_observers(context context) : Given<context>(context)
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
             await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            // Wait for all observers to process the 3 events.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
-            await projectionHandler.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First + 2);
+            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+
+            // Wait for all observers to process the appended events.
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
 
             // Reset counters before revision to measure replay.
             Reactor.HandledEvents = 0;

--- a/Integration/DotNET.InProcess/for_EventStoreSubscriptions/given/subscription_states_after_subscribing.cs
+++ b/Integration/DotNET.InProcess/for_EventStoreSubscriptions/given/subscription_states_after_subscribing.cs
@@ -18,24 +18,9 @@ public class subscription_states_after_subscribing(ChronicleInProcessFixture chr
             await EventStore.Subscriptions.Subscribe(id, sourceEventStore, configure);
         }
 
-        // The EventStoreSubscriptionsReactor is a kernel-side system reactor registered asynchronously
-        // via ReactorsReactor processing EventStoreAdded. Wait until it is available.
-        IReactorHandler? subscriptionsReactor = null;
-        var deadline = DateTimeOffset.UtcNow.Add(TimeSpanFactory.FromSeconds(60));
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            try
-            {
-                subscriptionsReactor = EventStore.Reactors.GetHandlerById("$system.Cratis.Chronicle.Observation.EventStoreSubscriptions.EventStoreSubscriptionsReactor");
-                break;
-            }
-            catch (UnknownReactorId)
-            {
-                await Task.Delay(100);
-            }
-        }
-
-        subscriptionsReactor.ShouldNotBeNull();
+        var subscriptionsReactor = await EventStore.Reactors.WaitForHandlerById(
+            "$system.Cratis.Chronicle.Observation.EventStoreSubscriptions.EventStoreSubscriptionsReactor",
+            TimeSpanFactory.FromSeconds(60));
         var systemStorage = GetSystemEventLogStorage();
         var tailSequenceNumber = (await systemStorage.GetTailSequenceNumber()).Value;
         await subscriptionsReactor.WaitTillReachesEventSequenceNumber(tailSequenceNumber);

--- a/Integration/DotNET.InProcess/for_JobsManager/when_starting/job_with_single_step/and_resuming_successfully_completed_job.cs
+++ b/Integration/DotNET.InProcess/for_JobsManager/when_starting/job_with_single_step/and_resuming_successfully_completed_job.cs
@@ -25,7 +25,7 @@ public class and_resuming_successfully_completed_job(context context) : Given<co
             await JobStepProcessor.WaitForStepsToBeCompleted();
             JobId = StartJobResult.AsT0;
             var job = await EventStore.Jobs.GetJob(JobId.Value);
-            var x = await EventStore.Jobs.WaitTillJobMeetsPredicate(JobId.Value, state => state.Status == JobStatus.CompletedSuccessfully, TimeSpanFactory.FromSeconds(20));
+            await EventStore.Jobs.WaitTillJobMeetsPredicate(JobId.Value, state => state.Status == JobStatus.CompletedSuccessfully && state.Progress.IsCompleted, TimeSpanFactory.FromSeconds(20));
             await JobsManager.Resume(JobId);
             CompletedJobState = await EventStore.Jobs.WaitTillJobMeetsPredicate(JobId.Value, state => state.Status == JobStatus.CompletedSuccessfully && state.Progress.IsCompleted, TimeSpanFactory.FromSeconds(20));
             JobSteps = await job.GetJobSteps();

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_and_is_not_behind.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_and_is_not_behind.cs
@@ -44,7 +44,7 @@ public class and_reactor_has_observed_events_previously_and_is_not_behind(contex
         {
             var reactor = await EventStore.Reactors.Register<ReactorWithoutDelay>();
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind.cs
@@ -45,7 +45,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind(contex
             await reactor.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reactor.WaitTillHandledEventReaches(HandledEventsBefore + FirstEvents.Count + CatchupEvents.Count);
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_multiple_partitions/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
@@ -45,7 +45,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind_by_one
             await reactor.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reactor.WaitTillHandledEventReaches(FirstEvents.Count + CatchupEvents.Count);
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind.cs
@@ -47,7 +47,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind(contex
             await reactor.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reactor.WaitTillHandledEventReaches(HandledEventsBefore + FirstEvents.Count + CatchupEvents.Count);
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/existing/with_single_partition/and_reactor_has_observed_events_previously_but_is_now_behind_by_one.cs
@@ -45,7 +45,7 @@ public class and_reactor_has_observed_events_previously_but_is_now_behind_by_one
             await reactor.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reactor.WaitTillHandledEventReaches(FirstEvents.Count + CatchupEvents.Count);
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_multiple_partitions/and_reactor_is_registered_while_there_are_events_in_sequence.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_multiple_partitions/and_reactor_is_registered_while_there_are_events_in_sequence.cs
@@ -33,7 +33,7 @@ public class and_reactor_is_registered_while_there_are_events_in_sequence(contex
             await reactor.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAppended);
             await Reactor.WaitTillHandledEventReaches(HandledEventsBefore + Events.Count);
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_multiple_partitions/and_reactor_is_registered_while_there_are_no_events_to_handle.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_multiple_partitions/and_reactor_is_registered_while_there_are_no_events_to_handle.cs
@@ -27,7 +27,7 @@ public class and_reactor_is_registered_while_there_are_no_events_to_handle(conte
         {
             var reactor = await EventStore.Reactors.Register<ReactorWithoutDelay>();
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_events_in_sequence.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_events_in_sequence.cs
@@ -36,7 +36,7 @@ public class and_reactor_is_registered_while_there_are_events_in_sequence(contex
             await Reactor.WaitTillHandledEventReaches(HandledEventsBefore + Events.Count);
             await reactor.WaitTillActive();
 
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_events_other_event_types_in_sequence.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_events_other_event_types_in_sequence.cs
@@ -30,7 +30,7 @@ public class and_reactor_is_registered_while_there_are_events_other_event_types_
         {
             var reactor = await EventStore.Reactors.Register<ReactorWithoutDelay>();
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_no_events_to_handle.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_connecting/non_existent/with_single_partition/and_reactor_is_registered_while_there_are_no_events_to_handle.cs
@@ -27,7 +27,7 @@ public class and_reactor_is_registered_while_there_are_no_events_to_handle(conte
         {
             var reactor = await EventStore.Reactors.Register<ReactorWithoutDelay>();
             await reactor.WaitTillActive();
-            ReactorState = await reactor.GetState();
+            ReactorState = await reactor.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_able_to_delete.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/given/a_reducer_able_to_delete.cs
@@ -21,8 +21,10 @@ public class a_reducer_able_to_delete<TReducer>(ChronicleInProcessFixture chroni
 
     async Task Establish()
     {
+        var startupTimeout = TimeSpanFactory.FromSeconds(30);
         _reducer = EventStore.Reducers.GetHandlerFor<TReducer>();
-        await _reducer.WaitTillActive();
+        await _reducer.WaitTillSubscribed(startupTimeout);
+        await _reducer.WaitTillActive(startupTimeout);
     }
 
     async Task Because()

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_waiting_for_observer_to_be_active.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event/and_waiting_for_observer_to_be_active.cs
@@ -38,13 +38,14 @@ public class and_waiting_for_observer_to_be_active(context context) : Given<cont
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reducer = EventStore.Reducers.GetHandlerFor<SomeReducer>();
-            await reducer.WaitTillActive();
+            await reducer.WaitTillActive(startupTimeout);
             await EventStore.EventLog.Append(EventSourceId, Event);
             await Tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             WaitingForObserverStateError = await Catch.Exception(async () => await EventStore.Reducers.WaitTillActive<SomeReducer>());
             await reducer.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState(startupTimeout);
 
             FailedPartitions = await reducer.GetFailedPartitions();
         }

--- a/Integration/DotNET.InProcess/for_Reducers/when_connecting/existing/with_multiple_partitions/and_reducer_has_observed_events_previously_but_is_now_behind.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_connecting/existing/with_multiple_partitions/and_reducer_has_observed_events_previously_but_is_now_behind.cs
@@ -45,8 +45,7 @@ public class and_reducer_has_observed_events_previously_but_is_now_behind(contex
             await reducer.WaitTillSubscribed();
             await reducer.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reducer.WaitTillHandledEventReaches(HandledEventsBefore + FirstEvents.Count + CatchupEvents.Count);
-            await reducer.WaitTillActive();
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/when_connecting/existing/with_single_partition/and_reducer_has_observed_events_previously_but_is_now_behind.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_connecting/existing/with_single_partition/and_reducer_has_observed_events_previously_but_is_now_behind.cs
@@ -48,8 +48,7 @@ public class and_reducer_has_observed_events_previously_but_is_now_behind(contex
             await reducer.WaitTillSubscribed();
             await reducer.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAfterDisconnect);
             await Reducer.WaitTillHandledEventReaches(HandledEventsBefore + FirstEvents.Count + CatchupEvents.Count);
-            await reducer.WaitTillActive();
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState();
             FailedPartitions = await reducer.GetFailedPartitions();
         }
     }

--- a/Integration/DotNET.InProcess/for_Reducers/when_connecting/non_existent/with_multiple_partitions/and_reducer_is_registered_while_there_are_events_in_sequence.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_connecting/non_existent/with_multiple_partitions/and_reducer_is_registered_while_there_are_events_in_sequence.cs
@@ -37,9 +37,7 @@ public class and_reducer_is_registered_while_there_are_events_in_sequence(contex
             await reducer.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAppended);
 
             await Reducer.WaitTillHandledEventReaches(HandledEventsBefore + Events.Count);
-            await reducer.WaitTillActive();
-
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/when_connecting/non_existent/with_single_partition/and_reducer_is_registered_while_there_are_events_in_sequence.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_connecting/non_existent/with_single_partition/and_reducer_is_registered_while_there_are_events_in_sequence.cs
@@ -36,9 +36,7 @@ public class and_reducer_is_registered_while_there_are_events_in_sequence(contex
             await reducer.WaitTillSubscribed();
             await reducer.WaitTillReachesEventSequenceNumber(LastEventSequenceNumberAppended);
             await Reducer.WaitTillHandledEventReaches(HandledEventsBefore + Events.Count);
-            await reducer.WaitTillActive();
-
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState();
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/and_needs_to_catch_up.cs
@@ -33,8 +33,9 @@ public class and_needs_to_catch_up(context context) : Given<context>(context)
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reducer = EventStore.Reducers.GetHandlerFor<ReducerThatCanFail>();
-            await reducer.WaitTillActive();
+            await reducer.WaitTillActive(startupTimeout);
             Observers[0].ShouldFail = true;
             Observers[1].ShouldFail = false;
             Observers[1].HandleTime = 1.Seconds();
@@ -60,8 +61,8 @@ public class and_needs_to_catch_up(context context) : Given<context>(context)
             JobsAfterCompleted = await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             FailedPartitionsAfterRetry = await reducer.GetFailedPartitions();
-            ReducerState = await reducer.GetState();
             await Observers[2].WaitTillHandledEventReaches(1);
+            ReducerState = await reducer.WaitTillActiveAndGetState(startupTimeout);
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/but_not_second_time.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/but_not_second_time.cs
@@ -27,8 +27,9 @@ public class but_not_second_time(context context) : Given<context>(context)
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reducer = EventStore.Reducers.GetHandlerFor<ReducerThatCanFail>();
-            await reducer.WaitTillActive();
+            await reducer.WaitTillActive(startupTimeout);
             Observers[0].ShouldFail = true;
             Observers[1].ShouldFail = false;
             await EventStore.EventLog.Append(EventSourceId, Event);
@@ -43,8 +44,8 @@ public class but_not_second_time(context context) : Given<context>(context)
             await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             FailedPartitionsAfterRetry = await reducer.GetFailedPartitions();
-            ReducerState = await reducer.GetState();
             await Observers[1].WaitTillHandledEventReaches(1);
+            ReducerState = await reducer.WaitTillActiveAndGetState(startupTimeout);
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/but_not_third_time.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_handling_event/and_it_fails/but_not_third_time.cs
@@ -33,9 +33,10 @@ public class but_not_third_time(context context) : Given<context>(context)
             // The retry backoff uses exponential delay: 2s for the first retry, 4s for the second.
             // The default 5s timeout is too tight for the second cycle, so use a longer timeout.
             var retryTimeout = TimeSpan.FromSeconds(10);
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
 
             var reducer = EventStore.Reducers.GetHandlerFor<ReducerThatCanFail>();
-            await reducer.WaitTillActive();
+            await reducer.WaitTillActive(startupTimeout);
             Observers[0].ShouldFail = true;
             Observers[1].ShouldFail = true;
             Observers[2].ShouldFail = false;
@@ -58,11 +59,9 @@ public class but_not_third_time(context context) : Given<context>(context)
             await EventStore.Jobs.WaitForThereToBeNoJobs(retryTimeout, JobStatus.CompletedWithFailures);
 
             FailedPartitionsAfterRetry = await reducer.GetFailedPartitions();
-            await reducer.WaitTillActive();
-
             await Observers[2].WaitTillHandledEventReaches(1);
 
-            ReducerState = await reducer.GetState();
+            ReducerState = await reducer.WaitTillActiveAndGetState(startupTimeout);
         }
     }
 

--- a/Integration/DotNET.InProcess/for_Webhooks/given/webhook_states_after_registering.cs
+++ b/Integration/DotNET.InProcess/for_Webhooks/given/webhook_states_after_registering.cs
@@ -18,24 +18,9 @@ public class webhook_states_after_registering(ChronicleInProcessFixture chronicl
             await Webhooks.Register(id, targetUrl, configure);
         }
 
-        // The WebhookReactor is a kernel-side system reactor registered asynchronously
-        // via ReactorsReactor processing EventStoreAdded. Retry until it is available.
-        IReactorHandler? webhookReactor = null;
-        var deadline = DateTimeOffset.UtcNow.AddSeconds(30);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            try
-            {
-                webhookReactor = EventStore.Reactors.GetHandlerById("$system.Cratis.Chronicle.Observation.Webhooks.WebhookReactor");
-                break;
-            }
-            catch (UnknownReactorId)
-            {
-                await Task.Delay(100);
-            }
-        }
-
-        webhookReactor.ShouldNotBeNull();
+        var webhookReactor = await EventStore.Reactors.WaitForHandlerById(
+            "$system.Cratis.Chronicle.Observation.Webhooks.WebhookReactor",
+            TimeSpanFactory.FromSeconds(30));
         var systemStorage = GetSystemEventLogStorage();
         var tailSequenceNumber = (await systemStorage.GetTailSequenceNumber()).Value;
         await webhookReactor.WaitTillReachesEventSequenceNumber(tailSequenceNumber);

--- a/Source/Clients/DotNET/Jobs/JobsWaitHelpers.cs
+++ b/Source/Clients/DotNET/Jobs/JobsWaitHelpers.cs
@@ -106,6 +106,37 @@ public static class JobsWaitHelpers
         jobs.WaitTillJobMeetsPredicate(jobId, state => state.Progress.IsStopped, timeout);
 
     /// <summary>
+    /// Waits for a job to reach a terminal state or to no longer exist.
+    /// </summary>
+    /// <param name="jobs"><see cref="IJobs"/> system.</param>
+    /// <param name="jobId">Job ID.</param>
+    /// <param name="timeout">Optional timeout. Defaults to 5 seconds.</param>
+    /// <returns>
+    /// The final <see cref="Job"/> state when it is retained; otherwise <see langword="null"/>
+    /// if the job has been removed after completion or deletion.
+    /// </returns>
+    public static async Task<Job?> WaitTillJobCompletesOrIsDeleted(this IJobs jobs, JobId jobId, TimeSpan? timeout = null)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (true)
+        {
+            var currentJob = await jobs.GetJob(jobId);
+            if (currentJob is null)
+            {
+                return null;
+            }
+
+            if (currentJob.Status is JobStatus.CompletedSuccessfully or JobStatus.CompletedWithFailures or JobStatus.Failed)
+            {
+                return currentJob;
+            }
+
+            await Task.Delay(DefaultDelay, cts.Token);
+        }
+    }
+
+    /// <summary>
     /// Waits for a job to be deleted.
     /// </summary>
     /// <param name="jobs"><see cref="IJobs"/> system.</param>

--- a/Source/Clients/DotNET/Reactors/ReactorWaitExtensions.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorWaitExtensions.cs
@@ -66,6 +66,30 @@ public static class ReactorWaitExtensions
     }
 
     /// <summary>
+    /// Waits for the reactor to reach a specific running state and returns that state snapshot.
+    /// </summary>
+    /// <param name="reactor">Reactor to wait for.</param>
+    /// <param name="runningState">The expected <see cref="ObserverRunningState"/> to wait for.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <returns>The <see cref="ReactorState"/> observed when the reactor reached the requested state.</returns>
+    public static async Task<ReactorState> WaitForStateAndGetState(this IReactorHandler reactor, ObserverRunningState runningState, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (true)
+        {
+            var state = await reactor.GetState();
+            if (state.RunningState == runningState)
+            {
+                return state;
+            }
+
+            await Task.Delay(DefaultDelay, cts.Token);
+        }
+    }
+
+    /// <summary>
     /// Wait till the reactor is active, with an optional timeout.
     /// </summary>
     /// <param name="reactor">Reactor to wait for.</param>
@@ -73,6 +97,15 @@ public static class ReactorWaitExtensions
     /// <returns>Awaitable task.</returns>
     public static Task WaitTillActive(this IReactorHandler reactor, TimeSpan? timeout = default) =>
          reactor.WaitForState(ObserverRunningState.Active, timeout);
+
+    /// <summary>
+    /// Waits until the reactor is active and returns that state snapshot.
+    /// </summary>
+    /// <param name="reactor">Reactor to wait for.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <returns>The <see cref="ReactorState"/> observed when the reactor became active.</returns>
+    public static Task<ReactorState> WaitTillActiveAndGetState(this IReactorHandler reactor, TimeSpan? timeout = default) =>
+        reactor.WaitForStateAndGetState(ObserverRunningState.Active, timeout);
 
     /// <summary>
     /// Wait till the reactor has been subscribed, with an optional timeout.

--- a/Source/Clients/DotNET/Reactors/ReactorWaitExtensions.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorWaitExtensions.cs
@@ -17,6 +17,31 @@ public static class ReactorWaitExtensions
     const int DefaultDelay = 50;
 
     /// <summary>
+    /// Waits for a reactor handler with the specified identifier to become available.
+    /// </summary>
+    /// <param name="reactors">The reactor system to query.</param>
+    /// <param name="reactorId">The identifier of the reactor to wait for.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <returns>The available <see cref="IReactorHandler"/>.</returns>
+    public static async Task<IReactorHandler> WaitForHandlerById(this IReactors reactors, ReactorId reactorId, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (true)
+        {
+            try
+            {
+                return reactors.GetHandlerById(reactorId);
+            }
+            catch (UnknownReactorId)
+            {
+                await Task.Delay(DefaultDelay, cts.Token);
+            }
+        }
+    }
+
+    /// <summary>
     /// Wait for the reactor to reach a specific running state.
     /// </summary>
     /// <param name="reactor">Reactor to wait for.</param>

--- a/Source/Clients/DotNET/Reducers/ReducerWaitExtensions.cs
+++ b/Source/Clients/DotNET/Reducers/ReducerWaitExtensions.cs
@@ -41,6 +41,30 @@ public static class ReducerWaitExtensions
     }
 
     /// <summary>
+    /// Waits for the reducer to reach a specific running state and returns that state snapshot.
+    /// </summary>
+    /// <param name="reducer">Reducer to wait for.</param>
+    /// <param name="runningState">The expected <see cref="ObserverRunningState"/> to wait for.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <returns>The <see cref="ReducerState"/> observed when the reducer reached the requested state.</returns>
+    public static async Task<ReducerState> WaitForStateAndGetState(this IReducerHandler reducer, ObserverRunningState runningState, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (true)
+        {
+            var state = await reducer.GetState();
+            if (state.RunningState == runningState)
+            {
+                return state;
+            }
+
+            await Task.Delay(DefaultDelay, cts.Token);
+        }
+    }
+
+    /// <summary>
     /// Wait till the reducer is active, with an optional timeout.
     /// </summary>
     /// <param name="reducer">Reducer to wait for.</param>
@@ -48,6 +72,15 @@ public static class ReducerWaitExtensions
     /// <returns>Awaitable task.</returns>
     public static Task WaitTillActive(this IReducerHandler reducer, TimeSpan? timeout = default) =>
         reducer.WaitForState(ObserverRunningState.Active, timeout);
+
+    /// <summary>
+    /// Waits until the reducer is active and returns that state snapshot.
+    /// </summary>
+    /// <param name="reducer">Reducer to wait for.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it will default to 5 seconds.</param>
+    /// <returns>The <see cref="ReducerState"/> observed when the reducer became active.</returns>
+    public static Task<ReducerState> WaitTillActiveAndGetState(this IReducerHandler reducer, TimeSpan? timeout = default) =>
+        reducer.WaitForStateAndGetState(ObserverRunningState.Active, timeout);
 
     /// <summary>
     /// Wait till the reactor has been subscribed, with an optional timeout.


### PR DESCRIPTION
## Fixed
- Removed timeout-prone manual polling from DotNET.InProcess migration and system-reactor spec setup
- Replaced fixed replay and projection sleeps with deterministic state-based waits in DotNET.InProcess specs