### PR TITLE
Fix projection replay losing child data in 4+ level model-bound hierarchies

### DIFF
--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_deep_hierarchy_using_event_source_as_child_key/and_events_are_appended_sequentially.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_deep_hierarchy_using_event_source_as_child_key/and_events_are_appended_sequentially.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_deep_hierarchy_using_event_source_as_child_key.and_events_are_appended_sequentially.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_deep_hierarchy_using_event_source_as_child_key;
+
+[Collection(ChronicleCollection.Name)]
+public class and_events_are_appended_sequentially(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid ModuleId;
+        public Guid FeatureId;
+        public Guid SliceId;
+        public Guid EventItemId;
+        public DeepHierarchyModule Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepHierarchyModuleCreated),
+            typeof(DeepHierarchyFeatureCreated),
+            typeof(DeepHierarchySliceCreated),
+            typeof(DeepHierarchyEventCreated)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(DeepHierarchyModule)];
+
+        async Task Because()
+        {
+            ModuleId = Guid.Parse("e5f6a7b8-c9d0-1234-efab-555555555555");
+            FeatureId = Guid.Parse("f6a7b8c9-d0e1-2345-fabc-666666666666");
+            SliceId = Guid.Parse("a7b8c9d0-e1f2-3456-abcd-777777777777");
+            EventItemId = Guid.Parse("b8c9d0e1-f2a3-4567-bcde-888888888888");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<DeepHierarchyModule>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(ModuleId, new DeepHierarchyModuleCreated("Authors"));
+            await EventStore.EventLog.Append(FeatureId, new DeepHierarchyFeatureCreated(ModuleId, FeatureId, "Registration"));
+            await EventStore.EventLog.Append(SliceId, new DeepHierarchySliceCreated(FeatureId, SliceId, "Register Author"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new DeepHierarchyEventCreated(SliceId, EventItemId, "AuthorRegistered"));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<DeepHierarchyModule>();
+            Result = await (await collection.FindAsync(m => m.Id == ModuleId)).FirstOrDefaultAsync();
+        }
+    }
+
+    DeepHierarchySlice Slice => Context.Result.Features.First().Slices.First();
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_set_the_module_name() => Context.Result.Name.ShouldEqual("Authors");
+    [Fact] void should_have_one_feature() => Context.Result.Features.Count().ShouldEqual(1);
+    [Fact] void should_set_the_feature_name() => Context.Result.Features.First().Name.ShouldEqual("Registration");
+    [Fact] void should_have_one_slice_in_the_feature() => Context.Result.Features.First().Slices.Count().ShouldEqual(1);
+    [Fact] void should_set_the_slice_name() => Slice.Name.ShouldEqual("Register Author");
+    [Fact] void should_have_one_event_on_the_slice() => Slice.Events.Count().ShouldEqual(1);
+    [Fact] void should_have_event_on_the_slice() => Slice.Events.Any(e => e.Id == Context.EventItemId && e.Name == "AuthorRegistered").ShouldBeTrue();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_deep_hierarchy_using_event_source_as_child_key/and_projection_is_replayed.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_deep_hierarchy_using_event_source_as_child_key/and_projection_is_replayed.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_deep_hierarchy_using_event_source_as_child_key.and_projection_is_replayed.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_deep_hierarchy_using_event_source_as_child_key;
+
+/// <summary>
+/// Integration spec that reproduces the bug where deeply nested children (4th level) lose
+/// their data after a projection replay. The key distinction from other hierarchy tests is
+/// that ONLY the root model is registered as a model-bound projection — intermediate types
+/// are nested-only, not standalone projections. Events for the 4th-level child are appended
+/// to the grandparent (Slice) event source, not to the child's own event source.
+/// </summary>
+[Collection(ChronicleCollection.Name)]
+public class and_projection_is_replayed(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid ModuleId;
+        public Guid FeatureId;
+        public Guid SliceId;
+        public Guid EventItemId;
+        public DeepHierarchyModule Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepHierarchyModuleCreated),
+            typeof(DeepHierarchyFeatureCreated),
+            typeof(DeepHierarchySliceCreated),
+            typeof(DeepHierarchyEventCreated)
+        ];
+
+        // Only the top-level type is registered — nested types are NOT standalone projections
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(DeepHierarchyModule)];
+
+        async Task Because()
+        {
+            ModuleId = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-111111111111");
+            FeatureId = Guid.Parse("b2c3d4e5-f6a7-8901-bcde-222222222222");
+            SliceId = Guid.Parse("c3d4e5f6-a7b8-9012-cdef-333333333333");
+            EventItemId = Guid.Parse("d4e5f6a7-b8c9-0123-defa-444444444444");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<DeepHierarchyModule>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            // Append to ModuleId event source
+            await EventStore.EventLog.Append(ModuleId, new DeepHierarchyModuleCreated("Authors"));
+            // Append to FeatureId event source (contains ModuleId as parentKey)
+            await EventStore.EventLog.Append(FeatureId, new DeepHierarchyFeatureCreated(ModuleId, FeatureId, "Registration"));
+            // Append to SliceId event source (contains FeatureId as parentKey; no explicit key → EventSourceId)
+            await EventStore.EventLog.Append(SliceId, new DeepHierarchySliceCreated(FeatureId, SliceId, "Register Author"));
+            // Append to SliceId event source (NOT EventItemId) — EventItemId is a property inside the event
+            var appendResult = await EventStore.EventLog.Append(SliceId, new DeepHierarchyEventCreated(SliceId, EventItemId, "AuthorRegistered"));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            await EventStore.Projections.Replay(projectionId);
+            await EventStore.Jobs.WaitForThereToBeNoJobs();
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<DeepHierarchyModule>();
+            Result = await (await collection.FindAsync(m => m.Id == ModuleId)).FirstOrDefaultAsync();
+        }
+    }
+
+    DeepHierarchySlice Slice => Context.Result.Features.First().Slices.First();
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_set_the_module_name() => Context.Result.Name.ShouldEqual("Authors");
+    [Fact] void should_have_one_feature() => Context.Result.Features.Count().ShouldEqual(1);
+    [Fact] void should_set_the_feature_name() => Context.Result.Features.First().Name.ShouldEqual("Registration");
+    [Fact] void should_have_one_slice_in_the_feature() => Context.Result.Features.First().Slices.Count().ShouldEqual(1);
+    [Fact] void should_set_the_slice_name() => Slice.Name.ShouldEqual("Register Author");
+    [Fact] void should_have_one_event_on_the_slice() => Slice.Events.Count().ShouldEqual(1);
+    [Fact] void should_have_event_on_the_slice() => Slice.Events.Any(e => e.Id == Context.EventItemId && e.Name == "AuthorRegistered").ShouldBeTrue();
+}
+
+/// <summary>
+/// Event appended to a Module's event source to create a module.
+/// </summary>
+[EventType]
+public record DeepHierarchyModuleCreated(string Name);
+
+/// <summary>
+/// Event appended to a Feature's own event source; carries ModuleId as parentKey.
+/// </summary>
+[EventType]
+public record DeepHierarchyFeatureCreated(Guid ModuleId, Guid FeatureId, string Name);
+
+/// <summary>
+/// Event appended to a Slice's own event source (SliceId = event source); carries FeatureId as parentKey.
+/// No explicit key on the ChildrenFrom → defaults to EventSourceId.
+/// </summary>
+[EventType]
+public record DeepHierarchySliceCreated(Guid FeatureId, Guid SliceId, string Name);
+
+/// <summary>
+/// Event appended to the SLICE's event source (not the EventItemId event source).
+/// The EventItemId is embedded as a property — this matches the Studio production pattern where
+/// EventAddedToSlice is appended to the Slice event source with EventItemId as a field.
+/// </summary>
+[EventType]
+public record DeepHierarchyEventCreated(Guid SliceId, Guid EventItemId, string Name);
+
+/// <summary>
+/// Root read model. Only this type is registered as a model-bound projection.
+/// </summary>
+[FromEvent<DeepHierarchyModuleCreated>]
+public record DeepHierarchyModule(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<DeepHierarchyFeatureCreated>(
+        key: nameof(DeepHierarchyFeatureCreated.FeatureId),
+        parentKey: nameof(DeepHierarchyFeatureCreated.ModuleId),
+        identifiedBy: nameof(DeepHierarchyFeature.Id))]
+    IEnumerable<DeepHierarchyFeature> Features);
+
+/// <summary>
+/// Nested child — NOT registered as a standalone projection.
+/// Uses EventSourceId as the child key (no explicit key on ChildrenFrom).
+/// </summary>
+[FromEvent<DeepHierarchyFeatureCreated>]
+public record DeepHierarchyFeature(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<DeepHierarchySliceCreated>(
+        parentKey: nameof(DeepHierarchySliceCreated.FeatureId),
+        identifiedBy: nameof(DeepHierarchySlice.Id))]
+    IEnumerable<DeepHierarchySlice> Slices);
+
+/// <summary>
+/// Grandchild — NOT registered as a standalone projection.
+/// Events has key=EventItemId, parentKey auto-discovered (SliceId property matches Slice.Id type).
+/// </summary>
+[FromEvent<DeepHierarchySliceCreated>]
+public record DeepHierarchySlice(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<DeepHierarchyEventCreated>(key: nameof(DeepHierarchyEventCreated.EventItemId))]
+    IEnumerable<DeepHierarchyEvent> Events);
+
+/// <summary>
+/// Great-grandchild — NOT registered as a standalone projection.
+/// Updated via class-level FromEvent; identified by EventItemId (auto-discovered via Id convention).
+/// </summary>
+[FromEvent<DeepHierarchyEventCreated>(key: nameof(DeepHierarchyEventCreated.EventItemId))]
+public record DeepHierarchyEvent(Guid Id, string Name);
+
+#pragma warning restore SA1402

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -202,6 +202,35 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         return arrayIndexers;
     }
 
