### PR TITLE
Fix kernel stability: observer retry deduplication, unresolvable projection key short-circuit

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/TestableCatchUpObserver.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/TestableCatchUpObserver.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_CatchUpObserver;
+
+/// <summary>
+/// A testable subclass of <see cref="CatchUpObserver"/> that exposes the grain interface type
+/// to satisfy the <c>IFoo → Foo</c> convention expected by the testing infrastructure.
+/// </summary>
+/// <param name="catchupServiceClient">The <see cref="IObserverServiceClient"/> for catch-up notifications.</param>
+/// <param name="storage">The <see cref="IStorage"/> for accessing key indexes.</param>
+/// <param name="jsonSerializerOptions">The serializer options used for JSON serialization.</param>
+/// <param name="logger">The logger.</param>
+public class TestableCatchUpObserver(
+    IObserverServiceClient catchupServiceClient,
+    IStorage storage,
+    JsonSerializerOptions jsonSerializerOptions,
+    ILogger<CatchUpObserver> logger)
+    : CatchUpObserver(catchupServiceClient, storage, jsonSerializerOptions, logger), IGrainType
+{
+    /// <inheritdoc/>
+    public Type GrainType => typeof(ICatchUpObserver);
+
+    /// <inheritdoc/>
+    protected override Task<IImmutableList<JobStepDetails>> PrepareSteps(CatchUpObserverRequest request) =>
+        base.PrepareSteps(request);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/given/TestObserverKeys.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/given/TestObserverKeys.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Storage.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_CatchUpObserver.given;
+
+class TestObserverKeys(IEnumerable<Key> keys) : IObserverKeys
+{
+    public async IAsyncEnumerator<Key> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+        {
+            yield return key;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/given/a_catch_up_observer_job.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/given/a_catch_up_observer_job.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Chronicle.Storage.Keys;
+using Cratis.Monads;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Core;
+using Orleans.TestKit;
+using Orleans.Utilities;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
+using IEventStoreNamespaceStorage = Cratis.Chronicle.Storage.IEventStoreNamespaceStorage;
+using IEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_CatchUpObserver.given;
+
+public class a_catch_up_observer_job : Specification
+{
+    protected TestKitSilo _silo = new();
+    protected TestableCatchUpObserver _job;
+    protected IObserver _observer;
+    protected IObserverServiceClient _catchupServiceClient;
+    protected IChronicleStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IJobStorage _jobStorage;
+    protected IJobStepStorage _jobStepStorage;
+    protected IJobTypes _jobTypes;
+    protected IObserverKeyIndexes _keyIndexes;
+    protected IObserverKeyIndex _keyIndex;
+    protected JobId _jobId;
+    protected JobKey _jobKey;
+    protected CatchUpObserverRequest _request;
+    protected IStorage<JobStateWithLastHandledEvent> _stateStorage;
+
+    protected static IObserverKeys CreateKeys(params Key[] keys) => new TestObserverKeys(keys);
+
+    async Task Establish()
+    {
+        _jobId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        _jobKey = new("event-store", "namespace");
+
+        var observerKey = new ObserverKey("observer-id", "event-store", "namespace", EventSequenceId.Log);
+        _request = new(
+            observerKey,
+            ObserverType.Projection,
+            EventSequenceNumber.First,
+            []);
+
+        _catchupServiceClient = Substitute.For<IObserverServiceClient>();
+        _storage = Substitute.For<IChronicleStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _jobStorage = Substitute.For<IJobStorage>();
+        _jobStepStorage = Substitute.For<IJobStepStorage>();
+        _jobTypes = Substitute.For<IJobTypes>();
+        _keyIndexes = Substitute.For<IObserverKeyIndexes>();
+        _keyIndex = Substitute.For<IObserverKeyIndex>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_namespaceStorage);
+        _namespaceStorage.Jobs.Returns(_jobStorage);
+        _namespaceStorage.JobSteps.Returns(_jobStepStorage);
+        _namespaceStorage.ObserverKeyIndexes.Returns(_keyIndexes);
+
+        _keyIndexes.GetFor(Arg.Any<ObserverKey>()).Returns(Task.FromResult(_keyIndex));
+        _keyIndex.GetKeys(Arg.Any<EventSequenceNumber>()).Returns(CreateKeys());
+
+        _jobStepStorage.GetForJob(Arg.Any<JobId>(), Arg.Any<JobStepStatus[]>())
+            .Returns(Task.FromResult(Catch<IImmutableList<JobStepState>>.Success(ImmutableList<JobStepState>.Empty)));
+
+        _jobTypes.GetFor(Arg.Any<Type>())
+            .Returns(Result<JobType, IJobTypes.GetForError>.Success(new JobType("CatchUpObserver")));
+
+        _silo.AddService(new JsonSerializerOptions());
+        _silo.AddService(_catchupServiceClient);
+        _silo.AddService(_storage);
+        _silo.AddService(_jobTypes);
+        _silo.AddService(NullLogger<IJob>.Instance);
+        _silo.AddService(NullLogger<ObserverManager<IJobObserver>>.Instance);
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        _silo.AddService(loggerFactory);
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(NullLogger.Instance);
+
+        _observer = Substitute.For<IObserver>();
+        _observer.GetFailedPartitionKeys().Returns(Task.FromResult(Enumerable.Empty<Key>()));
+        _silo.AddProbe(_ => _observer);
+
+        _stateStorage = _silo.StorageManager.GetStorage<JobStateWithLastHandledEvent>(
+            typeof(TestableCatchUpObserver).FullName!);
+
+        _job = await _silo.CreateGrainAsync<TestableCatchUpObserver>(_jobId, _jobKey);
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/when_preparing_steps/and_there_are_failed_partitions.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/when_preparing_steps/and_there_are_failed_partitions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_CatchUpObserver.when_preparing_steps;
+
+public class and_there_are_failed_partitions : given.a_catch_up_observer_job
+{
+    static readonly Key _key1 = (Key)"partition-1";
+    static readonly Key _key2 = (Key)"partition-2";
+    static readonly Key _key3 = (Key)"partition-3";
+    IEnumerable<Key>? _capturedKeys;
+
+    void Establish()
+    {
+        _keyIndex.GetKeys(Arg.Any<EventSequenceNumber>()).Returns(CreateKeys(_key1, _key2, _key3));
+        _observer.GetFailedPartitionKeys().Returns(Task.FromResult<IEnumerable<Key>>([_key2]));
+        _observer.When(o => o.RegisterCatchingUpPartitions(Arg.Any<IEnumerable<Key>>()))
+            .Do(call => _capturedKeys = call.Arg<IEnumerable<Key>>().ToList());
+    }
+
+    async Task Because() => await _job.Start(_request);
+
+    [Fact] void should_register_only_non_failed_keys() => _capturedKeys.ShouldNotBeNull();
+    [Fact] void should_include_first_partition() => _capturedKeys!.ShouldContain(_key1);
+    [Fact] void should_exclude_failed_partition() => _capturedKeys!.ShouldNotContain(_key2);
+    [Fact] void should_include_third_partition() => _capturedKeys!.ShouldContain(_key3);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/when_preparing_steps/and_there_are_no_failed_partitions.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_CatchUpObserver/when_preparing_steps/and_there_are_no_failed_partitions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_CatchUpObserver.when_preparing_steps;
+
+public class and_there_are_no_failed_partitions : given.a_catch_up_observer_job
+{
+    static readonly Key _key1 = (Key)"partition-1";
+    static readonly Key _key2 = (Key)"partition-2";
+    IEnumerable<Key>? _capturedKeys;
+
+    void Establish()
+    {
+        _keyIndex.GetKeys(Arg.Any<EventSequenceNumber>()).Returns(CreateKeys(_key1, _key2));
+        _observer.When(o => o.RegisterCatchingUpPartitions(Arg.Any<IEnumerable<Key>>()))
+            .Do(call => _capturedKeys = call.Arg<IEnumerable<Key>>().ToList());
+    }
+
+    async Task Because() => await _job.Start(_request);
+
+    [Fact] void should_register_all_keys_for_catching_up() => _capturedKeys.ShouldNotBeNull();
+    [Fact] void should_include_first_partition() => _capturedKeys!.ShouldContain(_key1);
+    [Fact] void should_include_second_partition() => _capturedKeys!.ShouldContain(_key2);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/TestableRetryFailedPartition.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/TestableRetryFailedPartition.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_RetryFailedPartition;
+
+/// <summary>
+/// A testable subclass of <see cref="RetryFailedPartition"/> that returns no job steps from
+/// <see cref="PrepareSteps"/>, causing <see cref="Job{TRequest,TJobState}.OnCompleted"/> to
+/// fire immediately when <see cref="IJob{TRequest}.Start"/> is called.
+/// </summary>
+/// <param name="jsonSerializerOptions">The serializer options used for JSON serialization.</param>
+/// <param name="logger">The logger.</param>
+public class TestableRetryFailedPartition(JsonSerializerOptions jsonSerializerOptions, ILogger<RetryFailedPartition> logger)
+    : RetryFailedPartition(jsonSerializerOptions, logger), IGrainType
+{
+    /// <inheritdoc/>
+    public Type GrainType => typeof(IRetryFailedPartition);
+
+    /// <inheritdoc/>
+    protected override Task<IImmutableList<JobStepDetails>> PrepareSteps(RetryFailedPartitionRequest request) =>
+        Task.FromResult<IImmutableList<JobStepDetails>>(ImmutableList<JobStepDetails>.Empty);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/given/a_retry_failed_partition_job.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/given/a_retry_failed_partition_job.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Monads;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Core;
+using Orleans.TestKit;
+using Orleans.Utilities;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
+using IEventStoreNamespaceStorage = Cratis.Chronicle.Storage.IEventStoreNamespaceStorage;
+using IEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_RetryFailedPartition.given;
+
+public class a_retry_failed_partition_job : Specification
+{
+    protected TestKitSilo _silo = new();
+    protected TestableRetryFailedPartition _job;
+    protected IObserver _observer;
+    protected IChronicleStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IJobStorage _jobStorage;
+    protected IJobStepStorage _jobStepStorage;
+    protected IJobTypes _jobTypes;
+    protected JobId _jobId;
+    protected JobKey _jobKey;
+    protected RetryFailedPartitionRequest _request;
+    protected IStorage<JobStateWithLastHandledEvent> _stateStorage;
+
+    async Task Establish()
+    {
+        _jobId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        _jobKey = new("event-store", "namespace");
+
+        var observerKey = new ObserverKey("observer-id", "event-store", "namespace", EventSequenceId.Log);
+        _request = new(
+            observerKey,
+            ObserverType.Projection,
+            (Key)"some-partition",
+            EventSequenceNumber.First,
+            []);
+
+        _storage = Substitute.For<IChronicleStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _jobStorage = Substitute.For<IJobStorage>();
+        _jobStepStorage = Substitute.For<IJobStepStorage>();
+        _jobTypes = Substitute.For<IJobTypes>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_namespaceStorage);
+        _namespaceStorage.Jobs.Returns(_jobStorage);
+        _namespaceStorage.JobSteps.Returns(_jobStepStorage);
+
+        _jobStepStorage.GetForJob(Arg.Any<JobId>(), Arg.Any<JobStepStatus[]>())
+            .Returns(Task.FromResult(Catch<IImmutableList<JobStepState>>.Success(ImmutableList<JobStepState>.Empty)));
+
+        _jobTypes.GetFor(Arg.Any<Type>())
+            .Returns(Result<JobType, IJobTypes.GetForError>.Success(new JobType("RetryFailedPartition")));
+
+        _silo.AddService(new JsonSerializerOptions());
+        _silo.AddService(_storage);
+        _silo.AddService(_jobTypes);
+        _silo.AddService(NullLogger<IJob>.Instance);
+        _silo.AddService(NullLogger<ObserverManager<IJobObserver>>.Instance);
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        _silo.AddService(loggerFactory);
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(NullLogger.Instance);
+
+        _observer = Substitute.For<IObserver>();
+        _silo.AddProbe(_ => _observer);
+
+        _stateStorage = _silo.StorageManager.GetStorage<JobStateWithLastHandledEvent>(
+            typeof(TestableRetryFailedPartition).FullName!);
+
+        _job = await _silo.CreateGrainAsync<TestableRetryFailedPartition>(_jobId, _jobKey);
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_all_events_were_handled.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_all_events_were_handled.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_RetryFailedPartition.when_completed;
+
+public class and_all_events_were_handled : given.a_retry_failed_partition_job
+{
+    static readonly EventSequenceNumber _lastHandled = 42UL;
+
+    void Establish()
+    {
+        _stateStorage.State.LastHandledEventSequenceNumber = _lastHandled;
+        _stateStorage.State.HandledAllEvents = true;
+    }
+
+    async Task Because() => await _job.Start(_request);
+
+    [Fact] void should_call_failed_partition_recovered() => _observer.Received(1).FailedPartitionRecovered((Key)"some-partition", _lastHandled);
+    [Fact] void should_not_call_failed_partition_partially_recovered() => _observer.DidNotReceive().FailedPartitionPartiallyRecovered(Arg.Any<Key>(), Arg.Any<EventSequenceNumber>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_no_events_were_handled.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_no_events_were_handled.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_RetryFailedPartition.when_completed;
+
+public class and_no_events_were_handled : given.a_retry_failed_partition_job
+{
+    async Task Because() => await _job.Start(_request);
+
+    [Fact] void should_not_call_failed_partition_recovered() => _observer.DidNotReceive().FailedPartitionRecovered(Arg.Any<Key>(), Arg.Any<EventSequenceNumber>());
+    [Fact] void should_not_call_failed_partition_partially_recovered() => _observer.DidNotReceive().FailedPartitionPartiallyRecovered(Arg.Any<Key>(), Arg.Any<EventSequenceNumber>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_not_all_events_were_handled.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_RetryFailedPartition/when_completed/and_not_all_events_were_handled.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_RetryFailedPartition.when_completed;
+
+public class and_not_all_events_were_handled : given.a_retry_failed_partition_job
+{
+    static readonly EventSequenceNumber _lastHandled = 20UL;
+
+    void Establish()
+    {
+        _stateStorage.State.LastHandledEventSequenceNumber = _lastHandled;
+        _stateStorage.State.HandledAllEvents = false;
+    }
+
+    async Task Because() => await _job.Start(_request);
+
+    [Fact] void should_call_failed_partition_partially_recovered() => _observer.Received(1).FailedPartitionPartiallyRecovered((Key)"some-partition", _lastHandled);
+    [Fact] void should_not_call_failed_partition_recovered() => _observer.DidNotReceive().FailedPartitionRecovered(Arg.Any<Key>(), Arg.Any<EventSequenceNumber>());
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
@@ -12,6 +13,7 @@ using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Observation.Jobs;
 using Cratis.Chronicle.Storage.EventTypes;
+using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Observation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -105,6 +107,9 @@ public class an_observer : Specification
 
         _eventSequence.GetTailSequenceNumber().Returns(EventSequenceNumber.Unavailable);
         _eventSequence.GetNextSequenceNumberGreaterOrEqualTo(Arg.Any<EventSequenceNumber>(), Arg.Any<IEnumerable<EventType>>()).Returns(EventSequenceNumber.Unavailable);
+
+        _jobsManager.GetJobsOfType<IRetryFailedPartition, RetryFailedPartitionRequest>()
+            .Returns(Task.FromResult<IImmutableList<JobState>>(ImmutableList<JobState>.Empty));
 
         _observer = await _silo.CreateGrainAsync<Observer>(_observerKey);
 

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/given/a_handle_event_step.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/given/a_handle_event_step.cs
@@ -5,6 +5,7 @@ using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.EventSequences;
@@ -50,6 +51,9 @@ public class a_handle_event_step : Specification
             NeedsInitialState: false);
 
         _projection = Substitute.For<IProjection>();
+        _projection.Identifier.Returns(new ProjectionId("test-projection"));
+        _projection.Path.Returns(new ProjectionPath("TestProjection"));
+        _projection.ChildProjections.Returns([]);
         _projection.InitialModelState.Returns(_projectionInitialModelState);
         _projection.TargetReadModelSchema.Returns(new JsonSchema { Title = "TestModel" });
     }

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_child_key_is_unresolvable.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_child_key_is_unresolvable.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_HandleEvent;
+
+public class when_child_key_is_unresolvable : given.a_handle_event_step
+{
+    IProjection _childProjection;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        _childProjection = Substitute.For<IProjection>();
+        _childProjection.Path.Returns(new ProjectionPath("Items"));
+        _childProjection.Identifier.Returns(new ProjectionId("items-child"));
+        _childProjection.ChildrenPropertyPath.Returns(new PropertyPath("Items"));
+        _childProjection.ChildProjections.Returns([]);
+        _childProjection.HasKeyResolverFor(_event.Context.EventType).Returns(true);
+        _childProjection.GetKeyResolverFor(_event.Context.EventType).Returns(
+            (_, _, _) => Task.FromResult(KeyResolverResult.Unresolvable()));
+
+        _projection.Accepts(_event.Context.EventType).Returns(false);
+        _projection.ChildrenPropertyPath.Returns(PropertyPath.Root);
+        _projection.ChildProjections.Returns([_childProjection]);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_return_context() => _result.ShouldEqual(_context);
+    [Fact] void should_not_add_any_deferred_futures() => _result.DeferredFutures.ShouldBeEmpty();
+    [Fact] void should_not_call_child_on_next() => _childProjection.DidNotReceive().OnNext(Arg.Any<ProjectionEventContext>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_root_key_is_unresolvable.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_root_key_is_unresolvable.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_HandleEvent;
+
+public class when_root_key_is_unresolvable : given.a_handle_event_step
+{
+    ProjectionEventContext _result;
+
+    void Establish() => _context.MarkKeyUnresolvable();
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_return_context() => _result.ShouldEqual(_context);
+    [Fact] void should_not_call_on_next() => _projection.DidNotReceive().OnNext(Arg.Any<ProjectionEventContext>());
+}

--- a/Source/Kernel/Core/Observation/IObserver.cs
+++ b/Source/Kernel/Core/Observation/IObserver.cs
@@ -166,6 +166,13 @@ public interface IObserver : IStateMachine<ObserverState>, IGrainWithStringKey
     Task<bool> HasFailedPartitions();
 
     /// <summary>
+    /// Get the keys of all currently failed partitions.
+    /// </summary>
+    /// <returns>Collection of <see cref="Key"/> for failed partitions.</returns>
+    [AlwaysInterleave]
+    Task<IEnumerable<Key>> GetFailedPartitionKeys();
+
+    /// <summary>
     /// Catch up the observer.
     /// </summary>
     /// <returns>Awaitable task.</returns>

--- a/Source/Kernel/Core/Observation/Jobs/CatchUpObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/CatchUpObserver.cs
@@ -83,6 +83,8 @@ public class CatchUpObserver(
     protected override async Task<IImmutableList<JobStepDetails>> PrepareSteps(CatchUpObserverRequest request)
     {
         var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey);
+        var failedPartitions = await observer.GetFailedPartitionKeys();
+        var failedPartitionSet = failedPartitions.ToHashSet();
 
         var observerKeyIndexes = storage.GetEventStore(JobKey.EventStore).GetNamespace(JobKey.Namespace).ObserverKeyIndexes;
         var index = await observerKeyIndexes.GetFor(request.ObserverKey);
@@ -93,6 +95,11 @@ public class CatchUpObserver(
 
         await foreach (var key in keys)
         {
+            if (failedPartitionSet.Contains(key))
+            {
+                continue;
+            }
+
             steps.Add(CreateStep<IHandleEventsForPartition>(
                 new HandleEventsForPartitionArguments(
                     request.ObserverKey,

--- a/Source/Kernel/Core/Observation/Jobs/RetryFailedPartition.cs
+++ b/Source/Kernel/Core/Observation/Jobs/RetryFailedPartition.cs
@@ -25,17 +25,19 @@ public class RetryFailedPartition(
         using var scope = logger.BeginJobScope(JobId, JobKey);
         var observer = GrainFactory.GetGrain<IObserver>(Request.ObserverKey);
 
-        if (State is { HandledAllEvents: false, LastHandledEventSequenceNumber.IsActualValue: true })
-        {
-            logger.NotAllEventsWereHandled(nameof(RetryFailedPartition), State.LastHandledEventSequenceNumber);
-            await observer.FailedPartitionPartiallyRecovered(Request.Key, State.LastHandledEventSequenceNumber);
-        }
-
         if (!State.LastHandledEventSequenceNumber.IsActualValue)
         {
             logger.NoEventsWereHandled(nameof(RetryFailedPartition));
             return;
         }
+
+        if (!State.HandledAllEvents)
+        {
+            logger.NotAllEventsWereHandled(nameof(RetryFailedPartition), State.LastHandledEventSequenceNumber);
+            await observer.FailedPartitionPartiallyRecovered(Request.Key, State.LastHandledEventSequenceNumber);
+            return;
+        }
+
         await observer.FailedPartitionRecovered(Request.Key, State.LastHandledEventSequenceNumber);
     }
 

--- a/Source/Kernel/Core/Observation/Observer.Failing.cs
+++ b/Source/Kernel/Core/Observation/Observer.Failing.cs
@@ -97,6 +97,10 @@ public partial class Observer
     {
         using var scope = logger.BeginObserverScope(_observerId, _observerKey);
         logger.TryingToRecoverFailedPartition(failedPartition.Partition);
-        await _jobsManager.Start<IRetryFailedPartition, RetryFailedPartitionRequest>(new(_observerKey, Definition.Type, failedPartition.Partition, failedPartition.LastAttempt.SequenceNumber, Definition.EventTypes));
+        var request = new RetryFailedPartitionRequest(_observerKey, Definition.Type, failedPartition.Partition, failedPartition.LastAttempt.SequenceNumber, Definition.EventTypes);
+        await _jobsManager.StartOrResumeObserverJobFor<IRetryFailedPartition, RetryFailedPartitionRequest>(
+            logger,
+            request,
+            requestPredicate: r => r.Key == failedPartition.Partition);
     }
 }

--- a/Source/Kernel/Core/Observation/Observer.cs
+++ b/Source/Kernel/Core/Observation/Observer.cs
@@ -126,6 +126,9 @@ public partial class Observer(
     public Task<bool> HasFailedPartitions() => Task.FromResult(Failures.HasFailedPartitions);
 
     /// <inheritdoc/>
+    public Task<IEnumerable<Key>> GetFailedPartitionKeys() => Task.FromResult(Failures.Partitions.Select(p => p.Partition));
+
+    /// <inheritdoc/>
     public Task<IEnumerable<EventType>> GetEventTypes() => Task.FromResult(Definition.EventTypes);
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Projections/Engine/KeyResolverResult.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolverResult.cs
@@ -25,4 +25,11 @@ public abstract record KeyResolverResult
     /// <param name="future">The projection future.</param>
     /// <returns>A <see cref="DeferredKey"/> result.</returns>
     public static KeyResolverResult Deferred(ProjectionFuture future) => new DeferredKey(future);
+
+    /// <summary>
+    /// Creates an unresolvable result — all resolution strategies were exhausted.
+    /// No future is created; the event is silently skipped for the affected child projection.
+    /// </summary>
+    /// <returns>An <see cref="UnresolvableKey"/> result.</returns>
+    public static KeyResolverResult Unresolvable() => new UnresolvableKey();
 }

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -499,7 +499,14 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         // For a 4-level hierarchy (Root → Feature → Slice → EventItem), the parent (Slice) has
         // ChildrenPropertyPath = "slices" which is relative to Feature, not to root. We need
         // "features.slices.id" — so we must walk up the hierarchy to collect all segments.
+        // For a 2-level hierarchy (Root → Hub) where the parent is the root (ChildrenPropertyPath
+        // not set), the child's ChildrenPropertyPath ("hubs") provides the collection prefix, giving
+        // "hubs.id" so the sink can locate the root document containing the matching hub.
         var childPropertyPath = BuildFullParentChildPropertyPath(parentProjection, parentIdentifiedByProperty);
+        if (!parentProjection.ChildrenPropertyPath.IsSet && projection.ChildrenPropertyPath.IsSet)
+        {
+            childPropertyPath = new PropertyPath($"{projection.ChildrenPropertyPath}.{childPropertyPath}");
+        }
         logger.FromParentHierarchyLookupBySink(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
 
         logger.FromParentHierarchySinkQuery(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
@@ -522,22 +529,14 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
 
         logger.FromParentHierarchySinkDidNotFindRoot(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
 
-        // Determine which identifier to use:
-        // - For root parents: use the child's identifier (how the child is identified in the root's collection)
-        // - For nested parents: use the parent's identifier (how the parent is identified in its parent's collection)
-        var parentIdentifierForFuture = parentProjection.HasParent
-            ? parentProjection.IdentifiedByProperty
-            : projection.IdentifiedByProperty;
-
-        var future = CreateDeferredFutureObject(
-            projection,
-            @event,
-            parentProjection.ChildrenPropertyPath,
-            identifiedByProperty,
-            parentIdentifierForFuture,
-            parentKey);
-
-        return new ParentEventResult(null, KeyResolverResult.Deferred(future));
+        // All resolution strategies failed: event log, child creation event, and sink lookup all returned nothing.
+        // This is almost always a sign of a badly-defined projection (wrong parent key property, missing parent
+        // event type, or out-of-order events whose parent truly never exists). Creating a deferred future here
+        // would cause it to accumulate across every subsequent event in the batch without ever resolving, creating
+        // an ever-growing MongoDB read on each event. Signal this as permanently unresolvable instead so the
+        // event is silently skipped and no future is stored.
+        logger.FromParentHierarchyKeyUnresolvable(projection.Path, parentKey.Value?.ToString() ?? "null");
+        return new ParentEventResult(null, KeyResolverResult.Unresolvable());
     }
 
     ProjectionFuture CreateDeferredFutureObject(

--- a/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
@@ -132,4 +132,7 @@ internal static partial class KeyResolversLogMessages
 
     [LoggerMessage(LogLevel.Debug, "FromParentHierarchy: resolved key via child's creation event type='{EventType}', key='{Key}'")]
     internal static partial void FromParentHierarchyResolvedViaChildCreationEvent(this ILogger<KeyResolvers> logger, string eventType, string key);
+
+    [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: all resolution strategies exhausted for child projection '{Path}' with parent key '{ParentKey}' — event will be skipped (no future created). This typically indicates a badly-defined projection.")]
+    internal static partial void FromParentHierarchyKeyUnresolvable(this ILogger<KeyResolvers> logger, string path, string parentKey);
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/HandleEvent.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/HandleEvent.cs
@@ -19,6 +19,13 @@ public class HandleEvent(IEventSequenceStorage eventSequenceStorage, ISink sink,
     public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
     {
         logger.HandlingEvent(context.Event.Context.SequenceNumber);
+
+        if (context.IsUnresolvable)
+        {
+            logger.SkippingDueToUnresolvableKey(context.Event.Context.SequenceNumber, projection.Identifier, projection.Path);
+            return context;
+        }
+
         var eventType = context.Event.Context.EventType;
         if (projection.Accepts(eventType))
         {
@@ -42,6 +49,13 @@ public class HandleEvent(IEventSequenceStorage eventSequenceStorage, ISink sink,
                 {
                     logger.ChildKeyResolutionDeferred(child.Path, eventType.Id, context.Event.Context.SequenceNumber);
                     context.AddDeferredFuture(deferredChild.Future);
+                    continue;
+                }
+
+                // Handle permanently unresolvable key — skip this child with no future created
+                if (keyResult is UnresolvableKey)
+                {
+                    logger.ChildKeyUnresolvable(child.Path, eventType.Id, context.Event.Context.SequenceNumber);
                     continue;
                 }
 

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/HandleEventLogging.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/HandleEventLogging.cs
@@ -33,4 +33,10 @@ internal static partial class HandleEventLogging
 
     [LoggerMessage(LogLevel.Debug, "Child projection '{ChildPath}' key resolution deferred for event type '{EventType}' at sequence {SequenceNumber} - creating future")]
     internal static partial void ChildKeyResolutionDeferred(this ILogger<HandleEvent> logger, string childPath, EventTypeId eventType, ulong sequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "Child projection '{ChildPath}' key is unresolvable for event type '{EventType}' at sequence {SequenceNumber} - child event skipped with no future created. This typically indicates a badly-defined projection.")]
+    internal static partial void ChildKeyUnresolvable(this ILogger<HandleEvent> logger, string childPath, EventTypeId eventType, ulong sequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "Skipping HandleEvent for sequence {SequenceNumber} — projection '{ProjectionId}' at path '{Path}' has an unresolvable root key")]
+    internal static partial void SkippingDueToUnresolvableKey(this ILogger<HandleEvent> logger, ulong sequenceNumber, string projectionId, string path);
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveFutures.cs
@@ -30,8 +30,8 @@ public class ResolveFutures(
     /// <inheritdoc/>
     public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
     {
-        // If this event was deferred, don't try to resolve futures (we have no valid data yet)
-        if (context.IsDeferred)
+        // If this event was deferred or key is permanently unresolvable, don't try to resolve futures
+        if (context.IsDeferred || context.IsUnresolvable)
         {
             return context;
         }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveKey.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveKey.cs
@@ -35,6 +35,14 @@ public class ResolveKey(IEventSequenceStorage eventSequenceStorage, ISink sink, 
             return context;
         }
 
+        // Handle permanently unresolvable key - all resolution strategies exhausted with no parent found
+        if (keyResult is UnresolvableKey)
+        {
+            logger.KeyUnresolvable(context.Event.Context.SequenceNumber, projection.Identifier, projection.Path);
+            context.MarkKeyUnresolvable();
+            return context;
+        }
+
         var resolvedKey = (keyResult as ResolvedKey)!;
         var key = resolvedKey.Key;
         key = EnsureCorrectTypeForArrayIndexersOnKey(projection, key);

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveKeyLogging.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/ResolveKeyLogging.cs
@@ -16,4 +16,7 @@ internal static partial class ResolveKeyLogging
 
     [LoggerMessage(LogLevel.Debug, "Key resolution deferred for event {SequenceNumber} - projection '{ProjectionId}' at path '{Path}' - creating future")]
     internal static partial void KeyResolutionDeferred(this ILogger<ResolveKey> logger, ulong sequenceNumber, string projectionId, string path);
+
+    [LoggerMessage(LogLevel.Warning, "Key is unresolvable for event {SequenceNumber} - projection '{ProjectionId}' at path '{Path}' - event will be skipped. This typically indicates a badly-defined projection.")]
+    internal static partial void KeyUnresolvable(this ILogger<ResolveKey> logger, ulong sequenceNumber, string projectionId, string path);
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SaveChanges.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SaveChanges.cs
@@ -18,8 +18,8 @@ public class SaveChanges(ISink sink, IChangesetStorage changesetStorage, ILogger
     /// <inheritdoc/>
     public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
     {
-        // Don't save if the event was deferred (waiting for parent data)
-        if (context.IsDeferred)
+        // Don't save if the event was deferred or the key is permanently unresolvable
+        if (context.IsDeferred || context.IsUnresolvable)
         {
             logger.NotSavingDueToDeferred(context.Event.Context.SequenceNumber);
             return context;

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SetInitialState.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/SetInitialState.cs
@@ -21,8 +21,8 @@ public class SetInitialState(ISink sink, ILogger<SetInitialState> logger) : ICan
     /// <inheritdoc/>
     public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
     {
-        // Don't set initial state if the event was deferred (key is undefined)
-        if (context.IsDeferred)
+        // Don't set initial state if the event was deferred or the key is permanently unresolvable
+        if (context.IsDeferred || context.IsUnresolvable)
         {
             return context;
         }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/StoreFutures.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/StoreFutures.cs
@@ -17,6 +17,11 @@ public class StoreFutures(
     /// <inheritdoc/>
     public async ValueTask<ProjectionEventContext> Perform(IProjection projection, ProjectionEventContext context)
     {
+        if (context.IsUnresolvable)
+        {
+            return context;
+        }
+
         // Store any deferred futures that were created during processing
         foreach (var future in context.DeferredFutures)
         {

--- a/Source/Kernel/Core/Projections/Engine/ProjectionEventContext.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionEventContext.cs
@@ -30,6 +30,7 @@ public record ProjectionEventContext(
     readonly List<ProjectionFuture> _deferredFutures = [];
     readonly List<FailedPartition> _failedPartitions = [];
     readonly List<PendingFutureSave> _pendingFutureSaves = [];
+    bool _isKeyUnresolvable;
 
     /// <summary>
     /// Gets the collection of deferred futures that need to be stored.
@@ -40,6 +41,12 @@ public record ProjectionEventContext(
     /// Gets whether this event has been deferred (has futures that couldn't be resolved).
     /// </summary>
     public bool IsDeferred => _deferredFutures.Count > 0;
+
+    /// <summary>
+    /// Gets whether the root key could not be resolved after all strategies were exhausted.
+    /// The event is silently skipped for this projection when true.
+    /// </summary>
+    public bool IsUnresolvable => _isKeyUnresolvable;
 
     /// <summary>
     /// Gets the collection of failed partitions from bulk operations.
@@ -90,6 +97,11 @@ public record ProjectionEventContext(
 
         _deferredFutures.Add(future);
     }
+
+    /// <summary>
+    /// Marks the root key as permanently unresolvable. Subsequent pipeline steps skip all processing.
+    /// </summary>
+    public void MarkKeyUnresolvable() => _isKeyUnresolvable = true;
 
     /// <summary>
     /// Adds a failed partition to the context.

--- a/Source/Kernel/Core/Projections/Engine/UnresolvableKey.cs
+++ b/Source/Kernel/Core/Projections/Engine/UnresolvableKey.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.Engine;
+
+/// <summary>
+/// Represents a key resolution that permanently failed — all resolution strategies were exhausted
+/// and no parent was found. No deferred future is created; the event is silently skipped for the
+/// affected child projection.
+/// </summary>
+public record UnresolvableKey : KeyResolverResult;

--- a/Source/Kernel/Core/Projections/IProjectionsManager.cs
+++ b/Source/Kernel/Core/Projections/IProjectionsManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Orleans.Concurrency;
 
 namespace Cratis.Chronicle.Projections;
 
@@ -20,6 +21,7 @@ public interface IProjectionsManager : IGrainWithStringKey
     /// Get all the <see cref="ProjectionDefinition">projection definitions</see> available.
     /// </summary>
     /// <returns>A collection of <see cref="ProjectionDefinition"/>.</returns>
+    [AlwaysInterleave]
     Task<IEnumerable<ProjectionDefinition>> GetProjectionDefinitions();
 
     /// <summary>


### PR DESCRIPTION
## Fixed

- `RetryFailedPartition.OnCompleted` called both `FailedPartitionPartiallyRecovered` and `FailedPartitionRecovered` when only partial recovery occurred, prematurely clearing the failure state and resetting the retry counter
- `Observer.StartRecoverJobForFailedPartition` always started a new retry job on every reminder tick and rehydration instead of deduplicating against already-running or stopped jobs for the same partition, causing 3+ concurrent retry jobs per failing partition
- `CatchUpObserver.PrepareSteps` iterated all partition keys without checking which partitions had already failed, causing catch-up steps to be created for partitions that were being retried — amplifying load on stuck subscriber grains
- `IProjectionsManager.GetProjectionDefinitions` was not marked `[AlwaysInterleave]`, causing it to queue behind the projections startup timer and time out (30 s) when the server started under load
- Projection engine created unbounded deferred futures for badly-defined projections (wrong parent key property or missing parent event type): each unresolvable event added a future that was re-evaluated on every subsequent event in the batch, creating an ever-growing MongoDB scan. Now signals `UnresolvableKey` and silently skips the event with a warning log
- `TryFindParentByFallback` built an incorrect sink query path for two-level hierarchies where the parent is at root level — produced `"id"` instead of `"hubs.id"` — preventing the sink from locating the correct root document