### PR TITLE
Fix AllSnapshotsForReadModel HTTP 500 caused by missing EventSequenceId

### DIFF
--- a/Source/Clients/Api/ReadModels/ReadModelSnapshot.cs
+++ b/Source/Clients/Api/ReadModels/ReadModelSnapshot.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.EventSequences;
 
 namespace Cratis.Chronicle.Api.ReadModels;
 
@@ -37,6 +38,7 @@ public record ReadModelSnapshot(DateTimeOffset Occurred, JsonObject Instance, IE
             EventStore = eventStore,
             Namespace = @namespace,
             ReadModelIdentifier = readModel,
+            EventSequenceId = EventSequenceId.Log,
             ReadModelKey = readModelKey
         });
 

--- a/Source/Kernel/Contracts/ReadModels/GetSnapshotsByKeyRequest.cs
+++ b/Source/Kernel/Contracts/ReadModels/GetSnapshotsByKeyRequest.cs
@@ -30,8 +30,8 @@ public class GetSnapshotsByKeyRequest
     /// <summary>
     /// Gets or sets the event sequence identifier.
     /// </summary>
-    [ProtoMember(4)]
-    public string EventSequenceId { get; set; } = string.Empty;
+    [ProtoMember(4), DefaultValue("event-log")]
+    public string EventSequenceId { get; set; } = "event-log";
 
     /// <summary>
     /// Gets or sets the read model key.


### PR DESCRIPTION
## Fixed
- Time Machine read model snapshots (`AllSnapshotsForReadModel`) no longer return HTTP 500 with "Value cannot be empty (Parameter 'name')". The `EventSequenceId` was omitted from the `GetSnapshotsByKeyRequest`, causing MongoDB to be called with an empty collection name. Fixed by supplying `EventSequenceId.Log` at the call site and defaulting `GetSnapshotsByKeyRequest.EventSequenceId` to `"event-log"` (consistent with `GetAllInstancesRequest` and `PreviewProjectionRequest`).