### PR TITLE
Encrypt PII fields at rest in managed read models

### DIFF
--- a/Documentation/compliance/read-models.md
+++ b/Documentation/compliance/read-models.md
@@ -4,57 +4,83 @@ uid: Chronicle.Compliance.ReadModels
 
 # Read models and PII
 
-Read models are built by projecting events from the event log. When those events contain PII-encrypted values, Chronicle decrypts them transparently before delivering the event data to your projection or reducer. The read model itself stores the decrypted plaintext — the encryption boundary is the event log.
+Chronicle stores PII fields encrypted at rest in both the event log and managed read models (projections and reducers). The encryption and decryption is handled automatically by the kernel — your application code works with plaintext values at all times.
 
-## How decryption flows through projections
+## Observer decryption
 
-When a projection processes an event, the Chronicle kernel:
+All observers — reactors, webhooks, reducers, and projections — receive decrypted events from a single, central decryption point in `Observer.Handle()`. This means encryption is applied consistently regardless of the observer type, and no observer implementation needs to handle decryption itself.
 
-1. Reads the encrypted ciphertext from the event log.
-2. Looks up the encryption key for the event source identifier.
-3. Decrypts all PII properties before passing the event to the projection handler.
-4. The projection writes the decrypted value into the read model.
+The compliance identifier used for key lookup follows this rule: if an explicit `Subject` was set on the event at append time, that value is used. Otherwise, the `EventSourceId` is used as the fallback identifier. This mirrors the encryption key that was used when the event was originally written to the event log.
 
-This means your projection code and read model records are written exactly as if the data were never encrypted:
+## Projections — automatic PII lineage
+
+Projection-backed read models benefit from automatic PII lineage. The kernel knows which read model properties are mapped from PII event properties and encrypts them transparently before writing to storage. No `[PII]` attribute is needed on the read model type.
 
 ```csharp
 [EventType]
 public record EmployeeRegistered(PersonName Name, string Department);
 
 [ReadModel]
-public record Employee(EmployeeId Id, string Name, string Department)
+[FromEvent<EmployeeRegistered>]
+public record Employee(
+    [Key] EmployeeId Id,
+    string Name,        // mapped from PersonName — stored encrypted at rest
+    string Department)
 {
-    // ...
-}
-
-public class EmployeeProjection : IProjectionFor<Employee>
-{
-    public void Define(IProjectionBuilderFor<Employee> builder) =>
-        builder.From<EmployeeRegistered>(e => e
-            .Set(m => m.Name).To(ev => ev.Name)   // PersonName is already decrypted
-            .Set(m => m.Department).To(ev => ev.Department));
+    public static ISubject<Employee?> ById(EmployeeId id) =>
+        Query.ForEventSource<Employee>(id);
 }
 ```
 
-## What happens when the encryption key is deleted
+The `Name` property is stored encrypted in MongoDB because `PersonName` is a PII-marked type. When a query returns `Employee` records, the kernel decrypts the values before they reach the caller.
 
-Deleting an encryption key is the Chronicle mechanism for GDPR erasure. Once the key is gone, decryption of PII properties for that event source will fail. Chronicle handles this gracefully:
+## Reducers — explicit `[PII]` required
 
