### PR TITLE
Apply MongoDB indexes defined via [Index] attribute when a Sink is first created

### DIFF
--- a/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler.cs
+++ b/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler.cs
@@ -53,7 +53,7 @@ public class a_projection_replay_handler : Specification
         _projectionPipelineManager.GetFor(
             _observerDetails.Key.EventStore,
             _observerDetails.Key.Namespace,
-            Arg.Any<Engine.IProjection>()).Returns(_projectionPipeline);
+            Arg.Any<Engine.IProjection>()).Returns(Task.FromResult(_projectionPipeline));
 
         _handler = new ProjectionReplayHandler(
             _projections,

--- a/Source/Kernel/Core/Observation/ProjectionCatchupHandler.cs
+++ b/Source/Kernel/Core/Observation/ProjectionCatchupHandler.cs
@@ -50,7 +50,7 @@ public class ProjectionCatchupHandler(
                 return Result<ICanHandleCatchupForObserver.Error>.Success();
             }
 
-            var pipeline = projectionPipelineManager.GetFor(observerDetails.Key.EventStore, observerDetails.Key.Namespace, projection);
+            var pipeline = await projectionPipelineManager.GetFor(observerDetails.Key.EventStore, observerDetails.Key.Namespace, projection);
             await doWork(pipeline);
             return Result<ICanHandleCatchupForObserver.Error>.Success();
         }

