### PR TITLE
Remove mandatory encryption certificate requirement in production

### DIFF
--- a/Documentation/hosting/encryption-certificate.md
+++ b/Documentation/hosting/encryption-certificate.md
@@ -194,18 +194,6 @@ If authentication fails after configuration:
 2. Check for special characters that may need escaping in environment variables
 3. Ensure the password matches what was used during certificate generation
 
-### Production Startup Failure
-
-In production, Chronicle will fail to start if no encryption certificate is configured:
-
-```bash
-InvalidOperationException: An encryption certificate is required in production for Data Protection key security.
-Configure 'EncryptionCertificate:CertificatePath' and 'EncryptionCertificate:CertificatePassword'
-in your configuration.
-```
-
-Ensure you have configured the certificate path and password as described above.
-
 ## Next Steps
 
 - [Local Certificates](local-certificates.md) - TLS certificate setup for development

--- a/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
@@ -57,15 +57,6 @@ public static class ServiceCollectionExtensions
                 encryptionCert.CertificatePassword);
             dataProtectionBuilder.ProtectKeysWithCertificate(certificate);
         }
-#if !DEVELOPMENT
-        else
-        {
-            throw new InvalidOperationException(
-                "An encryption certificate is required in production for Data Protection key security. " +
-                "Configure 'EncryptionCertificate:CertificatePath' and 'EncryptionCertificate:CertificatePassword' " +
-                "in your configuration. See the Chronicle documentation for more details on generating and configuring certificates.");
-        }
-#endif
 
         // Add ASP.NET Identity
         services.AddIdentityCore<User>(options =>


### PR DESCRIPTION
## Fixed
- Production environment no longer requires an encryption certificate to be configured