-- PII properties decrypt to an empty value (empty string for `string`-backed types).
-- Non-PII properties are returned as-is.
-- The read model update still runs — it just stores empty values for the PII fields.
-- Existing read model documents that were written before erasure continue to contain the decrypted value until they are re-projected.
+Reducers use arbitrary C# logic to compute state. The kernel cannot infer which properties derive from PII fields because the transformation is opaque. You must annotate PII properties on the read model record with `[PII]`.
+
+```csharp
+[EventType]
+public record PatientAdmitted(PersonName Name, DateTimeOffset AdmittedAt);
+
+public record PatientSummary(Guid PatientId, [PII] string Name, DateTimeOffset LastAdmittedAt);
+
+public class PatientSummaryReducer : IReducerFor<PatientSummary>
+{
+    public Task<PatientSummary> On(PatientAdmitted @event, PatientSummary? current, EventContext context)
+    {
+        return Task.FromResult(new PatientSummary(
+            Guid.Parse(context.EventSourceId.Value),
+            @event.Name,
+            @event.AdmittedAt));
+    }
+}
+```
+
+The `[PII]` attribute on `Name` tells the kernel to encrypt that property before storage and decrypt it on retrieval.
+
+## The `_subject` field
+
+Every managed read model document written by Chronicle contains a reserved `_subject` field. This field stores the compliance identifier (the `Subject` or `EventSourceId`) that was used as the encryption key reference for that document. Chronicle uses `_subject` to look up the correct key when decrypting on retrieval.
+
+> **Do not** declare a property named `_subject` in your read model records. Chronicle reserves this name for internal use.
+
+## GDPR erasure
+
+Deleting an encryption key is the Chronicle mechanism for GDPR erasure:
+
+1. Delete the key for the subject (the data subject's identifier) via the Compliance API.
+2. Trigger a re-projection or re-reduction of the affected read models.
+
+After key deletion, decryption of PII properties for that subject fails gracefully — Chronicle writes empty values for erased PII fields. Existing read model documents that were written before erasure continue to contain encrypted ciphertext until they are re-projected.
 
 > [!IMPORTANT]
-> If a complete and verifiable erasure is required, you must trigger a re-projection of the read model after deleting the key. This overwrites any cached plaintext values in the read model store.
+> Re-projection is required for a complete, verifiable erasure. Until re-projection runs, the ciphertext remains in the read model store. Chronicle cannot decrypt it, but the ciphertext is still present.
 
-## Re-projecting after key deletion
+For full erasure of event content, combine key deletion with [event redaction](../events/redaction.md).
 
-Chronicle's catch-up projection mechanism lets you replay all events and rebuild the read model from scratch. After deleting the key for a particular event source, force a catch-up for that event source to ensure the read model reflects the erased state.
+## Querying
 
-## Querying PII data
-
-Read model queries return the decrypted plaintext value. There is nothing special to do in query code:
+Read model queries are transparent to PII encryption. No changes to query code are needed:
 
 ```csharp
 [ReadModel]
@@ -65,30 +91,4 @@ public record Employee(EmployeeId Id, string Name, string Department)
 }
 ```
 
-The `Name` field contains the decrypted person name when the key exists, or an empty string when the key has been deleted.
-
-## Storing PII in read models
-
-Because read models store decrypted plaintext, they are themselves subject to data protection requirements. Consider:
-
-- Applying appropriate access controls to the read model store (MongoDB collection permissions, for example).
-- Treating the read model store as sensitive data in your infrastructure security posture.
-- Re-projecting affected read models as part of your GDPR erasure workflow to propagate key deletion.
-
-For full erasure of event content, combine key deletion with [event redaction](../events/redaction.md).
-
-## Model-bound projections and PII
-
-Model-bound projections using `[FromEvent<T>]` attributes behave identically — decryption happens at the event layer before the attribute mapping runs.
-
-```csharp
-[ReadModel]
-[FromEvent<EmployeeRegistered>]
-public record Employee(
-    [Key] EmployeeId Id,
-    string Name,        // mapped from PersonName — arrives decrypted
-    string Department)
-{
-    // ...
-}
-```
+Chronicle decrypts PII fields automatically before returning results to the caller. When the encryption key has been deleted for a subject, `Name` returns an empty string — the caller receives an `Employee` record with an empty name, never an exception or partial result.

--- a/Source/Clients/DotNET/Events/EventContext.cs
+++ b/Source/Clients/DotNET/Events/EventContext.cs
@@ -24,6 +24,7 @@ namespace Cratis.Chronicle.Events;
 /// <param name="Tags">The tags associated with the event.</param>
 /// <param name="Hash">The <see cref="EventHash"/> of the event content.</param>
 /// <param name="ObservationState">Holds the state relevant for the observer observing.</param>
+/// <param name="Subject">The <see cref="Subject"/> identifying the compliance target for this event. Defaults to <see cref="Subject.NotSet"/>.</param>
 public record EventContext(
     EventType EventType,
     EventSourceType EventSourceType,
@@ -39,8 +40,14 @@ public record EventContext(
     Identity CausedBy,
     IEnumerable<Tag> Tags,
     EventHash Hash,
-    EventObservationState ObservationState = EventObservationState.Initial)
+    EventObservationState ObservationState = EventObservationState.Initial,
+    Subject? Subject = null)
 {
+    /// <summary>
+    /// Gets a value indicating whether the subject is the event source id (no explicit <see cref="Subject"/> was set, or <see cref="Subject"/> equals <see cref="EventSourceId"/>).
+    /// </summary>
+    public bool SubjectIsEventSourceId => Subject is null || !Subject.IsSet || Subject.Value == EventSourceId.Value;
+
     /// <summary>
     /// Creates an 'empty' <see cref="EventContext"/> with the event source id set to empty and all properties default.
     /// </summary>

--- a/Source/Kernel/Concepts/Events/EventContext.cs
+++ b/Source/Kernel/Concepts/Events/EventContext.cs
@@ -24,6 +24,7 @@ namespace Cratis.Chronicle.Concepts.Events;
 /// <param name="Tags">A collection of <see cref="Tag"/> for the event.</param>
 /// <param name="Hash">The <see cref="EventHash"/> of the event content.</param>
 /// <param name="ObservationState">Holds the state relevant for the observer observing.</param>
+/// <param name="Subject">The <see cref="Subject"/> identifying the compliance target for this event. Defaults to <see cref="Subject.NotSet"/>.</param>
 public record EventContext(
     EventType EventType,
     EventSourceType EventSourceType,
@@ -39,8 +40,14 @@ public record EventContext(
     Identity CausedBy,
     IEnumerable<Tag> Tags,
     EventHash Hash,
-    EventObservationState ObservationState = EventObservationState.Initial)
+    EventObservationState ObservationState = EventObservationState.Initial,
+    Subject? Subject = null)
 {
+    /// <summary>
+    /// Gets a value indicating whether the subject is the event source id (no explicit <see cref="Subject"/> was set, or <see cref="Subject"/> equals <see cref="EventSourceId"/>).
+    /// </summary>
+    public bool SubjectIsEventSourceId => Subject is null || !Subject.IsSet || Subject.Value == EventSourceId.Value;
+
     /// <summary>
     /// Creates an 'empty' <see cref="EventContext"/> with the event source id set to empty and all properties default.
     /// </summary>
@@ -70,6 +77,7 @@ public record EventContext(
     /// <param name="correlationId">The <see cref="CorrelationId"/> for the event.</param>
     /// <param name="tags">Collection of <see cref="Tag"/> for the event.</param>
     /// <param name="occurred">Optional occurred.</param>
+    /// <param name="subject">Optional <see cref="Subject"/> identifying the compliance target.</param>
     /// <returns>A new <see cref="EventContext"/>.</returns>
     public static EventContext From(
         EventStoreName eventStore,
@@ -82,7 +90,8 @@ public record EventContext(
         EventSequenceNumber sequenceNumber,
         CorrelationId correlationId,
         IEnumerable<Tag>? tags = null,
-        DateTimeOffset? occurred = default)
+        DateTimeOffset? occurred = default,
+        Subject? subject = null)
     {
         return new(
             eventType,
@@ -97,11 +106,10 @@ public record EventContext(
             correlationId,
             [],
             Identity.NotSet,
-            [],
-            EventHash.NotSet)
-        {
-            Tags = tags ?? []
-        };
+            tags ?? [],
+            EventHash.NotSet,
+            EventObservationState.Initial,
+            subject);
     }
 
     /// <summary>

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/given/all_dependencies.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.given;
+
+public class all_dependencies : Specification
+{
+    protected static readonly EventStoreName EventStore = "test-store";
+    protected static readonly EventStoreNamespaceName EventStoreNamespace = "test-namespace";
+    protected const string Identifier = "subject-identifier";
+
+    protected IJsonComplianceManager _complianceManager;
+    protected IExpandoObjectConverter _converter;
+    protected JsonSchema _schemaWithPii;
+    protected JsonSchema _schemaWithoutPii;
+    protected ExpandoObject _instance;
+
+    void Establish()
+    {
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
+        _converter = Substitute.For<IExpandoObjectConverter>();
+
+        _schemaWithPii = new JsonSchema();
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                {
+                    ComplianceJsonSchemaExtensions.ComplianceKey,
+                    new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) }
+                }
+            }
+        };
+        _schemaWithPii.Properties["name"] = property;
+
+        _schemaWithoutPii = new JsonSchema();
+        _schemaWithoutPii.Properties["value"] = new JsonSchemaProperty();
+
+        dynamic expando = new ExpandoObject();
+        expando.name = "test-name";
+        _instance = expando;
+
+        _converter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new JsonObject { ["name"] = "test-name" });
+
+        _converter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ =>
+            {
+                dynamic result = new ExpandoObject();
+                result.name = "encrypted-name";
+                return result;
+            });
+
+        _complianceManager.Apply(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<string>(),
+                Arg.Any<JsonObject>())
+            .Returns(_ => Task.FromResult(new JsonObject { ["name"] = "encrypted-name" }));
+
+        _complianceManager.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<string>(),
+                Arg.Any<JsonObject>())
+            .Returns(_ => Task.FromResult(new JsonObject { ["name"] = "decrypted-name" }));
+    }
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_applying/and_schema_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_applying/and_schema_has_no_pii.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_applying;
+
+public class and_schema_has_no_pii : given.all_dependencies
+{
+    ExpandoObject _result;
+
+    async Task Because() => _result = await ReadModelComplianceHelper.Apply(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithoutPii,
+        Identifier,
+        _instance,
+        _converter);
+
+    [Fact] void should_return_original_instance() => _result.ShouldEqual(_instance);
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Apply(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+    [Fact] void should_write_subject_to_instance() => ((IDictionary<string, object?>)_result).ContainsKey(WellKnownProperties.Subject).ShouldBeTrue();
+    [Fact] void should_write_correct_subject_value() => ((IDictionary<string, object?>)_result)[WellKnownProperties.Subject].ShouldEqual(Identifier);
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_applying/and_schema_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_applying/and_schema_has_pii_property.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_applying;
+
+public class and_schema_has_pii_property : given.all_dependencies
+{
+    ExpandoObject _result;
+
+    async Task Because() => _result = await ReadModelComplianceHelper.Apply(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        Identifier,
+        _instance,
+        _converter);
+
+    [Fact] void should_call_compliance_manager_apply() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, _schemaWithPii, Identifier, Arg.Any<JsonObject>());
+    [Fact] void should_write_subject_to_result() => ((IDictionary<string, object?>)_result).ContainsKey(WellKnownProperties.Subject).ShouldBeTrue();
+    [Fact] void should_write_correct_subject_value() => ((IDictionary<string, object?>)_result)[WellKnownProperties.Subject].ShouldEqual(Identifier);
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_no_pii.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing;
+
+public class and_schema_has_no_pii : given.all_dependencies
+{
+    ExpandoObject _result;
+
+    async Task Because() => _result = await ReadModelComplianceHelper.Release(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithoutPii,
+        _instance,
+        _converter);
+
+    [Fact] void should_return_original_instance() => _result.ShouldEqual(_instance);
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_pii_and_subject_is_present.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_pii_and_subject_is_present.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing;
+
+public class and_schema_has_pii_and_subject_is_present : given.all_dependencies
+{
+    ExpandoObject _result;
+
+    void Establish() => ((IDictionary<string, object?>)_instance)[WellKnownProperties.Subject] = Identifier;
+
+    async Task Because() => _result = await ReadModelComplianceHelper.Release(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance,
+        _converter);
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(EventStore, EventStoreNamespace, _schemaWithPii, Identifier, Arg.Any<JsonObject>());
+    [Fact] void should_return_decrypted_instance() => _result.ShouldNotBeNull();
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_pii_but_no_subject_in_document.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing/and_schema_has_pii_but_no_subject_in_document.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing;
+
+public class and_schema_has_pii_but_no_subject_in_document : given.all_dependencies
+{
+    ExpandoObject _result;
+
+    async Task Because() => _result = await ReadModelComplianceHelper.Release(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance,
+        _converter);
+
+    [Fact] void should_return_original_instance() => _result.ShouldEqual(_instance);
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/given/all_dependencies.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Observation.Reducers.Clients;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Sinks;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.given;
+
+public class all_dependencies : Specification
+{
+    protected static readonly EventStoreName EventStore = "test-store";
+    protected static readonly EventStoreNamespaceName EventStoreNamespace = "test-namespace";
+    protected const string EventSourceIdValue = "event-source-id";
+    protected const string SubjectValue = "explicit-subject";
+
+    protected ISink _sink;
+    protected IObjectComparer _objectComparer;
+    protected IJsonComplianceManager _complianceManager;
+    protected IExpandoObjectConverter _expandoObjectConverter;
+    protected ReadModelDefinition _readModelDefinition;
+    protected ReducerPipeline _pipeline;
+    protected JsonSchema _schema;
+
+    void Establish()
+    {
+        _sink = Substitute.For<ISink>();
+        _objectComparer = Substitute.For<IObjectComparer>();
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+
+        _schema = new JsonSchema();
+
+        _readModelDefinition = new ReadModelDefinition(
+            "test-read-model",
+            "TestCollection",
+            "Test Read Model",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Reducer,
+            "test-observer",
+            new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.MongoDB),
+            new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, _schema } },
+            []);
+
+        _sink.FindOrDefault(Arg.Any<Key>()).Returns(Task.FromResult<ExpandoObject?>(null));
+
+        _objectComparer.Compare(Arg.Any<ExpandoObject>(), Arg.Any<ExpandoObject>(), out Arg.Any<IEnumerable<PropertyDifference>>())
+            .Returns(false);
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new JsonObject());
+
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new ExpandoObject());
+
+        _complianceManager.Apply(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject()));
+
+        _complianceManager.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject()));
+
+        _sink.ApplyChanges(Arg.Any<Key>(), Arg.Any<IChangeset<AppendedEvent, ExpandoObject>>(), Arg.Any<EventSequenceNumber>())
+            .Returns(Task.FromResult(Enumerable.Empty<FailedPartition>()));
+
+        _pipeline = new ReducerPipeline(
+            _readModelDefinition,
+            _sink,
+            _objectComparer,
+            _complianceManager,
+            _expandoObjectConverter,
+            EventStore,
+            EventStoreNamespace);
+    }
+
+    protected AppendedEvent CreateEvent(string eventSourceId, Subject? subject = null)
+    {
+        var context = EventContext.From(
+            EventStore,
+            EventStoreNamespace,
+            EventType.Unknown,
+            EventSourceType.Default,
+            eventSourceId,
+            EventStreamType.All,
+            EventStreamId.Default,
+            EventSequenceNumber.First,
+            CorrelationId.NotSet,
+            subject: subject);
+        return new AppendedEvent(context, new ExpandoObject());
+    }
+
+    protected ReducerContext CreateContext(string eventSourceId, Subject? subject = null) =>
+        new(new[] { CreateEvent(eventSourceId, subject) }, new Key(eventSourceId, new ArrayIndexers([])));
+
+    protected ReducerDelegate CreateReducer(ExpandoObject? returnState) =>
+        (_, _) => Task.FromResult(new ReducerSubscriberResult(
+            new ObserverSubscriberResult(ObserverSubscriberState.Ok, EventSequenceNumber.First, [], string.Empty),
+            returnState));
+}

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_no_pii.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_read_model_has_no_pii : given.all_dependencies
+{
+    ExpandoObject _returnedState;
+
+    void Establish()
+    {
+        _returnedState = new ExpandoObject();
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(null));
+    }
+
+    async Task Because() => await _pipeline.Handle(
+        CreateContext(EventSourceIdValue),
+        CreateReducer(_returnedState));
+
+    [Fact] void should_not_call_release() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<Schemas.JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+    [Fact] void should_not_call_apply() => _complianceManager.DidNotReceive().Apply(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<Schemas.JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_pii_and_initial_state_exists.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_pii_and_initial_state_exists.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_read_model_has_pii_and_initial_state_exists : given.all_dependencies
+{
+    ExpandoObject _initialState;
+    ExpandoObject _returnedState;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                {
+                    ComplianceJsonSchemaExtensions.ComplianceKey,
+                    new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) }
+                }
+            }
+        };
+        _schema.Properties["name"] = property;
+
+        _initialState = new ExpandoObject();
+        ((IDictionary<string, object?>)_initialState)[WellKnownProperties.Subject] = EventSourceIdValue;
+
+        _returnedState = new ExpandoObject();
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(_initialState));
+    }
+
+    async Task Because() => await _pipeline.Handle(
+        CreateContext(EventSourceIdValue),
+        CreateReducer(_returnedState));
+
+    [Fact] void should_call_release_for_initial_state() => _complianceManager.Received(1).Release(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+    [Fact] void should_call_apply_on_result() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_pii_and_initial_state_is_null.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_has_pii_and_initial_state_is_null.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_read_model_has_pii_and_initial_state_is_null : given.all_dependencies
+{
+    ExpandoObject _returnedState;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                {
+                    ComplianceJsonSchemaExtensions.ComplianceKey,
+                    new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) }
+                }
+            }
+        };
+        _schema.Properties["name"] = property;
+
+        _returnedState = new ExpandoObject();
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(null));
+    }
+
+    async Task Because() => await _pipeline.Handle(
+        CreateContext(EventSourceIdValue),
+        CreateReducer(_returnedState));
+
+    [Fact] void should_not_call_release() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+    [Fact] void should_call_apply_with_event_source_id_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_subject_is_different_from_event_source_id.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_subject_is_different_from_event_source_id.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_subject_is_different_from_event_source_id : given.all_dependencies
+{
+    ExpandoObject _returnedState;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                {
+                    ComplianceJsonSchemaExtensions.ComplianceKey,
+                    new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) }
+                }
+            }
+        };
+        _schema.Properties["name"] = property;
+
+        _returnedState = new ExpandoObject();
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(null));
+    }
+
+    async Task Because() => await _pipeline.Handle(
+        CreateContext(EventSourceIdValue, (Subject)SubjectValue),
+        CreateReducer(_returnedState));
+
+    [Fact] void should_call_apply_with_subject_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), SubjectValue, Arg.Any<JsonObject>());
+    [Fact] void should_not_use_event_source_id_as_identifier() => _complianceManager.DidNotReceive().Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
@@ -1,14 +1,17 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Configuration;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation.Jobs;
+using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.Observation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -39,6 +42,9 @@ public class an_observer : Specification
     protected TestStorageStats _failedPartitionsStorageStats => _silo.StorageManager.GetStorageStats(nameof(FailedPartition))!;
     protected IEventSequence _eventSequence;
     protected IConfigurationForObserverProvider _configurationProvider;
