### PR TITLE
Add EventTypeNullablePropertyAnalyzer and CHR0012 rule

### DIFF
--- a/Documentation/code-analysis/CHR0012.md
+++ b/Documentation/code-analysis/CHR0012.md
@@ -1,0 +1,44 @@
+# CHR0012: Event type has nullable property
+
+## Rule Description
+
+Event types should not have nullable properties. An event is a fact — an immutable record of something that happened. A nullable property introduces ambiguity: it is unclear whether the absence of a value is meaningful or simply means "not applicable". The recommended approach is to use separate, purpose-specific events to represent each distinct outcome.
+
+## Severity
+
+Warning
+
+## Example
+
+### Violation
+
+```csharp
+[EventType]
+public record OrderPlaced(string OrderId, string? PromotionCode);
+```
+
+The nullable `PromotionCode` property triggers CHR0012 because it conflates two distinct domain facts into one event: an order placed with a promotion, and an order placed without one.
+
+### Fix
+
+Model each fact as a distinct domain event:
+
+```csharp
+[EventType]
+public record OrderPlaced;
+
+[EventType]
+public record PromotionAssociatedWithOrder(string PromotionCode);
+```
+
+`PromotionAssociatedWithOrder` represents the actual domain fact — a promotion was applied to an order — rather than being a variant of `OrderPlaced`. Each event carries only the data relevant to that specific fact, and no property is ever null.
+
+## Why This Matters
+
+Nullable properties on events create problems that grow over time:
+
+- **Schema ambiguity** — Consumers cannot tell whether `null` means "unknown", "not applicable", or "was not provided".
+- **Projection complexity** — Projections must guard against null everywhere instead of reacting to well-defined events.
+- **Migration difficulty** — Changing a nullable property to a required one — or splitting it into separate events — requires a schema migration across the entire event log.
+
+Separate events describe intent clearly, keep projections simple, and leave the event log as a precise record of what happened.

--- a/Documentation/code-analysis/index.md
+++ b/Documentation/code-analysis/index.md
@@ -15,6 +15,7 @@ All rules follow the identifier format `CHR####` where the numbers are sequentia
 | [CHR0005](CHR0005.md) | Reactor event parameter must have [EventType] attribute | Error | Event parameters in reactor methods must be marked with [EventType] attribute |
 | [CHR0006](CHR0006.md) | Reducer method signature must match allowed signatures | Warning | Reducer methods must follow allowed signatures |
 | [CHR0007](CHR0007.md) | Reducer event parameter must have [EventType] attribute | Error | Event parameters in reducer methods must be marked with [EventType] attribute |
+| [CHR0012](CHR0012.md) | Event type has nullable property | Warning | Event types should not have nullable properties; use separate events instead |
 
 ## Quick Fixes
 

--- a/Documentation/code-analysis/toc.yml
+++ b/Documentation/code-analysis/toc.yml
@@ -14,3 +14,5 @@
   href: CHR0006.md
 - name: CHR0007 - Reducer event parameter must have [EventType] attribute
   href: CHR0007.md
+- name: CHR0012 - Event type has nullable property
+  href: CHR0012.md

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/EventWithNullableProperties.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/EventWithNullableProperties.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appending;
+
+[EventType]
+public record EventWithNullableProperties(string Name, string? Comment, DateOnly? StartDate);

