### PR TITLE
Queue EventStore subscriptions for not-yet-existing source event stores

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_subscriptions_are_waiting_for_it.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_subscriptions_are_waiting_for_it.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Namespaces;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_source_event_store_is_added;
+
+public class and_subscriptions_are_waiting_for_it : Specification
+{
+    const string TargetEventStore = "Lobby";
+    const string SourceEventStore = "StudioAdmin";
+
+    TestKitSilo _silo;
+    EventStoreSubscriptionsManager _manager;
+    IObserver _observer;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        _silo.AddService(localSiloDetails);
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        _observer = Substitute.For<IObserver>();
+        _observer.IsSubscribed().Returns(false);
+        _silo.AddProbe(_ => _observer);
+
+        _manager = await _silo.CreateGrainAsync<EventStoreSubscriptionsManager>(TargetEventStore);
+
+        await _manager.Add(
+            new EventStoreSubscriptionDefinition(
+                new EventStoreSubscriptionId(SourceEventStore),
+                new EventStoreName(SourceEventStore),
+                [new EventType("5db7cfa2-0fcb-4791-b174-83ff2806d654", EventTypeGeneration.First)]));
+
+        await _manager.Add(
+            new EventStoreSubscriptionDefinition(
+                new EventStoreSubscriptionId("another-source"),
+                new EventStoreName("another-source"),
+                [new EventType("f0034052-e036-4b1b-9fd1-1aaf8f8d4eb4", EventTypeGeneration.First)]));
+    }
+
+    async Task Because() => await _manager.SourceEventStoreAdded(new EventStoreName(SourceEventStore));
+
+    [Fact] void should_subscribe_only_matching_pending_subscriptions() =>
+        _observer.Received(1).Subscribe<IEventStoreSubscriptionObserverSubscriber>(
+            ObserverType.External,
+            Arg.Any<IEnumerable<EventType>>(),
+            Arg.Any<SiloAddress>(),
+            Arg.Is<object?>(metadata => metadata is string && (string)metadata == TargetEventStore),
+            Arg.Any<bool>());
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_waiting_until_subscribed/and_subscription_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_waiting_until_subscribed/and_subscription_does_not_exist.cs
@@ -27,5 +27,5 @@ public class and_subscription_does_not_exist : Specification
         _error = await Catch.Exception(() =>
             _manager.WaitUntilSubscribed(new EventStoreSubscriptionId("does-not-exist"), TimeSpan.FromSeconds(1)));
 
-    [Fact] void should_throw_invalid_operation_exception() => _error.ShouldBeOfExactType<InvalidOperationException>();
+    [Fact] void should_throw_timeout_exception() => _error.ShouldBeOfExactType<TimeoutException>();
 }

--- a/Source/Kernel/Core/EventStoreAdded.cs
+++ b/Source/Kernel/Core/EventStoreAdded.cs
@@ -10,5 +10,5 @@ namespace Cratis.Chronicle;
 /// Represents the event that gets appended when an event store is added.
 /// </summary>
 /// <param name="EventStore">The <see cref="EventStoreName"/> that was added.</param>