+    protected IEventTypesStorage _eventTypesStorage;
+    protected IJsonComplianceManager _complianceManager;
+    protected IExpandoObjectConverter _expandoObjectConverter;
     protected Observers _observersConfig;
 
     async Task Establish()
@@ -50,6 +56,15 @@ public class an_observer : Specification
         _subscriber = Substitute.For<IObserverSubscriber>();
         _jobsManager = Substitute.For<IJobsManager>();
         _eventSequence = Substitute.For<IEventSequence>();
+        _eventTypesStorage = Substitute.For<IEventTypesStorage>();
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+
+        // By default, no event types are registered, so events pass through unchanged.
+        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(false);
+        _silo.AddService(_eventTypesStorage);
+        _silo.AddService(_complianceManager);
+        _silo.AddService(_expandoObjectConverter);
 
         _silo.AddProbe(_ => _subscriber);
         _silo.AddProbe(_ => _jobsManager);

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_explicit_subject.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.EventTypes;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_handling;
+
+public class and_event_has_explicit_subject : given.an_observer_with_subscription_for_specific_event_type
+{
+    static readonly Subject _subject = new("explicit-subject-value");
+    string? _capturedIdentifier;
+    EventTypeSchema _schema;
+
+    void Establish()
+    {
+        _schema = new EventTypeSchema(
+            event_type,
+            EventTypeOwner.Client,
+            EventTypeSource.Code,
+            new JsonSchema());
+
+        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(true);
+        _eventTypesStorage.GetFor(event_type.Id, event_type.Generation).Returns(_schema);
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>()).Returns(new JsonObject());
+        _complianceManager
+            .When(m => m.Release(
+                Arg.Any<Cratis.Chronicle.Concepts.EventStoreName>(),
+                Arg.Any<Cratis.Chronicle.Concepts.EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<string>(),
+                Arg.Any<JsonObject>()))
+            .Do(callInfo => _capturedIdentifier = callInfo.ArgAt<string>(3));
+        _complianceManager.Release(
+            Arg.Any<Cratis.Chronicle.Concepts.EventStoreName>(),
+            Arg.Any<Cratis.Chronicle.Concepts.EventStoreNamespaceName>(),
+            Arg.Any<JsonSchema>(),
+            Arg.Any<string>(),
+            Arg.Any<JsonObject>())
+            .Returns(new JsonObject());
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>()).Returns(new ExpandoObject());
+
+        _subscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(ObserverSubscriberResult.Ok(42UL));
+    }
+
+    async Task Because()
+    {
+        var eventWithSubject = AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL) with
+        {
+            Context = AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL).Context with
+            {
+                Subject = _subject
+            }
+        };
+        await _observer.Handle("Something", [eventWithSubject]);
+    }
+
+    [Fact] void should_use_subject_value_as_identifier() => _capturedIdentifier.ShouldEqual(_subject.Value);
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_pii_property.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.EventTypes;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_handling;
+
+public class and_event_has_pii_property : given.an_observer_with_subscription_for_specific_event_type
+{
+    IEnumerable<AppendedEvent> _receivedEvents = [];
+    ExpandoObject _decryptedContent;
+    EventTypeSchema _schema;
+
+    void Establish()
+    {
+        _decryptedContent = new ExpandoObject();
+        ((IDictionary<string, object?>)_decryptedContent)["ssn"] = "123-45-6789";
+
+        _schema = new EventTypeSchema(
+            event_type,
+            EventTypeOwner.Client,
+            EventTypeSource.Code,
+            new JsonSchema());
+
+        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(true);
+        _eventTypesStorage.GetFor(event_type.Id, event_type.Generation).Returns(_schema);
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>()).Returns(new JsonObject());
+        _complianceManager.Release(
+            Arg.Any<Cratis.Chronicle.Concepts.EventStoreName>(),
+            Arg.Any<Cratis.Chronicle.Concepts.EventStoreNamespaceName>(),
+            Arg.Any<JsonSchema>(),
+            Arg.Any<string>(),
+            Arg.Any<JsonObject>())
+            .Returns(new JsonObject());
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>()).Returns(_decryptedContent);
+
+        _subscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(callInfo =>
+            {
+                _receivedEvents = callInfo.ArgAt<IEnumerable<AppendedEvent>>(1);
+                return ObserverSubscriberResult.Ok(42UL);
+            });
+    }
+
+    async Task Because() => await _observer.Handle("Something", [AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL)]);
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(
+        Arg.Any<Cratis.Chronicle.Concepts.EventStoreName>(),
+        Arg.Any<Cratis.Chronicle.Concepts.EventStoreNamespaceName>(),
+        Arg.Any<JsonSchema>(),
+        Arg.Any<string>(),
+        Arg.Any<JsonObject>());
+    [Fact] void should_deliver_decrypted_content_to_subscriber() => _receivedEvents.First().Content.ShouldEqual(_decryptedContent);
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_type_schema_is_unknown.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_type_schema_is_unknown.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_handling;
+
+public class and_event_type_schema_is_unknown : given.an_observer_with_subscription_for_specific_event_type
+{
+    IEnumerable<AppendedEvent> _receivedEvents = [];
+    ExpandoObject _originalContent;
+
+    void Establish()
+    {
+        _originalContent = new ExpandoObject();
+        ((IDictionary<string, object?>)_originalContent)["raw"] = "encrypted-data";
+
+        var appendedEvent = AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL) with
+        {
+            Context = AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL).Context,
+            Content = _originalContent
+        };
+
+        // HasFor returns false (default set in an_observer Establish)
+        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(false);
+
+        _subscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(callInfo =>
+            {
+                _receivedEvents = callInfo.ArgAt<IEnumerable<AppendedEvent>>(1);
+                return ObserverSubscriberResult.Ok(42UL);
+            });
+    }
+
+    async Task Because()
+    {
+        var appendedEvent = new AppendedEvent(
+            AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL).Context,
+            _originalContent);
+        await _observer.Handle("Something", [appendedEvent]);
+    }
+
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(
+        Arg.Any<Cratis.Chronicle.Concepts.EventStoreName>(),
+        Arg.Any<Cratis.Chronicle.Concepts.EventStoreNamespaceName>(),
+        Arg.Any<Cratis.Chronicle.Schemas.JsonSchema>(),
+        Arg.Any<string>(),
+        Arg.Any<System.Text.Json.Nodes.JsonObject>());
+    [Fact] void should_pass_event_through_unchanged() => _receivedEvents.First().Content.ShouldEqual(_originalContent);
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/given/all_dependencies.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_DecryptInitialState.given;
+
+public class all_dependencies : Specification
+{
+    protected static readonly EventStoreName EventStore = "test-store";
+    protected static readonly EventStoreNamespaceName EventStoreNamespace = "test-namespace";
+    protected const string EventSourceIdValue = "event-source-id";
+
+    protected IJsonComplianceManager _complianceManager;
+    protected IExpandoObjectConverter _expandoObjectConverter;
+    protected IProjection _projection;
+    protected DecryptInitialState _step;
+    protected JsonSchema _schema;
+    protected IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    protected IObjectComparer _objectComparer;
+
+    void Establish()
+    {
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+        _projection = Substitute.For<IProjection>();
+        _objectComparer = Substitute.For<IObjectComparer>();
+
+        _schema = new JsonSchema();
+        _projection.TargetReadModelSchema.Returns(_schema);
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new JsonObject());
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new ExpandoObject());
+
+        _complianceManager.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject()));
+
+        _step = new DecryptInitialState(_complianceManager, _expandoObjectConverter, EventStore, EventStoreNamespace);
+    }
+
+    protected ProjectionEventContext CreateContext(ExpandoObject? initialState)
+    {
+        var @event = new AppendedEvent(
+            EventContext.From(
+                EventStore,
+                EventStoreNamespace,
+                EventType.Unknown,
+                EventSourceType.Default,
+                EventSourceIdValue,
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                CorrelationId.NotSet),
+            new ExpandoObject());
+
+        var changeset = new Changeset<AppendedEvent, ExpandoObject>(_objectComparer, @event, initialState ?? new ExpandoObject());
+        if (initialState is not null)
+        {
+            changeset.InitialState = initialState;
+        }
+
+        return new ProjectionEventContext(
+            new Key(EventSourceIdValue, new ArrayIndexers([])),
+            @event,
+            changeset,
+            ProjectionOperationType.None,
+            false);
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_has_no_pii.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_DecryptInitialState.when_performing;
+
+public class and_initial_state_has_no_pii : given.all_dependencies
+{
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        dynamic state = new ExpandoObject();
+        state.value = "some-value";
+        ((IDictionary<string, object?>)(ExpandoObject)state)[WellKnownProperties.Subject] = "some-subject";
+        _context = CreateContext(state);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<Schemas.JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_has_pii_and_subject_is_stored.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_has_pii_and_subject_is_stored.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_DecryptInitialState.when_performing;
+
+public class and_initial_state_has_pii_and_subject_is_stored : given.all_dependencies
+{
+    const string StoredSubject = "stored-subject";
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) } }
+            }
+        };
+        _schema.Properties["name"] = property;
+
+        dynamic state = new ExpandoObject();
+        state.name = "encrypted-name";
+        ((IDictionary<string, object?>)(ExpandoObject)state)[WellKnownProperties.Subject] = StoredSubject;
+        _context = CreateContext(state);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), StoredSubject, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_is_null.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_DecryptInitialState/when_performing/and_initial_state_is_null.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_DecryptInitialState.when_performing;
+
+public class and_initial_state_is_null : given.all_dependencies
+{
+    ProjectionEventContext _result;
+
+    async Task Because()
+    {
+        var context = CreateContext(null);
+        context.Changeset.InitialState = null!;
+        _result = await _step.Perform(_projection, context);
+    }
+
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<Schemas.JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+    [Fact] void should_return_context() => _result.ShouldNotBeNull();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/given/all_dependencies.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.given;
+
+public class all_dependencies : Specification
+{
+    protected static readonly EventStoreName EventStore = "test-store";
+    protected static readonly EventStoreNamespaceName EventStoreNamespace = "test-namespace";
+    protected const string EventSourceIdValue = "event-source-id";
+    protected const string SubjectValue = "explicit-subject";
+
+    protected IJsonComplianceManager _complianceManager;
+    protected IExpandoObjectConverter _expandoObjectConverter;
+    protected IObjectComparer _objectComparer;
+    protected IProjection _projection;
+    protected EncryptChangeset _step;
+    protected JsonSchema _schema;
+
+    void Establish()
+    {
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+        _objectComparer = Substitute.For<IObjectComparer>();
+        _projection = Substitute.For<IProjection>();
+
+        _schema = new JsonSchema();
+        _projection.TargetReadModelSchema.Returns(_schema);
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new JsonObject());
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>())
+            .Returns(_ => new ExpandoObject());
+
+        _complianceManager.Apply(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject()));
+
+        _objectComparer.Compare(Arg.Any<ExpandoObject>(), Arg.Any<ExpandoObject>(), out Arg.Any<IEnumerable<PropertyDifference>>())
+            .Returns(true);  // true = equal (no differences)
+
+        _step = new EncryptChangeset(_complianceManager, _expandoObjectConverter, _objectComparer, EventStore, EventStoreNamespace);
+    }
+
+    protected ProjectionEventContext CreateContext(string eventSourceId, Subject? subject = null)
+    {
+        var @event = new AppendedEvent(
+            EventContext.From(
+                EventStore,
+                EventStoreNamespace,
+                EventType.Unknown,
+                EventSourceType.Default,
+                eventSourceId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                CorrelationId.NotSet,
+                subject: subject),
+            new ExpandoObject());
+
+        var changeset = new Changeset<AppendedEvent, ExpandoObject>(_objectComparer, @event, new ExpandoObject());
+
+        return new ProjectionEventContext(
+            new Key(eventSourceId, new ArrayIndexers([])),
+            @event,
+            changeset,
+            ProjectionOperationType.None,
+            false);
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_event_has_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_event_has_explicit_subject.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
+
+public class and_event_has_explicit_subject : given.all_dependencies
+{
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) } }
+            }
+        };
+        _schema.Properties["name"] = property;
+        _context = CreateContext(EventSourceIdValue, (Subject)SubjectValue);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_use_subject_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), SubjectValue, Arg.Any<JsonObject>());
+    [Fact] void should_not_use_event_source_id() => _complianceManager.DidNotReceive().Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_no_pii.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
+
+public class and_read_model_has_no_pii : given.all_dependencies
+{
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish() => _context = CreateContext(EventSourceIdValue);
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_not_call_compliance_manager_apply() => _complianceManager.DidNotReceive().Apply(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<Schemas.JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+    [Fact] void should_return_context() => _result.ShouldNotBeNull();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_pii_property.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
+
+public class and_read_model_has_pii_property : given.all_dependencies
+{
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) } }
+            }
+        };
+        _schema.Properties["name"] = property;
+        _context = CreateContext(EventSourceIdValue);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_call_apply_with_event_source_id_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
@@ -26,6 +27,7 @@ public class all_dependencies : Specification
     protected ISink _sink;
     protected IReadModel _readModel;
     protected ReadModelDefinition _readModelDefinition;
