### PR TITLE
Fix nullable DateTimeOffset schema format mapping

### DIFF
--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_format_types.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_format_types.cs
@@ -5,7 +5,7 @@ namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
 
 public class when_generating_schema_for_type_with_format_types : given.a_json_schema_generator
 {
-    record TypeWithFormats(Guid AnId, int ACount, DateTimeOffset OccurredAt);
+    record TypeWithFormats(Guid AnId, int ACount, DateTimeOffset OccurredAt, DateTimeOffset? OptionalOccurredAt);
 
     JsonSchema _result;
 
@@ -14,4 +14,5 @@ public class when_generating_schema_for_type_with_format_types : given.a_json_sc
     [Fact] void should_inject_guid_format_for_guid_property() => _result.ActualProperties["AnId"].Format.ShouldEqual("guid");
     [Fact] void should_inject_int32_format_for_int_property() => _result.ActualProperties["ACount"].Format.ShouldEqual("int32");
     [Fact] void should_inject_date_time_offset_format_for_date_time_offset_property() => _result.ActualProperties["OccurredAt"].Format.ShouldEqual("date-time-offset");
+    [Fact] void should_inject_date_time_offset_format_for_nullable_date_time_offset_property() => _result.ActualProperties["OptionalOccurredAt"].Format.ShouldEqual("date-time-offset");
 }

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -95,6 +95,7 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     JsonNode TransformNode(JsonSchemaExporterContext context, JsonNode schema)
     {
         var type = context.TypeInfo.Type;
+        var formatType = Nullable.GetUnderlyingType(type) ?? type;
 
         // Handle concept types - redirect to the underlying primitive type's schema
         if (type.IsConcept())
@@ -124,9 +125,9 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
         if (schema is not JsonObject schemaObj) return schema;
 
         // Add format for known types
-        if (_typeFormats.IsKnown(type))
+        if (_typeFormats.IsKnown(formatType))
         {
-            schemaObj["format"] = _typeFormats.GetFormatForType(type);
+            schemaObj["format"] = _typeFormats.GetFormatForType(formatType);
         }
 
         // Add compliance metadata for the type


### PR DESCRIPTION
## Fixed
- Ensure nullable `DateTimeOffset` properties are emitted with `date-time-offset` schema format so projection context mappings preserve `Occurred` timestamps.
- Add a regression spec for `JsonSchemaGenerator` covering nullable `DateTimeOffset` format generation.