### PR TITLE
Simplify event type references in integration specs and docs

### DIFF
--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/EventSequenceRedactionViaSequenceWaitHelpers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/EventSequenceRedactionViaSequenceWaitHelpers.cs
@@ -8,7 +8,7 @@ namespace Cratis.Chronicle.InProcess.Integration.for_EventSequence.when_redactin
 
 static class EventSequenceRedactionViaSequenceWaitHelpers
 {
-    public static async Task<KernelAppendedEvent> WaitForRedactedEvent(this Cratis.Chronicle.XUnit.Integration.IChronicleSetupFixture fixture, Cratis.Chronicle.Events.EventSequenceNumber sequenceNumber, TimeSpan? timeout = default)
+    public static async Task<KernelAppendedEvent> WaitForRedactedEvent(this IChronicleSetupFixture fixture, Events.EventSequenceNumber sequenceNumber, TimeSpan? timeout = default)
     {
         timeout ??= TimeSpanFactory.FromSeconds(30);
         using var cts = new CancellationTokenSource(timeout.Value);
@@ -26,7 +26,7 @@ static class EventSequenceRedactionViaSequenceWaitHelpers
         }
     }
 
-    public static async Task<KernelAppendedEvent> WaitForSystemEvent(this Cratis.Chronicle.XUnit.Integration.IChronicleSetupFixture fixture, string eventTypeId, TimeSpan? timeout = default)
+    public static async Task<KernelAppendedEvent> WaitForSystemEvent(this IChronicleSetupFixture fixture, string eventTypeId, TimeSpan? timeout = default)
     {
         timeout ??= TimeSpanFactory.FromSeconds(30);
         using var cts = new CancellationTokenSource(timeout.Value);

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_source_type_filter/and_event_does_not_match_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_source_type_filter/and_event_does_not_match_filter.cs
@@ -46,7 +46,7 @@ public class and_event_does_not_match_filter(context context) : Given<context>(c
             await EventStore.EventLog.Append(EventSourceId, NonMatchingEvent);
 
             // Append an event with the matching event source type — should be handled
-            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventSourceType: new Events.EventSourceType("order"));
+            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventSourceType: new EventSourceType("order"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reactor.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First.Next());
             ReactorState = await reactor.GetState();

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_source_type_filter/and_event_matches_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_source_type_filter/and_event_matches_filter.cs
@@ -39,7 +39,7 @@ public class and_event_matches_filter(context context) : Given<context>(context)
         {
             var reactor = EventStore.Reactors.GetHandlerFor<ReactorFilteredByEventSourceType>();
             await reactor.WaitTillActive();
-            await EventStore.EventLog.Append(EventSourceId, Event, eventSourceType: new Events.EventSourceType("order"));
+            await EventStore.EventLog.Append(EventSourceId, Event, eventSourceType: new EventSourceType("order"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reactor.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
             ReactorState = await reactor.GetState();

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_stream_type_filter/and_event_does_not_match_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_stream_type_filter/and_event_does_not_match_filter.cs
@@ -46,7 +46,7 @@ public class and_event_does_not_match_filter(context context) : Given<context>(c
             await EventStore.EventLog.Append(EventSourceId, NonMatchingEvent);
 
             // Append an event with the matching event stream type — should be handled
-            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventStreamType: new Events.EventStreamType("orders"));
+            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventStreamType: new EventStreamType("orders"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reactor.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First.Next());
             ReactorState = await reactor.GetState();

--- a/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_stream_type_filter/and_event_matches_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reactors/when_appending_event_with_event_stream_type_filter/and_event_matches_filter.cs
@@ -39,7 +39,7 @@ public class and_event_matches_filter(context context) : Given<context>(context)
         {
             var reactor = EventStore.Reactors.GetHandlerFor<ReactorFilteredByEventStreamType>();
             await reactor.WaitTillActive();
-            await EventStore.EventLog.Append(EventSourceId, Event, eventStreamType: new Events.EventStreamType("orders"));
+            await EventStore.EventLog.Append(EventSourceId, Event, eventStreamType: new EventStreamType("orders"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reactor.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
             ReactorState = await reactor.GetState();

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_source_type_filter/and_event_does_not_match_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_source_type_filter/and_event_does_not_match_filter.cs
@@ -46,7 +46,7 @@ public class and_event_does_not_match_filter(context context) : Given<context>(c
             await EventStore.EventLog.Append(EventSourceId, NonMatchingEvent);
 
             // Append an event with the matching event source type — should be handled
-            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventSourceType: new Events.EventSourceType("order"));
+            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventSourceType: new EventSourceType("order"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reducer.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First.Next());
             ReducerState = await reducer.GetState();

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_source_type_filter/and_event_matches_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_source_type_filter/and_event_matches_filter.cs
@@ -39,7 +39,7 @@ public class and_event_matches_filter(context context) : Given<context>(context)
         {
             var reducer = EventStore.Reducers.GetHandlerFor<ReducerFilteredByEventSourceType>();
             await reducer.WaitTillActive();
-            await EventStore.EventLog.Append(EventSourceId, Event, eventSourceType: new Events.EventSourceType("order"));
+            await EventStore.EventLog.Append(EventSourceId, Event, eventSourceType: new EventSourceType("order"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reducer.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
             ReducerState = await reducer.GetState();

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_stream_type_filter/and_event_does_not_match_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_stream_type_filter/and_event_does_not_match_filter.cs
@@ -46,7 +46,7 @@ public class and_event_does_not_match_filter(context context) : Given<context>(c
             await EventStore.EventLog.Append(EventSourceId, NonMatchingEvent);
 
             // Append an event with the matching event stream type — should be handled
-            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventStreamType: new Events.EventStreamType("invoices"));
+            await EventStore.EventLog.Append(EventSourceId, MatchingEvent, eventStreamType: new EventStreamType("invoices"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reducer.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First.Next());
             ReducerState = await reducer.GetState();

--- a/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_stream_type_filter/and_event_matches_filter.cs
+++ b/Integration/DotNET.InProcess/for_Reducers/when_appending_event_with_event_stream_type_filter/and_event_matches_filter.cs
@@ -39,7 +39,7 @@ public class and_event_matches_filter(context context) : Given<context>(context)
         {
             var reducer = EventStore.Reducers.GetHandlerFor<ReducerFilteredByEventStreamType>();
             await reducer.WaitTillActive();
-            await EventStore.EventLog.Append(EventSourceId, Event, eventStreamType: new Events.EventStreamType("invoices"));
+            await EventStore.EventLog.Append(EventSourceId, Event, eventStreamType: new EventStreamType("invoices"));
             await _tcs.Task.WaitAsync(TimeSpanFactory.DefaultTimeout());
             await reducer.WaitTillReachesEventSequenceNumber(EventSequenceNumber.First);
             ReducerState = await reducer.GetState();

--- a/Source/Kernel/Concepts/Observation/ObserverFilters.cs
+++ b/Source/Kernel/Concepts/Observation/ObserverFilters.cs
@@ -9,8 +9,8 @@ namespace Cratis.Chronicle.Concepts.Observation;
 /// Represents the filters to apply when an observer subscribes to an event sequence.
 /// </summary>
 /// <param name="Tags">Collection of tags used to filter which events are observed. Only events tagged with at least one of these tags are dispatched to the observer.</param>
-/// <param name="EventSourceType">Optional <see cref="Events.EventSourceType"/> filter. When <see cref="Events.EventSourceType.Unspecified"/>, all event source types are observed.</param>
-/// <param name="EventStreamType">Optional <see cref="Events.EventStreamType"/> filter. When <see cref="Events.EventStreamType.All"/>, all event stream types are observed.</param>
+/// <param name="EventSourceType">Optional <see cref="Events.EventSourceType"/> filter. When <see cref="EventSourceType.Unspecified"/>, all event source types are observed.</param>
+/// <param name="EventStreamType">Optional <see cref="Events.EventStreamType"/> filter. When <see cref="EventStreamType.All"/>, all event stream types are observed.</param>
 public record ObserverFilters(
     IEnumerable<string> Tags,
     EventSourceType? EventSourceType = default,


### PR DESCRIPTION
## Changed
- Simplified integration specs to use in-scope event type names instead of fully qualified references.
- Updated observer filter XML docs to use concise type references for event source and event stream defaults.