### PR TITLE
Add EventTypeAdded system event for first-time registrations

### DIFF
--- a/Source/Kernel/Core/EventSequences/Migrations/EventTypeAdded.cs
+++ b/Source/Kernel/Core/EventSequences/Migrations/EventTypeAdded.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Events.EventSequences.Migrations;
+
+/// <summary>
+/// System event appended to the System event sequence when an event type is first registered.
+/// </summary>
+/// <param name="EventTypeId">The <see cref="Concepts.Events.EventTypeId"/> of the event type that was added.</param>
+/// <param name="Generation">The initial <see cref="EventTypeGeneration"/> registered for the event type.</param>
+/// <param name="Schema">The JSON schema of the initial generation.</param>
+[EventType, AllEventStores]
+public record EventTypeAdded(
+    EventTypeId EventTypeId,
+    EventTypeGeneration Generation,
+    string Schema);

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -51,6 +51,7 @@ internal sealed class EventTypes(IStorage storage, IGrainFactory grainFactory) :
             var owner = (Concepts.Events.EventTypeOwner)(int)eventType.Owner;
             var source = (Concepts.Events.EventTypeSource)(int)eventType.Source;
             var eventTypeId = new EventTypeId(eventType.Type.Id);
+            var hasExistingEventType = await eventTypesStorage.HasFor(eventTypeId);
 
             // Detect new generations before registration
             var newGenerations = new List<(EventTypeGeneration Generation, string Schema)>();
@@ -123,15 +124,26 @@ internal sealed class EventTypes(IStorage storage, IGrainFactory grainFactory) :
                     source);
             }
 
-            // Append system events for new generations
+            // Append system events for newly discovered event type generations.
             if (newGenerations.Count > 0)
             {
                 var systemEventSequence = grainFactory.GetSystemEventSequence(request.EventStore);
-                foreach (var (generation, genSchema) in newGenerations)
+
+                if (!hasExistingEventType)
                 {
+                    var firstGeneration = newGenerations.OrderBy(_ => _.Generation.Value).First();
                     await systemEventSequence.Append(
                         (EventSourceId)eventTypeId.Value,
-                        new EventTypeGenerationAdded(eventTypeId, generation, genSchema));
+                        new EventTypeAdded(eventTypeId, firstGeneration.Generation, firstGeneration.Schema));
+                }
+                else
+                {
+                    foreach (var (generation, genSchema) in newGenerations)
+                    {
+                        await systemEventSequence.Append(
+                            (EventSourceId)eventTypeId.Value,
+                            new EventTypeGenerationAdded(eventTypeId, generation, genSchema));
+                    }
                 }
             }
         }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Events.EventSequences.Migrations;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_event_type_already_exists_and_gets_new_generation : given.all_dependencies
+{
+    Exception _exception;
+
+    void Establish() =>
+        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration?>())
+            .Returns(callInfo =>
+            {
+                var generation = callInfo.ArgAt<EventTypeGeneration?>(1);
+
+                if (generation is null)
+                {
+                    return true;
+                }
+
+                return generation.Value == 1;
+            });
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 2 },
+                    Schema = "{}",
+                    Migrations =
+                    {
+                        new EventTypeMigrationDefinition
+                        {
+                            FromGeneration = 1,
+                            ToGeneration = 2,
+                            UpcastJmesPath = "{}",
+                            DowncastJmesPath = "{}"
+                        }
+                    },
+                    Generations =
+                    {
+                        new EventTypeGenerationDefinition { Generation = 1, Schema = "{}" },
+                        new EventTypeGenerationDefinition { Generation = 2, Schema = "{}" }
+                    }
+                }
+            ]
+        }));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_append_event_type_generation_added_system_event() =>
+        _systemEventSequence.Received(1).Append(
+            Arg.Is<EventSourceId>(id => id.Value == "some-event"),
+            Arg.Is<EventTypeGenerationAdded>(@event =>
+                @event.EventTypeId.Value == "some-event" &&
+                @event.Generation.Value == 2 &&
+                @event.Schema == "{}"));
+    [Fact] void should_not_append_event_type_added_system_event() =>
+        _systemEventSequence.DidNotReceive().Append(
+            Arg.Any<EventSourceId>(),
+            Arg.Any<EventTypeAdded>());
+}

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_is_new.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_is_new.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+using Cratis.Chronicle.Events.EventSequences.Migrations;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_event_type_is_new : given.all_dependencies
+{
+    Exception _exception;
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 1 },
+                    Schema = "{}"
+                }
+            ]
+        }));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+    [Fact] void should_append_event_type_added_system_event() =>
+        _systemEventSequence.Received(1).Append(
+            Arg.Is<EventSourceId>(id => id.Value == "some-event"),
+            Arg.Is<EventTypeAdded>(@event =>
+                @event.EventTypeId.Value == "some-event" &&
+                @event.Generation.Value == 1 &&
+                @event.Schema == "{}"));
+    [Fact] void should_not_append_event_type_generation_added_system_event() =>
+        _systemEventSequence.DidNotReceive().Append(
+            Arg.Any<EventSourceId>(),
+            Arg.Any<EventTypeGenerationAdded>());
+}


### PR DESCRIPTION
## Added
- Added a new `EventTypeAdded` system event to record first-time event type creation in the system event sequence.

## Changed
- Updated event type registration to append `EventTypeAdded` for first-time registrations and append `EventTypeGenerationAdded` only when adding new generations to existing event types.
- Extended registration specs to verify both first-time creation tracking and existing-type generation tracking behavior.