### PR TITLE
Fix EventStoreSubscriptions instability causing outbox-to-inbox forwarding to stall

### DIFF
--- a/Integration/DotNET.InProcess/Projections/ProjectionTypes/ConstantKeyProjection.cs
+++ b/Integration/DotNET.InProcess/Projections/ProjectionTypes/ConstantKeyProjection.cs
@@ -10,7 +10,7 @@ public class ConstantKeyProjection : IProjectionFor<ReadModel>
 {
     public void Define(IProjectionBuilderFor<ReadModel> builder) => builder
         .From<EventWithPropertiesForAllSupportedTypes>(_ => _
-            .UsingConstantKey(ConstantKeyProjection.ConstantKeyValue)
+            .UsingConstantKey(ConstantKeyValue)
             .Set(m => m.StringValue).To(e => e.StringValue));
 
     public const string ConstantKeyValue = "constant-key";

--- a/Source/Infrastructure/Schemas/JsonSchema.cs
+++ b/Source/Infrastructure/Schemas/JsonSchema.cs
@@ -441,7 +441,7 @@ public class JsonSchema
                         schemaObj["format"] = _typeFormats.GetFormatForType(context.TypeInfo.Type);
                     }
 
-                    if (context.TypeInfo.Kind == System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Object)
+                    if (context.TypeInfo.Kind == JsonTypeInfoKind.Object)
                     {
                         schemaObj["title"] = context.TypeInfo.Type.Name;
                     }

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription_with_different_event_types.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription_with_different_event_types.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.EventSequences;
+using ContractEventStoreSubscriptionDefinition = Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptions.when_adding;
+
+public class an_existing_subscription_with_different_event_types : given.an_event_store_subscriptions_service
+{
+    IEventSequence _eventSequence;
+    IEventStoreSubscriptionsManager _subscriptionsManager;
+    AddEventStoreSubscriptions _request;
+
+    void Establish()
+    {
+        _eventSequence = Substitute.For<IEventSequence>();
+        _grainFactory.GetGrain<IEventSequence>(Arg.Any<string>()).Returns(_eventSequence);
+        _eventSequence.Append(
+            Arg.Any<EventSourceId>(),
+            Arg.Any<object>(),
+            Arg.Any<CorrelationId>(),
+            Arg.Any<IEnumerable<Causation>>(),
+            Arg.Any<Identity>(),
+            Arg.Any<IEnumerable<Tag>>(),
+            Arg.Any<EventSourceType>(),
+            Arg.Any<EventStreamType>(),
+            Arg.Any<EventStreamId>()).Returns(AppendResult.Success(CorrelationId.New(), EventSequenceNumber.First));
+
+        var existingDefinition = new Concepts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition(
+            new EventStoreSubscriptionId("test-subscription-id"),
+            new EventStoreName("source-event-store"),
+            [new EventType("existing-event-type", EventTypeGeneration.First)]);
+
+        _subscriptionsManager = Substitute.For<IEventStoreSubscriptionsManager>();
+        _subscriptionsManager.GetSubscriptionDefinitions().Returns([existingDefinition]);
+        _grainFactory.GetGrain<IEventStoreSubscriptionsManager>(Arg.Any<string>()).Returns(_subscriptionsManager);
+
+        _request = new AddEventStoreSubscriptions
+        {
+            TargetEventStore = "target-event-store",
+            Subscriptions =
+            [
+                new ContractEventStoreSubscriptionDefinition
+                {
+                    Identifier = "test-subscription-id",
+                    SourceEventStore = "source-event-store",
+                    EventTypes =
+                    [
+                        new Contracts.Events.EventType
+                        {
+                            Id = "new-event-type",
+                            Generation = 1
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    async Task Because() => await _service.Add(_request);
+
+    [Fact] void should_append_subscription_added_event_for_updated_definition() =>
+        _eventSequence.Received(1).Append(
+            Arg.Is<EventSourceId>(id => id.Value == "test-subscription-id"),
+            Arg.Any<EventStoreSubscriptionAdded>(),
+            Arg.Any<CorrelationId>(),
+            Arg.Any<IEnumerable<Causation>>(),
+            Arg.Any<Identity>(),
+            Arg.Any<IEnumerable<Tag>>(),
+            Arg.Any<EventSourceType>(),
+            Arg.Any<EventStreamType>(),
+            Arg.Any<EventStreamId>());
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription_with_different_source_event_store.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription_with_different_source_event_store.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.EventSequences;
+using ContractEventStoreSubscriptionDefinition = Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptions.when_adding;
+
+public class an_existing_subscription_with_different_source_event_store : given.an_event_store_subscriptions_service
+{
+    IEventSequence _eventSequence;
+    IEventStoreSubscriptionsManager _subscriptionsManager;
+    AddEventStoreSubscriptions _request;
+
+    void Establish()
+    {
+        _eventSequence = Substitute.For<IEventSequence>();
+        _grainFactory.GetGrain<IEventSequence>(Arg.Any<string>()).Returns(_eventSequence);
+        _eventSequence.Append(
+            Arg.Any<EventSourceId>(),
+            Arg.Any<object>(),
+            Arg.Any<CorrelationId>(),
+            Arg.Any<IEnumerable<Causation>>(),
+            Arg.Any<Identity>(),
+            Arg.Any<IEnumerable<Tag>>(),
+            Arg.Any<EventSourceType>(),
+            Arg.Any<EventStreamType>(),
+            Arg.Any<EventStreamId>()).Returns(AppendResult.Success(CorrelationId.New(), EventSequenceNumber.First));
+
+        var existingDefinition = new Concepts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition(
+            new EventStoreSubscriptionId("test-subscription-id"),
+            new EventStoreName("old-source-event-store"),
+            [new EventType("InvitationAccepted", EventTypeGeneration.First)]);
+
+        _subscriptionsManager = Substitute.For<IEventStoreSubscriptionsManager>();
+        _subscriptionsManager.GetSubscriptionDefinitions().Returns([existingDefinition]);
+        _grainFactory.GetGrain<IEventStoreSubscriptionsManager>(Arg.Any<string>()).Returns(_subscriptionsManager);
+
+        _request = new AddEventStoreSubscriptions
+        {
+            TargetEventStore = "target-event-store",
+            Subscriptions =
+            [
+                new ContractEventStoreSubscriptionDefinition
+                {
+                    Identifier = "test-subscription-id",
+                    SourceEventStore = "new-source-event-store",
+                    EventTypes =
+                    [
+                        new Contracts.Events.EventType
+                        {
+                            Id = "InvitationAccepted",
+                            Generation = 1
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    async Task Because() => await _service.Add(_request);
+
+    [Fact] void should_append_subscription_added_event_for_updated_source_event_store() =>
+        _eventSequence.Received(1).Append(
+            Arg.Is<EventSourceId>(id => id.Value == "test-subscription-id"),
+            Arg.Any<EventStoreSubscriptionAdded>(),
+            Arg.Any<CorrelationId>(),
+            Arg.Any<IEnumerable<Causation>>(),
+            Arg.Any<Identity>(),
+            Arg.Any<IEnumerable<Tag>>(),
+            Arg.Any<EventSourceType>(),
+            Arg.Any<EventStreamType>(),
+            Arg.Any<EventStreamId>());
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_receiving_subscription_reminder/and_subscription_is_already_subscribed.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_receiving_subscription_reminder/and_subscription_is_already_subscribed.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Namespaces;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_receiving_subscription_reminder;
+
+public class and_subscription_is_already_subscribed : Specification
+{
+    const string TargetEventStore = "Lobby";
+    const string SourceEventStore = "StudioAdmin";
+    const string ReminderName = "event-store-subscription-subscribe:StudioAdmin";
+
+    TestKitSilo _silo;
+    EventStoreSubscriptionsManager _manager;
+    IObserver _observer;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        _silo.AddService(localSiloDetails);
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        _observer = Substitute.For<IObserver>();
+        _observer.IsSubscribed().Returns(true);
+        _silo.AddProbe(_ => _observer);
+
+        _manager = await _silo.CreateGrainAsync<EventStoreSubscriptionsManager>(TargetEventStore);
+
+        await _manager.Add(
+            new EventStoreSubscriptionDefinition(
+                new EventStoreSubscriptionId(SourceEventStore),
+                new EventStoreName(SourceEventStore),
+                [new EventType("5db7cfa2-0fcb-4791-b174-83ff2806d654", EventTypeGeneration.First)]));
+    }
+
+    async Task Because() => await _manager.ReceiveReminder(ReminderName, default);
+
+    [Fact] void should_unsubscribe_before_subscribing_again() => _observer.Received(1).Unsubscribe();
+
+    [Fact] void should_pass_target_event_store_name_as_subscriber_metadata() =>
+        _observer.Received(1).Subscribe<IEventStoreSubscriptionObserverSubscriber>(
+            ObserverType.External,
+            Arg.Any<IEnumerable<EventType>>(),
+            Arg.Any<SiloAddress>(),
+            Arg.Is<object?>(metadata => metadata is string && (string)metadata == TargetEventStore),
+            Arg.Any<bool>());
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_removing/a_subscription.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_removing/a_subscription.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Namespaces;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_removing;
+
+public class a_subscription : Specification
+{
+    const string TargetEventStore = "Core";
+    const string SourceEventStore = "Lobby";
+
+    TestKitSilo _silo;
+    EventStoreSubscriptionsManager _manager;
+    IObserver _observer;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        _silo.AddService(localSiloDetails);
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([Concepts.EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        _observer = Substitute.For<IObserver>();
+        _observer.IsSubscribed().Returns(true);
+        _silo.AddProbe(_ => _observer);
+
+        _manager = await _silo.CreateGrainAsync<EventStoreSubscriptionsManager>(TargetEventStore);
+
+        await _manager.Add(
+            new EventStoreSubscriptionDefinition(
+                new EventStoreSubscriptionId(SourceEventStore),
+                new Concepts.EventStoreName(SourceEventStore),
+                [new Concepts.Events.EventType("5db7cfa2-0fcb-4791-b174-83ff2806d654", Concepts.Events.EventTypeGeneration.First)]));
+    }
+
+    async Task Because() => await _manager.Remove(new EventStoreSubscriptionId(SourceEventStore));
+
+    [Fact] void should_unsubscribe_observer() => _observer.Received(1).Unsubscribe();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling/without_explicit_read_model.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling/without_explicit_read_model.cs
@@ -22,7 +22,7 @@ public class without_explicit_read_model : for_LanguageService.given.a_language_
     {
         var compileResult = _languageService.Compile(
             Declaration,
-            Cratis.Chronicle.Concepts.Projections.ProjectionOwner.Client,
+            Concepts.Projections.ProjectionOwner.Client,
             [],
             _eventTypeSchemas);
 

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling/without_explicit_read_model_and_incompatible_event_property_types.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling/without_explicit_read_model_and_incompatible_event_property_types.cs
@@ -19,7 +19,7 @@ public class without_explicit_read_model_and_incompatible_event_property_types :
     {
         var compileResult = _languageService.Compile(
             Declaration,
-            Cratis.Chronicle.Concepts.Projections.ProjectionOwner.Client,
+            Concepts.Projections.ProjectionOwner.Client,
             [],
             _eventTypeSchemas);
 

--- a/Source/Kernel/Core.Specs/Services/Observation/for_ObserverInformationConverters/when_converting_to_contract/and_observer_is_replayable.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_ObserverInformationConverters/when_converting_to_contract/and_observer_is_replayable.cs
@@ -41,5 +41,5 @@ public class and_observer_is_replayable : Specification
 
     [Fact] void should_set_is_replayable_to_true() => _result.IsReplayable.ShouldBeTrue();
     [Fact] void should_have_correct_id() => _result.Id.ShouldEqual(_definition.Identifier.Value);
-    [Fact] void should_have_correct_running_state() => _result.RunningState.ShouldEqual(Contracts.Observation.ObserverRunningState.Active);
+    [Fact] void should_have_correct_running_state() => _result.RunningState.ShouldEqual(ObserverRunningState.Active);
 }

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_getting_replayable_observers_for_event_types/and_there_are_matching_observers.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_getting_replayable_observers_for_event_types/and_there_are_matching_observers.cs
@@ -57,5 +57,5 @@ public class and_there_are_matching_observers : given.all_dependencies
     [Fact] void should_return_one_observer() => _result.Count().ShouldEqual(1);
     [Fact] void should_have_correct_observer_id() => _result.First().Id.ShouldEqual(_replayableDefinition.Identifier.Value);
     [Fact] void should_be_marked_as_replayable() => _result.First().IsReplayable.ShouldBeTrue();
-    [Fact] void should_have_correct_type() => _result.First().Type.ShouldEqual(Contracts.Observation.ObserverType.Reactor);
+    [Fact] void should_have_correct_type() => _result.First().Type.ShouldEqual(ObserverType.Reactor);
 }

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
@@ -37,7 +37,7 @@ public class EventStoreSubscriptionsManager(
     {
         _targetEventStoreName = this.GetPrimaryKeyString();
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_targetEventStoreName).GetAll();
-        var tasks = State.Subscriptions.Select(definition => SubscribeIfNotSubscribed(definition, namespaces));
+        var tasks = State.Subscriptions.Select(definition => EnsureSubscriptionOnActivation(definition, namespaces));
         await Task.WhenAll(tasks);
     }
 
@@ -56,13 +56,21 @@ public class EventStoreSubscriptionsManager(
     /// <inheritdoc/>
     public async Task Remove(EventStoreSubscriptionId subscriptionId)
     {
+        var definition = State.Subscriptions.FirstOrDefault(s => s.Identifier == subscriptionId);
+        if (definition is null)
+        {
+            return;
+        }
+
         var subscriptions = State.Subscriptions.ToList();
         subscriptions.RemoveAll(s => s.Identifier == subscriptionId);
         State.Subscriptions = subscriptions;
         await WriteStateAsync();
 
+        await RemoveReminder(GetSubscriptionReminderName(subscriptionId));
+
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_targetEventStoreName).GetAll();
-        await Unsubscribe(namespaces, subscriptionId);
+        await Unsubscribe(namespaces, definition);
     }
 
     /// <inheritdoc/>
@@ -85,7 +93,7 @@ public class EventStoreSubscriptionsManager(
         }
 
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_targetEventStoreName).GetAll();
-        await SubscribeIfNotSubscribed(definition, namespaces);
+        await RefreshSubscription(definition, namespaces);
         await RemoveReminder(reminderName);
     }
 
@@ -107,10 +115,35 @@ public class EventStoreSubscriptionsManager(
         await Task.WhenAll(tasks);
     }
 
-    async Task SubscribeIfNotSubscribed(EventStoreSubscriptionDefinition definition, IEnumerable<EventStoreNamespaceName> namespaces)
+    async Task EnsureSubscriptionOnActivation(EventStoreSubscriptionDefinition definition, IEnumerable<EventStoreNamespaceName> namespaces)
     {
-        var tasks = namespaces.Select(namespaceName => SubscribeIfNotSubscribed(definition, namespaceName));
+        await ScheduleSubscriptionReminder(definition.Identifier);
+        await RefreshSubscription(definition, namespaces);
+    }
+
+    async Task RefreshSubscription(EventStoreSubscriptionDefinition definition, IEnumerable<EventStoreNamespaceName> namespaces)
+    {
+        var tasks = namespaces.Select(namespaceName => RefreshSubscription(definition, namespaceName));
         await Task.WhenAll(tasks);
+    }
+
+    async Task RefreshSubscription(EventStoreSubscriptionDefinition definition, EventStoreNamespaceName namespaceName)
+    {
+        var observer = GetObserver(definition, namespaceName);
+        var subscribed = await observer.IsSubscribed();
+
+        if (subscribed)
+        {
+            logger.Unsubscribing(definition.Identifier, namespaceName);
+            await observer.Unsubscribe();
+        }
+
+        logger.Subscribing(definition.Identifier, namespaceName);
+        await observer.Subscribe<IEventStoreSubscriptionObserverSubscriber>(
+            ObserverType.External,
+            definition.EventTypes.ToArray(),
+            localSiloDetails.SiloAddress,
+            _targetEventStoreName.Value);
     }
 
     async Task SubscribeIfNotSubscribed(EventStoreSubscriptionDefinition definition, EventStoreNamespaceName namespaceName)
@@ -132,12 +165,9 @@ public class EventStoreSubscriptionsManager(
         logger.AlreadySubscribed(definition.Identifier, namespaceName);
     }
 
-    async Task Unsubscribe(IEnumerable<EventStoreNamespaceName> namespaces, EventStoreSubscriptionId subscriptionId)
+    async Task Unsubscribe(IEnumerable<EventStoreNamespaceName> namespaces, EventStoreSubscriptionDefinition definition)
     {
-        logger.Unregistering(subscriptionId);
-
-        var definition = State.Subscriptions.FirstOrDefault(s => s.Identifier == subscriptionId);
-        if (definition is null) return;
+        logger.Unregistering(definition.Identifier);
 
         var tasks = namespaces.Select(namespaceName => UnsubscribeIfSubscribed(definition, namespaceName));
         await Task.WhenAll(tasks);

--- a/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
+++ b/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
@@ -40,7 +40,7 @@ internal sealed class EventStoreSubscriptions(
             var existingSubscriptions = await subscriptionsManager.GetSubscriptionDefinitions();
             var existing = existingSubscriptions.FirstOrDefault(s => s.Identifier == definition.Identifier);
 
-            if (existing is null)
+            if (existing is null || !HasSameDefinition(existing, definition))
             {
                 await eventSequence.Append(subscription.Identifier, new EventStoreSubscriptionAdded(
                     definition.SourceEventStore,
@@ -70,5 +70,17 @@ internal sealed class EventStoreSubscriptions(
             SourceEventStore = definition.SourceEventStore.Value,
             EventTypes = definition.EventTypes.Select(et => new Contracts.Events.EventType { Id = et.Id, Generation = et.Generation }).ToList()
         });
+    }
+
+    static bool HasSameDefinition(ConceptsEventStoreSubscriptionDefinition existing, ConceptsEventStoreSubscriptionDefinition incoming)
+    {
+        if (existing.SourceEventStore != incoming.SourceEventStore)
+        {
+            return false;
+        }
+
+        var existingEventTypes = existing.EventTypes.ToHashSet();
+        var incomingEventTypes = incoming.EventTypes.ToHashSet();
+        return existingEventTypes.SetEquals(incomingEventTypes);
     }
 }

--- a/Source/Kernel/Core/Setup/ChronicleServerStartupTask.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerStartupTask.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.EventTypes;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Namespaces;
+using Cratis.Chronicle.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Observation.Reactors.Kernel;
 using Cratis.Chronicle.Observation.Webhooks;
 using Cratis.Chronicle.Patching;
@@ -58,6 +59,9 @@ internal sealed class ChronicleServerStartupTask(
             await eventTypes.DiscoverAndRegister(eventStore);
             var namespaces = grainFactory.GetGrain<INamespaces>(eventStore);
             await namespaces.EnsureDefault();
+
+            var eventStoreSubscriptionsManager = grainFactory.GetGrain<IEventStoreSubscriptionsManager>(eventStore);
+            await eventStoreSubscriptionsManager.Ensure();
 
             var readModelsManager = grainFactory.GetGrain<IReadModelsManager>(eventStore);
             await readModelsManager.Ensure();


### PR DESCRIPTION
## Fixed

- Event forwarding from outbox to inbox could stall after a Kernel restart because persisted subscriptions were not resumed at startup
- Removing a subscription did not unsubscribe the underlying observer due to a state-mutation ordering bug
- Implicit subscriptions with evolved event type filters or changed source event stores were silently ignored, leaving stale definitions in place
- Observer endpoint attachment could go stale between activations; grain activation and reminder fire now perform a full refresh (unsubscribe + re-subscribe) to heal the connection