+    protected IJsonComplianceManager _complianceManager;
     protected Contracts.ReadModels.IReadModels _service;
 
     void Establish()
@@ -48,7 +50,7 @@ public class all_dependencies : Specification
             ReadModelObserverType.Projection,
             "test-observer",
             new SinkDefinition(SinkConfigurationId.None, SinkTypeId.None),
-            new Dictionary<ReadModelGeneration, JsonSchema>(),
+            new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, new JsonSchema() } },
             []);
 
         _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
@@ -61,12 +63,14 @@ public class all_dependencies : Specification
 
         var clusterClient = Substitute.For<IClusterClient>();
         var expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+        _complianceManager = Substitute.For<IJsonComplianceManager>();
 
         _service = new ReadModels(
             clusterClient,
             _grainFactory,
             _storage,
             expandoObjectConverter,
+            _complianceManager,
             new JsonSerializerOptions());
     }
 }

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instances/and_read_model_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instances/and_read_model_has_pii_property.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.ReadModels;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_instances;
+
+/// <summary>
+/// Spec verifying that PII fields are decrypted before returning instances.
+/// </summary>
+public class and_read_model_has_pii_property : given.all_dependencies
+{
+    GetInstancesResponse _result;
+    ExpandoObject _encryptedInstance;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) } }
+            }
+        };
+
+        _readModelDefinition = _readModelDefinition with
+        {
+            Schemas = new Dictionary<Concepts.ReadModels.ReadModelGeneration, JsonSchema>
+            {
+                {
+                    (Concepts.ReadModels.ReadModelGeneration)1,
+                    new JsonSchema { Properties = { ["name"] = property } }
+                }
+            }
+        };
+
+        _readModel.GetDefinition().Returns(Task.FromResult(_readModelDefinition));
+
+        _encryptedInstance = new ExpandoObject();
+        ((IDictionary<string, object?>)_encryptedInstance)[WellKnownProperties.Subject] = "some-subject";
+        ((IDictionary<string, object?>)_encryptedInstance)["name"] = "encrypted-value";
+
+        _sink.GetInstances(Arg.Any<Concepts.ReadModels.ReadModelContainerName?>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(new ReadModelInstances([_encryptedInstance], 1));
+
+        _complianceManager.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject { ["name"] = "decrypted-value" }));
+    }
+
+    async Task Because() => _result = await _service.GetInstances(new GetInstancesRequest
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModel = "test-read-model",
+        Page = 0,
+        PageSize = 20
+    });
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), "some-subject", Arg.Any<JsonObject>());
+    [Fact] void should_return_one_instance() => _result.Instances.Count.ShouldEqual(1);
+}

