### PR TITLE
Fix specs for typed EventSourceId and add converter specs

### DIFF
--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/GuidConcept.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/GuidConcept.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter;
+
+record GuidConcept(Guid Value) : ConceptAs<Guid>(Value)
+{
+    public static implicit operator Guid(GuidConcept concept) => concept.Value;
+    public static implicit operator GuidConcept(Guid value) => new(value);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/StringConcept.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/StringConcept.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter;
+
+record StringConcept(string Value) : ConceptAs<string>(Value)
+{
+    public static implicit operator string(StringConcept concept) => concept.Value;
+    public static implicit operator StringConcept(string value) => new(value);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_concept_wrapping_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_concept_wrapping_a_guid.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_reading;
+
+public class with_a_concept_wrapping_a_guid : Specification
+{
+    static readonly Guid _guid = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    JsonSerializerOptions _options;
+    EventSourceId<GuidConcept> _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Deserialize<EventSourceId<GuidConcept>>($"\"{_guid}\"", _options)!;
+
+    [Fact] void should_have_the_concept_with_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(new GuidConcept(_guid));
+    [Fact] void should_have_the_guid_string_as_event_source_id_value() => ((EventSourceId)_result).Value.ShouldEqual(_guid.ToString());
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_guid_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_guid_string.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_reading;
+
+public class with_a_guid_string : Specification
+{
+    static readonly Guid _guid = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    JsonSerializerOptions _options;
+    EventSourceId<Guid> _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Deserialize<EventSourceId<Guid>>($"\"{_guid}\"", _options)!;
+
+    [Fact] void should_have_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_guid);
+    [Fact] void should_have_the_guid_string_as_event_source_id_value() => ((EventSourceId)_result).Value.ShouldEqual(_guid.ToString());
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_string_value.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_reading/with_a_string_value.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_reading;
+
+public class with_a_string_value : Specification
+{
+    const string Input = "some-id";
+    JsonSerializerOptions _options;
+    EventSourceId<string> _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Deserialize<EventSourceId<string>>($"\"{Input}\"", _options)!;
+
+    [Fact] void should_have_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(Input);
+    [Fact] void should_have_the_string_as_event_source_id_value() => ((EventSourceId)_result).Value.ShouldEqual(Input);
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_concept_wrapping_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_concept_wrapping_a_guid.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_writing;
+
+public class with_a_concept_wrapping_a_guid : Specification
+{
+    static readonly Guid _guid = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    JsonSerializerOptions _options;
+    string _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Serialize(new EventSourceId<GuidConcept>(new GuidConcept(_guid)), _options);
+
+    [Fact] void should_serialize_as_the_guid_string() => _result.ShouldEqual($"\"{_guid}\"");
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_concept_wrapping_a_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_concept_wrapping_a_string.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_writing;
+
+public class with_a_concept_wrapping_a_string : Specification
+{
+    const string Input = "some-concept-id";
+    JsonSerializerOptions _options;
+    string _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Serialize(new EventSourceId<StringConcept>(new StringConcept(Input)), _options);
+
+    [Fact] void should_serialize_as_the_plain_string() => _result.ShouldEqual($"\"{Input}\"");
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_guid_type.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_writing;
+
+public class with_a_guid_type : Specification
+{
+    static readonly Guid _guid = Guid.Parse("b4e2b6a0-1b3e-4e6a-8c4d-2f7e9b1a3c5d");
+    JsonSerializerOptions _options;
+    string _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Serialize(new EventSourceId<Guid>(_guid), _options);
+
+    [Fact] void should_serialize_as_the_guid_string() => _result.ShouldEqual($"\"{_guid}\"");
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverter/when_writing/with_a_string_type.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverter.when_writing;
+
+public class with_a_string_type : Specification
+{
+    const string Input = "some-id";
+    JsonSerializerOptions _options;
+    string _result;
+
+    void Establish() => _options = new JsonSerializerOptions { Converters = { new EventSourceIdJsonConverterFactory() } };
+
+    void Because() => _result = JsonSerializer.Serialize(new EventSourceId<string>(Input), _options);
+
+    [Fact] void should_serialize_as_the_plain_string() => _result.ShouldEqual($"\"{Input}\"");
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_a_typed_event_source_id.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_a_typed_event_source_id.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverterFactory.when_checking_if_can_convert;
+
+public class with_a_typed_event_source_id : Specification
+{
+    EventSourceIdJsonConverterFactory _factory;
+    bool _result;
+
+    void Establish() => _factory = new();
+
+    void Because() => _result = _factory.CanConvert(typeof(EventSourceId<Guid>));
+
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_an_untyped_event_source_id.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_an_untyped_event_source_id.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverterFactory.when_checking_if_can_convert;
+
+public class with_an_untyped_event_source_id : Specification
+{
+    EventSourceIdJsonConverterFactory _factory;
+    bool _result;
+
+    void Establish() => _factory = new();
+
+    void Because() => _result = _factory.CanConvert(typeof(EventSourceId));
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_another_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSourceIdJsonConverterFactory/when_checking_if_can_convert/with_another_type.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.for_EventSourceIdJsonConverterFactory.when_checking_if_can_convert;
+
+public class with_another_type : Specification
+{
+    EventSourceIdJsonConverterFactory _factory;
+    bool _result;
+
+    void Establish() => _factory = new();
+
+    void Because() => _result = _factory.CanConvert(typeof(string));
+
+    [Fact] void should_return_false() => _result.ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_guid_type.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_guid_type : Specification
 
     void Because() => _result = (EventSourceId<GuidConcept>)_expected.ToString();
 
-    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_guid_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_expected.ToString());
     [Fact] void should_have_the_concept_with_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(new GuidConcept(_expected));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_concept_wrapping_a_string_type.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_string_type : Specification
 
     void Because() => _result = (EventSourceId<StringConcept>)Input;
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(Input);
     [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(Input));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_a_string/with_a_guid_type.cs
@@ -10,6 +10,6 @@ public class with_a_guid_type : Specification
 
     void Because() => _result = (EventSourceId<Guid>)_expected.ToString();
 
-    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_guid_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_expected.ToString());
     [Fact] void should_have_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_expected);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_guid_type.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_guid_type : Specification
 
     void Because() => _result = EventSourceId<GuidConcept>.From(new EventSourceId(_expected.ToString()));
 
-    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_guid_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_expected.ToString());
     [Fact] void should_have_the_concept_with_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(new GuidConcept(_expected));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_concept_wrapping_a_string_type.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_string_type : Specification
 
     void Because() => _result = EventSourceId<StringConcept>.From(new EventSourceId(Input));
 
-    [Fact] void should_have_the_string_as_value() => _result.Value.ShouldEqual(Input);
+    [Fact] void should_have_the_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(Input);
     [Fact] void should_have_the_concept_with_the_string_as_typed_value() => _result.TypedValue.ShouldEqual(new StringConcept(Input));
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_guid_type.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_converting_from_an_event_source_id/with_a_guid_type.cs
@@ -10,6 +10,6 @@ public class with_a_guid_type : Specification
 
     void Because() => _result = EventSourceId<Guid>.From(new EventSourceId(_expected.ToString()));
 
-    [Fact] void should_have_the_guid_string_as_value() => _result.Value.ShouldEqual(_expected.ToString());
+    [Fact] void should_have_the_guid_string_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_expected.ToString());
     [Fact] void should_have_the_parsed_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_expected);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_guid.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_guid : Specification
 
     void Because() => _result = _input;
 
-    [Fact] void should_have_the_guid_string_representation_as_value() => _result.Value.ShouldEqual(_input.Value.ToString());
+    [Fact] void should_have_the_guid_string_representation_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_input.Value.ToString());
     [Fact] void should_have_the_concept_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_string.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_concept_wrapping_a_string.cs
@@ -10,6 +10,6 @@ public class with_a_concept_wrapping_a_string : Specification
 
     void Because() => _result = _input;
 
-    [Fact] void should_have_the_concept_string_value_as_value() => _result.Value.ShouldEqual(_input.Value);
+    [Fact] void should_have_the_concept_string_value_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_input.Value);
     [Fact] void should_have_the_concept_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
 }

--- a/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_guid.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_TypedEventSourceId/when_creating_from_typed_value/with_a_guid.cs
@@ -10,6 +10,6 @@ public class with_a_guid : Specification
 
     void Because() => _result = _input;
 
-    [Fact] void should_have_the_guid_string_representation_as_value() => _result.Value.ShouldEqual(_input.ToString());
+    [Fact] void should_have_the_guid_string_representation_as_value() => ((EventSourceId)_result).Value.ShouldEqual(_input.ToString());
     [Fact] void should_have_the_guid_as_typed_value() => _result.TypedValue.ShouldEqual(_input);
 }

--- a/Source/Clients/DotNET/Events/EventSourceIdJsonConverter.cs
+++ b/Source/Clients/DotNET/Events/EventSourceIdJsonConverter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cratis.Chronicle.Events;
+
+/// <summary>
+/// Represents a <see cref="JsonConverter{T}"/> for <see cref="EventSourceId{T}"/> that serializes
+/// the typed value as a plain string for wire compatibility with <see cref="EventSourceId"/>.
+/// </summary>
+/// <typeparam name="T">The underlying type wrapped by <see cref="EventSourceId{T}"/>.</typeparam>
+public class EventSourceIdJsonConverter<T> : JsonConverter<EventSourceId<T>>
+    where T : IComparable
+{
+    /// <inheritdoc/>
+    public override EventSourceId<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return value is null ? null : (EventSourceId<T>)value;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, EventSourceId<T> value, JsonSerializerOptions options)
+    {
+        EventSourceId id = value;
+        writer.WriteStringValue(id.Value);
+    }
+}

