### PR TITLE
Fix nested object projection for nullable reference types and CI failure reporting

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [dotnet-build]
     strategy:
+      fail-fast: false
       matrix:
         namespace:
           - 'for_EventSequence'
@@ -96,7 +97,6 @@ jobs:
           - 'Jobs'
           - 'Patches'
           - 'Projections'
-    continue-on-error: true
     env:
       NAMESPACE: Cratis.Chronicle.InProcess.Integration.${{ matrix.namespace }}
       CHRONICLE_TEST_TIMEOUT_SECONDS: 45

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/SliceProjection.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/SliceProjection.cs
@@ -3,9 +3,9 @@
 
 namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_object;
 
-public class SliceProjection : IProjectionFor<Slice>
+public class SliceProjection : IProjectionFor<NestedSlice>
 {
-    public void Define(IProjectionBuilderFor<Slice> builder) => builder
+    public void Define(IProjectionBuilderFor<NestedSlice> builder) => builder
         .From<SliceCreated>(b => b.Set(m => m.Name).To(e => e.Name))
         .Nested(_ => _.Command, nested => nested
             .From<CommandSetForSlice>()

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/clearing_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/clearing_the_nested_object.cs
@@ -8,7 +8,7 @@ namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_proj
 [Collection(ChronicleCollection.Name)]
 public class clearing_the_nested_object(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, Slice>(fixture)
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, NestedSlice>(fixture)
     {
         public override IEnumerable<Type> EventTypes => [typeof(SliceCreated), typeof(CommandSetForSlice), typeof(SliceCommandRenamed), typeof(CommandClearedForSlice)];
 

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/setting_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/setting_the_nested_object.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_proj
 [Collection(ChronicleCollection.Name)]
 public class setting_the_nested_object(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, Slice>(fixture)
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, NestedSlice>(fixture)
     {
         public override IEnumerable<Type> EventTypes => [typeof(SliceCreated), typeof(CommandSetForSlice), typeof(SliceCommandRenamed), typeof(CommandClearedForSlice)];
 
@@ -42,15 +42,15 @@ public record SliceCommandRenamed(string NewName);
 [EventType]
 public record CommandClearedForSlice;
 
-public class CommandItem
+public class NestedCommandItem
 {
     public string Name { get; set; } = string.Empty;
     public string Schema { get; set; } = string.Empty;
 }
 
-public record Slice(
+public record NestedSlice(
     string Name,
-    CommandItem? Command,
+    NestedCommandItem? Command,
     EventSequenceNumber __lastHandledEventSequenceNumber = default!);
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/updating_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_object/updating_the_nested_object.cs
@@ -8,7 +8,7 @@ namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_proj
 [Collection(ChronicleCollection.Name)]
 public class updating_the_nested_object(context context) : Given<context>(context)
 {
-    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, Slice>(fixture)
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, NestedSlice>(fixture)
     {
         public override IEnumerable<Type> EventTypes => [typeof(SliceCreated), typeof(CommandSetForSlice), typeof(SliceCommandRenamed), typeof(CommandClearedForSlice)];
 

--- a/Source/Infrastructure/Schemas/JsonSchema.cs
+++ b/Source/Infrastructure/Schemas/JsonSchema.cs
@@ -330,7 +330,12 @@ public class JsonSchema
                 var nonNull = anyOf.FirstOrDefault(s =>
                     s.Type != JsonObjectType.Null &&
                     !(s.HasReference && s.Reference?.Type == JsonObjectType.Null));
-                return nonNull ?? this;
+                if (nonNull is not null)
+                {
+                    return nonNull.HasReference ? (nonNull.Reference ?? nonNull) : nonNull;
+                }
+
+                return this;
             }
 
             return this;


### PR DESCRIPTION
## Fixed
- Nested object projections with nullable reference type properties (e.g. \`CommandItem?\`) now correctly auto-map all properties. Previously \`ActualTypeSchema\` returned the raw \`\$ref\` from an \`anyOf: [\$ref, null]\` schema without resolving it, causing schema traversal failures and broken property mappers.
- Integration spec failures in the \`integration-specs\` matrix job now correctly fail the workflow. Previously \`continue-on-error: true\` silently swallowed all spec failures.