--- a/Source/Kernel/Core/Observation/ProjectionReplayHandler.cs
+++ b/Source/Kernel/Core/Observation/ProjectionReplayHandler.cs
@@ -92,7 +92,7 @@ public class ProjectionReplayHandler(
             {
                 return ICanHandleReplayForObserver.Error.CouldNotGetReplayContext;
             }
-            var pipeline = projectionPipelineManager.GetFor(observerDetails.Key.EventStore, observerDetails.Key.Namespace, projection);
+            var pipeline = await projectionPipelineManager.GetFor(observerDetails.Key.EventStore, observerDetails.Key.Namespace, projection);
             await doWork(pipeline, projection, replayContext);
             return Result<ICanHandleReplayForObserver.Error>.Success();
         }

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipelineFactory.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipelineFactory.cs
@@ -28,7 +28,7 @@ public class ReducerPipelineFactory(
     {
         var namespaceStorage = storage.GetEventStore(eventStore).GetNamespace(@namespace);
         var readModel = await grainFactory.GetGrain<IReadModel>(new ReadModelGrainKey(definition.ReadModel, eventStore)).GetDefinition();
-        var sink = namespaceStorage.Sinks.GetFor(readModel);
+        var sink = await namespaceStorage.Sinks.GetFor(readModel);
         return new ReducerPipeline(readModel, sink, objectComparer);
     }
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/IProjectionPipelineManager.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/IProjectionPipelineManager.cs
@@ -19,7 +19,7 @@ public interface IProjectionPipelineManager
     /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the pipeline is for.</param>
     /// <param name="projection"><see cref="EngineProjection"/> the pipeline is for.</param>
     /// <returns>The <see cref="IProjectionPipeline"/> instance.</returns>
-    IProjectionPipeline GetFor(EventStoreName eventStore, EventStoreNamespaceName @namespace, EngineProjection projection);
+    Task<IProjectionPipeline> GetFor(EventStoreName eventStore, EventStoreNamespaceName @namespace, EngineProjection projection);
 
     /// <summary>
     /// Evict any projection pipeline for a specific projection identifier.

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
@@ -33,7 +33,7 @@ public class ProjectionPipelineManager(
     readonly ConcurrentDictionary<string, IProjectionPipeline> _pipelines = new();
 
     /// <inheritdoc/>
-    public IProjectionPipeline GetFor(
+    public async Task<IProjectionPipeline> GetFor(
         EventStoreName eventStore,
         EventStoreNamespaceName @namespace,
         EngineProjection projection)
@@ -46,7 +46,7 @@ public class ProjectionPipelineManager(
 
         var namespaceStorage = storage.GetEventStore(eventStore).GetNamespace(@namespace);
         var eventSequenceStorage = namespaceStorage.GetEventSequence(projection.EventSequenceId);
-        var sink = namespaceStorage.Sinks.GetFor(projection.ReadModel);
+        var sink = await namespaceStorage.Sinks.GetFor(projection.ReadModel);
 
         var projectionFutures = grainFactory.GetProjectionFutures(eventStore, @namespace, projection.Identifier);
         var resolveFuturesStep = new ResolveFutures(projectionFutures, typeFormats, loggerFactory.CreateLogger<ResolveFutures>());

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
@@ -153,7 +153,7 @@ public class ProjectionObserverSubscriber(
         var eventStoreStorage = storage.GetEventStore(_key.EventStore);
         var eventTypeSchemas = await eventStoreStorage.EventTypes.GetLatestForAllEventTypes();
         var projection = await projectionFactory.Create(_key.EventStore, _key.Namespace, State, readModel, eventTypeSchemas);
-        _pipeline = projectionPipelineManager.GetFor(_key.EventStore, _key.Namespace, projection);
+        _pipeline = await projectionPipelineManager.GetFor(_key.EventStore, _key.Namespace, projection);
         _schema = readModel.GetSchemaForLatestGeneration();
     }
 }

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -111,7 +111,7 @@ internal sealed class ReadModels(
         var readModel = grainFactory.GetReadModel(request.ReadModel, request.EventStore);
         var definition = await readModel.GetDefinition();
         var sinks = storage.GetEventStore(request.EventStore).GetNamespace(request.Namespace).Sinks;
-        var sink = sinks.GetFor(definition);
+        var sink = await sinks.GetFor(definition);
         var skip = Math.Max(0, request.Page * request.PageSize);
 
         Concepts.ReadModels.ReadModelContainerName? occurrence = null;

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/given/a_sink_with_indexes.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/given/a_sink_with_indexes.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.given;
+
+public class a_sink_with_indexes : Specification
+{
+    protected Sink _sink;
+    protected IMongoDBConverter _converter;
+    protected ISinkCollections _collections;
+    protected IChangesetConverter _changesetConverter;
+    protected IExpandoObjectConverter _expandoObjectConverter;
+    protected IMongoCollection<BsonDocument> _collection;
+    protected IMongoIndexManager<BsonDocument> _indexManager;
+    protected IAsyncCursor<BsonDocument> _indexCursor;
+    protected ReadModelDefinition _readModel;
+    protected PropertyPath _indexedProperty = "SomeProperty";
+
+    void Establish()
+    {
+        _converter = Substitute.For<IMongoDBConverter>();
+        _collections = Substitute.For<ISinkCollections>();
+        _changesetConverter = Substitute.For<IChangesetConverter>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+        _collection = Substitute.For<IMongoCollection<BsonDocument>>();
+        _indexManager = Substitute.For<IMongoIndexManager<BsonDocument>>();
+        _indexCursor = Substitute.For<IAsyncCursor<BsonDocument>>();
+
+        _collections.GetCollection().Returns(_collection);
+        _collection.Indexes.Returns(_indexManager);
+        _indexManager.ListAsync(Arg.Any<CancellationToken>()).Returns(_indexCursor);
+
+        _readModel = new ReadModelDefinition(
+            "SomethingId",
+            "Something",
+            "Something",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, new JsonSchema() }
+            },
+            [new IndexDefinition(_indexedProperty)]);
+
+        _sink = new Sink(
+            _readModel,
+            _converter,
+            _collections,
+            _changesetConverter,
+            _expandoObjectConverter);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_already_exist.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_already_exist.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_ensuring_indexes;
+
+public class and_indexes_already_exist : given.a_sink_with_indexes
+{
+    void Establish()
+    {
+        var existingIndexDocument = new BsonDocument("name", $"chronicle_idx_{_indexedProperty.Path}");
+        _indexCursor.MoveNextAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true), Task.FromResult(false));
+        _indexCursor.Current.Returns([existingIndexDocument]);
+    }
+
+    async Task Because() => await _sink.EnsureIndexes();
+
+    [Fact] void should_not_create_the_index() =>
+        _indexManager.DidNotReceive().CreateOneAsync(
+            Arg.Any<CreateIndexModel<BsonDocument>>(),
+            Arg.Any<CreateOneIndexOptions>(),
+            Arg.Any<CancellationToken>());
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_are_not_yet_created.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_are_not_yet_created.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_ensuring_indexes;
+
+public class and_indexes_are_not_yet_created : given.a_sink_with_indexes
+{
+    void Establish() => _indexCursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+
+    async Task Because() => await _sink.EnsureIndexes();
+
+    [Fact] void should_create_the_index() =>
+        _indexManager.Received(1).CreateOneAsync(
+            Arg.Is<CreateIndexModel<BsonDocument>>(model =>
+                model.Options.Name == $"chronicle_idx_{_indexedProperty.Path}"),
+            Arg.Any<CreateOneIndexOptions>(),
+            Arg.Any<CancellationToken>());
+}

--- a/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_known_type/and_sink_already_exists.cs
+++ b/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_known_type/and_sink_already_exists.cs
@@ -5,15 +5,16 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Schemas;
 
-namespace Cratis.Chronicle.Storage.Sinks.for_Sinks;
+namespace Cratis.Chronicle.Storage.Sinks.for_Sinks.when_getting_for_known_type;
 
-public class when_asking_for_known_type : Specification
+public class and_sink_already_exists : Specification
 {
     static SinkTypeId _type = "df371e5d-b244-48d0-aaad-f298a127dd92";
-    Sinks _stores;
+
+    Sinks _sinks;
     ISinkFactory _factory;
-    ISink _store;
-    bool _result;
+    ISink _sink;
+    ISink _result;
     ReadModelDefinition _model;
 
     void Establish()
@@ -26,17 +27,24 @@ public class when_asking_for_known_type : Specification
             ReadModelSource.Code,
             ReadModelObserverType.Projection,
             ReadModelObserverIdentifier.Unspecified,
-            SinkDefinition.None,
+            new SinkDefinition(SinkConfigurationId.None, _type),
             new Dictionary<ReadModelGeneration, JsonSchema>(),
             []);
-        _store = Substitute.For<ISink>();
+
+        _sink = Substitute.For<ISink>();
         _factory = Substitute.For<ISinkFactory>();
         _factory.TypeId.Returns(_type);
-        _factory.CreateFor(string.Empty, string.Empty, _model).Returns(_store);
-        _stores = new(string.Empty, string.Empty, new KnownInstancesOf<ISinkFactory>([_factory]));
+        _factory.CreateFor(string.Empty, string.Empty, _model).Returns(_sink);
+        _sinks = new(string.Empty, string.Empty, new KnownInstancesOf<ISinkFactory>([_factory]));
     }
 
-    void Because() => _result = _stores.HasType(_type);
+    async Task Because()
+    {
+        await _sinks.GetFor(_model);
+        _sink.ClearReceivedCalls();
+        _result = await _sinks.GetFor(_model);
+    }
 
-    [Fact] void should_have_type() => _result.ShouldBeTrue();
+    [Fact] void should_return_the_same_sink() => _result.ShouldEqual(_sink);
+    [Fact] void should_not_ensure_indexes_again() => _sink.DidNotReceive().EnsureIndexes();
 }

--- a/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_known_type/and_sink_does_not_exist_yet.cs
+++ b/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_known_type/and_sink_does_not_exist_yet.cs
@@ -5,15 +5,16 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Schemas;
 
-namespace Cratis.Chronicle.Storage.Sinks.for_Sinks;
+namespace Cratis.Chronicle.Storage.Sinks.for_Sinks.when_getting_for_known_type;
 
-public class when_asking_for_known_type : Specification
+public class and_sink_does_not_exist_yet : Specification
 {
     static SinkTypeId _type = "df371e5d-b244-48d0-aaad-f298a127dd92";
-    Sinks _stores;
+
+    Sinks _sinks;
     ISinkFactory _factory;
-    ISink _store;
-    bool _result;
+    ISink _sink;
+    ISink _result;
     ReadModelDefinition _model;
 
     void Establish()
@@ -26,17 +27,19 @@ public class when_asking_for_known_type : Specification
             ReadModelSource.Code,
             ReadModelObserverType.Projection,
             ReadModelObserverIdentifier.Unspecified,
-            SinkDefinition.None,
+            new SinkDefinition(SinkConfigurationId.None, _type),
             new Dictionary<ReadModelGeneration, JsonSchema>(),
             []);
-        _store = Substitute.For<ISink>();
+
+        _sink = Substitute.For<ISink>();
         _factory = Substitute.For<ISinkFactory>();
         _factory.TypeId.Returns(_type);
-        _factory.CreateFor(string.Empty, string.Empty, _model).Returns(_store);
-        _stores = new(string.Empty, string.Empty, new KnownInstancesOf<ISinkFactory>([_factory]));
+        _factory.CreateFor(string.Empty, string.Empty, _model).Returns(_sink);
+        _sinks = new(string.Empty, string.Empty, new KnownInstancesOf<ISinkFactory>([_factory]));
     }
 
