### PR TITLE
Add bulk GetFor overloads to IEventTypesStorage and cache schemas in Observer

### DIFF
--- a/Documentation/compliance/arc.md
+++ b/Documentation/compliance/arc.md
@@ -1,0 +1,9 @@
+---
+uid: Chronicle.Compliance.Arc
+---
+
+# Compliance in Arc applications
+
+Chronicle compliance — PII encryption, key-based erasure, and automatic decryption — works transparently when you use Arc read models and queries. No additional configuration is required: the same encryption and decryption behavior described in [Read models and PII](read-models.md) applies whether you access read models directly or through Arc's generated command and query proxies.
+
+For detailed guidance on using compliance features from an Arc application, see <xref:Arc.Chronicle.Compliance>.

--- a/Documentation/compliance/index.md
+++ b/Documentation/compliance/index.md
@@ -54,4 +54,5 @@ If the identifier itself is sensitive, use a non-sensitive surrogate key as the 
 | [Applying PII to ConceptAs types](pii-with-concepts.md) | How to mark domain value types as PII once and apply everywhere |
 | [Working with compliance from the client](client.md) | How to annotate events and ConceptAs types in your .NET client code |
 | [Read models and PII](read-models.md) | How PII encryption affects projections, reducers, and read model queries |
+| [Compliance in Arc applications](arc.md) | Using read models and queries with compliance in Arc |
 | [Event Redaction](../events/redaction.md) | Removing event content for GDPR right-to-erasure requests |

--- a/Documentation/compliance/toc.yml
+++ b/Documentation/compliance/toc.yml
@@ -8,3 +8,5 @@
   href: client.md
 - name: Read models and PII
   href: read-models.md
+- name: Compliance in Arc applications
+  href: arc.md

--- a/Source/Clients/Testing/EventSequences/InMemoryEventTypesStorage.cs
+++ b/Source/Clients/Testing/EventSequences/InMemoryEventTypesStorage.cs
@@ -58,6 +58,14 @@ internal sealed class InMemoryEventTypesStorage : IEventTypesStorage
         Task.FromResult(Enumerable.Empty<KernelEventTypes::EventTypeSchema>());
 
     /// <inheritdoc/>
+    public Task<IEnumerable<KernelEventTypes::EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds) =>
+        Task.FromResult(Enumerable.Empty<KernelEventTypes::EventTypeSchema>());
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<KernelEventTypes::EventTypeSchema>> GetFor(IEnumerable<EventType> eventTypes) =>
+        Task.FromResult(Enumerable.Empty<KernelEventTypes::EventTypeSchema>());
+
+    /// <inheritdoc/>
     public Task<bool> HasFor(EventTypeId type, EventTypeGeneration? generation = default) =>
         Task.FromResult(true);
 

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
@@ -19,6 +19,8 @@ using Orleans.Core;
 using Orleans.Streams;
 using Orleans.TestKit;
 using Orleans.TestKit.Storage;
+using IChronicleEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
 using IEventSequence = Cratis.Chronicle.EventSequences.IEventSequence;
 
 namespace Cratis.Chronicle.Observation.for_Observer.given;
@@ -42,6 +44,8 @@ public class an_observer : Specification
     protected TestStorageStats _failedPartitionsStorageStats => _silo.StorageManager.GetStorageStats(nameof(FailedPartition))!;
     protected IEventSequence _eventSequence;
     protected IConfigurationForObserverProvider _configurationProvider;
+    protected IChronicleStorage _storage;
+    protected IChronicleEventStoreStorage _eventStoreStorage;
     protected IEventTypesStorage _eventTypesStorage;
     protected IJsonComplianceManager _complianceManager;
     protected IExpandoObjectConverter _expandoObjectConverter;
@@ -56,13 +60,20 @@ public class an_observer : Specification
         _subscriber = Substitute.For<IObserverSubscriber>();
         _jobsManager = Substitute.For<IJobsManager>();
         _eventSequence = Substitute.For<IEventSequence>();
+        _storage = Substitute.For<IChronicleStorage>();
+        _eventStoreStorage = Substitute.For<IChronicleEventStoreStorage>();
         _eventTypesStorage = Substitute.For<IEventTypesStorage>();
         _complianceManager = Substitute.For<IJsonComplianceManager>();
         _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
 