--- a/Source/Kernel/Core/Compliance/ReadModelComplianceHelper.cs
+++ b/Source/Kernel/Core/Compliance/ReadModelComplianceHelper.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Compliance;
+
+/// <summary>
+/// Provides compliance apply/release operations for read model <see cref="ExpandoObject"/> instances.
+/// </summary>
+public static class ReadModelComplianceHelper
+{
+    /// <summary>
+    /// Encrypts PII fields in a read model instance and writes the compliance subject.
+    /// </summary>
+    /// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> to use for applying compliance.</param>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the read model belongs to.</param>
+    /// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> the read model belongs to.</param>
+    /// <param name="schema">The <see cref="JsonSchema"/> describing the read model's properties.</param>
+    /// <param name="identifier">The compliance subject identifier used as the encryption key reference.</param>
+    /// <param name="instance">The <see cref="ExpandoObject"/> read model instance to encrypt.</param>
+    /// <param name="converter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
+    /// <returns>A new <see cref="ExpandoObject"/> with PII fields encrypted and <c>_subject</c> written.</returns>
+    public static async Task<ExpandoObject> Apply(
+        IJsonComplianceManager complianceManager,
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        JsonSchema schema,
+        string identifier,
+        ExpandoObject instance,
+        IExpandoObjectConverter converter)
+    {
+        if (!schema.HasComplianceMetadata())
+        {
+            ((IDictionary<string, object?>)instance)[WellKnownProperties.Subject] = identifier;
+            return instance;
+        }
+
+        var json = converter.ToJsonObject(instance, schema);
+        var applied = await complianceManager.Apply(eventStore, eventStoreNamespace, schema, identifier, json);
+        var result = converter.ToExpandoObject(applied, schema);
+        ((IDictionary<string, object?>)result)[WellKnownProperties.Subject] = identifier;
+        return result;
+    }
+
+    /// <summary>
+    /// Decrypts PII fields in a read model instance using the stored <c>_subject</c> field.
+    /// </summary>
+    /// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> to use for releasing compliance.</param>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the read model belongs to.</param>
+    /// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> the read model belongs to.</param>
+    /// <param name="schema">The <see cref="JsonSchema"/> describing the read model's properties.</param>
+    /// <param name="instance">The <see cref="ExpandoObject"/> read model instance to decrypt.</param>
+    /// <param name="converter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
+    /// <returns>A new <see cref="ExpandoObject"/> with PII fields decrypted, or the original instance if no subject is stored.</returns>
+    public static async Task<ExpandoObject> Release(
+        IJsonComplianceManager complianceManager,
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        JsonSchema schema,
+        ExpandoObject instance,
+        IExpandoObjectConverter converter)
+    {
+        if (!schema.HasComplianceMetadata())
+        {
+            return instance;
+        }
+
+        var dict = (IDictionary<string, object?>)instance;
+        if (!dict.TryGetValue(WellKnownProperties.Subject, out var subjectObj) || subjectObj is not string identifier)
+        {
+            return instance;
+        }
+
+        var json = converter.ToJsonObject(instance, schema);
+        var released = await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, json);
+        return converter.ToExpandoObject(released, schema);
+    }
+}

--- a/Source/Kernel/Core/Observation/Observer.Handling.cs
+++ b/Source/Kernel/Core/Observation/Observer.Handling.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Dynamic;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
+
 namespace Cratis.Chronicle.Observation;
 
 public partial class Observer
@@ -108,7 +110,8 @@ public partial class Observer
 
                     var subscriber = (GrainFactory.GetGrain(_subscription.SubscriberType, key) as IObserverSubscriber)!;
                     tailEventSequenceNumber = firstEvent.Context.SequenceNumber;
-                    var result = await subscriber.OnNext(partition, eventsToHandle, new(_subscription.Arguments));
+                    var decryptedEvents = await DecryptEvents(eventsToHandle);
+                    var result = await subscriber.OnNext(partition, decryptedEvents, new(_subscription.Arguments));
                     numEventsSuccessfullyHandled = result.HandledAnyEvents
                         ? eventsToHandle.Count(_ => _.Context.SequenceNumber <= result.LastSuccessfulObservation)
                         : EventCount.Zero;
@@ -176,6 +179,36 @@ public partial class Observer
                 logger.ObserverFailedForUnknownReasonsAfterHandlingEvents(ex);
             }
         }
+    }
+
+    async Task<IEnumerable<AppendedEvent>> DecryptEvents(IEnumerable<AppendedEvent> events)
+    {
+        var releasedEvents = new List<AppendedEvent>();
+        foreach (var @event in events)
+        {
+            if (await eventTypesStorage.HasFor(@event.Context.EventType.Id, @event.Context.EventType.Generation))
+            {
+                var schema = await eventTypesStorage.GetFor(@event.Context.EventType.Id, @event.Context.EventType.Generation);
+                var identifier = @event.Context.Subject?.IsSet == true
+                    ? @event.Context.Subject.Value
+                    : @event.Context.EventSourceId.Value;
+                var contentAsJson = expandoObjectConverter.ToJsonObject(@event.Content, schema.Schema);
+                var released = await complianceManager.Release(
+                    @event.Context.EventStore,
+                    @event.Context.Namespace,
+                    schema.Schema,
+                    identifier,
+                    contentAsJson);
+                var releasedContent = expandoObjectConverter.ToExpandoObject(released, schema.Schema);
+                releasedEvents.Add(@event with { Content = releasedContent });
+            }
+            else
+            {
+                releasedEvents.Add(@event);
+            }
+        }
+
+        return releasedEvents;
     }
 
     bool ShouldHandleEvent(Key partition)

--- a/Source/Kernel/Core/Observation/Observer.cs
+++ b/Source/Kernel/Core/Observation/Observer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
@@ -11,9 +12,11 @@ using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Observation.Jobs;
 using Cratis.Chronicle.Observation.States;
 using Cratis.Chronicle.StateMachines;
+using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.Observation;
 using Cratis.Metrics;
 using Microsoft.Extensions.DependencyInjection;
@@ -28,6 +31,9 @@ namespace Cratis.Chronicle.Observation;
 /// <param name="observerDefinition"><see cref="IPersistentState{T}"/> for the observer definition.</param>
 /// <param name="failures"><see cref="IPersistentState{T}"/> for failed partitions.</param>
 /// <param name="configurationProvider">The <see cref="IConfigurationForObserverProvider"/> for getting the <see cref="Observers"/> configuration.</param>
+/// <param name="eventTypesStorage"><see cref="IEventTypesStorage"/> for looking up event type schemas.</param>
+/// <param name="complianceManager"><see cref="IJsonComplianceManager"/> for decrypting PII fields.</param>
+/// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting between JSON and expando objects.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
 /// <param name="meter"><see cref="Meter{T}"/> for the observer.</param>
 /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
@@ -39,6 +45,9 @@ public partial class Observer(
     [PersistentState(nameof(FailedPartition), WellKnownGrainStorageProviders.FailedPartitions)]
     IPersistentState<FailedPartitions> failures,
     IConfigurationForObserverProvider configurationProvider,
+    IEventTypesStorage eventTypesStorage,
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter,
     ILogger<Observer> logger,
     [FromKeyedServices(WellKnown.MeterName)] IMeter<Observer> meter,
     ILoggerFactory loggerFactory) : StateMachine<ObserverState>, IObserver, IRemindable

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
@@ -3,8 +3,11 @@
 
 using System.Dynamic;
 using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Sinks;
 
@@ -19,10 +22,18 @@ namespace Cratis.Chronicle.Observation.Reducers;
 /// <param name="readModel">The <see cref="ReadModelDefinition"/> the sink is for.</param>
 /// <param name="sink"><see cref="ISink"/> to use in pipeline.</param>
 /// <param name="objectComparer"><see cref="IObjectComparer"/> for comparing objects.</param>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for encrypting and decrypting PII fields.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