-    void Because() => _result = _stores.HasType(_type);
+    async Task Because() => _result = await _sinks.GetFor(_model);
 
-    [Fact] void should_have_type() => _result.ShouldBeTrue();
+    [Fact] void should_return_the_sink() => _result.ShouldEqual(_sink);
+    [Fact] void should_ensure_indexes() => _sink.Received(1).EnsureIndexes();
 }

--- a/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_unknown_type.cs
+++ b/Source/Kernel/Storage.Specs/Sinks/for_Sinks/when_getting_for_unknown_type.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Storage.Sinks.for_Sinks;
 
@@ -13,7 +14,7 @@ public class when_getting_for_unknown_type : Specification
 
     void Establish() => _sinks = new(string.Empty, string.Empty, new KnownInstancesOf<ISinkFactory>([]));
 
-    void Because() => _result = Catch.Exception(() => _sinks.GetFor("bc5e82fd-9845-4464-9802-a7e21bd8a919", SinkConfigurationId.None, new ReadModelDefinition(
+    async Task Because() => _result = await Catch.Exception(async () => await _sinks.GetFor(new ReadModelDefinition(
         string.Empty,
         string.Empty,
         string.Empty,
@@ -21,7 +22,7 @@ public class when_getting_for_unknown_type : Specification
         ReadModelSource.Code,
         ReadModelObserverType.Projection,
         ReadModelObserverIdentifier.Unspecified,
-        null!,
+        new SinkDefinition(SinkConfigurationId.None, "bc5e82fd-9845-4464-9802-a7e21bd8a919"),
         new Dictionary<ReadModelGeneration, JsonSchema>(),
         [])));
 

--- a/Source/Kernel/Storage.Specs/Storage.Specs.csproj
+++ b/Source/Kernel/Storage.Specs/Storage.Specs.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
         <!-- Exclude broken tests that reference old refactored types -->
         <Compile Remove="Sinks/InMemory/for_InMemorySink/when_trying_to_find_root_key_by_child_value/**/*.cs" />
-        <Compile Remove="Sinks/for_Sinks/*.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Kernel/Storage/Sinks/ISinks.cs
+++ b/Source/Kernel/Storage/Sinks/ISinks.cs
@@ -23,5 +23,5 @@ public interface ISinks
     /// </summary>
     /// <param name="readModel"><see cref="ReadModelDefinition"/> to get for.</param>
     /// <returns><see cref="ISink"/> instance.</returns>
-    ISink GetFor(ReadModelDefinition readModel);
+    Task<ISink> GetFor(ReadModelDefinition readModel);
 }

--- a/Source/Kernel/Storage/Sinks/Sinks.cs
+++ b/Source/Kernel/Storage/Sinks/Sinks.cs
@@ -27,12 +27,14 @@ public class Sinks(
     readonly ConcurrentDictionary<SinkKey, ISink> _sinks = new();
 
     /// <inheritdoc/>
-    public ISink GetFor(ReadModelDefinition readModel)
+    public async Task<ISink> GetFor(ReadModelDefinition readModel)
     {
         ThrowIfUnknownSink(readModel.Sink.Type);
         var key = new SinkKey(readModel.Sink.Type, readModel.Sink.Configuration, readModel.ContainerName);
-        if (_sinks.TryGetValue(key, out var store)) return store;
-        return _sinks[key] = _factories[readModel.Sink.Type].CreateFor(eventStoreName, eventStoreNamespaceName, readModel);
+        if (_sinks.TryGetValue(key, out var existing)) return existing;
+        var sink = _factories[readModel.Sink.Type].CreateFor(eventStoreName, eventStoreNamespaceName, readModel);
+        await sink.EnsureIndexes();
+        return _sinks.GetOrAdd(key, sink);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Fixed
- MongoDB indexes declared with the `[Index]` attribute on read models are now applied to the collection when a Sink is first obtained, ensuring queries that rely on those indexes perform correctly from the start.

## Added
- Unit specs verifying that `EnsureIndexes()` is called exactly once when a new Sink is created and is not called again for cached Sinks.
- MongoDB Sink integration specs verifying that indexes are created when they do not yet exist, and skipped when they already exist.
