### PR TITLE
Fix implicit subscription reliability for built-in system reactors

### DIFF
--- a/Integration/DotNET.InProcess/for_EventStoreSubscriptions/when_registering_implicit_subscriptions/and_reactor_infers_external_inbox_subscription.cs
+++ b/Integration/DotNET.InProcess/for_EventStoreSubscriptions/when_registering_implicit_subscriptions/and_reactor_infers_external_inbox_subscription.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.Storage;
+using context = Cratis.Chronicle.InProcess.Integration.for_EventStoreSubscriptions.when_registering_implicit_subscriptions.and_reactor_infers_external_inbox_subscription.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.for_EventStoreSubscriptions.when_registering_implicit_subscriptions;
+
+[Collection(ChronicleCollection.Name)]
+public class and_reactor_infers_external_inbox_subscription(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
+    {
+        public const string LobbyEventStoreName = "Lobby";
+        public const string AdminEventStoreName = "Admin";
+        public IEnumerable<Concepts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition> StoredSubscriptions { get; private set; } = [];
+
+        public override IEnumerable<Type> EventTypes => [typeof(AdminUserInvited)];
+
+        public override IEnumerable<Type> Reactors => [typeof(LobbyReactor)];
+
+        async Task Because()
+        {
+            var lobbyEventStore = await ChronicleClient.GetEventStore(LobbyEventStoreName);
+            await lobbyEventStore.RegisterAll();
+
+            var subscriptionsReactor = await lobbyEventStore.Reactors.WaitForHandlerById(
+                "$system.Cratis.Chronicle.Observation.EventStoreSubscriptions.EventStoreSubscriptionsReactor",
+                TimeSpanFactory.FromSeconds(60));
+
+            var lobbyStorage = Services.GetRequiredService<IStorage>().GetEventStore(LobbyEventStoreName);
+            var lobbySystemSequence = lobbyStorage
+                .GetNamespace(Concepts.EventStoreNamespaceName.Default)
+                .GetEventSequence(Concepts.EventSequences.EventSequenceId.System);
+            var tailSequenceNumber = (await lobbySystemSequence.GetTailSequenceNumber()).Value;
+            await subscriptionsReactor.WaitTillReachesEventSequenceNumber(tailSequenceNumber);
+
+            StoredSubscriptions = await lobbyStorage.EventStoreSubscriptions.GetAll();
+        }
+    }
+
+    [Fact]
+    void should_have_persisted_one_subscription() =>
+        Context.StoredSubscriptions.Count().ShouldEqual(1);
+
+    [Fact]
+    void should_use_admin_event_store_as_subscription_identifier() =>
+        Context.StoredSubscriptions.Single().Identifier.Value.ShouldEqual(context.AdminEventStoreName);
+
+    [Fact]
+    void should_have_admin_as_source_event_store() =>
+        Context.StoredSubscriptions.Single().SourceEventStore.Value.ShouldEqual(context.AdminEventStoreName);
+
+    [Fact]
+    void should_include_the_inferred_external_event_type() =>
+        Context.StoredSubscriptions.Single().EventTypes.Select(_ => _.Id.Value).ShouldContain("7f7d0845-09f0-4e74-b689-684f5488f865");
+
+    [EventType("7f7d0845-09f0-4e74-b689-684f5488f865")]
+    [EventStore(context.AdminEventStoreName)]
+    record AdminUserInvited;
+
+    [Reactor]
+    class LobbyReactor : IReactor
+    {
+        public Task Invited(AdminUserInvited @event) => Task.CompletedTask;
+    }
+}

--- a/Source/Kernel/Core/Services/EventStores.cs
+++ b/Source/Kernel/Core/Services/EventStores.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using Cratis.Chronicle.Contracts;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventTypes;
+using Cratis.Chronicle.Observation.Reactors.Kernel;
 using Cratis.Chronicle.Storage;
 using Cratis.Reactive;
 using ProtoBuf.Grpc;
@@ -17,7 +18,8 @@ namespace Cratis.Chronicle.Services;
 /// <param name="grainFactory">The <see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="storage">The <see cref="IStorage"/> for working with the storage.</param>
 /// <param name="eventTypes">The <see cref="IEventTypes"/> for managing event types.</param>
-internal sealed class EventStores(IGrainFactory grainFactory, IStorage storage, IEventTypes eventTypes) : IEventStores
+/// <param name="reactors">The <see cref="IReactors"/> for discovering and registering kernel reactors.</param>
+internal sealed class EventStores(IGrainFactory grainFactory, IStorage storage, IEventTypes eventTypes, IReactors reactors) : IEventStores
 {
     /// <inheritdoc/>
     public async Task<IEnumerable<string>> GetEventStores()
@@ -46,6 +48,11 @@ internal sealed class EventStores(IGrainFactory grainFactory, IStorage storage, 
         // Ensure was called — causing DiscoverAndRegister to be skipped and leaving server
         // types such as EventRedactionRequested unregistered.
         await eventTypes.DiscoverAndRegister(eventStoreName);
+
+        // Always register kernel reactors in the default namespace.
+        // A store can exist without having emitted EventStoreAdded (for example if it was
+        // implicitly created), in which case ReactorsReactor would not have run.
+        await reactors.DiscoverAndRegister(eventStoreName, Concepts.EventStoreNamespaceName.Default);
 
         if (!exists)
         {

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -98,7 +98,11 @@ public static class ChronicleServerSiloBuilderExtensions
             var jsonSerializerOptions = sp.GetRequiredService<JsonSerializerOptions>();
             var projections = new Cratis.Chronicle.Services.Projections.Projections(grainFactory, expandoObjectConverter, sp.GetRequiredService<ILanguageService>(), sp);
             return new Cratis.Chronicle.Contracts.Services(
-                new Cratis.Chronicle.Services.EventStores(grainFactory, storage, sp.GetRequiredService<IEventTypes>()),
+                new Cratis.Chronicle.Services.EventStores(
+                    grainFactory,
+                    storage,
+                    sp.GetRequiredService<IEventTypes>(),
+                    sp.GetRequiredService<Cratis.Chronicle.Observation.Reactors.Kernel.IReactors>()),
                 new Cratis.Chronicle.Services.Namespaces(grainFactory, storage),
                 new Cratis.Chronicle.Services.Recommendations.Recommendations(grainFactory, storage),
                 new Cratis.Chronicle.Services.Identities.Identities(storage),


### PR DESCRIPTION
## Fixed
- Ensure kernel reactors are discovered and registered during event store ensure so built-in `$system` reactors are available even when the store was implicitly created.
- Add an in-process integration spec that verifies inferred external inbox subscriptions persist to `event-store-subscriptions`.
