### PR TITLE
Fix deferred future resolution for nested projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,4 @@ vite*.map
 certificates/
 
 .grpc-schema-gen*
+.playwright-mcp

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,12 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.7.3" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.3" />
-    <PackageVersion Include="Cratis.Arc" Version="20.8.3" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.3" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.3" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.3" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.3" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.3" />
+    <PackageVersion Include="Cratis.Arc" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.9" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,43 +9,43 @@
     <PackageVersion Include="protobuf-net.Grpc.Reflection" Version="1.2.2" />
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.6" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.3" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.7.3" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.3" />
-    <PackageVersion Include="Cratis.Arc" Version="20.8.9" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.9" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.9" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.9" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.9" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.9" />
+    <PackageVersion Include="Cratis.Arc" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.10" />
     <!-- Microsoft -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <!-- Orleans -->
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.1.0" />
@@ -64,14 +64,14 @@
     <PackageVersion Include="OrleansTestKit10" Version="10.0.0" />
     <PackageVersion Include="Orleans.Providers.MongoDB" Version="9.5.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <!-- Roslyn-->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
@@ -91,7 +91,7 @@
     <PackageVersion Include="castle.core" Version="5.2.1" />
     <PackageVersion Include="humanizer" Version="3.0.10" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
-    <PackageVersion Include="NJsonSchema" Version="11.6.0" />
+    <PackageVersion Include="NJsonSchema" Version="11.6.1" />
     <PackageVersion Include="JsonCons.JmesPath" Version="1.0.0" />
     <PackageVersion Include="protobuf-net.BuildTools" Version="3.2.52">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -101,7 +101,7 @@
     <PackageVersion Include="protobuf-net.Grpc" Version="1.2.5" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageVersion Include="mongodb.driver" Version="3.7.1" />
+    <PackageVersion Include="mongodb.driver" Version="3.8.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
@@ -110,7 +110,7 @@
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <!-- Testing & Specifications -->
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Cratis.Specifications" Version="3.0.4" />
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,12 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.7.3" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.7.3" />
-    <PackageVersion Include="Cratis.Arc" Version="20.8.10" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.10" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.10" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.10" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.10" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.10" />
+    <PackageVersion Include="Cratis.Arc" Version="20.8.11" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.8.11" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.8.11" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.8.11" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.8.11" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.8.11" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/Concepts/MetricId.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/Concepts/MetricId.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.Concepts;
+
+public record MetricId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    public static readonly MetricId NotSet = new(Guid.Empty);
+    public static implicit operator MetricId(Guid value) => new(value);
+    public static implicit operator EventSourceId(MetricId id) => new(id.Value.ToString());
+    public static MetricId New() => new(Guid.NewGuid());
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/Events/MetricAddedToHub.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/Events/MetricAddedToHub.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.Concepts;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.Events;
+
+[EventType]
+public record MetricAddedToHub(MetricId MetricId, string Name);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/ReadModels/Metric.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/ReadModels/Metric.cs
@@ -6,12 +6,10 @@ using Cratis.Chronicle.ReadModels;
 
 namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.ReadModels;
 
-public class Hub
+public class Metric
 {
     [Index]
-    public HubId HubId { get; set; } = HubId.NotSet;
+    public MetricId MetricId { get; set; } = MetricId.NotSet;
 
     public string Name { get; set; } = string.Empty;
-
-    public IList<Metric> Metrics { get; set; } = [];
 }

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/SimulationDashboardProjection.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/SimulationDashboardProjection.cs
@@ -22,5 +22,8 @@ public class SimulationDashboardProjection : IProjectionFor<SimulationDashboard>
             .From<WeightsSetForSimulationConfiguration>()
             .Children(m => m.Hubs, m => m
                 .IdentifiedBy(r => r.HubId)
-                .From<HubAddedToSimulationConfiguration>(e => e.UsingKey(e => e.HubId))));
+                .From<HubAddedToSimulationConfiguration>(e => e.UsingKey(e => e.HubId))
+                .Children(h => h.Metrics, h => h
+                    .IdentifiedBy(r => r.MetricId)
+                    .From<MetricAddedToHub>(e => e.UsingKey(e => e.MetricId)))));
 }

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_all_events_are_appended_in_one_transaction.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_all_events_are_appended_in_one_transaction.cs
@@ -34,7 +34,7 @@ public class and_all_events_are_appended_in_one_transaction(context context) : G
         public SimulationDashboard Result;
         public EventSequenceNumber LastEventSequenceNumber = EventSequenceNumber.First;
 
-        public override IEnumerable<Type> EventTypes => [typeof(SimulationAdded), typeof(SimulationConfigurationAdded), typeof(HubAddedToSimulationConfiguration), typeof(WeightsSetForSimulationConfiguration)];
+        public override IEnumerable<Type> EventTypes => [typeof(SimulationAdded), typeof(SimulationConfigurationAdded), typeof(HubAddedToSimulationConfiguration), typeof(WeightsSetForSimulationConfiguration), typeof(MetricAddedToHub)];
         public override IEnumerable<Type> Projections => [typeof(SimulationDashboardProjection)];
 
         protected override void ConfigureServices(IServiceCollection services)

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_child_event_arrives_before_parent.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_child_event_arrives_before_parent.cs
@@ -27,7 +27,7 @@ public class and_child_event_arrives_before_parent(context context) : Given<cont
         public SimulationDashboard Result;
         public EventSequenceNumber LastEventSequenceNumber = EventSequenceNumber.First;
 
-        public override IEnumerable<Type> EventTypes => [typeof(SimulationAdded), typeof(SimulationConfigurationAdded), typeof(HubAddedToSimulationConfiguration), typeof(WeightsSetForSimulationConfiguration)];
+        public override IEnumerable<Type> EventTypes => [typeof(SimulationAdded), typeof(SimulationConfigurationAdded), typeof(HubAddedToSimulationConfiguration), typeof(WeightsSetForSimulationConfiguration), typeof(MetricAddedToHub)];
         public override IEnumerable<Type> Projections => [typeof(SimulationDashboardProjection)];
 
         protected override void ConfigureServices(IServiceCollection services)

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_metric_event_arrives_before_hub_is_added.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_children_within_children_using_parent_key_from_context/and_metric_event_arrives_before_hub_is_added.cs
@@ -7,27 +7,37 @@ using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecti
 using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.ReadModels;
 using Cratis.Chronicle.Observation;
 using MongoDB.Driver;
-using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.and_parent_key_is_resolved_from_sink.context;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context.and_metric_event_arrives_before_hub_is_added.context;
 
 namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_children_within_children_using_parent_key_from_context;
 
 [Collection(ChronicleCollection.Name)]