+    /// <summary>
+    /// Builds the full property path from the root document to the identified-by property of
+    /// <paramref name="projection"/>, walking up the parent chain to collect all intermediate
+    /// array segment names.
+    /// </summary>
+    /// <param name="projection">The projection whose chain is walked to build the full path.</param>
+    /// <param name="identifiedByProperty">The property that identifies items at the leaf level.</param>
+    /// <remarks>
+    /// For a 3-level hierarchy (Root → Feature → Slice), the Feature projection's
+    /// <c>ChildrenPropertyPath</c> is already relative to root (e.g. "features"), so the path
+    /// is simply "features.id". For a 4-level hierarchy (Root → Feature → Slice → EventItem),
+    /// the Slice projection's <c>ChildrenPropertyPath</c> is "slices" (relative to Feature),
+    /// not to root. Walking up the chain gives ["features", "slices"], yielding the correct
+    /// MongoDB path "features.slices.id" for a flat document query.
+    /// </remarks>
+    static PropertyPath BuildFullParentChildPropertyPath(IProjection projection, PropertyPath identifiedByProperty)
+    {
+        var segments = new List<string>();
+        var current = projection;
+        while (current?.ChildrenPropertyPath.IsSet == true)
+        {
+            segments.Insert(0, current.ChildrenPropertyPath.Path);
+            current = current.Parent;
+        }
+
+        segments.Add(identifiedByProperty.Path);
+        return new PropertyPath(string.Join('.', segments));
+    }
+
     async Task<KeyResolverResult> ResolveParentKey(
         KeyResolver parentKeyResolver,
         Storage.EventSequences.IEventSequenceStorage eventSequenceStorage,
@@ -464,11 +493,13 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
             return new ParentEventResult(null, KeyResolverResult.Deferred(deferredFuture));
         }
 
