### PR TITLE
Fix __subject propagation and PII decryption in read model Watch

### DIFF
--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_no_pii.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_no_pii.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing_json;
+
+public class and_schema_has_no_pii : given.all_dependencies
+{
+    JsonObject _instance;
+    JsonObject _result;
+
+    void Establish() => _instance = new JsonObject { ["value"] = "test-value" };
+
+    async Task Because() => _result = await ReadModelComplianceHelper.ReleaseJson(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithoutPii,
+        _instance);
+
+    [Fact] void should_return_original_instance() => _result.ShouldEqual(_instance);
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_pii_and_subject_is_present.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_pii_and_subject_is_present.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing_json;
+
+public class and_schema_has_pii_and_subject_is_present : given.all_dependencies
+{
+    JsonObject _instance;
+    JsonObject _result;
+
+    void Establish() => _instance = new JsonObject
+    {
+        [WellKnownProperties.Subject] = Identifier,
+        ["name"] = "encrypted-name"
+    };
+
+    async Task Because() => _result = await ReadModelComplianceHelper.ReleaseJson(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance);
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(EventStore, EventStoreNamespace, _schemaWithPii, Identifier, Arg.Any<JsonObject>());
+    [Fact] void should_return_decrypted_instance() => _result.ShouldNotBeNull();
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_pii_but_no_subject_in_document.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_ReadModelComplianceHelper/when_releasing_json/and_schema_has_pii_but_no_subject_in_document.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_ReadModelComplianceHelper.when_releasing_json;
+
+public class and_schema_has_pii_but_no_subject_in_document : given.all_dependencies
+{
+    JsonObject _instance;
+    JsonObject _result;
+
+    void Establish() => _instance = new JsonObject { ["name"] = "encrypted-name" };
+
+    async Task Because() => _result = await ReadModelComplianceHelper.ReleaseJson(
+        _complianceManager,
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance);
+
+    [Fact] void should_return_original_instance() => _result.ShouldEqual(_instance);
+    [Fact] void should_not_call_compliance_manager() => _complianceManager.DidNotReceive().Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
@@ -11,6 +11,7 @@ using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Sinks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.given;
 
@@ -30,8 +31,11 @@ public class all_dependencies : Specification
     protected IJsonComplianceManager _complianceManager;
     protected Contracts.ReadModels.IReadModels _service;
 
+    protected IClusterClient _clusterClient;
+
     void Establish()
     {
+        _clusterClient = Substitute.For<IClusterClient, IKeyedServiceProvider>();
         _grainFactory = Substitute.For<IGrainFactory>();
         _storage = Substitute.For<IStorage>();
 
@@ -61,12 +65,11 @@ public class all_dependencies : Specification
         _readModel.GetDefinition().Returns(_readModelDefinition);
         _grainFactory.GetGrain<IReadModel>(Arg.Any<string>()).Returns(_readModel);
 
-        var clusterClient = Substitute.For<IClusterClient>();
         var expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
         _complianceManager = Substitute.For<IJsonComplianceManager>();
 
         _service = new ReadModels(
-            clusterClient,
+            _clusterClient,
             _grainFactory,
             _storage,
             expandoObjectConverter,

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_read_model_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_read_model_has_pii_property.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams;
+using ProjectionChangeset = Cratis.Chronicle.Projections.ProjectionChangeset;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_watching;
+
+public class and_read_model_has_pii_property : given.all_dependencies
+{
+    IStreamProvider _streamProvider;
+    IAsyncStream<ProjectionChangeset> _changesetStream;
+    StreamSubscriptionHandle<ProjectionChangeset> _subscriptionHandle;
+    TaskCompletionSource _observerCaptured;
+    IAsyncObserver<ProjectionChangeset>? _capturedObserver;
+
+    void Establish()
+    {
+        var property = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata(Guid.NewGuid(), string.Empty) } }
+            }
+        };
+
+        _readModelDefinition = _readModelDefinition with
+        {
+            Schemas = new Dictionary<Concepts.ReadModels.ReadModelGeneration, JsonSchema>
+            {
+                {
+                    (Concepts.ReadModels.ReadModelGeneration)1,
+                    new JsonSchema { Properties = { ["name"] = property } }
+                }
+            }
+        };
+        _readModel.GetDefinition().Returns(Task.FromResult(_readModelDefinition));
+
+        _observerCaptured = new();
+        _streamProvider = Substitute.For<IStreamProvider>();
+        _changesetStream = Substitute.For<IAsyncStream<ProjectionChangeset>>();
+        _subscriptionHandle = Substitute.For<StreamSubscriptionHandle<ProjectionChangeset>>();
+
+        // GetStreamProvider resolves via ServiceProvider.GetRequiredKeyedService<IStreamProvider>(name).
+        // Make ServiceProvider return the _clusterClient itself, which also implements IKeyedServiceProvider.
+        _clusterClient.ServiceProvider.Returns((IServiceProvider)_clusterClient);
+        var keyedClient = (IKeyedServiceProvider)_clusterClient;
+        keyedClient.GetKeyedService(Arg.Any<Type>(), Arg.Any<object?>()).Returns(_streamProvider);
+        keyedClient.GetRequiredKeyedService(Arg.Any<Type>(), Arg.Any<object?>()).Returns(_streamProvider);
+
+        _streamProvider.GetStream<ProjectionChangeset>(Arg.Any<StreamId>()).Returns(_changesetStream);
+        _subscriptionHandle.UnsubscribeAsync().Returns(Task.CompletedTask);
+
+        // Set up all SubscribeAsync overloads — the exact one called depends on which Orleans extension is used
+        Task<StreamSubscriptionHandle<ProjectionChangeset>> SubscribeHandler(NSubstitute.Core.CallInfo ci)
+        {
+            _capturedObserver = ci.Arg<IAsyncObserver<ProjectionChangeset>>();
+            _observerCaptured.SetResult();
+            return Task.FromResult(_subscriptionHandle);
+        }
+
+        _changesetStream.SubscribeAsync(Arg.Any<IAsyncObserver<ProjectionChangeset>>())
+            .Returns(SubscribeHandler);
+        _changesetStream.SubscribeAsync(Arg.Any<IAsyncObserver<ProjectionChangeset>>(), Arg.Any<StreamSequenceToken?>())
+            .Returns(SubscribeHandler);
+        _changesetStream.SubscribeAsync(Arg.Any<IAsyncObserver<ProjectionChangeset>>(), Arg.Any<StreamSequenceToken?>(), Arg.Any<string?>())
+            .Returns(SubscribeHandler);
+
+        _complianceManager
+            .Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), Arg.Any<string>(), Arg.Any<JsonObject>())
+            .Returns(ci => Task.FromResult(new JsonObject { ["name"] = "decrypted-value" }));
+    }
+
+    async Task Because()
+    {
+        _service.Watch(
+            new WatchRequest { EventStore = "test-store", ReadModelIdentifier = "test-read-model" },
+            default).Subscribe(_ => { });
+
+        await _observerCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var model = new JsonObject
+        {
+            [WellKnownProperties.Subject] = "some-subject",
+            ["name"] = "encrypted-name"
+        };
+
+        await _capturedObserver!.OnNextAsync(new ProjectionChangeset("test-namespace", "key-1", model));
+    }
+
+    [Fact] void should_call_compliance_manager_release() => _complianceManager.Received(1).Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<JsonSchema>(), "some-subject", Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core/Compliance/ReadModelComplianceHelper.cs
+++ b/Source/Kernel/Core/Compliance/ReadModelComplianceHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Schemas;
@@ -45,6 +46,35 @@ public static class ReadModelComplianceHelper
         var result = converter.ToExpandoObject(applied, schema);
         ((IDictionary<string, object?>)result)[WellKnownProperties.Subject] = identifier;
         return result;