-[EventType("8a8d7c3e-4f6b-4e5a-9c7d-2b1f3e4a5d6c")]
+[EventType]
 public record EventStoreAdded(EventStoreName EventStore);

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
@@ -99,7 +99,8 @@ public class EventStoreSubscriptionsManager(
 
         if (definition is null)
         {
-            throw new InvalidOperationException($"Subscription '{subscriptionId}' not found");
+            logger.SubscriptionDefinitionNotFoundWithinTimeout(subscriptionId, timeout);
+            throw new TimeoutException($"Subscription '{subscriptionId}' was not registered within {timeout.TotalMilliseconds}ms");
         }
 
         while (DateTime.UtcNow - startTime < timeout)
@@ -119,6 +120,34 @@ public class EventStoreSubscriptionsManager(
 
         logger.SubscriptionNotReadyWithinTimeout(subscriptionId, timeout);
         throw new TimeoutException($"Subscription '{subscriptionId}' did not become ready within {timeout.TotalMilliseconds}ms");
+    }
+
+    /// <inheritdoc/>
+    public async Task SourceEventStoreAdded(EventStoreName sourceEventStore)
+    {
+        var pendingDefinitions = State.Subscriptions
+            .Where(_ => _.SourceEventStore == sourceEventStore)
+            .ToArray();
+
+        if (pendingDefinitions.Length == 0)
+        {
+            return;
+        }
+
+        logger.SourceEventStoreBecameAvailable(sourceEventStore, pendingDefinitions.Length);
+
+        var namespaces = await GrainFactory.GetGrain<INamespaces>(_targetEventStoreName).GetAll();
+        foreach (var definition in pendingDefinitions)
+        {
+            try
+            {
+                await RefreshSubscription(definition, namespaces);
+            }
+            catch (Exception ex)
+            {
+                logger.ErrorRefreshingForNewSourceEventStore(ex, definition.Identifier, sourceEventStore);
+            }
+        }
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManagerLogging.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManagerLogging.cs
@@ -36,8 +36,17 @@ internal static partial class EventStoreSubscriptionsManagerLogging
     [LoggerMessage(LogLevel.Information, "Event store subscription '{SubscriptionId}' is ready to receive events")]
     internal static partial void SubscriptionReadyForUse(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId);
 
+    [LoggerMessage(LogLevel.Warning, "Event store subscription '{SubscriptionId}' was not registered within {Timeout}")]
+    internal static partial void SubscriptionDefinitionNotFoundWithinTimeout(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId, TimeSpan timeout);
+
     [LoggerMessage(LogLevel.Warning, "Event store subscription '{SubscriptionId}' did not become ready within {Timeout}")]
     internal static partial void SubscriptionNotReadyWithinTimeout(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId, TimeSpan timeout);
+
+    [LoggerMessage(LogLevel.Information, "Source event store '{SourceEventStore}' became available; retrying {SubscriptionCount} pending subscriptions")]
+    internal static partial void SourceEventStoreBecameAvailable(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreName sourceEventStore, int subscriptionCount);
+
+    [LoggerMessage(LogLevel.Error, "Error refreshing subscription '{SubscriptionId}' after source event store '{SourceEventStore}' was added")]
+    internal static partial void ErrorRefreshingForNewSourceEventStore(this ILogger<EventStoreSubscriptionsManager> logger, Exception exception, EventStoreSubscriptionId subscriptionId, EventStoreName sourceEventStore);
 
     [LoggerMessage(LogLevel.Debug, "Event store subscription '{SubscriptionId}' health check failed - refreshing subscription")]
     internal static partial void SubscriptionHealthCheckFailed(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId);

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactor.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactor.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Observation.Reactors.Kernel;
+using Cratis.Chronicle.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;
@@ -15,9 +16,10 @@ namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;
 /// Represents a reactor that handles event store subscription lifecycle events.
 /// </summary>
 /// <param name="grainFactory">The <see cref="IGrainFactory"/> for creating grains.</param>
+/// <param name="storage"><see cref="IStorage"/> for getting all event stores.</param>
 /// <param name="logger">The <see cref="ILogger{EventStoreSubscriptionsReactor}"/> for logging.</param>
 [Reactor(eventSequence: WellKnownEventSequences.System, systemEventStoreOnly: false, defaultNamespaceOnly: true)]
-public class EventStoreSubscriptionsReactor(IGrainFactory grainFactory, ILogger<EventStoreSubscriptionsReactor> logger) : Reactor
+public class EventStoreSubscriptionsReactor(IGrainFactory grainFactory, IStorage storage, ILogger<EventStoreSubscriptionsReactor> logger) : Reactor
 {
     /// <summary>
     /// Handles the addition of an event store subscription.
@@ -56,5 +58,39 @@ public class EventStoreSubscriptionsReactor(IGrainFactory grainFactory, ILogger<
         await subscriptionsManager.Remove(subscriptionId);
 
         logger.SubscriptionRemoved(eventContext.EventSourceId);
+    }
+
+    /// <summary>
+    /// Handles the addition of a source event store and retries any pending subscriptions immediately.
+    /// </summary>
+    /// <param name="event">The event containing the event store information.</param>
+    /// <param name="eventContext">The context of the event.</param>
+    /// <returns>Await Task.</returns>
+    public async Task EventStoreAdded(EventStoreAdded @event, EventContext eventContext)
+    {
+        if (eventContext.EventStore != Concepts.EventStoreName.System)
+        {
+            return;
+        }
+
+        var targetEventStores = (await storage.GetEventStores()).ToArray();
+        logger.SourceEventStoreAdded(@event.EventStore, targetEventStores.Length);
+
+        var tasks = targetEventStores.Select(targetEventStore =>
+            NotifySubscriptionsManagerOfSourceEventStore(targetEventStore, @event.EventStore));
+        await Task.WhenAll(tasks);
+    }
+
+    async Task NotifySubscriptionsManagerOfSourceEventStore(Concepts.EventStoreName targetEventStore, Concepts.EventStoreName sourceEventStore)
+    {
+        try
+        {
+            var subscriptionsManager = grainFactory.GetGrain<IEventStoreSubscriptionsManager>(targetEventStore.Value);
+            await subscriptionsManager.SourceEventStoreAdded(sourceEventStore);
+        }
+        catch (Exception ex)
+        {
+            logger.ErrorRetryingPendingSubscriptions(ex, targetEventStore, sourceEventStore);
+        }
     }
 }

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactorLogging.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactorLogging.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;
@@ -22,4 +23,10 @@ internal static partial class EventStoreSubscriptionsReactorLogging
 
     [LoggerMessage(LogLevel.Information, "Event store subscription removed for event source '{EventSourceId}'")]
     internal static partial void SubscriptionRemoved(this ILogger<EventStoreSubscriptionsReactor> logger, EventSourceId eventSourceId);
+
+    [LoggerMessage(LogLevel.Information, "Source event store '{SourceEventStore}' was added; checking pending subscriptions across {TargetEventStoreCount} event stores")]
+    internal static partial void SourceEventStoreAdded(this ILogger<EventStoreSubscriptionsReactor> logger, EventStoreName sourceEventStore, int targetEventStoreCount);
+
+    [LoggerMessage(LogLevel.Error, "Error retrying pending subscriptions for target event store '{TargetEventStore}' after source event store '{SourceEventStore}' was added")]
+    internal static partial void ErrorRetryingPendingSubscriptions(this ILogger<EventStoreSubscriptionsReactor> logger, Exception exception, EventStoreName targetEventStore, EventStoreName sourceEventStore);
 }

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/IEventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/IEventStoreSubscriptionsManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Concepts;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;
 
@@ -43,6 +44,13 @@ public interface IEventStoreSubscriptionsManager : IGrainWithStringKey
     /// <param name="timeout">The maximum time to wait.</param>
     /// <returns>Awaitable task.</returns>
     /// <exception cref="TimeoutException">Thrown if the subscription does not become ready within the timeout.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the subscription is not found.</exception>
     Task WaitUntilSubscribed(EventStoreSubscriptionId subscriptionId, TimeSpan timeout);
+
+    /// <summary>
+    /// Notifies the manager that a source event store has been added.
+    /// Any subscriptions waiting for this source event store should be retried immediately.
+    /// </summary>
+    /// <param name="sourceEventStore">The source <see cref="EventStoreName"/> that became available.</param>
+    /// <returns>Awaitable task.</returns>
+    Task SourceEventStoreAdded(EventStoreName sourceEventStore);
 }


### PR DESCRIPTION
## Fixed

- Cross-event-store subscriptions set up against a source event store that does not yet exist are now queued and automatically retried when the source event store becomes available, instead of failing with an `InvalidOperationException`.
