### PR TITLE
Sort using directives alphabetically in EventStoreSubscriptions files

### DIFF
--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactorLogging.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsReactorLogging.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/IEventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/IEventStoreSubscriptionsManager.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions;
 


### PR DESCRIPTION
## Changed

- Sort `using` directives alphabetically in `EventStoreSubscriptionsReactorLogging.cs` and `IEventStoreSubscriptionsManager.cs`.
