### PR TITLE
Update Cratis.Specifications to 3.0.5 and increase CI timeout to 45s

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -99,7 +99,7 @@ jobs:
     continue-on-error: true
     env:
       NAMESPACE: Cratis.Chronicle.InProcess.Integration.${{ matrix.namespace }}
-      CHRONICLE_TEST_TIMEOUT_SECONDS: 30
+      CHRONICLE_TEST_TIMEOUT_SECONDS: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,8 +112,8 @@
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <!-- Testing & Specifications -->
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Cratis.Specifications" Version="3.0.4" />
-    <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.4" />
+    <PackageVersion Include="Cratis.Specifications" Version="3.0.5" />
+    <PackageVersion Include="Cratis.Specifications.XUnit" Version="3.0.5" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Fixed
- Integration test jobs were timing out in CI under load — `and_observers_consume_second_generation` and `when_projecting_with_nested_object` both exceeded the 30s `CHRONICLE_TEST_TIMEOUT_SECONDS` budget. Timeout raised to 45s.

## Changed
- `Cratis.Specifications` and `Cratis.Specifications.XUnit` updated to 3.0.5, which introduces `SpecificationCancelledException`: when a lifecycle method (`Establish`, `Because`, or `Destroy`) is cancelled by a polling timeout (`WaitTillActive`, `WaitForState`, etc.), it now throws with a message naming the phase and pointing to `CHRONICLE_TEST_TIMEOUT_SECONDS` instead of surfacing as an opaque `TaskCanceledException` or silent null assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)