--- a/Source/Clients/DotNET/Events/EventSourceIdJsonConverterFactory.cs
+++ b/Source/Clients/DotNET/Events/EventSourceIdJsonConverterFactory.cs
@@ -6,8 +6,6 @@ using System.Text.Json.Serialization;
 
 namespace Cratis.Chronicle.Events;
 
-#pragma warning disable SA1402,MA0048 // File may only contain a single type
-
 /// <summary>
 /// Represents a <see cref="JsonConverterFactory"/> that produces <see cref="EventSourceIdJsonConverter{T}"/>
 /// instances for any closed <see cref="EventSourceId{T}"/> type.
@@ -25,28 +23,5 @@ public class EventSourceIdJsonConverterFactory : JsonConverterFactory
         var typeArg = typeToConvert.GetGenericArguments()[0];
         var converterType = typeof(EventSourceIdJsonConverter<>).MakeGenericType(typeArg);
         return (Activator.CreateInstance(converterType) as JsonConverter)!;
-    }
-}
-
-/// <summary>
-/// Represents a <see cref="JsonConverter{T}"/> for <see cref="EventSourceId{T}"/> that serializes
-/// the typed value as a plain string for wire compatibility with <see cref="EventSourceId"/>.
-/// </summary>
-/// <typeparam name="T">The underlying type wrapped by <see cref="EventSourceId{T}"/>.</typeparam>
-public class EventSourceIdJsonConverter<T> : JsonConverter<EventSourceId<T>>
-    where T : IComparable
-{
-    /// <inheritdoc/>
-    public override EventSourceId<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        var value = reader.GetString();
-        return value is null ? null : (EventSourceId<T>)value;
-    }
-
-    /// <inheritdoc/>
-    public override void Write(Utf8JsonWriter writer, EventSourceId<T> value, JsonSerializerOptions options)
-    {
-        EventSourceId id = value;
-        writer.WriteStringValue(id.Value);
     }
 }


### PR DESCRIPTION
## Fixed

- Updated `EventSourceId<T>` specs to use `((EventSourceId)_result).Value` for string wire-value assertions — `Value` now returns `T` since the type inherits `ConceptAs<T>` directly

## Added

- Specs for `EventSourceIdJsonConverterFactory`: `CanConvert` returns `true` for `EventSourceId<T>`, `false` for the untyped `EventSourceId` and other types
- Specs for `EventSourceIdJsonConverter<T>`: reading a JSON string into `EventSourceId<T>` and writing back to a plain string, covering `string`, `Guid`, and `ConceptAs` wrappers over both