### PR TITLE
Make the Index attribute work with Record parameters

### DIFF
--- a/Source/Clients/DotNET/ReadModels/IndexAttribute.cs
+++ b/Source/Clients/DotNET/ReadModels/IndexAttribute.cs
@@ -6,5 +6,5 @@ namespace Cratis.Chronicle.ReadModels;
 /// <summary>
 /// Attribute for specifying that a property on a read model should be indexed.
 /// </summary>
-[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
 public sealed class IndexAttribute : Attribute;


### PR DESCRIPTION
## Fixed

- Fixing the `IndexAttribute` to work with parameters for record "properties".