--- a/Integration/DotNET.InProcess/for_EventSequence/when_appending/an_event_with_nullable_properties_set_to_null.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_appending/an_event_with_nullable_properties_set_to_null.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appending.an_event_with_nullable_properties_set_to_null.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_appending;
+
+[Collection(ChronicleCollection.Name)]
+public class an_event_with_nullable_properties_set_to_null(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
+    {
+        public override IEnumerable<Type> EventTypes => [typeof(EventWithNullableProperties)];
+
+        public IAppendResult Result { get; private set; }
+
+        async Task Because() =>
+            Result = await EventStore.EventLog.Append("source", new EventWithNullableProperties("Test", null, null));
+    }
+
+    [Fact] void should_succeed() => Context.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_constraint_violations() => Context.Result.HasConstraintViolations.ShouldBeFalse();
+    [Fact] void should_not_have_errors() => Context.Result.HasErrors.ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/given/an_event_type_nullable_property_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/given/an_event_type_nullable_property_analyzer.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer.given;
+
+public class an_event_type_nullable_property_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Concepts.Events;",
+            "",
+            "namespace Cratis.Chronicle.Concepts.Events",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class EventTypeAttribute : Attribute",
+            "    {",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_all_properties_are_non_nullable.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_all_properties_are_non_nullable.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer.when_analyzing_event_type;
+
+public class and_all_properties_are_non_nullable : given.an_event_type_nullable_property_analyzer
+{
+    const string Usage = """
+    [EventType]
+    public class MyEvent
+    {
+        public string Name { get; init; } = string.Empty;
+        public int Count { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage));
+
+    [Fact] Task should_not_report_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_property_is_nullable_reference_type.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_property_is_nullable_reference_type.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer.when_analyzing_event_type;
+
+public class and_property_is_nullable_reference_type : given.an_event_type_nullable_property_analyzer
+{
+    const string Usage = """
+    [EventType]
+    public class MyEvent
+    {
+        public string Name { get; init; } = string.Empty;
+        public string? {|#0:Comment|} { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.EventTypeHasNullableProperty, DiagnosticSeverity.Warning, "MyEvent", "Comment"));
+
+    [Fact] Task should_report_nullable_property_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_property_is_nullable_value_type.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_property_is_nullable_value_type.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer.when_analyzing_event_type;
+
+public class and_property_is_nullable_value_type : given.an_event_type_nullable_property_analyzer
+{
+    const string Usage = """
+    [EventType]
+    public class MyEvent
+    {
+        public string Name { get; init; } = string.Empty;
+        public int? {|#0:Count|} { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.EventTypeHasNullableProperty, DiagnosticSeverity.Warning, "MyEvent", "Count"));
+
+    [Fact] Task should_report_nullable_property_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_type_does_not_have_event_type_attribute.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_analyzing_event_type/and_type_does_not_have_event_type_attribute.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer.when_analyzing_event_type;
+
+public class and_type_does_not_have_event_type_attribute : given.an_event_type_nullable_property_analyzer
+{
+    const string Usage = """
+    public class MyEvent
+    {
+        public string Name { get; init; } = string.Empty;
+        public int? Count { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage));
+
+    [Fact] Task should_not_report_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_EventTypeNullablePropertyAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_EventTypeNullablePropertyAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.EventTypeNullablePropertyAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0012_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.EventTypeHasNullableProperty).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/EventTypeNullablePropertyAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/EventTypeNullablePropertyAnalyzer.cs
@@ -16,7 +16,7 @@ public class EventTypeNullablePropertyAnalyzer : DiagnosticAnalyzer
     static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticIds.EventTypeHasNullableProperty,
         title: "Event type has nullable property",
-        messageFormat: "Event type '{0}' has nullable property '{1}'. Consider using a separate event to represent the absence of this data instead of a nullable property.",
+        messageFormat: "Event type '{0}' has nullable property '{1}'. Consider modeling this as a separate domain event representing the specific fact that occurred, rather than making a property nullable.",
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/EventTypeNullablePropertyAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/EventTypeNullablePropertyAnalyzer.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that warns when event types have nullable properties.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class EventTypeNullablePropertyAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.EventTypeHasNullableProperty,
+        title: "Event type has nullable property",
+        messageFormat: "Event type '{0}' has nullable property '{1}'. Consider using a separate event to represent the absence of this data instead of a nullable property.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Event types should not have nullable properties. Instead, use separate events to represent optional data.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!WellKnownTypes.HasEventTypeAttribute(typeSymbol))
+        {
+            return;
+        }
+
+        foreach (var member in typeSymbol.GetMembers().OfType<IPropertySymbol>())
+        {
+            if (IsNullable(member.Type))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule,
+                    member.Locations.FirstOrDefault() ?? Location.None,
+                    typeSymbol.Name,
+                    member.Name));
+            }
+        }
+    }
+
+    static bool IsNullable(ITypeSymbol typeSymbol) =>
+        IsNullableValueType(typeSymbol) || IsNullableReferenceType(typeSymbol);
+
+    static bool IsNullableValueType(ITypeSymbol typeSymbol) =>
+        typeSymbol is INamedTypeSymbol namedType &&
+        namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+
+    static bool IsNullableReferenceType(ITypeSymbol typeSymbol) =>
+        typeSymbol.NullableAnnotation == NullableAnnotation.Annotated &&
+        typeSymbol.IsReferenceType;
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -62,4 +62,9 @@ public static class DiagnosticIds
     /// Declarative projection event types must all be from the same event store.
     /// </summary>
     public const string DeclarativeProjectionEventTypesMustBeFromSameEventStore = "CHR0011";