+    }
+
+    /// <summary>
+    /// Decrypts PII fields in a read model <see cref="JsonObject"/> instance using the stored <c>__subject</c> field.
+    /// </summary>
+    /// <param name="complianceManager">The <see cref="IJsonComplianceManager"/> to use for releasing compliance.</param>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the read model belongs to.</param>
+    /// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> the read model belongs to.</param>
+    /// <param name="schema">The <see cref="JsonSchema"/> describing the read model's properties.</param>
+    /// <param name="instance">The <see cref="JsonObject"/> read model instance to decrypt.</param>
+    /// <returns>A <see cref="JsonObject"/> with PII fields decrypted, or the original instance if no subject is stored.</returns>
+    public static async Task<JsonObject> ReleaseJson(
+        IJsonComplianceManager complianceManager,
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        JsonSchema schema,
+        JsonObject instance)
+    {
+        if (!schema.HasComplianceMetadata())
+        {
+            return instance;
+        }
+
+        if (instance[WellKnownProperties.Subject]?.GetValue<string>() is not string identifier)
+        {
+            return instance;
+        }
+
+        return await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, instance);
     }
 
     /// <summary>

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
@@ -120,10 +120,16 @@ public class ProjectionObserverSubscriber(
             {
                 var model = expandoObjectConverter.ToJsonObject(changeset.CurrentState, _schema!);
 
-                // Mirror the metadata field that the storage sink writes so that watched models
+                // Mirror the metadata fields that the storage sink writes so that watched models
                 // match what a direct read from the underlying store returns.
                 model[WellKnownProperties.LasHandledEventSequenceNumber] =
                     JsonValue.Create((ulong)lastSuccessfullyObservedEvent!.Context.SequenceNumber);
+
+                var stateDict = (IDictionary<string, object?>)changeset.CurrentState;
+                if (stateDict.TryGetValue(WellKnownProperties.Subject, out var subjectValue) && subjectValue is string subject)
+                {
+                    model[WellKnownProperties.Subject] = JsonValue.Create(subject);
+                }
 
                 await _changeStream!.OnNextAsync(new ProjectionChangeset(_key.Namespace, partition.ToString(), model));
             }

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -303,17 +303,23 @@ internal sealed class ReadModels(
 
                 var stream = streamProvider.GetStream<ProjectionChangeset>(streamId);
 
-                var subscription = await stream.SubscribeAsync((changeset, _) =>
+                var schema = definition.GetSchemaForLatestGeneration();
+                var subscription = await stream.SubscribeAsync(async (changeset, _) =>
                 {
+                    var decrypted = await ReadModelComplianceHelper.ReleaseJson(
+                        complianceManager,
+                        request.EventStore,
+                        changeset.Namespace,
+                        schema,
+                        changeset.ReadModel);
+
                     observer.OnNext(new ReadModelChangeset
                     {
                         Namespace = changeset.Namespace,
                         ModelKey = changeset.ReadModelKey,
-                        ReadModel = changeset.ReadModel.ToJsonString(jsonSerializerOptions),
+                        ReadModel = decrypted.ToJsonString(jsonSerializerOptions),
                         Removed = false
                     });
-
-                    return Task.CompletedTask;
                 });
 
                 context.CancellationToken.Register(() => subscription.UnsubscribeAsync().GetAwaiter().GetResult());

--- a/Source/Kernel/Storage/WellKnownProperties.cs
+++ b/Source/Kernel/Storage/WellKnownProperties.cs
@@ -23,5 +23,5 @@ public static class WellKnownProperties
     /// <summary>
     /// The property name for the subject (compliance identity target) of the event.
     /// </summary>
-    public const string Subject = "_subject";
+    public const string Subject = "__subject";
 }


### PR DESCRIPTION
## Fixed
- PII fields in watched read models were sent to clients encrypted because the \`__subject\` field (used as the encryption-key reference) was dropped when the projection subscriber converted the encrypted state to JSON. The subject is now copied into the stream changeset alongside \`__lastHandledEventSequenceNumber\`, and \`ReadModels.Watch\` decrypts each changeset before forwarding it to the client.
- \`WellKnownProperties.Subject\` was using a single-underscore prefix (\`_subject\`) inconsistent with all other well-known property constants (\`__initialized\`, \`__lastHandledEventSequenceNumber\`). Renamed to \`__subject\`.

## Added
- \`ReadModelComplianceHelper.ReleaseJson\` — decrypts PII directly from a \`JsonObject\` by reading the stored \`__subject\` field, avoiding an \`ExpandoObject\` roundtrip for callers that already hold JSON.