### PR TITLE
Add identity provider certificate options and split TLS docs

### DIFF
--- a/Documentation/hosting/configuration/authentication.md
+++ b/Documentation/hosting/configuration/authentication.md
@@ -2,6 +2,8 @@
 
 Authentication is always enabled. When `authority` is not configured, Chronicle uses its built-in OpenIdDict OAuth authority. When `authority` is set to an external OAuth provider URL, Chronicle will use that instead of the internal authority.
 
+Identity provider certificate configuration is documented on [Identity Provider Certificate](identity-provider-certificate.md).
+
 ## Example configuration
 
 ```json

--- a/Documentation/hosting/configuration/configuration-file.md
+++ b/Documentation/hosting/configuration/configuration-file.md
@@ -33,6 +33,13 @@ Chronicle Server loads configuration from a `chronicle.json` file in the applica
         "authority": null,
         "defaultAdminUsername": "admin",
         "defaultAdminPassword": "admin"
+    },
+    "identityProvider": {
+        "certificate": {
+            "enabled": true,
+            "certificatePath": "/path/to/identity-provider.pfx",
+            "certificatePassword": "your-password"
+        }
     }
 }
 ```
@@ -47,4 +54,5 @@ Environment variables can override any of these values. See [Configuration Prece
 | observers | Retry and timeout settings for observers |
 | events | Event queue configuration |
 | authentication | Authentication and default admin settings |
+| identityProvider | Optional internal identity provider certificate settings |
 

--- a/Documentation/hosting/configuration/identity-provider-certificate.md
+++ b/Documentation/hosting/configuration/identity-provider-certificate.md
@@ -1,0 +1,74 @@
+# Identity Provider Certificate Configuration
+
+When Chronicle uses the internal OAuth authority (`authentication.authority` is not set), you can configure a dedicated certificate for identity provider endpoints.
+
+This certificate configuration is separate from Workbench TLS and uses its own configuration path:
+
+- `identityProvider.certificate`
+
+## Fallback behavior
+
+Identity provider certificate resolution follows this order:
+
+1. If `identityProvider.certificate` is set, use it.
+2. If `identityProvider.certificate` is not set, fall back to top-level `tls`.
+
+This preserves backward compatibility with existing configurations that only use `tls`.
+
+## Configuration
+
+### Dedicated identity provider certificate
+
+```json
+{
+  "authentication": {
+    "authority": null
+  },
+  "identityProvider": {
+    "certificate": {
+      "enabled": true,
+      "certificatePath": "/certs/identity-provider.pfx",
+      "certificatePassword": "your-password"
+    }
+  }
+}
+```
+
+### Reuse top-level TLS certificate (fallback)
+
+```json
+{
+  "tls": {
+    "enabled": true,
+    "certificatePath": "/certs/server.pfx",
+    "certificatePassword": "your-password"
+  },
+  "authentication": {
+    "authority": null
+  }
+}
+```
+
+In this configuration, `identityProvider.certificate` is not set, so Chronicle uses `tls` for identity provider endpoint scheme decisions.
+
+## Environment variables
+
+```bash
+Cratis__Chronicle__IdentityProvider__Certificate__Enabled=true
+Cratis__Chronicle__IdentityProvider__Certificate__CertificatePath=/certs/identity-provider.pfx
+Cratis__Chronicle__IdentityProvider__Certificate__CertificatePassword=your-password
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| identityProvider.certificate.enabled | boolean | true | Whether TLS is enabled for identity provider endpoints |
+| identityProvider.certificate.certificatePath | string | null | Path to the identity provider certificate file (PFX format) |
+| identityProvider.certificate.certificatePassword | string | null | Password for the identity provider certificate file |
+
+## Related topics
+
+- [Authentication](authentication.md)
+- [TLS](tls.md)
+- [Workbench TLS Configuration](workbench-tls.md)

--- a/Documentation/hosting/configuration/index.md
+++ b/Documentation/hosting/configuration/index.md
@@ -23,7 +23,9 @@ Chronicle Server can be configured using a `chronicle.json` file or environment 
 | Observers | Retry and timeout settings |
 | Events | Event queue configuration |
 | Authentication | External authority and default admin settings |
-| TLS | Certificate configuration for secure transport |
+| TLS | gRPC TLS certificate configuration |
+| Workbench TLS | Dedicated Workbench TLS and certificate configuration |
+| Identity Provider Certificate | Dedicated certificate configuration for internal OAuth authority |
 
 ## Topics
 
@@ -34,7 +36,9 @@ Chronicle Server can be configured using a `chronicle.json` file or environment 
 - [Observers](observers.md) - Retry and timeout settings for observer subscriptions.
 - [Events](events.md) - Configure event queues.
 - [Authentication](authentication.md) - External authority and default admin settings.
-- [TLS](tls.md) - Configure TLS certificates for Chronicle Server.
+- [TLS](tls.md) - Configure top-level gRPC TLS certificates.
+- [Workbench TLS](workbench-tls.md) - Configure Workbench TLS and certificates.
+- [Identity Provider Certificate](identity-provider-certificate.md) - Configure internal OAuth authority certificates.
 - [Environment Variables](environment-variables.md) - Configure with `Cratis__Chronicle__` settings.
 - [Open Telemetry](open-telemetry.md) - Export metrics, traces, and logs via OTLP.
 - [Docker Configuration](docker.md) - Configure Chronicle in Docker.

--- a/Documentation/hosting/configuration/tls.md
+++ b/Documentation/hosting/configuration/tls.md
@@ -41,11 +41,10 @@ The top-level `tls` configuration controls the gRPC listener:
 
 Use `tls.enabled=false` only when TLS is terminated by upstream infrastructure such as ingress or reverse proxies.
 
-## Workbench-specific TLS
+## Related TLS and certificate pages
 
-The Workbench (admin UI) can have its own TLS configuration, independent of gRPC. This is useful for deployments behind an ingress or reverse proxy (e.g., Azure Container Apps, Nginx, Azure App Gateway) that terminates TLS upstream.
-
-See [Workbench TLS](workbench-tls.md) for details.
+- [Workbench TLS Configuration](workbench-tls.md) for Workbench-specific TLS and certificates.
+- [Identity Provider Certificate Configuration](identity-provider-certificate.md) for internal OAuth authority certificates.
 
 ## Development vs production
 

--- a/Documentation/hosting/configuration/toc.yml
+++ b/Documentation/hosting/configuration/toc.yml
@@ -18,6 +18,8 @@
   href: tls.md
 - name: Workbench TLS
   href: workbench-tls.md
+- name: Identity Provider Certificate
+  href: identity-provider-certificate.md
 - name: Client Bootstrap
   href: client-bootstrap.md
 - name: Environment Variables

--- a/Source/Kernel/Core/Configuration/ChronicleOptions.cs
+++ b/Source/Kernel/Core/Configuration/ChronicleOptions.cs
@@ -67,6 +67,11 @@ public class ChronicleOptions
     public Authentication Authentication { get; init; } = new Authentication();
 
     /// <summary>
+    /// Gets or inits the optional identity provider configuration.
+    /// </summary>
+    public IdentityProviderOptions? IdentityProvider { get; init; }
+
+    /// <summary>
     /// Gets the encryption certificate configuration for Data Protection keys.
     /// When not configured, keys are auto-generated and stored in the database.
     /// </summary>
@@ -91,7 +96,7 @@ public class ChronicleOptions
 
     /// <summary>
     /// Gets the effective TLS configuration for the Workbench.
-    /// Falls back to the top-level <see cref="Tls"/> if <see cref="Workbench"/> or <see cref="Configuration.Workbench.Tls"/> is not set.
+    /// Falls back to the top-level <see cref="Tls"/> if <see cref="Workbench"/> or <see cref="Workbench.Tls"/> is not set.
     /// </summary>
     public Tls WorkbenchTls => Workbench?.Tls ?? Tls;
 

--- a/Source/Kernel/Core/Configuration/IdentityProviderOptions.cs
+++ b/Source/Kernel/Core/Configuration/IdentityProviderOptions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents configuration for Chronicle's internal identity provider.
+/// </summary>
+public class IdentityProviderOptions
+{
+    /// <summary>
+    /// Gets or inits the optional certificate configuration used by the internal identity provider.
+    /// When not set, Chronicle falls back to the top-level <see cref="ChronicleOptions.Tls"/> configuration.
+    /// </summary>
+    public Tls? Certificate { get; init; }
+}

--- a/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
@@ -87,13 +87,14 @@ public static class OpenIddictServiceCollectionExtensions
                 }
 #endif
 
-                // Determine if the Workbench has TLS enabled (token endpoint runs on the management port)
-                var workbenchTls = chronicleOptions.WorkbenchTls;
-                var workbenchHasSecureCertificate = workbenchTls.Enabled && !string.IsNullOrEmpty(workbenchTls.CertificatePath);
+                // Determine if the identity provider has TLS enabled (token endpoint runs on the management port).
+                // Prefer IdentityProvider:Certificate when configured and fall back to top-level Tls for backward compatibility.
+                var identityProviderCertificate = chronicleOptions.IdentityProvider?.Certificate ?? chronicleOptions.Tls;
+                var identityProviderHasSecureCertificate = identityProviderCertificate.Enabled && !string.IsNullOrEmpty(identityProviderCertificate.CertificatePath);
 
                 // Allow HTTP connections when Workbench TLS is disabled (e.g. behind ingress/reverse proxy)
 #if DEVELOPMENT
-                if (!workbenchHasSecureCertificate)
+                if (!identityProviderHasSecureCertificate)
                 {
                     options.UseAspNetCore()
                            .EnableTokenEndpointPassthrough()
@@ -105,7 +106,7 @@ public static class OpenIddictServiceCollectionExtensions
                            .EnableTokenEndpointPassthrough();
                 }
 #else
-                if (!workbenchHasSecureCertificate)
+                if (!identityProviderHasSecureCertificate)
                 {
                     options.UseAspNetCore()
                            .EnableTokenEndpointPassthrough()
@@ -124,9 +125,9 @@ public static class OpenIddictServiceCollectionExtensions
                 }
                 else
                 {
-                    // Use Workbench TLS config to determine the issuer scheme
+                    // Use identity provider certificate config to determine the issuer scheme
                     // since the token endpoint is served on the management port
-                    var internalScheme = workbenchHasSecureCertificate ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
+                    var internalScheme = identityProviderHasSecureCertificate ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
                     var internalAuthority = new UriBuilder(internalScheme, "localhost", chronicleOptions.ManagementPort).Uri;
                     options.SetIssuer(internalAuthority);
                 }
@@ -149,9 +150,10 @@ public static class OpenIddictServiceCollectionExtensions
                 }
                 else
                 {
-                    // Use Workbench TLS config since tokens are served on the management port
-                    var validationWorkbenchTls = chronicleOptions.WorkbenchTls;
-                    var validationHasSecureCertificate = validationWorkbenchTls.Enabled && !string.IsNullOrEmpty(validationWorkbenchTls.CertificatePath);
+                    // Use identity provider certificate config since tokens are served on the management port.
+                    // Prefer IdentityProvider:Certificate when configured and fall back to top-level Tls.
+                    var validationIdentityProviderCertificate = chronicleOptions.IdentityProvider?.Certificate ?? chronicleOptions.Tls;
+                    var validationHasSecureCertificate = validationIdentityProviderCertificate.Enabled && !string.IsNullOrEmpty(validationIdentityProviderCertificate.CertificatePath);
                     scheme = validationHasSecureCertificate ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
                     host = "localhost";
                 }


### PR DESCRIPTION
## Added
- Added optional `identityProvider.certificate` Chronicle configuration for internal OAuth authority endpoint TLS decisions.
- Added a dedicated identity provider certificate configuration page under hosting configuration.

## Changed
- Internal OAuth authority now prefers `identityProvider.certificate` and falls back to top-level `tls` for backward compatibility.
- Split Workbench TLS and identity provider certificate guidance into separate hosting configuration pages.