### PR TITLE
Fix race condition in WaitUntilSubscribed and add typed EventSourceId

### DIFF
--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/GuidConcept.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/GuidConcept.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId;
+
+record GuidConcept(Guid Value) : ConceptAs<Guid>(Value)
+{
+    public static implicit operator Guid(GuidConcept concept) => concept.Value;
+    public static implicit operator GuidConcept(Guid value) => new(value);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/StringConcept.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/StringConcept.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId;
+
+record StringConcept(string Value) : ConceptAs<string>(Value)
+{
+    public static implicit operator string(StringConcept concept) => concept.Value;
+    public static implicit operator StringConcept(string value) => new(value);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_guid_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_a_string;
+
+public class with_a_concept_wrapping_a_guid_type : Specification
+{
+    static readonly Guid _expected = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    EventSourceId<GuidConcept> _result;
+
+    void Because() => _result = (EventSourceId<GuidConcept>)_expected.ToString();
+
+    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_concept_with_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(new GuidConcept(_expected));
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
@@ -5,11 +5,11 @@ namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_a_
 
 public class with_a_concept_wrapping_a_string_type : Specification
 {
-    const string _input = "some-concept-id";
+    const string Input = "some-concept-id";
     EventSourceId<StringConcept> _result;
 
-    void Because() => _result = (EventSourceId<StringConcept>)_input;
+    void Because() => _result = (EventSourceId<StringConcept>)Input;
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
-    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(_input));
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(Input));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_a_string;
+
+public class with_a_concept_wrapping_a_string_type : Specification
+{
+    const string _input = "some-concept-id";
+    EventSourceId<StringConcept> _result;
+
+    void Because() => _result = (EventSourceId<StringConcept>)_input;
+
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
+    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(_input));
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_guid_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_a_string;
+
+public class with_a_guid_type : Specification
+{
+    static readonly Guid _expected = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    EventSourceId<Guid> _result;
+
+    void Because() => _result = (EventSourceId<Guid>)_expected.ToString();
+
+    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_expected);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_guid_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an_event_source_id;
+
+public class with_a_concept_wrapping_a_guid_type : Specification
+{
+    static readonly Guid _expected = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    EventSourceId<GuidConcept> _result;
+
+    void Because() => _result = EventSourceId<GuidConcept>.From(new EventSourceId(_expected.ToString()));
+
+    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_concept_with_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(new GuidConcept(_expected));
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
@@ -5,11 +5,11 @@ namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an
 
 public class with_a_concept_wrapping_a_string_type : Specification
 {
-    const string _input = "some-concept-id";
+    const string Input = "some-concept-id";
     EventSourceId<StringConcept> _result;
 
-    void Because() => _result = EventSourceId<StringConcept>.From(new EventSourceId(_input));
+    void Because() => _result = EventSourceId<StringConcept>.From(new EventSourceId(Input));
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
-    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(_input));
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(Input));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an_event_source_id;
+
+public class with_a_concept_wrapping_a_string_type : Specification
+{
+    const string _input = "some-concept-id";
+    EventSourceId<StringConcept> _result;
+
+    void Because() => _result = EventSourceId<StringConcept>.From(new EventSourceId(_input));
+
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
+    [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(_input));
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_guid_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an_event_source_id;
+
+public class with_a_guid_type : Specification
+{
+    static readonly Guid _expected = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    EventSourceId<Guid> _result;
+
+    void Because() => _result = EventSourceId<Guid>.From(new EventSourceId(_expected.ToString()));
+
+    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_expected);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_string_type.cs
@@ -5,11 +5,11 @@ namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an
 
 public class with_a_string_type : Specification
 {
-    const string _input = "some-id";
+    const string Input = "some-id";
     EventSourceId<string> _result;
 
-    void Because() => _result = EventSourceId<string>.From(new EventSourceId(_input));
+    void Because() => _result = EventSourceId<string>.From(new EventSourceId(Input));
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
-    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(Input);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_string_type.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_converting_from_an_event_source_id;
+
+public class with_a_string_type : Specification
+{
+    const string _input = "some-id";
+    EventSourceId<string> _result;
+
+    void Because() => _result = EventSourceId<string>.From(new EventSourceId(_input));
+
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
+    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_guid.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_creating_from_typed_value;
+
+public class with_a_concept_wrapping_a_guid : Specification
+{
+    static readonly GuidConcept _input = new(Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d"));
+    EventSourceId<GuidConcept> _result;
+
+    void Because() => _result = _input;
+
+    [Fact] void should_have_the_guid_string_representation_as_value() => _result.Value.ShouldEqual(_input.Value.ToString());
+    [Fact] void should_have_the_concept_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_string.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_creating_from_typed_value;
+
+public class with_a_concept_wrapping_a_string : Specification
+{
+    static readonly StringConcept _input = new("some-concept-id");
+    EventSourceId<StringConcept> _result;
+
+    void Because() => _result = _input;
+
+    [Fact] void should_have_the_concept_string_value_as_value() => _result.Value.ShouldEqual(_input.Value);
+    [Fact] void should_have_the_concept_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_guid.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_creating_from_typed_value;
+
+public class with_a_guid : Specification
+{
+    static readonly Guid _input = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    EventSourceId<Guid> _result;
+
+    void Because() => _result = _input;
+
+    [Fact] void should_have_the_guid_string_representation_as_value() => _result.Value.ShouldEqual(_input.ToString());
+    [Fact] void should_have_the_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_string.cs
@@ -5,11 +5,11 @@ namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_creating_from_type
 
 public class with_a_string : Specification
 {
-    const string _input = "some-id";
+    const string Input = "some-id";
     EventSourceId<string> _result;
 
-    void Because() => _result = new EventSourceId<string>(_input);
+    void Because() => _result = new EventSourceId<string>(Input);
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
-    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(Input);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_string.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_TypedEventSourceId.when_creating_from_typed_value;
+
+public class with_a_string : Specification
+{
+    const string _input = "some-id";
+    EventSourceId<string> _result;
+
+    void Because() => _result = new EventSourceId<string>(_input);
+
+    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(_input);
+    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
+}

--- a/Source/Clients/DotNET/Events/EventSourceId.cs
+++ b/Source/Clients/DotNET/Events/EventSourceId.cs
@@ -3,6 +3,8 @@
 
 namespace Cratis.Chronicle.Events;
 
+#pragma warning disable SA1402 // File may only contain a single type
+
 /// <summary>
 /// Represents the unique identifier of an instance of an event source.
 /// </summary>
@@ -46,4 +48,70 @@ public record EventSourceId(string Value) : ConceptAs<string>(Value)
     /// </summary>
     /// <returns>A new <see cref="EventSourceId"/>.</returns>
     public static EventSourceId New() => Guid.NewGuid();
+}
+
+/// <summary>
+/// Represents a type-safe <see cref="EventSourceId"/> wrapping a strongly-typed value.
+/// Converts the typed value to its string representation automatically, supporting
+/// <see cref="string"/>, <see cref="Guid"/>, <see cref="ConceptAs{T}"/> wrappers, and any type with a <see cref="object.ToString"/> implementation.
+/// </summary>
+/// <typeparam name="T">The type of the underlying value.</typeparam>
+/// <param name="TypedValue">The typed value that this identifier wraps.</param>
+public record EventSourceId<T>(T TypedValue) : EventSourceId(ConvertToString(TypedValue))
+{
+    /// <summary>
+    /// Implicitly convert from <typeparamref name="T"/> to <see cref="EventSourceId{T}"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    /// <returns>A converted <see cref="EventSourceId{T}"/>.</returns>
+    public static implicit operator EventSourceId<T>(T value) => new(value);
+
+    /// <summary>
+    /// Implicitly convert from <see cref="EventSourceId{T}"/> to <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="id"><see cref="EventSourceId{T}"/> to convert from.</param>
+    /// <returns>The underlying typed value.</returns>
+    public static implicit operator T(EventSourceId<T> id) => id.TypedValue;
+
+    /// <summary>
+    /// Implicitly convert from <see cref="string"/> to <see cref="EventSourceId{T}"/>,
+    /// parsing the string value into <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="value"><see cref="string"/> to convert from.</param>
+    /// <returns>A converted <see cref="EventSourceId{T}"/>.</returns>
+    public static implicit operator EventSourceId<T>(string value) => new(ParseValue(value));
+
+    /// <summary>
+    /// Create an <see cref="EventSourceId{T}"/> from an <see cref="EventSourceId"/>,
+    /// parsing its string value back into <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="id"><see cref="EventSourceId"/> to convert from.</param>
+    /// <returns>A converted <see cref="EventSourceId{T}"/>.</returns>
+    public static EventSourceId<T> From(EventSourceId id) => new(ParseValue(id.Value));
+
+    static string ConvertToString(T value) =>
+        value switch
+        {
+            string s => s,
+            Guid g => g.ToString(),
+            ConceptAs<string> c => c.Value,
+            ConceptAs<Guid> c => c.Value.ToString(),
+            _ => value!.ToString()!
+        };
+
+    static T ParseValue(string value)
+    {
+        var targetType = typeof(T);
+
+        if (targetType == typeof(string)) return (T)(object)value;
+        if (targetType == typeof(Guid)) return (T)(object)Guid.Parse(value);
+
+        if (typeof(ConceptAs<string>).IsAssignableFrom(targetType))
+            return (T)Activator.CreateInstance(targetType, value)!;
+
+        if (typeof(ConceptAs<Guid>).IsAssignableFrom(targetType))
+            return (T)Activator.CreateInstance(targetType, Guid.Parse(value))!;
+
+        return (T)Convert.ChangeType(value, targetType);
+    }
 }

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_waiting_until_subscribed/and_subscription_definition_arrives_while_waiting.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_waiting_until_subscribed/and_subscription_definition_arrives_while_waiting.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Namespaces;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_waiting_until_subscribed;
+
+/// <summary>
+/// Proves the fix for the race condition where the gRPC <c>Add</c> handler calls
+/// <c>WaitUntilSubscribed</c> before the <c>EventStoreSubscriptionsReactor</c> has processed
+/// the <c>EventStoreSubscriptionAdded</c> event and written the definition into grain state.
+/// The old code threw <see cref="InvalidOperationException"/> immediately; the fix polls until
+/// the definition appears.
+/// </summary>
+public class and_subscription_definition_arrives_while_waiting : Specification
+{
+    const string TargetEventStore = "Lobby";
+    const string SourceEventStore = "StudioAdmin";
+
+    TestKitSilo _silo;
+    EventStoreSubscriptionsManager _manager;
+    EventStoreSubscriptionDefinition _definition;
+    Exception _error;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        _silo.AddService(localSiloDetails);
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        var observer = Substitute.For<IObserver>();
+        observer.IsSubscribed().Returns(true);
+        _silo.AddProbe(_ => observer);
+
+        _manager = await _silo.CreateGrainAsync<EventStoreSubscriptionsManager>(TargetEventStore);
+
+        _definition = new EventStoreSubscriptionDefinition(
+            new EventStoreSubscriptionId(SourceEventStore),
+            new EventStoreName(SourceEventStore),
+            [new EventType("5db7cfa2-0fcb-4791-b174-83ff2806d654", EventTypeGeneration.First)]);
+    }
+
+    async Task Because()
+    {
+        // Start waiting BEFORE the definition exists in state — this is the race condition:
+        // the gRPC Add handler calls WaitUntilSubscribed immediately after appending
+        // EventStoreSubscriptionAdded, but the reactor that calls manager.Add() is asynchronous.
+        var waitTask = _manager.WaitUntilSubscribed(
+            new EventStoreSubscriptionId(SourceEventStore),
+            TimeSpan.FromSeconds(2));
+
+        // Let the polling loop spin a few iterations without finding the definition.
+        await Task.Delay(50);
+
+        // Simulate the reactor delivering the definition (as EventStoreSubscriptionsReactor.Added does).
+        await _manager.Add(_definition);
+
+        // WaitUntilSubscribed should now find the definition and return successfully.
+        _error = await Catch.Exception(() => waitTask);
+    }
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+}

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
@@ -76,13 +76,32 @@ public class EventStoreSubscriptionsManager(
     /// <inheritdoc/>
     public async Task WaitUntilSubscribed(EventStoreSubscriptionId subscriptionId, TimeSpan timeout)
     {
-        var definition = State.Subscriptions.FirstOrDefault(s => s.Identifier == subscriptionId) ??
-            throw new InvalidOperationException($"Subscription '{subscriptionId}' not found");
-
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_targetEventStoreName).GetAll();
         var namespacesToWaitFor = namespaces.ToList();
 
         var startTime = DateTime.UtcNow;
+
+        // The subscription definition is written by the EventStoreSubscriptionsReactor reacting to the
+        // EventStoreSubscriptionAdded event. That reactor processes asynchronously, so the definition may
+        // not yet be in State.Subscriptions when this method is called immediately after appending the event.
+        // Poll until the definition appears in state before proceeding to check IsSubscribed.
+        EventStoreSubscriptionDefinition? definition = null;
+        while (DateTime.UtcNow - startTime < timeout)
+        {
+            definition = State.Subscriptions.FirstOrDefault(s => s.Identifier == subscriptionId);
+            if (definition is not null)
+            {
+                break;
+            }
+
+            await Task.Delay(10);
+        }
+
+        if (definition is null)
+        {
+            throw new InvalidOperationException($"Subscription '{subscriptionId}' not found");
+        }
+
         while (DateTime.UtcNow - startTime < timeout)
         {
             var tasks = namespacesToWaitFor.Select(ns => CheckSubscriptionForNamespace(definition, ns));


### PR DESCRIPTION
## Fixed
- `WaitUntilSubscribed` no longer throws immediately when the subscription definition has not yet arrived in grain state — it now polls within the timeout window, fixing a startup race condition that prevented external event store subscriptions (e.g. Lobby → Studio) from being established.

## Added
- Typed `EventSourceId` on the client for stronger type safety when working with event source identifiers.