-        // By default, no event types are registered, so events pass through unchanged.
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(false);
-        _silo.AddService(_eventTypesStorage);
+        // Wire the storage chain: IStorage → IEventStoreStorage → IEventTypesStorage
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.EventTypes.Returns(_eventTypesStorage);
+
+        // By default, no schemas are known — events pass through unchanged.
+        _eventTypesStorage.GetFor(Arg.Any<IEnumerable<EventType>>()).Returns([]);
+
+        _silo.AddService(_storage);
         _silo.AddService(_complianceManager);
         _silo.AddService(_expandoObjectConverter);
 

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer_with_subscription_and_schema_for_event_type.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer_with_subscription_and_schema_for_event_type.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Observation.for_Observer.given;
+
+public class an_observer_with_subscription_and_schema_for_event_type : an_observer_with_subscription_for_specific_event_type
+{
+    protected EventTypeSchema event_type_schema;
+
+    async Task Establish()
+    {
+        event_type_schema = new EventTypeSchema(event_type, EventTypeOwner.Client, EventTypeSource.Code, new JsonSchema());
+
+        _eventTypesStorage.GetFor(Arg.Any<IEnumerable<EventType>>()).Returns([event_type_schema]);
+
+        await _observer.Subscribe<IObserverSubscriber>(ObserverType.Reactor, [event_type], SiloAddress.Zero);
+
+        _storageStats.ResetCounts();
+        _failedPartitionsStorageStats.ResetCounts();
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_explicit_subject.cs
@@ -4,28 +4,18 @@
 using System.Dynamic;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts.Events;
-using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Observation.for_Observer.when_handling;
 
-public class and_event_has_explicit_subject : given.an_observer_with_subscription_for_specific_event_type
+public class and_event_has_explicit_subject : given.an_observer_with_subscription_and_schema_for_event_type
 {
     static readonly Subject _subject = new("explicit-subject-value");
     string? _capturedIdentifier;
-    EventTypeSchema _schema;
 
     void Establish()
     {
-        _schema = new EventTypeSchema(
-            event_type,
-            EventTypeOwner.Client,
-            EventTypeSource.Code,
-            new JsonSchema());
-
-        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(true);
-        _eventTypesStorage.GetFor(event_type.Id, event_type.Generation).Returns(_schema);
         _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>()).Returns(new JsonObject());
         _complianceManager
             .When(m => m.Release(

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_has_pii_property.cs
@@ -4,31 +4,20 @@
 using System.Dynamic;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts.Events;
-using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Observation.for_Observer.when_handling;
 
-public class and_event_has_pii_property : given.an_observer_with_subscription_for_specific_event_type
+public class and_event_has_pii_property : given.an_observer_with_subscription_and_schema_for_event_type
 {
     IEnumerable<AppendedEvent> _receivedEvents = [];
     ExpandoObject _decryptedContent;
-    EventTypeSchema _schema;
 
     void Establish()
     {
         _decryptedContent = new ExpandoObject();
         ((IDictionary<string, object?>)_decryptedContent)["ssn"] = "123-45-6789";
-
-        _schema = new EventTypeSchema(
-            event_type,
-            EventTypeOwner.Client,
-            EventTypeSource.Code,
-            new JsonSchema());
-
-        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(true);
-        _eventTypesStorage.GetFor(event_type.Id, event_type.Generation).Returns(_schema);
 
         _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>()).Returns(new JsonObject());
         _complianceManager.Release(

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_type_schema_is_unknown.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_handling/and_event_type_schema_is_unknown.cs
@@ -23,9 +23,6 @@ public class and_event_type_schema_is_unknown : given.an_observer_with_subscript
             Content = _originalContent
         };
 
-        // HasFor returns false (default set in an_observer Establish)
-        _eventTypesStorage.HasFor(event_type.Id, event_type.Generation).Returns(false);
-
         _subscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
             .Returns(callInfo =>
             {

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_subscribing/and_event_types_have_known_schemas.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_subscribing/and_event_types_have_known_schemas.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_subscribing;
+
+public class and_event_types_have_known_schemas : given.an_observer
+{
+    EventType _event_type;
+    EventTypeSchema _schema;
+
+    void Establish()
+    {
+        _event_type = new("d9a13e10-21a4-4cfc-896e-fda8dfeb79bb", EventTypeGeneration.First);
+        _schema = new EventTypeSchema(_event_type, EventTypeOwner.Client, EventTypeSource.Code, new JsonSchema());
+        _eventTypesStorage.GetFor(Arg.Any<IEnumerable<EventType>>()).Returns([_schema]);
+    }
+
+    async Task Because() => await _observer.Subscribe<NullObserverSubscriber>(ObserverType.Reactor, [_event_type], SiloAddress.Zero);
+
+    [Fact] void should_fetch_schemas_for_the_subscribed_event_types() => _eventTypesStorage.Received(1).GetFor(Arg.Any<IEnumerable<EventType>>());
+}

--- a/Source/Kernel/Core/Observation/Observer.Handling.cs
+++ b/Source/Kernel/Core/Observation/Observer.Handling.cs
@@ -185,9 +185,8 @@ public partial class Observer
         var releasedEvents = new List<AppendedEvent>();
         foreach (var @event in events)
         {
-            if (await eventTypesStorage.HasFor(@event.Context.EventType.Id, @event.Context.EventType.Generation))
+            if (_eventTypeSchemas.TryGetValue(@event.Context.EventType, out var schema))
             {
-                var schema = await eventTypesStorage.GetFor(@event.Context.EventType.Id, @event.Context.EventType.Generation);
                 var identifier = @event.Context.Subject.Value;
                 var contentAsJson = expandoObjectConverter.ToJsonObject(@event.Content, schema.Schema);
                 var released = await complianceManager.Release(

--- a/Source/Kernel/Core/Observation/Observer.cs
+++ b/Source/Kernel/Core/Observation/Observer.cs
@@ -6,6 +6,7 @@ using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
@@ -16,7 +17,7 @@ using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Observation.Jobs;
 using Cratis.Chronicle.Observation.States;
 using Cratis.Chronicle.StateMachines;
-using Cratis.Chronicle.Storage.EventTypes;
+using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Observation;
 using Cratis.Metrics;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +32,7 @@ namespace Cratis.Chronicle.Observation;
 /// <param name="observerDefinition"><see cref="IPersistentState{T}"/> for the observer definition.</param>
 /// <param name="failures"><see cref="IPersistentState{T}"/> for failed partitions.</param>
 /// <param name="configurationProvider">The <see cref="IConfigurationForObserverProvider"/> for getting the <see cref="Observers"/> configuration.</param>
-/// <param name="eventTypesStorage"><see cref="IEventTypesStorage"/> for looking up event type schemas.</param>
+/// <param name="storage"><see cref="IStorage"/> for accessing storage.</param>
 /// <param name="complianceManager"><see cref="IJsonComplianceManager"/> for decrypting PII fields.</param>
 /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> for converting between JSON and expando objects.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
@@ -45,7 +46,7 @@ public partial class Observer(
     [PersistentState(nameof(FailedPartition), WellKnownGrainStorageProviders.FailedPartitions)]
     IPersistentState<FailedPartitions> failures,
     IConfigurationForObserverProvider configurationProvider,
-    IEventTypesStorage eventTypesStorage,
+    IStorage storage,
     IJsonComplianceManager complianceManager,
     IExpandoObjectConverter expandoObjectConverter,
     ILogger<Observer> logger,
@@ -61,6 +62,7 @@ public partial class Observer(
     IAppendedEventsQueues _appendedEventsQueues = null!;
     IMeterScope<Observer>? _metrics;
     bool _isPreparingCatchup;
+    Dictionary<EventType, EventTypeSchema> _eventTypeSchemas = [];
 
     /// <inheritdoc/>
     protected override Type InitialState => typeof(Routing);
@@ -137,6 +139,9 @@ public partial class Observer(
         where TObserverSubscriber : IObserverSubscriber
     {
         var owner = GetOwner<TObserverSubscriber>();
+
+        var eventTypeSchemas = await storage.GetEventStore(_observerKey.EventStore).EventTypes.GetFor(eventTypes);
+        _eventTypeSchemas = eventTypeSchemas.ToDictionary(s => s.Type);
 
         using var scope = logger.BeginObserverScope(_observerId, _observerKey);
 

--- a/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
@@ -182,6 +182,29 @@ public class EventTypesStorage(
         return eventType.ToDefinition();
     }
 
+    /// <inheritdoc/>
+    public async Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds)
+    {
+        var ids = eventTypeIds.ToList();
+        var filter = Builders<EventType>.Filter.In(et => et.Id, ids);
+        using var result = await GetCollection().FindAsync(filter).ConfigureAwait(false);
+        var schemas = await result.ToListAsync();
+        return schemas.Select(_ => _.ToKernel());
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<Concepts.Events.EventType> eventTypes)
+    {
+        var eventTypesList = eventTypes.ToList();
+        var ids = eventTypesList.ConvertAll(et => et.Id);
+        var filter = Builders<EventType>.Filter.In(et => et.Id, ids);
+        using var result = await GetCollection().FindAsync(filter).ConfigureAwait(false);
+        var mongoTypeMap = (await result.ToListAsync()).ToDictionary(m => m.Id);
+        return eventTypesList
+            .Where(et => mongoTypeMap.ContainsKey(et.Id))
+            .Select(et => mongoTypeMap[et.Id].ToKernel(et.Generation));
+    }
+
     IMongoCollection<EventType> GetCollection() => sharedDatabase.GetCollection<EventType>(WellKnownCollectionNames.EventTypes);
 
     FilterDefinition<EventType> GetFilterForSpecificEventType(EventTypeId type) => Builders<EventType>.Filter.Eq(et => et.Id, type);

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
@@ -92,6 +92,31 @@ public static class EventTypeConverters
     }
 
     /// <summary>
+    /// Convert to <see cref="EventTypeSchema"/> from <see cref="EventType"/> for a specific <see cref="EventTypeGeneration"/>.
+    /// </summary>
+    /// <param name="schema"><see cref="EventType"/> to convert from.</param>
+    /// <param name="generation">The <see cref="EventTypeGeneration"/> to use.</param>
+    /// <returns>Converted <see cref="EventTypeSchema"/>.</returns>
+    public static EventTypeSchema ToKernel(this EventType schema, EventTypeGeneration generation)
+    {
+        var schemaJson = schema.Schemas.TryGetValue((uint)generation, out var json)
+            ? json
+            : schema.Schemas.First().Value;
+
+        var result = JsonSchema.FromJsonAsync(schemaJson).GetAwaiter().GetResult();
+        result.EnsureComplianceMetadata();
+
+        return new EventTypeSchema(
+            new Concepts.Events.EventType(
+               schema.Id,
+               generation,
+               schema.Tombstone),
+            schema.Owner,
+            schema.Source,
+            result);
+    }
+
+    /// <summary>
     /// Convert to <see cref="EventTypeDefinition"/> from <see cref="EventType"/>.
     /// </summary>
     /// <param name="eventType"><see cref="EventType"/> to convert from.</param>

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
@@ -114,6 +114,28 @@ public class EventTypesStorage(EventStoreName eventStore, IDatabase database) : 
     public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() => _eventTypesSubject;
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds)
+    {
+        var ids = eventTypeIds.Select(id => id.Value).ToList();
+        await using var scope = await database.EventStore(eventStore);
+        var eventTypes = await scope.DbContext.EventTypes.Where(e => ids.Contains(e.Id)).ToListAsync();
+        return eventTypes.Select(_ => _.ToKernel());
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<Concepts.Events.EventType> eventTypes)
+    {
+        var eventTypesList = eventTypes.ToList();
+        var ids = eventTypesList.ConvertAll(et => et.Id.Value);
+        await using var scope = await database.EventStore(eventStore);
+        var storedTypes = await scope.DbContext.EventTypes.Where(e => ids.Contains(e.Id)).ToListAsync();
+        var storedTypeMap = storedTypes.ToDictionary(s => (EventTypeId)s.Id);
+        return eventTypesList
+            .Where(et => storedTypeMap.ContainsKey(et.Id))
+            .Select(et => storedTypeMap[et.Id].ToKernel(et.Generation));
+    }
+
+    /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(Concepts.Events.EventType eventType) => throw new NotImplementedException();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
+++ b/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
@@ -89,4 +89,18 @@ public interface IEventTypesStorage
     /// If generation is not provided, it will get what is associated with the <see cref="EventType"/>.
     /// </remarks>
     Task<EventTypeSchema> GetFor(EventTypeId type, EventTypeGeneration? generation = default);
+
+    /// <summary>
+    /// Gets a collection of <see cref="EventTypeSchema"/> for a collection of <see cref="EventTypeId"/>.
+    /// </summary>
+    /// <param name="eventTypeIds">The <see cref="EventTypeId"/> collection to get for.</param>
+    /// <returns>A collection of <see cref="EventTypeSchema"/>, one per matched type.</returns>
+    Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds);
+
+    /// <summary>
+    /// Gets a collection of <see cref="EventTypeSchema"/> for a collection of <see cref="EventType"/>.
+    /// </summary>
+    /// <param name="eventTypes">The <see cref="EventType"/> collection to get for.</param>
+    /// <returns>A collection of <see cref="EventTypeSchema"/>, one per matched type respecting each type's generation.</returns>
+    Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventType> eventTypes);
 }


### PR DESCRIPTION
## Added
- Bulk \`GetFor(IEnumerable<EventTypeId>)\` and \`GetFor(IEnumerable<EventType>)\` overloads on \`IEventTypesStorage\` — implemented for MongoDB, SQL, and the in-memory testing stub
- Observer now bulk-fetches and caches event type schemas during \`Subscribe\` so \`DecryptEvents\` uses a dictionary lookup with no per-event storage round-trips

## Changed
- Compliance documentation for Arc applications added under the Chronicle compliance section