+
+    /// <summary>
+    /// Event type has nullable property.
+    /// </summary>
+    public const string EventTypeHasNullableProperty = "CHR0012";
 }

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_non_nullable_value_type_property_is_absent.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_non_nullable_value_type_property_is_absent.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchema.when_validating;
+
+public class and_required_non_nullable_value_type_property_is_absent : Specification
+{
+    record EventWithRequiredDate(string Name, DateOnly StartDate);
+
+    JsonSchema _schema;
+    IList<JsonSchemaValidationError> _result;
+
+    void Establish() => _schema = JsonSchema.FromType<EventWithRequiredDate>();
+
+    void Because()
+    {
+        var json = JsonSerializer.Serialize(new { name = "Test" });
+        _result = _schema.Validate(json);
+    }
+
+    [Fact] void should_report_one_error() => _result.Count.ShouldEqual(1);
+    [Fact] void should_report_property_required_error() => _result[0].Kind.ShouldEqual(JsonSchemaValidationErrorKind.PropertyRequired);
+    [Fact] void should_report_error_for_start_date() => _result[0].Path.ShouldEqual("startDate");
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_nullable_reference_type_property_is_absent.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_nullable_reference_type_property_is_absent.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchema.when_validating;
+
+public class and_required_nullable_reference_type_property_is_absent : Specification
+{
+    record EventWithNullableComment(string Name, string? Comment);
+
+    JsonSchema _schema;
+    IList<JsonSchemaValidationError> _result;
+
+    void Establish() => _schema = JsonSchema.FromType<EventWithNullableComment>();
+
+    void Because()
+    {
+        var json = JsonSerializer.Serialize(new { name = "Test" });
+        _result = _schema.Validate(json);
+    }
+
+    [Fact] void should_not_report_any_errors() => _result.ShouldBeEmpty();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_nullable_value_type_property_is_absent.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_validating/and_required_nullable_value_type_property_is_absent.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchema.when_validating;
+
+public class and_required_nullable_value_type_property_is_absent : Specification
+{
+    record EventWithNullableDate(string Name, DateOnly? StartDate);
+
+    JsonSchema _schema;
+    IList<JsonSchemaValidationError> _result;
+
+    void Establish() => _schema = JsonSchema.FromType<EventWithNullableDate>();
+
+    void Because()
+    {
+        var json = JsonSerializer.Serialize(new { name = "Test" });
+        _result = _schema.Validate(json);
+    }
+
+    [Fact] void should_not_report_any_errors() => _result.ShouldBeEmpty();
+}

--- a/Source/Infrastructure/Schemas/JsonSchema.cs
+++ b/Source/Infrastructure/Schemas/JsonSchema.cs
@@ -490,7 +490,7 @@ public class JsonSchema
                     .Select(req => req?.GetValue<string>())
                     .Where(propName => propName is not null))
                 {
-                    if (!obj.ContainsKey(propName!))
+                    if (!obj.ContainsKey(propName!) && !PropertyAllowsNull(propName!))
                     {
                         errors.Add(new JsonSchemaValidationError(propName, JsonSchemaValidationErrorKind.PropertyRequired, $"Property '{propName}' is required."));
                     }
@@ -503,6 +503,21 @@ public class JsonSchema
         }
 
         return errors;
+
+        bool PropertyAllowsNull(string propName)
+        {
+            if (!Properties.TryGetValue(propName, out var propSchema))
+            {
+                return false;
+            }
+
+            if (propSchema.Type.HasFlag(JsonObjectType.Null))
+            {
+                return true;
+            }
+
+            return propSchema.AnyOf.Any(s => s.Type == JsonObjectType.Null);
+        }
     }
 
     static JsonObjectType ParseTypeFromNode(JsonObject node)


### PR DESCRIPTION
# Summary

Introduce a new analyzer for event types with nullable properties and a corresponding rule.

## Added

- EventTypeNullablePropertyAnalyzer to analyze event types for nullable properties.
- CHR0012 rule to warn against using nullable properties in event types.
- Tests for the new analyzer and rule.

## Changed

- Updated documentation to include the new CHR0012 rule.
- Allow null values on nullable properties

