### PR TITLE
Fix collection of production bugs

### DIFF
--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Generator.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Generator.cs
@@ -420,6 +420,13 @@ public class Generator : IGenerator
             return normalizedExpression;
         }
 
+        // Convert $value(innerValue) back to literal "innerValue" syntax for round-tripping
+        if (normalizedExpression.StartsWith($"{WellKnownExpressions.Value}(", StringComparison.Ordinal) && normalizedExpression.EndsWith(')'))
+        {
+            var innerValue = normalizedExpression[(WellKnownExpressions.Value.Length + 1)..^1];
+            return $"literal \"{innerValue}\"";
+        }
+
         // Numeric literals
         if (double.TryParse(normalizedExpression, out _))
         {

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/ProjectionValidator.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/ProjectionValidator.cs
@@ -22,8 +22,8 @@ public class ProjectionValidator(
     IEnumerable<ReadModelDefinition> readModelDefinitions,
     IEnumerable<EventTypeSchema> eventTypeSchemas)
 {
-    readonly Dictionary<ReadModelIdentifier, ReadModelDefinition> _readModelLookup = readModelDefinitions.ToDictionary(_ => _.Identifier);
-    readonly Dictionary<EventType, EventTypeSchema> _eventTypeLookup = eventTypeSchemas.ToDictionary(_ => _.Type);
+    readonly Dictionary<ReadModelIdentifier, ReadModelDefinition> _readModelLookup = readModelDefinitions.DistinctBy(_ => _.Identifier).ToDictionary(_ => _.Identifier);
+    readonly Dictionary<EventType, EventTypeSchema> _eventTypeLookup = eventTypeSchemas.DistinctBy(_ => _.Type).ToDictionary(_ => _.Type);
 
     /// <summary>
     /// Validates a projection against the available read models and event type schemas.

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SetInitialState.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SetInitialState.cs
@@ -32,6 +32,12 @@ public class SetInitialState(ISink sink, ILogger<SetInitialState> logger) : ICan
             return context;
         }
 
+        // Don't set initial state if the key value could not be resolved
+        if (context.Key.Value is null)
+        {
+            return context;
+        }
+
         logger.GettingInitialValues(context.Event.Context.SequenceNumber);
 
         // If we are joining, or adding a child - we do want to set initial state

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -378,11 +378,6 @@ internal sealed class ReadModels(
 
         while (await cursor.MoveNext())
         {
-            if (!cursor.Current.Any())
-            {
-                break;
-            }
-
             foreach (var appendedEvent in cursor.Current)
             {
                 var correlationId = appendedEvent.Context.CorrelationId;

--- a/Source/Kernel/Server/UserIdentityMiddleware.cs
+++ b/Source/Kernel/Server/UserIdentityMiddleware.cs
@@ -26,6 +26,7 @@ public class UserIdentityMiddleware(RequestDelegate next)
                 string.IsNullOrEmpty(name) &&
                 string.IsNullOrEmpty(username))
             {
+                await next(context);
                 return;
             }
 

--- a/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverter.cs
@@ -91,7 +91,7 @@ public class MongoDBConverter(
                 ToBsonValue(key.Value, idPropertyName);
 
         // If the schema does not have the Id property, we assume it is the event source identifier, which is of type string.
-        return bsonValue == BsonNull.Value ? new BsonString(key.Value.ToString()) : bsonValue;
+        return bsonValue == BsonNull.Value ? new BsonString(key.Value?.ToString() ?? string.Empty) : bsonValue;
     }
 
     /// <inheritdoc/>

--- a/Source/Workbench/Components/TimeMachineDialog/TimeMachineDialog.tsx
+++ b/Source/Workbench/Components/TimeMachineDialog/TimeMachineDialog.tsx
@@ -90,13 +90,3 @@ export const TimeMachineDialog = ({ readModelKey, readModel }: TimeMachineDialog
         </Dialog>
     );
 };
-
-
-/*
-at System.Collections.Generic.Dictionary\u00602.Add(TKey key, TValue value)\n
-at System.Linq.Enumerable.SpanToDictionary[TSource,TKey](ReadOnlySpan\u00601 source, Func\u00602 keySelector, IEqualityComparer\u00601 comparer)\n
-at System.Linq.Enumerable.ToDictionary[TSource,TKey](IEnumerable\u00601 source, Func\u00602 keySelector, IEqualityComparer\u00601 comparer)\n
-at Cratis.Chronicle.Projections.DefinitionLanguage.ProjectionValidator..ctor(IEnumerable\u00601 readModelDefinitions, IEnumerable\u00601 eventTypeSchemas) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Projections/DefinitionLanguage/ProjectionValidator.cs:line 25\n
-at Cratis.Chronicle.Projections.DefinitionLanguage.Compiler.Compile(Document document, ProjectionOwner owner, IEnumerable\u00601 readModelDefinitions, IEnumerable\u00601 eventTypeSchemas) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Projections/DefinitionLanguage/Compiler.cs:line 75\n   at Cratis.Chronicle.Projections.DefinitionLanguage.LanguageService.\u003C\u003Ec__DisplayClass4_0.\u003CCompile\u003Eb__2(Document document) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Projections/DefinitionLanguage/LanguageService.cs:line 43\n   at OneOf.OneOfBase\u00602.Match[TResult](Func\u00602 f0, Func\u00602 f1)\n   at Cratis.Chronicle.Projections.DefinitionLanguage.LanguageService.\u003C\u003Ec__DisplayClass4_0.\u003CCompile\u003Eb__0(IEnumerable\u00601 tokens) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Projections/DefinitionLanguage/LanguageService.cs:line 39\n   at OneOf.OneOfBase\u00602.Match[TResult](Func\u00602 f0, Func\u00602 f1)\n   at Cratis.Chronicle.Projections.DefinitionLanguage.LanguageService.Compile(String definition, ProjectionOwner owner, IEnumerable\u00601 readModelDefinitions, IEnumerable\u00601 eventTypeSchemas) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Projections/DefinitionLanguage/LanguageService.cs:line 33\n   at Cratis.Chronicle.Services.Projections.Projections.Preview(PreviewProjectionRequest request, CallContext context) in /Volumes/Code/Cratis/Chronicle/Source/Kernel/Services/Projections/Projections.cs:line 92\n   at Cratis.Chronicle.Api.Projections.PreviewProjection.Handle(IProjections projections)\n   at Cratis.Tasks.AwaitableHelpers.AwaitIfNeeded(Object maybeAwaitable)\n   at Cratis.Arc.Commands.ModelBound.ModelBoundCommandHandler.Handle(CommandContext commandContext)\n   at Cratis.Arc.Commands.CommandPipeline.Execute(Object command, IServiceProvider serviceProvider)",
-
-    */

--- a/Source/Workbench/Layout/Default/NamespaceSelector/NamespaceSelector.tsx
+++ b/Source/Workbench/Layout/Default/NamespaceSelector/NamespaceSelector.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState, useEffect } from "react";
 
 import { OverlayPanel } from "primereact/overlaypanel";
 import { useLayoutContext } from "../context/LayoutContext";
@@ -11,10 +11,19 @@ import { ItemsList } from 'Components/ItemsList/ItemsList';
 import { INamespaceSelectorProps, NamespaceSelectorViewModel } from './NamespaceSelectorViewModel';
 import { withViewModel } from '@cratis/arc.react.mvvm';
 import css from './NamespaceSelector.module.css';
+import { useParams } from 'react-router-dom';
+import { type EventStoreAndNamespaceParams } from 'Shared';
 
 export const NamespaceSelector = withViewModel<NamespaceSelectorViewModel, INamespaceSelectorProps>(NamespaceSelectorViewModel, ({ viewModel }) => {
     const { layoutConfig } = useLayoutContext();
     const [search, setSearch] = useState<string>('');
+    const params = useParams<EventStoreAndNamespaceParams>();
+
+    useEffect(() => {
+        if (params.eventStore) {
+            viewModel.setEventStore(params.eventStore);
+        }
+    }, [params.eventStore, viewModel]);
 
     const op = useRef<OverlayPanel>(null);
 

--- a/Source/Workbench/Layout/Default/NamespaceSelector/NamespaceSelectorViewModel.ts
+++ b/Source/Workbench/Layout/Default/NamespaceSelector/NamespaceSelectorViewModel.ts
@@ -29,6 +29,10 @@ export class NamespaceSelectorViewModel {
     currentNamespace: string = '';
     namespaces: string[] = [];
 
+    setEventStore(eventStore: string) {
+        this._namespaces.setEventStore(eventStore);
+    }
+
     onNamespaceSelected(namespace: string) {
         this.currentNamespace = namespace;
         this._props.onNamespaceSelected(namespace);

--- a/Source/Workbench/State/Namespaces/INamespaces.ts
+++ b/Source/Workbench/State/Namespaces/INamespaces.ts
@@ -21,5 +21,11 @@ export abstract class INamespaces {
      * Gets the observable namespaces.
      */
     abstract readonly namespaces: BehaviorSubject<string[]>;
+
+    /**
+     * Notifies the service that the active event store has changed, triggering subscription if needed.
+     * @param eventStore - The name of the now-active event store.
+     */
+    abstract setEventStore(eventStore: string): void;
 }
 

--- a/Source/Workbench/State/Namespaces/Namespaces.ts
+++ b/Source/Workbench/State/Namespaces/Namespaces.ts
@@ -26,11 +26,14 @@ export class Namespaces implements INamespaces {
         private readonly _messenger: IMessenger,
         @inject('params') private readonly _params: EventStoreAndNamespaceParams,
         private readonly _namespacesQuery: AllNamespaces) {
+    }
 
-        // Initialize after a microtask to allow params to be fully set
-        Promise.resolve().then(() => {
-            this.ensureSubscription();
-        });
+    /** @inheritdoc */
+    setEventStore(eventStore: string) {
+        if (eventStore) {
+            this._params.eventStore = eventStore;
+        }
+        this.ensureSubscription();
     }
 
     private ensureSubscription() {


### PR DESCRIPTION
## Fixed

- Null reference exception in projection pipeline when a key value is null — `MongoDBConverter.ToBsonValue` and `SetInitialState` now guard against null key values (#3134)
- `UserIdentityMiddleware` was swallowing all requests when any identity field (sub/name/email) was absent due to a bare `return` that skipped calling `next(context)` (#3134)
- `ProjectionValidator` crashed with a duplicate-key exception when multiple projections shared the same read model or event type identifier — deduplicated with `DistinctBy` before building lookup dictionaries (#3134)
- TimeMachine only returned the first page of snapshots — an early `break` on an empty cursor batch exited before MongoDB returned subsequent pages (#3134)
- Projection Generator emitted `$value(inner)` expressions verbatim in PDL output instead of converting them back to `literal "inner"` syntax, causing round-trip parse failures in the projection editor (#3134)
- Namespace list not appearing in the Workbench sidebar — the `Namespaces` singleton scheduled its subscription via a constructor microtask that fired before the event store route parameter was available; replaced with an explicit `setEventStore()` call driven by `useParams`/`useEffect` in `NamespaceSelector` (#3134)
- Removed a production error stack trace accidentally committed as a JSX comment inside `TimeMachineDialog.tsx` (#3134)