+/// <param name="eventStore">The <see cref="EventStoreName"/> this pipeline belongs to.</param>
+/// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> this pipeline belongs to.</param>
 public class ReducerPipeline(
     ReadModelDefinition readModel,
     ISink sink,
-    IObjectComparer objectComparer) : IReducerPipeline
+    IObjectComparer objectComparer,
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter,
+    EventStoreName eventStore,
+    EventStoreNamespaceName eventStoreNamespace) : IReducerPipeline
 {
     /// <inheritdoc/>
     public ReadModelDefinition ReadModel { get; } = readModel;
@@ -45,23 +56,53 @@ public class ReducerPipeline(
     /// <inheritdoc/>
     public async Task Handle(ReducerContext context, ReducerDelegate reducer)
     {
+        var schema = ReadModel.GetSchemaForLatestGeneration();
         var initial = await Sink.FindOrDefault(context.Key);
+
+        if (initial is not null)
+        {
+            initial = await ReadModelComplianceHelper.Release(
+                complianceManager,
+                eventStore,
+                eventStoreNamespace,
+                schema,
+                initial,
+                expandoObjectConverter);
+        }
 
         var result = await reducer(context.Events, initial);
 
         if (result.ObserverResult.State != ObserverSubscriberState.Ok) return;
 
+        var firstEventContext = context.Events.First().Context;
+        var subject = firstEventContext.Subject;
+        var identifier = subject is not null && subject.IsSet
+            ? subject.Value
+            : firstEventContext.EventSourceId.Value;
+
         var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, context.Events.First(), initial ?? new ExpandoObject());
-        if (result.ReadModelState == null)
+        if (result.ReadModelState is null)
         {
-            if (initial != null)
+            if (initial is not null)
             {
                 changeset.Add(new Removed(initial));
             }
         }
-        else if (!objectComparer.Compare(initial, result.ReadModelState, out var differences))
+        else
         {
-            changeset.Add(new PropertiesChanged<ExpandoObject>(null!, differences));
+            var encryptedState = await ReadModelComplianceHelper.Apply(
+                complianceManager,
+                eventStore,
+                eventStoreNamespace,
+                schema,
+                identifier,
+                result.ReadModelState,
+                expandoObjectConverter);
+
+            if (!objectComparer.Compare(initial, encryptedState, out var differences))
+            {
+                changeset.Add(new PropertiesChanged<ExpandoObject>(null!, differences));
+            }
         }
 
         if (changeset.HasChanges)

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipelineFactory.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipelineFactory.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Observation.Reducers;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Storage;
 
@@ -15,10 +17,14 @@ namespace Cratis.Chronicle.Observation.Reducers;
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="storage"><see cref="IStorage"/> for working with storage.</param>
 /// <param name="objectComparer"><see cref="IObjectComparer"/> for comparing objects.</param>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for encrypting and decrypting PII fields.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
 public class ReducerPipelineFactory(
     IGrainFactory grainFactory,
     IStorage storage,
-    IObjectComparer objectComparer) : IReducerPipelineFactory
+    IObjectComparer objectComparer,
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter) : IReducerPipelineFactory
 {
     /// <inheritdoc/>
     public async Task<IReducerPipeline> Create(
@@ -29,6 +35,6 @@ public class ReducerPipelineFactory(
         var namespaceStorage = storage.GetEventStore(eventStore).GetNamespace(@namespace);
         var readModel = await grainFactory.GetGrain<IReadModel>(new ReadModelGrainKey(definition.ReadModel, eventStore)).GetDefinition();
         var sink = await namespaceStorage.Sinks.GetFor(readModel);
-        return new ReducerPipeline(readModel, sink, objectComparer);
+        return new ReducerPipeline(readModel, sink, objectComparer, complianceManager, expandoObjectConverter, eventStore, @namespace);
     }
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/ProjectionPipelineManager.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Concurrent;
 using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
@@ -21,6 +23,8 @@ namespace Cratis.Chronicle.Projections.Engine.Pipelines;
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="objectComparer"><see cref="IObjectComparer"/> for comparing objects.</param>
 /// <param name="typeFormats"><see cref="ITypeFormats"/> for resolving actual CLR types for schemas.</param>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for encrypting and decrypting PII fields.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
 /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
 [Singleton]
 public class ProjectionPipelineManager(
@@ -28,6 +32,8 @@ public class ProjectionPipelineManager(
     IGrainFactory grainFactory,
     IObjectComparer objectComparer,
     ITypeFormats typeFormats,
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter,
     ILoggerFactory loggerFactory) : IProjectionPipelineManager
 {
     readonly ConcurrentDictionary<string, IProjectionPipeline> _pipelines = new();
@@ -55,7 +61,9 @@ public class ProjectionPipelineManager(
         [
             new ResolveKey(eventSequenceStorage, sink, typeFormats, loggerFactory.CreateLogger<ResolveKey>()),
             new SetInitialState(sink, loggerFactory.CreateLogger<SetInitialState>()),
+            new DecryptInitialState(complianceManager, expandoObjectConverter, eventStore, @namespace),
             new HandleEvent(eventSequenceStorage, sink, loggerFactory.CreateLogger<HandleEvent>()),
+            new EncryptChangeset(complianceManager, expandoObjectConverter, objectComparer, eventStore, @namespace),
             new StoreFutures(projectionFutures, loggerFactory.CreateLogger<StoreFutures>()),
             resolveFuturesStep,
             new SaveChanges(sink, namespaceStorage.Changesets, loggerFactory.CreateLogger<SaveChanges>())

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/DecryptInitialState.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/DecryptInitialState.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+
+/// <summary>
+/// Represents an implementation of <see cref="ICanPerformProjectionPipelineStep"/> that decrypts
+/// PII fields in the initial state using the stored <see cref="WellKnownProperties.Subject"/> field.
+/// </summary>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for decrypting PII fields.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
+/// <param name="eventStore">The <see cref="EventStoreName"/> this step belongs to.</param>
+/// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> this step belongs to.</param>
+public class DecryptInitialState(
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter,
+    EventStoreName eventStore,
+    EventStoreNamespaceName eventStoreNamespace) : ICanPerformProjectionPipelineStep
+{
+    /// <inheritdoc/>
+    public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
+    {
+        if (context.Changeset.InitialState is null)
+        {
+            return context;
+        }
+
+        var schema = projection.TargetReadModelSchema;
+        if (!schema.HasComplianceMetadata())
+        {
+            return context;
+        }
+
+        var initialState = context.Changeset.InitialState;
+        var dict = (IDictionary<string, object?>)initialState;
+        if (!dict.ContainsKey(WellKnownProperties.Subject))
+        {
+            return context;
+        }
+
+        var decrypted = await ReadModelComplianceHelper.Release(
+            complianceManager,
+            eventStore,
+            eventStoreNamespace,
+            schema,
+            initialState,
+            expandoObjectConverter);
+
+        context.Changeset.InitialState = decrypted;
+        return context;
+    }
+}

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+
+/// <summary>
+/// Represents an implementation of <see cref="ICanPerformProjectionPipelineStep"/> that encrypts
+/// PII fields in the current state and writes the compliance subject into the document before saving.
+/// </summary>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for encrypting PII fields.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting between ExpandoObject and JsonObject.</param>
+/// <param name="objectComparer">The <see cref="IObjectComparer"/> for computing property differences.</param>
+/// <param name="eventStore">The <see cref="EventStoreName"/> this step belongs to.</param>
+/// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> this step belongs to.</param>
+public class EncryptChangeset(
+    IJsonComplianceManager complianceManager,
+    IExpandoObjectConverter expandoObjectConverter,
+    IObjectComparer objectComparer,
+    EventStoreName eventStore,
+    EventStoreNamespaceName eventStoreNamespace) : ICanPerformProjectionPipelineStep
+{
+    /// <inheritdoc/>
+    public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
+    {
+        if (context.IsDeferred)
+        {
+            return context;
+        }
+
+        var eventContext = context.Event.Context;
+        var subject = eventContext.Subject;
+        var identifier = subject is not null && subject.IsSet
+            ? subject.Value
+            : eventContext.EventSourceId.Value;
+
+        var schema = projection.TargetReadModelSchema;
+        var currentState = context.Changeset.CurrentState;
+
+        var encrypted = await ReadModelComplianceHelper.Apply(
+            complianceManager,
+            eventStore,
+            eventStoreNamespace,
+            schema,
+            identifier,
+            currentState,
+            expandoObjectConverter);
+
+        var hasDifferences = !objectComparer.Compare(currentState, encrypted, out var differences);
+
+        if (hasDifferences && differences is not null && differences.Any())
+        {
+            context.Changeset.Add(new PropertiesChanged<ExpandoObject>(encrypted, differences));
+        }
+
+        return context;
+    }
+}

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -4,6 +4,7 @@
 using System.Dynamic;
 using System.Reactive.Linq;
 using System.Text.Json;
+using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
@@ -28,12 +29,14 @@ namespace Cratis.Chronicle.Services.ReadModels;
 /// <param name="grainFactory">The grain factory.</param>
 /// <param name="storage">The storage.</param>
 /// <param name="expandoObjectConverter">The expando object converter.</param>
+/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> for decrypting PII fields.</param>
 /// <param name="jsonSerializerOptions">The JSON serializer options.</param>
 internal sealed class ReadModels(
     IClusterClient clusterClient,
     IGrainFactory grainFactory,
     IStorage storage,
     IExpandoObjectConverter expandoObjectConverter,
+    IJsonComplianceManager complianceManager,
     JsonSerializerOptions jsonSerializerOptions) : IReadModels
 {
     /// <inheritdoc/>
@@ -125,7 +128,21 @@ internal sealed class ReadModels(
             skip,
             request.PageSize);
 
-        var instancesAsJson = instances?.Select(instance => JsonSerializer.Serialize(instance)).ToList() ?? [];
+        var schema = definition.GetSchemaForLatestGeneration();
+        var decryptedInstances = new List<ExpandoObject>();
+        foreach (var instance in instances ?? [])
+        {
+            var decrypted = await ReadModelComplianceHelper.Release(
+                complianceManager,
+                request.EventStore,
+                request.Namespace,
+                schema,
+                instance,
+                expandoObjectConverter);
+            decryptedInstances.Add(decrypted);
+        }
+
+        var instancesAsJson = decryptedInstances.Select(instance => JsonSerializer.Serialize(instance)).ToList();
         return new()
         {
             Instances = instancesAsJson,

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -124,7 +124,7 @@ public static class ChronicleServerSiloBuilderExtensions
                 projections,
                 new Cratis.Chronicle.Services.Observation.Webhooks.Webhooks(grainFactory, storage, sp.GetRequiredService<IWebhookDefinitionComparer>(), sp.GetRequiredService<Cratis.Chronicle.Security.IEncryption>(), sp.GetRequiredService<IOAuthClient>(), sp.GetRequiredService<IWebhookMediator>()),
                 new Cratis.Chronicle.Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(grainFactory, storage),
-                new Cratis.Chronicle.Services.ReadModels.ReadModels(clusterClient, grainFactory, storage, expandoObjectConverter, jsonSerializerOptions),
+                new Cratis.Chronicle.Services.ReadModels.ReadModels(clusterClient, grainFactory, storage, expandoObjectConverter, sp.GetRequiredService<IJsonComplianceManager>(), jsonSerializerOptions),
                 new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage),
                 new Cratis.Chronicle.Services.Seeding.EventSeeding(grainFactory),
                 new Cratis.Chronicle.Services.Security.Users(grainFactory, storage),

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/given/an_event_converter.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/given/an_event_converter.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Storage.EventTypes;
+using Cratis.Chronicle.Storage.Identities;
+using MongoDB.Bson;
+using JsonExpandoObjectConverter = Cratis.Chronicle.Json.IExpandoObjectConverter;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.for_EventConverter.given;
+
+public class an_event_converter : Specification
+{
+    protected IEventTypesStorage _eventTypesStorage;
+    protected IIdentityStorage _identityStorage;
+    protected JsonExpandoObjectConverter _expandoObjectConverter;
+    protected EventConverter _converter;
+
+    void Establish()
+    {
+        _eventTypesStorage = Substitute.For<IEventTypesStorage>();
+        _identityStorage = Substitute.For<IIdentityStorage>();
+        _expandoObjectConverter = Substitute.For<JsonExpandoObjectConverter>();
+
+        _identityStorage.GetFor(Arg.Any<IEnumerable<IdentityId>>()).Returns(Identity.NotSet);
+
+        _converter = new EventConverter(
+            EventStoreName.NotSet,
+            EventStoreNamespaceName.NotSet,
+            _eventTypesStorage,
+            _identityStorage,
+            _expandoObjectConverter);
+    }
+
+    protected static Event CreateEvent(Subject? subject = null) =>
+        new(
+            0UL,
+            CorrelationId.NotSet,
+            [],
+            [IdentityId.NotSet],
+            new EventTypeId(Guid.NewGuid().ToString()),
+            DateTimeOffset.UtcNow,
+            EventSourceType.Default,
+            "test-source",
+            EventStreamType.All,
+            EventStreamId.Default,
+            [],
+            new Dictionary<string, BsonDocument>
+            {
+                ["1"] = BsonDocument.Parse("{\"name\":\"test\"}")
+            },
+            new Dictionary<string, string> { ["1"] = "hash" },
+            [],
+            subject);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_explicit_subject.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_explicit_subject.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.for_EventConverter.when_converting_event_to_appended_event;
+
+public class and_event_has_explicit_subject : given.an_event_converter
+{
+    static readonly Subject _subject = new("explicit-subject-id");
+    Event _event;
+    AppendedEvent _result;
+
+    void Establish()
+    {
+        _event = CreateEvent(_subject);
+        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(false);
+    }
+
+    async Task Because() => _result = await _converter.ToAppendedEvent(_event);
+
+    [Fact] void should_set_subject_on_context() => _result.Context.Subject.ShouldEqual(_subject);
+    [Fact] void should_not_be_subject_is_event_source_id() => _result.Context.SubjectIsEventSourceId.ShouldBeFalse();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_no_subject.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_no_subject.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.for_EventConverter.when_converting_event_to_appended_event;
+
+public class and_event_has_no_subject : given.an_event_converter
+{
+    Event _event;
+    AppendedEvent _result;
+
+    void Establish()
+    {
+        _event = CreateEvent(subject: null);
+        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(false);
+    }
+
+    async Task Because() => _result = await _converter.ToAppendedEvent(_event);
+
+    [Fact] void should_set_subject_to_not_set() => _result.Context.Subject.ShouldEqual(Subject.NotSet);
+    [Fact] void should_be_subject_is_event_source_id() => _result.Context.SubjectIsEventSourceId.ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/with_pii_property/encrypted_content_is_preserved.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/with_pii_property/encrypted_content_is_preserved.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.for_EventConverter.when_converting_event_to_appended_event.with_pii_property;
+
+public class encrypted_content_is_preserved : given.an_event_converter
+{
+    static readonly string _encryptedValue = "encrypted::abc123";
+    Event _event;
+    AppendedEvent _result;
+    EventTypeSchema _schema;
+    ExpandoObject _convertedContent;
+
+    void Establish()
+    {
+        _schema = new EventTypeSchema(
+            new EventType(Guid.NewGuid().ToString(), 1),
+            EventTypeOwner.Client,
+            EventTypeSource.Code,
+            new JsonSchema());
+
+        _convertedContent = new ExpandoObject();
+        ((IDictionary<string, object?>)_convertedContent)["name"] = _encryptedValue;
+
+        _event = CreateEvent();
+        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
+        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(_schema);
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>()).Returns(_convertedContent);
+    }
+
+    async Task Because() => _result = await _converter.ToAppendedEvent(_event);
+
+    [Fact] void should_use_schema_based_converter() => _expandoObjectConverter.Received(1).ToExpandoObject(Arg.Any<JsonObject>(), Arg.Any<JsonSchema>());
+    [Fact] void should_return_the_raw_converted_content() => ((IDictionary<string, object?>)_result.Content)["name"].ShouldEqual(_encryptedValue);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/always_creates_subject_index.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/always_creates_subject_index.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_ensuring_indexes;
+
+public class always_creates_subject_index : given.a_sink_with_indexes
+{
+    void Establish() => _indexCursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+
+    async Task Because() => await _sink.EnsureIndexes();
+
+    [Fact]
+    void should_create_subject_index_with_correct_name() =>
+        _indexManager.Received(1).CreateOneAsync(
+            Arg.Is<CreateIndexModel<BsonDocument>>(model =>
+                model.Options.Name == "subject_index"),
+            Arg.Any<CreateOneIndexOptions>(),
+            Arg.Any<CancellationToken>());
+
+    [Fact]
+    void should_create_subject_index_as_sparse() =>
+        _indexManager.Received(1).CreateOneAsync(
+            Arg.Is<CreateIndexModel<BsonDocument>>(model =>
+                model.Options.Sparse == true),
+            Arg.Any<CreateOneIndexOptions>(),
+            Arg.Any<CancellationToken>());
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_already_exist.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_ensuring_indexes/and_indexes_already_exist.cs
@@ -11,9 +11,10 @@ public class and_indexes_already_exist : given.a_sink_with_indexes
     void Establish()
     {
         var existingIndexDocument = new BsonDocument("name", $"chronicle_idx_{_indexedProperty.Path}");
+        var subjectIndexDocument = new BsonDocument("name", "subject_index");
         _indexCursor.MoveNextAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true), Task.FromResult(false));
-        _indexCursor.Current.Returns([existingIndexDocument]);
+        _indexCursor.Current.Returns([existingIndexDocument, subjectIndexDocument]);
     }
 
     async Task Because() => await _sink.EnsureIndexes();

--- a/Source/Kernel/Storage.MongoDB/ClusterStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/ClusterStorage.cs
@@ -3,7 +3,6 @@
 
 using System.Reactive.Subjects;
 using System.Text.Json;
-using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Configuration;
@@ -18,7 +17,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// Represents an implementation of <see cref="IClusterStorage"/> for MongoDB.
 /// </summary>
 /// <param name="database">The <see cref="IDatabase"/> instance.</param>
-/// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> instance.</param>
 /// <param name="expandoObjectConverter">The <see cref="Json.IExpandoObjectConverter"/> instance.</param>
 /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> instance.</param>
 /// <param name="jobTypes">The <see cref="IJobTypes"/> instance.</param>
@@ -26,7 +24,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> instance.</param>
 public class ClusterStorage(
     IDatabase database,
-    IJsonComplianceManager complianceManager,
     Json.IExpandoObjectConverter expandoObjectConverter,
     JsonSerializerOptions jsonSerializerOptions,
     IJobTypes jobTypes,
@@ -54,7 +51,6 @@ public class ClusterStorage(
     public IEventStoreStorage CreateStorageForEventStore(EventStoreName eventStore, SinksFactory sinksFactory) => new EventStoreStorage(
         eventStore,
         database.GetEventStoreDatabase(eventStore),
-        complianceManager,
         expandoObjectConverter,
         jsonSerializerOptions,
         sinksFactory,

--- a/Source/Kernel/Storage.MongoDB/EventSequences/EventConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/EventConverter.cs
@@ -3,7 +3,6 @@
 
 using System.Dynamic;
 using System.Text.Json.Nodes;
-using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Storage.EventTypes;
@@ -23,14 +22,12 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// <param name="eventStoreNamespace"><see cref="EventStoreNamespaceName"/> the converter is for.</param>
 /// <param name="eventTypesStorage"><see cref="IEventTypesStorage"/> for event schemas.</param>
 /// <param name="identityStorage"><see cref="IIdentityStorage"/>.</param>
-/// <param name="jsonComplianceManager"><see cref="IJsonComplianceManager"/> for handling compliance on events.</param>
 /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting between json and expando object.</param>
 public class EventConverter(
     EventStoreName eventStoreName,
     EventStoreNamespaceName eventStoreNamespace,
     IEventTypesStorage eventTypesStorage,
     IIdentityStorage identityStorage,
-    IJsonComplianceManager jsonComplianceManager,
     Json.IExpandoObjectConverter expandoObjectConverter) : IEventConverter
 {
     /// <inheritdoc/>
@@ -38,7 +35,7 @@ public class EventConverter(
     {
         var (eventType, generationKey, content) = ExtractContent(@event);
         var hash = ExtractHash(@event, generationKey);
-        var resolvedContent = await ResolveContent(eventType, @event.EventSourceId, content);
+        var resolvedContent = await ResolveContent(eventType, content);
         var revisions = await ResolveRevisions(@event);
 
         var originalContent = @event.Revisions.Any() && @event.Content.TryGetValue(EventTypeGeneration.First.ToString(), out var originalBson)
@@ -62,7 +59,8 @@ public class EventConverter(
                 @event.Causation,
                 await identityStorage.GetFor(@event.CausedBy),
                 @event.Tags.Select(_ => new Tag(_)).ToArray(),
-                hash),
+                hash,
+                Subject: @event.Subject ?? Subject.NotSet),
             resolvedContent)
         {
             OriginalContent = originalContent,
@@ -138,7 +136,7 @@ public class EventConverter(
         return (eventType, generationKey, ParseContent(@event.Content, generationKey));
     }
 
-    async Task<ExpandoObject> ResolveContent(EventType eventType, EventSourceId eventSourceId, JsonObject content)
+    async Task<ExpandoObject> ResolveContent(EventType eventType, JsonObject content)
     {
         // Redaction events store their content as RedactionEventContent (with EventTypeId as a
         // string), but the registered EventRedacted schema uses Type for OriginalEventType.
@@ -152,8 +150,7 @@ public class EventConverter(
             return ConvertToRawExpandoObject(content);
 
         var schema = await eventTypesStorage.GetFor(eventType.Id, eventType.Generation);
-        var released = await jsonComplianceManager.Release(eventStoreName, eventStoreNamespace, schema.Schema, eventSourceId, content);
-        return expandoObjectConverter.ToExpandoObject(released, schema.Schema);
+        return expandoObjectConverter.ToExpandoObject(content, schema.Schema);
     }
 
     async Task<IEnumerable<ConceptsEventRevision>> ResolveRevisions(Event @event)

--- a/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Text.Json;
-using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Jobs;
@@ -60,7 +59,6 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
     /// <param name="eventStoreNamespaceDatabase">Provider for <see cref="IEventStoreNamespaceDatabase"/> to use.</param>
     /// <param name="eventTypesStorage">The <see cref="IEventTypesStorage"/> for working with the schema types.</param>
     /// <param name="observerDefinitionsStorage">The <see cref="IObserverDefinitionsStorage"/> for working with observer definitions.</param>
-    /// <param name="complianceManager"><see cref="IJsonComplianceManager"/> for handling compliance.</param>
     /// <param name="expandoObjectConverter"><see cref="Json.IExpandoObjectConverter"/> for converting between expando object and json objects.</param>
     /// <param name="jsonSerializerOptions">The global <see cref="JsonSerializerOptions"/>.</param>
     /// <param name="sinks"><see cref="ISinks"/> for getting all <see cref="ISinkFactory"/> instances.</param>
@@ -73,7 +71,6 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
         IEventStoreNamespaceDatabase eventStoreNamespaceDatabase,
         IEventTypesStorage eventTypesStorage,
         IObserverDefinitionsStorage observerDefinitionsStorage,
-        IJsonComplianceManager complianceManager,
         Json.IExpandoObjectConverter expandoObjectConverter,
         JsonSerializerOptions jsonSerializerOptions,
         ISinks sinks,
@@ -110,7 +107,6 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
             @namespace,
             eventTypesStorage,
             Identities,
-            complianceManager,
             expandoObjectConverter);
     }
 

--- a/Source/Kernel/Storage.MongoDB/EventStoreStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreStorage.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Text.Json;
-using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Configuration;
@@ -42,7 +41,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// </remarks>
 /// <param name="eventStore"><see cref="EventStore"/> the storage is for.</param>
 /// <param name="eventStoreDatabase"><see cref="IEventStoreDatabase"/> to use.</param>
-/// <param name="complianceManager"><see cref="IJsonComplianceManager"/> for handling compliance.</param>
 /// <param name="expandoObjectConverter"><see cref="Json.IExpandoObjectConverter"/> for conversions.</param>
 /// <param name="jsonSerializerOptions">The global <see cref="JsonSerializerOptions"/>.</param>
 /// <param name="sinksFactory"><see cref="ISinks"/> for getting all <see cref="ISinkFactory"/> instances.</param>
@@ -52,7 +50,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 public class EventStoreStorage(
     EventStoreName eventStore,
     IEventStoreDatabase eventStoreDatabase,
-    IJsonComplianceManager complianceManager,
     Json.IExpandoObjectConverter expandoObjectConverter,
     JsonSerializerOptions jsonSerializerOptions,
     SinksFactory sinksFactory,
@@ -113,7 +110,6 @@ public class EventStoreStorage(
                 eventStoreDatabase.GetNamespaceDatabase(@namespace),
                 EventTypes,
                 Observers,
-                complianceManager,
                 expandoObjectConverter,
                 jsonSerializerOptions,
                 sinksFactory(@namespace),

--- a/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Monads;
@@ -255,13 +256,10 @@ public class Sink(
     /// <inheritdoc/>
     public async Task EnsureIndexes()
     {
-        if (readModel.Indexes.Count == 0)
-        {
-            return;
-        }
-
         var collection = Collection;
         var existingIndexes = await GetExistingIndexNamesAsync(collection);
+
+        await EnsureSubjectIndex(collection, existingIndexes);
 
         foreach (var indexDefinition in readModel.Indexes)
         {
@@ -278,6 +276,21 @@ public class Sink(
 
             await collection.Indexes.CreateOneAsync(indexModel);
         }
+    }
+
+    async Task EnsureSubjectIndex(IMongoCollection<BsonDocument> collection, HashSet<string> existingIndexes)
+    {
+        const string SubjectIndexName = "subject_index";
+
+        if (existingIndexes.Contains(SubjectIndexName))
+        {
+            return;
+        }
+
+        await collection.Indexes.CreateOneAsync(
+            new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending(WellKnownProperties.Subject),
+                new CreateIndexOptions { Sparse = true, Name = SubjectIndexName }));
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Storage.MongoDB/Storage.cs
+++ b/Source/Kernel/Storage.MongoDB/Storage.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Reactive.Subjects;
 using System.Text.Json;
-using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Configuration;
@@ -21,7 +20,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// Represents an implementation of <see cref="IStorage"/> for MongoDB.
 /// </summary>
 /// <param name="database">The MongoDB <see cref="IDatabase"/>.</param>
-/// <param name="complianceManager"><see cref="IJsonComplianceManager"/> for handling compliance.</param>
 /// <param name="expandoObjectConverter"><see cref="Json.IExpandoObjectConverter"/> for conversions.</param>
 /// <param name="jsonSerializerOptions">The global <see cref="JsonSerializerOptions"/>.</param>
 /// <param name="sinkFactories"><see cref="IInstancesOf{T}"/> for getting all <see cref="ISinkFactory"/> instances.</param>
@@ -30,7 +28,6 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
 public class Storage(
     IDatabase database,
-    IJsonComplianceManager complianceManager,
     Json.IExpandoObjectConverter expandoObjectConverter,
     JsonSerializerOptions jsonSerializerOptions,
     IInstancesOf<ISinkFactory> sinkFactories,
@@ -89,7 +86,6 @@ public class Storage(
         var eventStoreStorage = new EventStoreStorage(
             eventStore,
             database.GetEventStoreDatabase(eventStore),
-            complianceManager,
             expandoObjectConverter,
             jsonSerializerOptions,
             @namespace => new Chronicle.Storage.Sinks.Sinks(eventStore, @namespace, sinkFactories),

--- a/Source/Kernel/Storage/WellKnownProperties.cs
+++ b/Source/Kernel/Storage/WellKnownProperties.cs
@@ -19,4 +19,9 @@ public static class WellKnownProperties
     /// The property name for whether an model instance is initialized.
     /// </summary>
     public const string ReadModelInstanceInitialized = "__initialized";
+
+    /// <summary>
+    /// The property name for the subject (compliance identity target) of the event.
+    /// </summary>
+    public const string Subject = "_subject";
 }


### PR DESCRIPTION
## Added

- PII fields in projection read models are now stored encrypted at rest. Lineage is derived automatically from event property mappings — no annotation is needed on the read model type.
- PII fields in reducer read models are now stored encrypted at rest. Annotate properties with `[PII]` on the read model record to declare which fields are protected.
- `ReadModelComplianceHelper` encrypts and decrypts PII fields on `ExpandoObject` read model instances using the schema's compliance metadata.
- `DecryptInitialState` and `EncryptChangeset` pipeline steps wrap the projection `HandleEvent` step to keep PII encrypted in the read model store.
- Sparse `_subject` index on every MongoDB read model collection, enabling efficient GDPR erasure queries by subject.

## Changed

- All observers (reactors, webhooks, reducers, projections) now receive fully decrypted events from a single central decryption point in the observer infrastructure, rather than each subscriber handling decryption independently.
- `EventContext` gains a `Subject` property so the compliance identifier travels with each `AppendedEvent` through the observer pipeline.
- Read model query results are decrypted transparently before being returned to callers — no changes are needed in query code.
- `EventConverter` no longer decrypts event content in the storage layer; decryption moves to the observer level (last-mile, just before subscriber dispatch).