-        // For root-level parents (ChildrenPropertyPath not set), use the child's path
-        // For nested parents, use the parent's path to query at the correct level
-        var childPropertyPath = parentProjection.ChildrenPropertyPath.IsSet
-            ? parentProjection.ChildrenPropertyPath + parentIdentifiedByProperty
-            : projection.ChildrenPropertyPath + parentIdentifiedByProperty;
+        // Build the full path from root to the parent's identified-by property.
+        // For a 3-level hierarchy (Root → Feature → Slice), the parent's ChildrenPropertyPath
+        // is already relative to root (e.g. "features"), so "features.id" is correct.
+        // For a 4-level hierarchy (Root → Feature → Slice → EventItem), the parent (Slice) has
+        // ChildrenPropertyPath = "slices" which is relative to Feature, not to root. We need
+        // "features.slices.id" — so we must walk up the hierarchy to collect all segments.
+        var childPropertyPath = BuildFullParentChildPropertyPath(parentProjection, parentIdentifiedByProperty);
         logger.FromParentHierarchyLookupBySink(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
 
         logger.FromParentHierarchySinkQuery(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
@@ -587,7 +618,9 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
 
             if (parentIdentifiedByProperty is not null)
             {
-                var childPropertyPath = parentProjection.ChildrenPropertyPath + parentIdentifiedByProperty;
+                // Use the full path from root to avoid missing intermediate array segments
+                // when the parent is itself nested more than one level below root.
+                var childPropertyPath = BuildFullParentChildPropertyPath(parentProjection, parentIdentifiedByProperty);
                 logger.CollectParentIndexersLookup(childPropertyPath.Path, childKeyValue);
 
                 var optionalRootKey = await sink.TryFindRootKeyByChildValue(childPropertyPath, childKeyValue);


### PR DESCRIPTION
## Fixed

- Projection replay no longer loses data in deeply nested child collections (4+ levels) when only the root model is registered as a projection. After replay, innermost arrays such as \`Module.Features[].Slices[].Events\` were left empty even though events existed.