### PR TITLE
Fix two bugs in ReadModel scenario projection processor

### DIFF
--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -156,7 +156,7 @@ internal static class ProjectionReadModelProcessor
 
         var state = initialState is not null
             ? initialState.AsExpandoObject(false)
-            : new ExpandoObject();
+            : CreateInitialStateFromSchema(schema);
 
         // Process events, retrying any that return DeferredKey once all other events have been processed.
         var deferredEvents = new Queue<KernelAppendedEvent>();
@@ -193,6 +193,18 @@ internal static class ProjectionReadModelProcessor
 
         var json = JsonSerializer.Serialize(state);
         return JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
+    }
+
+    static ExpandoObject CreateInitialStateFromSchema(JsonSchema schema)
+    {
+        var initialState = new ExpandoObject();
+        var dict = (IDictionary<string, object?>)initialState;
+        foreach (var property in schema.Properties.Values.Where(p => p.IsArray))
+        {
+            dict[property.Name] = new List<object>();
+        }
+
+        return initialState;
     }
 
     static KernelProjectionEngine::ProjectionFactory CreateProjectionFactory(Storage.IStorage storage) =>

--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -99,7 +99,7 @@ public static class ExpandoObjectExtensions
             var value = property.GetValue(original, null);
             if (value != null)
             {
-                value = GetActualValueFrom(value);
+                value = GetActualValueFrom(value, camelCaseProperties);
             }
             expandoAsDictionary[propertyName] = value!;
         }
@@ -311,7 +311,7 @@ public static class ExpandoObjectExtensions
         }
     }
 
-    static object GetActualValueFrom(object value)
+    static object GetActualValueFrom(object value, bool camelCaseProperties = false)
     {
         var valueType = value.GetType();
         if (!valueType.IsPrimitive &&
@@ -329,14 +329,14 @@ public static class ExpandoObjectExtensions
 
                 foreach (var element in enumerableValue)
                 {
-                    list.Add(GetActualValueFrom(element));
+                    list.Add(GetActualValueFrom(element, camelCaseProperties));
                 }
 
                 value = list.ToArray();
             }
             else
             {
-                value = value.AsExpandoObject();
+                value = value.AsExpandoObject(camelCaseProperties);
             }
         }
 


### PR DESCRIPTION
## Fixed
- `AsExpandoObject` now propagates the `camelCaseProperties` flag recursively through `GetActualValueFrom`, fixing `KeyNotFoundException` when projection events contain nested objects whose properties were kept in PascalCase instead of being camel-cased to match the schema.
- `ProjectionReadModelProcessor` now seeds array-typed schema properties with empty lists when creating the initial state (matching `ProjectionFactory.CreateInitialState` in the kernel), fixing `ArgumentNullException` thrown by `.ShouldBeEmpty()` on child collection properties that received no events during a test scenario.