-public class and_parent_key_is_resolved_from_sink(context context) : Given<context>(context)
+public class and_metric_event_arrives_before_hub_is_added(context context) : Given<context>(context)
 {
     const string SimulationName = "Test Simulation";
     const string ConfigurationName = "Test Configuration";
     const string HubName = "Test Hub";
+    const string MetricName = "Test Metric";
 
     public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
     {
         public SimulationId SimulationId;
         public ConfigurationId ConfigurationId;
         public HubId HubId;
+        public MetricId MetricId;
         public IEnumerable<FailedPartition> FailedPartitions = [];
         public SimulationDashboard Result;
         public EventSequenceNumber LastEventSequenceNumber = EventSequenceNumber.First;
 
-        public override IEnumerable<Type> EventTypes => [typeof(SimulationAdded), typeof(SimulationConfigurationAdded), typeof(HubAddedToSimulationConfiguration), typeof(WeightsSetForSimulationConfiguration), typeof(MetricAddedToHub)];
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(SimulationAdded),
+            typeof(SimulationConfigurationAdded),
+            typeof(HubAddedToSimulationConfiguration),
+            typeof(WeightsSetForSimulationConfiguration),
+            typeof(MetricAddedToHub)
+        ];
+
         public override IEnumerable<Type> Projections => [typeof(SimulationDashboardProjection)];
 
         protected override void ConfigureServices(IServiceCollection services)
@@ -40,6 +50,7 @@ public class and_parent_key_is_resolved_from_sink(context context) : Given<conte
             SimulationId = Guid.Parse("0089d57f-9095-4b56-b948-ab170de8e0ee");
             ConfigurationId = Guid.Parse("754fd741-adae-4fbd-8c47-2d622cc0b274");
             HubId = Guid.Parse("eff2cf7a-4121-438b-94fd-139775a09f57");
+            MetricId = Guid.Parse("de8ebf14-2423-47b3-8b0f-dc6f4f65b74a");
         }
 
         async Task Because()
@@ -47,25 +58,24 @@ public class and_parent_key_is_resolved_from_sink(context context) : Given<conte
             var projection = EventStore.Projections.GetHandlerFor<SimulationDashboardProjection>();
             await projection.WaitTillActive();
 
-            // Root and configuration events on SimulationId source
             var appendResult = await EventStore.EventLog.Append(SimulationId, new SimulationAdded(SimulationName));
-            LastEventSequenceNumber = appendResult.SequenceNumber;
+            await projection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
 
             appendResult = await EventStore.EventLog.Append(SimulationId, new SimulationConfigurationAdded(ConfigurationId, ConfigurationName));
-            LastEventSequenceNumber = appendResult.SequenceNumber;
+            await projection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
 
-            // Hub event on HubId source (different event source) - the Sink resolves the parent hierarchy
+            // Third nested child arrives before its Hub parent exists.
+            await EventStore.EventLog.Append(HubId, new MetricAddedToHub(MetricId, MetricName));
+
             appendResult = await EventStore.EventLog.Append(ConfigurationId, new HubAddedToSimulationConfiguration(HubId, HubName));
             LastEventSequenceNumber = appendResult.SequenceNumber;
-
             await projection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
 
             FailedPartitions = await projection.GetFailedPartitions();
 
             var collection = ChronicleFixture.ReadModels.Database.GetCollection<SimulationDashboard>();
             var queryResult = await collection.FindAsync(_ => true);
-            var allResults = await queryResult.ToListAsync();
-            Result = allResults.FirstOrDefault();
+            Result = (await queryResult.ToListAsync()).FirstOrDefault();
         }
     }
 
@@ -85,10 +95,9 @@ public class and_parent_key_is_resolved_from_sink(context context) : Given<conte
     [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
     [Fact] void should_have_simulation_name() => Context.Result.Name.ShouldEqual(SimulationName);
     [Fact] void should_have_one_configuration() => Context.Result.Configurations.Count.ShouldEqual(1);
-    [Fact] void should_have_configuration_id_on_child() => Context.Result.Configurations[0].ConfigurationId.ShouldEqual(Context.ConfigurationId);
     [Fact] void should_have_configuration_name_on_child() => Context.Result.Configurations[0].Name.ShouldEqual(ConfigurationName);
     [Fact] void should_have_one_hub_on_configuration() => Context.Result.Configurations[0].Hubs.Count.ShouldEqual(1);
-    [Fact] void should_have_hub_id_on_nested_child() => Context.Result.Configurations[0].Hubs[0].HubId.ShouldEqual(Context.HubId);
     [Fact] void should_have_hub_name_on_nested_child() => Context.Result.Configurations[0].Hubs[0].Name.ShouldEqual(HubName);
+    [Fact] void should_have_one_metric_on_hub() => Context.Result.Configurations[0].Hubs[0].Metrics.Count.ShouldEqual(1);
     [Fact] void should_set_the_event_sequence_number_to_last_event() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
 }

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_non_replayable_observers.cs
@@ -52,27 +52,28 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reactorHandler = EventStore.Reactors.GetHandlerFor<SomeReactor>();
             var reducerHandler = EventStore.Reducers.GetHandlerFor<SomeReducer>();
             var nonReplayableReactorHandler = EventStore.Reactors.GetHandlerFor<NonReplayableReactor>();
             var nonReplayableReducerHandler = EventStore.Reducers.GetHandlerFor<NonReplayableReducer>();
 
-            await reactorHandler.WaitTillActive();
-            await reducerHandler.WaitTillActive();
-            await nonReplayableReactorHandler.WaitTillActive();
-            await nonReplayableReducerHandler.WaitTillActive();
+            await reactorHandler.WaitTillActive(startupTimeout);
+            await reducerHandler.WaitTillActive(startupTimeout);
+            await nonReplayableReactorHandler.WaitTillActive(startupTimeout);
+            await nonReplayableReducerHandler.WaitTillActive(startupTimeout);
 
             await EventStore.EventLog.Append(EventSourceId, FirstEvent);
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
-            await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
+            var lastAppendResult = await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+            var lastAppendedSequenceNumber = lastAppendResult.SequenceNumber;
 
             // Wait for all observers to process the appended events.
-            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
 
             // Mark the non-replayable observers as non-replayable in storage.
             await MarkObserverAsNonReplayable(typeof(NonReplayableReactor).GetReactorId());
@@ -91,8 +92,8 @@ public class a_single_event_with_non_replayable_observers(context context) : Giv
             await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             // Wait for replayable observers to finish processing the replay.
-            await Reactor.WaitTillHandledEventReaches(2);
-            await Reducer.WaitTillHandledEventReaches(2);
+            await Reactor.WaitTillHandledEventReaches(2, startupTimeout);
+            await Reducer.WaitTillHandledEventReaches(2, startupTimeout);
 
             ReactorState = await reactorHandler.GetState();
             ReducerState = await reducerHandler.GetState();

--- a/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_redacting/a_single_event_with_observers.cs
@@ -50,24 +50,25 @@ public class a_single_event_with_observers(context context) : Given<context>(con
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reactorHandler = EventStore.Reactors.GetHandlerFor<SomeReactor>();
             var reducerHandler = EventStore.Reducers.GetHandlerFor<SomeReducer>();
             var projectionHandler = EventStore.Projections.GetHandlerFor<SomeProjection>();
 
-            await reactorHandler.WaitTillActive();
-            await reducerHandler.WaitTillActive();
-            await projectionHandler.WaitTillActive();
+            await reactorHandler.WaitTillActive(startupTimeout);
+            await reducerHandler.WaitTillActive(startupTimeout);
+            await projectionHandler.WaitTillActive(startupTimeout);
 
             await EventStore.EventLog.Append(EventSourceId, FirstEvent);
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
-            await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
+            var lastAppendResult = await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+            var lastAppendedSequenceNumber = lastAppendResult.SequenceNumber;
 
             // Wait for all observers to process the appended events.
-            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
 
             // Reset counters before redaction to measure replay.
             Reactor.HandledEvents = 0;
@@ -80,8 +81,8 @@ public class a_single_event_with_observers(context context) : Given<context>(con
             await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             // Wait for observers to finish processing the replay.
-            await Reactor.WaitTillHandledEventReaches(2);
-            await Reducer.WaitTillHandledEventReaches(2);
+            await Reactor.WaitTillHandledEventReaches(2, startupTimeout);
+            await Reducer.WaitTillHandledEventReaches(2, startupTimeout);
 
             var storage = GetEventLogStorage();
             RedactedStoredEvent = await storage.GetEventAt((EventSequenceNumber.First + 1).Value);

--- a/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_non_replayable_observers.cs
@@ -54,27 +54,28 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reactorHandler = EventStore.Reactors.GetHandlerFor<SomeReactor>();
             var reducerHandler = EventStore.Reducers.GetHandlerFor<SomeReducer>();
             var nonReplayableReactorHandler = EventStore.Reactors.GetHandlerFor<NonReplayableReactor>();
             var nonReplayableReducerHandler = EventStore.Reducers.GetHandlerFor<NonReplayableReducer>();
 
-            await reactorHandler.WaitTillActive();
-            await reducerHandler.WaitTillActive();
-            await nonReplayableReactorHandler.WaitTillActive();
-            await nonReplayableReducerHandler.WaitTillActive();
+            await reactorHandler.WaitTillActive(startupTimeout);
+            await reducerHandler.WaitTillActive(startupTimeout);
+            await nonReplayableReactorHandler.WaitTillActive(startupTimeout);
+            await nonReplayableReducerHandler.WaitTillActive(startupTimeout);
 
             await EventStore.EventLog.Append(EventSourceId, FirstEvent);
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
-            await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
+            var lastAppendResult = await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+            var lastAppendedSequenceNumber = lastAppendResult.SequenceNumber;
 
             // Wait for all observers to process the appended events.
-            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await nonReplayableReactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await nonReplayableReducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
 
             // Mark the non-replayable observers as non-replayable in storage.
             await MarkObserverAsNonReplayable(typeof(NonReplayableReactor).GetReactorId());
@@ -93,8 +94,8 @@ public class an_event_with_non_replayable_observers(context context) : Given<con
             await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             // Wait for replayable observers to finish processing the replay.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
+            await Reactor.WaitTillHandledEventReaches(3, startupTimeout);
+            await Reducer.WaitTillHandledEventReaches(3, startupTimeout);
 
             ReactorState = await reactorHandler.GetState();
             ReducerState = await reducerHandler.GetState();

--- a/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_observers.cs
+++ b/Integration/DotNET.InProcess/for_EventSequence/when_revising/an_event_with_observers.cs
@@ -52,24 +52,25 @@ public class an_event_with_observers(context context) : Given<context>(context)
 
         async Task Because()
         {
+            var startupTimeout = TimeSpanFactory.FromSeconds(30);
             var reactorHandler = EventStore.Reactors.GetHandlerFor<SomeReactor>();
             var reducerHandler = EventStore.Reducers.GetHandlerFor<SomeReducer>();
             var projectionHandler = EventStore.Projections.GetHandlerFor<SomeProjection>();
 
-            await reactorHandler.WaitTillActive();
-            await reducerHandler.WaitTillActive();
-            await projectionHandler.WaitTillActive();
+            await reactorHandler.WaitTillActive(startupTimeout);
+            await reducerHandler.WaitTillActive(startupTimeout);
+            await projectionHandler.WaitTillActive(startupTimeout);
 
             await EventStore.EventLog.Append(EventSourceId, FirstEvent);
             await EventStore.EventLog.Append(EventSourceId, SecondEvent);
-            await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
+            var lastAppendResult = await EventStore.EventLog.Append(EventSourceId, ThirdEvent);
 
-            var lastAppendedSequenceNumber = EventSequenceNumber.First + 2;
+            var lastAppendedSequenceNumber = lastAppendResult.SequenceNumber;
 
             // Wait for all observers to process the appended events.
-            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
-            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber);
+            await reactorHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await reducerHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
+            await projectionHandler.WaitTillReachesEventSequenceNumber(lastAppendedSequenceNumber, startupTimeout);
 
             // Reset counters before revision to measure replay.
             Reactor.HandledEvents = 0;
@@ -82,8 +83,8 @@ public class an_event_with_observers(context context) : Given<context>(context)
             await EventStore.Jobs.WaitForThereToBeNoJobs();
 
             // Wait for observers to finish processing the replay.
-            await Reactor.WaitTillHandledEventReaches(3);
-            await Reducer.WaitTillHandledEventReaches(3);
+            await Reactor.WaitTillHandledEventReaches(3, startupTimeout);
+            await Reducer.WaitTillHandledEventReaches(3, startupTimeout);
 
             StoredEvent = await GetEventLogStorage().GetEventAt(EventSequenceNumber.First.Value);
             var systemStorage = GetSystemEventLogStorage();

--- a/Source/Clients/Api/Projections/Projection.cs
+++ b/Source/Clients/Api/Projections/Projection.cs
@@ -19,7 +19,7 @@ public record Projection(string Identifier, string ReadModel)
     /// <param name="projections"><see cref="IProjections"/> for interacting with projections.</param>
     /// <param name="eventStore">The event store to get projections for.</param>
     /// <returns>All projections.</returns>
-    internal static async Task<IEnumerable<Projection>> AllProjections(IProjections projections, string eventStore)
+    public static async Task<IEnumerable<Projection>> AllProjections(IProjections projections, string eventStore)
     {
         var definitions = await projections.GetAllDefinitions(new GetAllDefinitionsRequest { EventStore = eventStore });
         return definitions.Select(d => new Projection(d.Identifier, d.ReadModel));

--- a/Source/Clients/Api/Projections/ProjectionWithDeclaration.cs
+++ b/Source/Clients/Api/Projections/ProjectionWithDeclaration.cs
@@ -20,7 +20,7 @@ public record ProjectionWithDeclaration(string Identifier, string ContainerName,
     /// <param name="projections"><see cref="IProjections"/> for interacting with projections.</param>
     /// <param name="eventStore">The event store to get projections for.</param>
     /// <returns>All projections with their declaration representation.</returns>
-    internal static async Task<IEnumerable<ProjectionWithDeclaration>> AllProjectionsWithDeclarations(IProjections projections, string eventStore)
+    public static async Task<IEnumerable<ProjectionWithDeclaration>> AllProjectionsWithDeclarations(IProjections projections, string eventStore)
     {
         var declarations = await projections.GetAllDeclarations(new GetAllDeclarationsRequest { EventStore = eventStore });
         return declarations.Select(d => new ProjectionWithDeclaration(d.Identifier, d.ContainerName, d.Declaration));

--- a/Source/Clients/Api/ReadModelTypes/ReadModelDefinition.cs
+++ b/Source/Clients/Api/ReadModelTypes/ReadModelDefinition.cs
@@ -34,7 +34,7 @@ public record ReadModelDefinition(
     /// <param name="readModels"><see cref="IReadModels"/> for working with read models.</param>
     /// <param name="eventStore">The event store to get read models for.</param>
     /// <returns>Collection of read model definitions.</returns>
-    internal static async Task<IEnumerable<ReadModelDefinition>> AllReadModelDefinitions(IReadModels readModels, string eventStore)
+    public static async Task<IEnumerable<ReadModelDefinition>> AllReadModelDefinitions(IReadModels readModels, string eventStore)
     {
         var response = await readModels.GetDefinitions(new()
         {

--- a/Source/Clients/Api/ReadModels/ReadModelInstance.cs
+++ b/Source/Clients/Api/ReadModels/ReadModelInstance.cs
@@ -24,7 +24,7 @@ public record ReadModelInstance(JsonObject Instance)
     /// <param name="readModel">The name of the read model to get instances for.</param>
     /// <param name="occurrence">Optional occurrence name to get instances from.</param>
     /// <returns>Paged collection of read model instances.</returns>
-    internal static async Task<IEnumerable<ReadModelInstance>> ReadModelInstances(
+    public static async Task<IEnumerable<ReadModelInstance>> ReadModelInstances(
         IReadModelsService readModels,
         IQueryContextManager queryContextManager,
         string eventStore,

--- a/Source/Clients/Api/ReadModels/ReadModelOccurrence.cs
+++ b/Source/Clients/Api/ReadModels/ReadModelOccurrence.cs
@@ -22,7 +22,7 @@ public record ReadModelOccurrence(DateTimeOffset Occurred, string RevertContaine
     /// <param name="namespace">The namespace of the read model to get occurrences for.</param>
     /// <param name="readModel">The name of the read model to get occurrences for.</param>
     /// <returns>Collection of read model occurrences.</returns>
-    internal static async Task<IEnumerable<ReadModelOccurrence>> ReadModelOccurrences(
+    public static async Task<IEnumerable<ReadModelOccurrence>> ReadModelOccurrences(
         IReadModels readModels,
         string eventStore,
         string @namespace,

--- a/Source/Clients/Api/ReadModels/ReadModelSnapshot.cs
+++ b/Source/Clients/Api/ReadModels/ReadModelSnapshot.cs
@@ -25,7 +25,7 @@ public record ReadModelSnapshot(DateTimeOffset Occurred, JsonObject Instance, IE
     /// <param name="readModel">The read model identifier.</param>
     /// <param name="readModelKey">The read model key.</param>
     /// <returns>Collection of snapshots.</returns>
-    internal static async Task<IEnumerable<ReadModelSnapshot>> AllSnapshotsForReadModel(
+    public static async Task<IEnumerable<ReadModelSnapshot>> AllSnapshotsForReadModel(
         IReadModels readModels,
         string eventStore,
         string @namespace,

--- a/Source/Clients/Api/Security/Application.cs
+++ b/Source/Clients/Api/Security/Application.cs
@@ -28,7 +28,7 @@ public record Application(
     /// </summary>
     /// <param name="applications">The <see cref="IApplications"/> contract.</param>
     /// <returns>An observable for observing a collection of applications.</returns>
-    internal static ISubject<IEnumerable<Application>> AllApplications(IApplications applications) =>
+    public static ISubject<IEnumerable<Application>> AllApplications(IApplications applications) =>
         applications.InvokeAndWrapWithTransformSubject(
             token => applications.ObserveAll(token),
             response => response.ToApi());

--- a/Source/Clients/Api/Security/InitialAdminPasswordSetupStatus.cs
+++ b/Source/Clients/Api/Security/InitialAdminPasswordSetupStatus.cs
@@ -22,7 +22,7 @@ public record InitialAdminPasswordSetupStatus(
     /// </summary>
     /// <param name="users">The <see cref="IUsers"/> contract.</param>
     /// <returns>The <see cref="InitialAdminPasswordSetupStatus"/>.</returns>
-    internal static async Task<InitialAdminPasswordSetupStatus> GetStatus(IUsers users)
+    public static async Task<InitialAdminPasswordSetupStatus> GetStatus(IUsers users)
     {
         var status = await users.GetInitialAdminPasswordSetupStatus();
         return new InitialAdminPasswordSetupStatus(status.IsRequired, status.AdminUserId);

--- a/Source/Clients/Api/Security/User.cs
+++ b/Source/Clients/Api/Security/User.cs
@@ -30,7 +30,7 @@ public record User(
     /// </summary>
     /// <param name="users">The <see cref="IUsers"/> contract.</param>
     /// <returns>An observable for observing a collection of users.</returns>
-    internal static ISubject<IEnumerable<User>> AllUsers(IUsers users) =>
+    public static ISubject<IEnumerable<User>> AllUsers(IUsers users) =>
         users.InvokeAndWrapWithTransformSubject(
             token => users.ObserveAll(token),
             response => response.ToApi());

--- a/Source/Clients/Api/Seeding/SeedData.cs
+++ b/Source/Clients/Api/Seeding/SeedData.cs
@@ -21,7 +21,7 @@ public record SeedData(
     /// <param name="eventSeeding">The event seeding contract.</param>
     /// <param name="eventStore">The event store name.</param>
     /// <returns>Global seed data organized by event type and event source.</returns>
-    internal static async Task<SeedData> GlobalSeedData(IEventSeeding eventSeeding, string eventStore)
+    public static async Task<SeedData> GlobalSeedData(IEventSeeding eventSeeding, string eventStore)
     {
         var response = await eventSeeding.GetGlobalSeedData(new GetSeedDataRequest
         {
@@ -44,7 +44,7 @@ public record SeedData(
     /// <param name="eventStore">The event store name.</param>
     /// <param name="namespace">The namespace name.</param>
     /// <returns>Namespace-specific seed data organized by event type and event source.</returns>
-    internal static async Task<SeedData> NamespaceSeedData(IEventSeeding eventSeeding, string eventStore, string @namespace)
+    public static async Task<SeedData> NamespaceSeedData(IEventSeeding eventSeeding, string eventStore, string @namespace)
     {
         var response = await eventSeeding.GetNamespaceSeedData(new GetSeedDataRequest
         {

--- a/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleClientFixture.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.EventSequences;
+using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -62,6 +63,11 @@ public abstract class ChronicleClientFixture<TChronicleFixture> : IDisposable, I
     /// Gets the value indicating whether to auto discover artifacts.
     /// </summary>
     public virtual bool AutoDiscoverArtifacts { get; } = true;
+
+    /// <summary>
+    /// Gets the MongoDB container.
+    /// </summary>
+    public IContainer MongoDBContainer => ChronicleFixture.MongoDBContainer;
 
     /// <summary>
     /// Gets the docker network.

--- a/Source/Clients/XUnit.Integration/ChronicleInProcessFixture.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleInProcessFixture.cs
@@ -27,7 +27,7 @@ public class ChronicleInProcessFixture : ChronicleFixture
         var builder = new ContainerBuilder("mongo")
             .WithCommand("/bin/sh", "-c", "mongod --replSet rs0 --bind_ip_all > /proc/1/fd/1 2>/proc/1/fd/2 & until mongosh --quiet --eval 'db.adminCommand(\"ping\")' >/dev/null 2>&1; do sleep 0.1; done; mongosh --eval 'rs.initiate({_id:\"rs0\",members:[{_id:0,host:\"localhost:27017\"}]})' || true; tail -f /dev/null")
             .WithTmpfsMount("/data/db", AccessMode.ReadWrite)
-            .WithPortBinding(MongoDBPort, 27017)
+            .WithPortBinding(27017, assignRandomHostPort: true)
             .WithHostname(HostName)
             .WithBindMount(Path.Combine(Directory.GetCurrentDirectory(), "backups"), "/backups")
             .WithNetwork(network)

--- a/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
@@ -58,7 +58,7 @@ public class ChronicleOrleansInProcessWebApplicationFactory<TStartup>(
         var builder = Host.CreateDefaultBuilder();
         var chronicleOptions = new Configuration.ChronicleOptions();
 
-        var mongoServer = $"mongodb://localhost:{ChronicleFixture.MongoDBPort}/?directConnection=true";
+        var mongoServer = $"mongodb://localhost:{_fixture.MongoDBContainer.GetMappedPublicPort(27017)}/?directConnection=true";
 
         builder.AddCratisMongoDB(
             mongo =>

--- a/Source/Clients/XUnit.Integration/IChronicleSetupFixture.cs
+++ b/Source/Clients/XUnit.Integration/IChronicleSetupFixture.cs
@@ -7,6 +7,7 @@ extern alias KernelConcepts;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.EventSequences;
+using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Storage;
@@ -19,6 +20,11 @@ namespace Cratis.Chronicle.XUnit.Integration;
 /// </summary>
 public interface IChronicleSetupFixture : IClientArtifactsProvider
 {
+    /// <summary>
+    /// Gets the MongoDB container.
+    /// </summary>
+    public IContainer MongoDBContainer { get; }
+
     /// <summary>
     /// Gets the docker network.
     /// </summary>

--- a/Source/Kernel/Core/Projections/Engine/PendingFutureSave.cs
+++ b/Source/Kernel/Core/Projections/Engine/PendingFutureSave.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Projections.Engine;
+
+/// <summary>
+/// Represents a pending save for a resolved future that must be applied after the main changeset save.
+/// </summary>
+/// <param name="Key">The key to use when applying the changeset.</param>
+/// <param name="Changeset">The changeset containing the future's resolved changes.</param>
+public record PendingFutureSave(Key Key, IChangeset<AppendedEvent, ExpandoObject> Changeset);

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
@@ -49,7 +49,7 @@ public class ProjectionPipelineManager(
         var sink = await namespaceStorage.Sinks.GetFor(projection.ReadModel);
 
         var projectionFutures = grainFactory.GetProjectionFutures(eventStore, @namespace, projection.Identifier);
-        var resolveFuturesStep = new ResolveFutures(projectionFutures, typeFormats, loggerFactory.CreateLogger<ResolveFutures>());
+        var resolveFuturesStep = new ResolveFutures(projectionFutures, typeFormats, objectComparer, loggerFactory.CreateLogger<ResolveFutures>());
 
         IEnumerable<ICanPerformProjectionPipelineStep> steps =
         [

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
@@ -3,6 +3,8 @@
 
 using System.Collections;
 using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Dynamic;
 using Cratis.Chronicle.Properties;
@@ -17,10 +19,12 @@ namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
 /// </summary>
 /// <param name="projectionFutures"><see cref="IProjectionFutures"/> for managing futures.</param>
 /// <param name="typeFormats"><see cref="ITypeFormats"/> for resolving actual CLR types for schemas.</param>
+/// <param name="objectComparer"><see cref="IObjectComparer"/> for creating changesets when resolving futures.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
 public class ResolveFutures(
     IProjectionFutures projectionFutures,
     ITypeFormats typeFormats,
+    IObjectComparer objectComparer,
     ILogger<ResolveFutures> logger) : ICanPerformProjectionPipelineStep
 {
     /// <inheritdoc/>
@@ -130,21 +134,32 @@ public class ResolveFutures(
                     parentIndexers.Add(new ArrayIndexer(future.ChildPath, future.IdentifiedByProperty, childKey!));
                     var key = new Key(context.Key.Value, new ArrayIndexers(parentIndexers));
 
+                    // Use a separate changeset so the future's ChildAdded is saved in its own MongoDB
+                    // operation after the main changeset save, avoiding MongoDB's restriction on
+                    // pushing to a child of an array element being pushed in the same update.
+                    var futureChangeset = new Changeset<AppendedEvent, ExpandoObject>(
+                        objectComparer,
+                        future.Event,
+                        context.Changeset.CurrentState);
+
                     var futureContext = context with
                     {
                         Event = future.Event,
-                        Key = key
+                        Key = key,
+                        Changeset = futureChangeset
                     };
 
-                    var contextEvent = futureContext.Changeset.Incoming;
-                    futureContext.Changeset.Incoming = future.Event;
                     childProjection.OnNext(futureContext);
-                    futureContext.Changeset.Incoming = contextEvent;
 
                     // Successfully resolved the future
                     await projectionFutures.ResolveFuture(future.Id);
                     logger.ResolvedFuture(future.Id, future.ProjectionId);
                     resolvedAny = true;
+
+                    if (futureChangeset.HasChanges)
+                    {
+                        context.AddPendingFutureSave(key, futureChangeset);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -207,7 +222,20 @@ public class ResolveFutures(
         if (currentState is null) return false;
 
         var chain = BuildParentChain(childProjection);
-        if (chain.Count == 0) return false;
+
+        if (chain.Count == 0)
+        {
+            // The child projection's parent is root, so the resolved item is a direct child of the root.
+            // Use the child projection's ChildrenPropertyPath (e.g. [Configurations]) to find the
+            // collection. ParentPath is PropertyPath.Root for first-level children and cannot be used
+            // directly. The caller adds the child's own ArrayIndexer; no ancestor indexers are needed.
+            var directCollectionValue = childProjection.ChildrenPropertyPath.GetValue(currentState, ArrayIndexers.NoIndexers);
+            var directCollection = AsExpandoCollection(directCollectionValue);
+            if (directCollection is null) return false;
+            var directList = directCollection.ToList();
+
+            return directList.Contains(parentIdentifiedByProperty, parentKey);
+        }
 
         if (chain.Count == 1)
         {
@@ -253,7 +281,7 @@ public class ResolveFutures(
     /// key. When found, the full indexer chain (one entry per level, root-to-leaf) is written to
     /// <paramref name="resultIndexers"/>.
     /// </summary>
-    /// <param name="rootState">The root <see cref="ExpandoObject"/> to navigate from.</param>
+    /// <param name="rootState">The root <see cref="ExpandoObject"/> representing the current read model state.</param>
     /// <param name="chain">The ordered projection chain from root-most ancestor to the direct parent.</param>
     /// <param name="level">The current depth within <paramref name="chain"/>.</param>
     /// <param name="currentIndexers">Array indexers accumulated so far for levels above this one.</param>
@@ -274,6 +302,8 @@ public class ResolveFutures(
         var childrenPath = proj.ChildrenPropertyPath;
         var isLeaf = level == chain.Count - 1;
 
+        // Navigate from the root using the full children path with accumulated indexers so
+        // that multi-segment paths (e.g. "[Configurations].[Hubs]") are resolved correctly.
         var collectionValue = childrenPath.GetValue(rootState, new ArrayIndexers(currentIndexers));
         var collection = AsExpandoCollection(collectionValue);
         if (collection is null) return false;

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
@@ -59,7 +59,14 @@ public class ResolveFutures(
                     var parentKey = future.ParentKey.Value;
                     if (type is not null)
                     {
-                        parentKey = TypeConversion.Convert(type, parentKey);
+                        try
+                        {
+                            parentKey = TypeConversion.Convert(type, parentKey);
+                        }
+                        catch
+                        {
+                            // Keep original value — Contains() normalizes types during comparison
+                        }
                     }
 
                     // Find the child projection that this future belongs to by navigating the property path
@@ -73,10 +80,11 @@ public class ResolveFutures(
                     logger.FoundChildProjection(childProjection.Path, future.Id);
                     logger.CheckingParentInCurrentState(future.Id);
 
-                    // Check if parent exists in the current changeset's state
-                    // For direct children (parentPath is root), we need to look in the child collection
-                    // For nested children, we look in the parent's collection
-                    if (!ParentExistsInCurrentState(context.Changeset.CurrentState, future.ParentPath, future.ChildPath, future.ParentIdentifiedByProperty, parentKey))
+                    // Check if parent exists in the current changeset's state, collecting the full indexer
+                    // chain needed to navigate from root to the parent. For parents nested beyond one level,
+                    // this searches through intermediate array collections to find the matching parent and
+                    // records the identifier of each intermediate element.
+                    if (!TryFindParentWithIndexers(context.Changeset.CurrentState, childProjection, future.ParentPath, future.ParentIdentifiedByProperty, parentKey, out var parentIndexers))
                     {
                         // Parent still doesn't exist, skip this future
                         logger.ParentNotInCurrentState(future.Id);
@@ -106,16 +114,21 @@ public class ResolveFutures(
 
                     if (childType is not null && childKey is not null)
                     {
-                        childKey = TypeConversion.Convert(childType, childKey);
+                        try
+                        {
+                            childKey = TypeConversion.Convert(childType, childKey);
+                        }
+                        catch
+                        {
+                            // Keep original value — Contains() normalizes types during comparison
+                        }
                     }
 
-                    // Build the key for the future event
-                    // Use the current context's root key and add array indexers for navigating to the child
-                    var key = new Key(context.Key.Value, new ArrayIndexers(
-                    [
-                        new ArrayIndexer(future.ParentPath, future.ParentIdentifiedByProperty, parentKey),
-                        new ArrayIndexer(future.ChildPath, future.IdentifiedByProperty, childKey!)
-                    ]));
+                    // Build the key using the full parent indexer chain plus the child indexer.
+                    // parentIndexers contains one entry per ancestor level (root → parent), giving
+                    // EnsurePath everything it needs to navigate deeply nested arrays.
+                    parentIndexers.Add(new ArrayIndexer(future.ChildPath, future.IdentifiedByProperty, childKey!));
+                    var key = new Key(context.Key.Value, new ArrayIndexers(parentIndexers));
 
                     var futureContext = context with
                     {
@@ -164,41 +177,163 @@ public class ResolveFutures(
         return null;
     }
 
-    static bool ParentExistsInCurrentState(ExpandoObject? currentState, PropertyPath parentChildrenPath, PropertyPath childPath, PropertyPath parentIdentifiedByProperty, object parentKey)
+    /// <summary>
+    /// Checks whether the parent item exists in the current state and, if so, collects the full
+    /// chain of <see cref="ArrayIndexer"/> entries needed to navigate from root to that parent.
+    /// </summary>
+    /// <param name="currentState">The root <see cref="ExpandoObject"/> representing the current read model state.</param>
+    /// <param name="childProjection">The child projection whose parent chain is being resolved.</param>
+    /// <param name="parentPath">The <see cref="PropertyPath"/> identifying the parent's collection.</param>
+    /// <param name="parentIdentifiedByProperty">The <see cref="PropertyPath"/> of the property that identifies items in the parent collection.</param>
+    /// <param name="parentKey">The key value of the parent item being located.</param>
+    /// <param name="allIndexers">Receives the full root-to-parent indexer chain when the method returns <see langword="true"/>.</param>
+    /// <remarks>
+    /// For a direct child (one array level between root and parent), <paramref name="allIndexers"/>
+    /// receives a single entry for the parent's collection. For deeper hierarchies the method
+    /// recurses through each intermediate array, locating the enclosing element at each level and
+    /// recording its identifier, so that EnsurePath can navigate the full path
+    /// without missing-indexer errors.
+    /// </remarks>
+    /// <returns><see langword="true"/> if the parent was found; otherwise <see langword="false"/>.</returns>
+    static bool TryFindParentWithIndexers(
+        ExpandoObject? currentState,
+        IProjection childProjection,
+        PropertyPath parentPath,
+        PropertyPath parentIdentifiedByProperty,
+        object parentKey,
+        out List<ArrayIndexer> allIndexers)
     {
-        if (currentState is null)
+        allIndexers = [];
+        if (currentState is null) return false;
+
+        var chain = BuildParentChain(childProjection);
+        if (chain.Count == 0) return false;
+
+        if (chain.Count == 1)
         {
-            return false;
+            var collectionValue = chain[0].ChildrenPropertyPath.GetValue(currentState, ArrayIndexers.NoIndexers);
+            var collection = AsExpandoCollection(collectionValue);
+            if (collection is null) return false;
+            var collectionList = collection.ToList();
+            if (!collectionList.Contains(parentIdentifiedByProperty, parentKey)) return false;
+
+            var actualKey = GetActualStoredKey(collectionList, parentIdentifiedByProperty, parentKey);
+            allIndexers.Add(new ArrayIndexer(parentPath, parentIdentifiedByProperty, actualKey));
+            return true;
         }
 
-        // For direct children (parentChildrenPath is root/not set), we need to use childPath to locate the parent in the array
-        // For nested children, parentChildrenPath already points to the correct location
-        var arrayPath = (parentChildrenPath.IsSet && !parentChildrenPath.IsRoot) ? parentChildrenPath : childPath;
-
-        // Use PropertyPath.GetValue to navigate to the collection - it handles ExpandoObject navigation properly
-        var collectionValue = arrayPath.GetValue(currentState, ArrayIndexers.NoIndexers);
-
-        if (collectionValue is null)
-        {
-            return false;
-        }
-
-        // Try to cast to IEnumerable<ExpandoObject>, handling both List<object> and IEnumerable<ExpandoObject>
-        IEnumerable<ExpandoObject>? collection;
-        if (collectionValue is IEnumerable<ExpandoObject> expandoCollection)
-        {
-            collection = expandoCollection;
-        }
-        else if (collectionValue is IEnumerable enumerable)
-        {
-            collection = enumerable.OfType<ExpandoObject>();
-        }
-        else
-        {
-            return false;
-        }
-
-        // Check if the collection contains an item with the matching identifier
-        return collection.ToList().Contains(parentIdentifiedByProperty, parentKey);
+        return SearchLevel(currentState, chain, 0, [], parentIdentifiedByProperty, parentKey, allIndexers);
     }
+
+    /// <summary>
+    /// Builds the projection chain from the root-level child projection down to the direct parent of
+    /// <paramref name="childProjection"/>, in root-to-leaf order (index 0 = closest to root).
+    /// </summary>
+    /// <param name="childProjection">The projection whose ancestor chain is being built.</param>
+    /// <returns>Ordered list of ancestor projections, from root-most to the direct parent.</returns>
+    static List<IProjection> BuildParentChain(IProjection childProjection)
+    {
+        var chain = new List<IProjection>();
+        var current = childProjection.Parent;
+        while (current is not null)
+        {
+            var path = current.ChildrenPropertyPath;
+            if (!path.IsSet || path.IsRoot) break;
+
+            chain.Insert(0, current);
+            current = current.Parent;
+        }
+
+        return chain;
+    }
+
+    /// <summary>
+    /// Recursively navigates the current state through one level of the projection chain, searching
+    /// every element of the current array for a descendant that ultimately contains the target parent
+    /// key. When found, the full indexer chain (one entry per level, root-to-leaf) is written to
+    /// <paramref name="resultIndexers"/>.
+    /// </summary>
+    /// <param name="rootState">The root <see cref="ExpandoObject"/> to navigate from.</param>
+    /// <param name="chain">The ordered projection chain from root-most ancestor to the direct parent.</param>
+    /// <param name="level">The current depth within <paramref name="chain"/>.</param>
+    /// <param name="currentIndexers">Array indexers accumulated so far for levels above this one.</param>
+    /// <param name="parentIdentifiedByProperty">The property that identifies items in the leaf-level collection.</param>
+    /// <param name="parentKey">The key value to locate in the leaf-level collection.</param>
+    /// <param name="resultIndexers">Receives the complete root-to-parent indexer chain on success.</param>
+    /// <returns><see langword="true"/> if the parent was found at or below this level; otherwise <see langword="false"/>.</returns>
+    static bool SearchLevel(
+        ExpandoObject rootState,
+        List<IProjection> chain,
+        int level,
+        List<ArrayIndexer> currentIndexers,
+        PropertyPath parentIdentifiedByProperty,
+        object parentKey,
+        List<ArrayIndexer> resultIndexers)
+    {
+        var proj = chain[level];
+        var childrenPath = proj.ChildrenPropertyPath;
+        var isLeaf = level == chain.Count - 1;
+
+        var collectionValue = childrenPath.GetValue(rootState, new ArrayIndexers(currentIndexers));
+        var collection = AsExpandoCollection(collectionValue);
+        if (collection is null) return false;
+
+        if (isLeaf)
+        {
+            var leafList = collection.ToList();
+            if (!leafList.Contains(parentIdentifiedByProperty, parentKey)) return false;
+
+            resultIndexers.AddRange(currentIndexers);
+            var actualKey = GetActualStoredKey(leafList, parentIdentifiedByProperty, parentKey);
+            resultIndexers.Add(new ArrayIndexer(childrenPath, parentIdentifiedByProperty, actualKey));
+            return true;
+        }
+
+        var identifiedBy = proj.IdentifiedByProperty;
+        foreach (var item in collection)
+        {
+            if (item is not IDictionary<string, object> itemDict) continue;
+            if (!itemDict.TryGetValue(identifiedBy.Path, out var itemId) || itemId is null) continue;
+
+            var nextIndexers = new List<ArrayIndexer>(currentIndexers)
+            {
+                new(childrenPath, identifiedBy, itemId)
+            };
+
+            if (SearchLevel(rootState, chain, level + 1, nextIndexers, parentIdentifiedByProperty, parentKey, resultIndexers))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the value actually stored in the collection for the given identity property and key,
+    /// using type-converting lookup so that type mismatches (e.g. <c>EventSourceId</c> vs <c>Guid</c>)
+    /// are resolved. Falls back to <paramref name="key"/> when the item cannot be found.
+    /// </summary>
+    /// <param name="collection">The collection to search.</param>
+    /// <param name="identifiedByProperty">The property that holds the identifier on each item.</param>
+    /// <param name="key">The key to look up.</param>
+    /// <returns>The stored identifier value, or <paramref name="key"/> if not found.</returns>
+    static object GetActualStoredKey(IEnumerable<ExpandoObject> collection, PropertyPath identifiedByProperty, object key)
+    {
+        var item = collection.GetItem(identifiedByProperty, key);
+        if (item is IDictionary<string, object> dict
+            && dict.TryGetValue(identifiedByProperty.Path, out var storedValue)
+            && storedValue is not null)
+        {
+            return storedValue;
+        }
+
+        return key;
+    }
+
+    static IEnumerable<ExpandoObject>? AsExpandoCollection(object? value) =>
+        value switch
+        {
+            IEnumerable<ExpandoObject> expando => expando,
+            IEnumerable enumerable => enumerable.OfType<ExpandoObject>(),
+            _ => null
+        };
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SaveChanges.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SaveChanges.cs
@@ -53,6 +53,11 @@ public class SaveChanges(ISink sink, IChangesetStorage changesetStorage, ILogger
             context.Event.Context.CorrelationId,
             context.Changeset);
 
+        foreach (var pendingSave in context.PendingFutureSaves)
+        {
+            await sink.ApplyChanges(pendingSave.Key, pendingSave.Changeset, context.Event.Context.SequenceNumber);
+        }
+
         return context;
     }
 }

--- a/Source/Kernel/Core/Projections/Engine/ProjectionEventContext.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionEventContext.cs
@@ -27,6 +27,7 @@ public record ProjectionEventContext(
 {
     readonly List<ProjectionFuture> _deferredFutures = [];
     readonly List<FailedPartition> _failedPartitions = [];
+    readonly List<PendingFutureSave> _pendingFutureSaves = [];
 
     /// <summary>
     /// Gets the collection of deferred futures that need to be stored.
@@ -42,6 +43,11 @@ public record ProjectionEventContext(
     /// Gets the collection of failed partitions from bulk operations.
     /// </summary>
     public IEnumerable<FailedPartition> FailedPartitions => _failedPartitions;
+
+    /// <summary>
+    /// Gets the collection of pending future saves that must be applied after the main changeset save.
+    /// </summary>
+    public IEnumerable<PendingFutureSave> PendingFutureSaves => _pendingFutureSaves;
 
     /// <summary>
     /// Gets the <see cref="EventType"/> of the <see cref="Event"/>.
@@ -88,6 +94,14 @@ public record ProjectionEventContext(
     /// </summary>
     /// <param name="failedPartition">The <see cref="FailedPartition"/> to add.</param>
     public void AddFailedPartition(FailedPartition failedPartition) => _failedPartitions.Add(failedPartition);
+
+    /// <summary>
+    /// Adds a pending future save that will be applied after the main changeset is saved.
+    /// </summary>
+    /// <param name="key">The key to use when applying the changeset.</param>
+    /// <param name="changeset">The changeset containing the resolved future's changes.</param>
+    public void AddPendingFutureSave(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset) =>
+        _pendingFutureSaves.Add(new PendingFutureSave(key, changeset));
 
     /// <summary>
     /// Creates a new empty <see cref="ProjectionEventContext"/> with the given <see cref="IObjectComparer"/> and

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -207,7 +207,6 @@ logger.ServerConfigured();
 app.UseRouting();
 
 app.UseCratisArc();
-app.UseRouting();
 
 // Map workbench static files BEFORE authentication so they are publicly accessible
 if (chronicleOptions.Features.Workbench && chronicleOptions.Features.Api)

--- a/Source/Workbench/.frontend/App.tsx
+++ b/Source/Workbench/.frontend/App.tsx
@@ -23,8 +23,7 @@ function App() {
         <Arc
             development={isDevelopment}
             apiBasePath={basePath}
-            basePath={basePath}
-            queryDirectMode={true}>
+            basePath={basePath}>
             <MVVM>
                 <LayoutProvider>
                     <DialogComponents confirmation={ConfirmationDialog} busyIndicator={BusyIndicatorDialog}>


### PR DESCRIPTION
## Fixed

- Projection futures for 3-level nested child projections (e.g. root → Configuration → Hub → Metric) now resolve correctly when the deferred child arrives before its parent. Previously, the `ArrayIndexer` used for navigating the parent hierarchy held a raw `EventSourceId` key while the ExpandoObject stored a `Guid`, causing `EnsurePath` to create a duplicate parent element instead of finding the existing one.

- When a resolved future's `ChildAdded` was combined with the triggering event's `ChildAdded` in the same MongoDB update, the push to the nested child silently failed because the parent arrayFilter matched no pre-existing element. Resolved futures are now saved in a separate subsequent MongoDB operation via `PendingFutureSaves`.

- Events that set properties on a first-level-child projection (e.g. `WeightsSetForSimulationConfiguration` on a `Configuration`) were never resolved from deferred state because `TryFindParentWithIndexers` returned false for direct children of the root. The method now handles this case correctly.

- Test infrastructure: MongoDB test containers now bind to a random host port to prevent conflicts between concurrent test runs.