### PR TITLE
Fix post-release regressions: PII schema, Subject round-trip, and projection deferred key

### DIFF
--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_adorned_type.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_adorned_type.cs
@@ -9,7 +9,11 @@ namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
 public class when_generating_schema_for_pii_adorned_type : given.a_json_schema_generator_with_pii_support
 {
     [PII]
-    record PersonalData(string Name, string SocialSecurityNumber);
+    record PersonalData(string Value) : ConceptAs<string>(Value)
+    {
+        public static implicit operator PersonalData(string value) => new(value);
+        public static implicit operator string(PersonalData value) => value.Value;
+    }
 
     JsonSchema _result;
 

--- a/Source/Clients/DotNET/Events/EventContextConverters.cs
+++ b/Source/Clients/DotNET/Events/EventContextConverters.cs
@@ -55,5 +55,6 @@ internal static class EventContextConverters
         context.CausedBy.ToClient(),
         context.Tags.Select(_ => (Tag)_).ToArray(),
         context.Hash,
-        context.ObservationState.ToClient());
+        context.ObservationState.ToClient(),
+        Subject: new Subject(context.EventSourceId));
 }

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -108,14 +108,21 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
             // so we check the actual property nullability via NullabilityInfoContext. When the property
             // is nullable we append '?' to the format so that IsNullable() returns true and
             // GetDefaultValue() returns null rather than the primitive default (e.g. 0 for ulong).
-            if (IsNullableConceptProperty(context) &&
-                conceptSchema is JsonObject conceptSchemaObj &&
-                conceptSchemaObj.TryGetPropertyValue("format", out var format))
+            if (conceptSchema is JsonObject conceptSchemaObj)
             {
-                var formatStr = format!.GetValue<string>();
-                if (!formatStr.EndsWith('?'))
+                if (_metadataResolver.HasMetadataFor(type))
                 {
-                    conceptSchemaObj["format"] = formatStr + "?";
+                    AddComplianceMetadata(conceptSchemaObj, _metadataResolver.GetMetadataFor(type));
+                }
+
+                if (IsNullableConceptProperty(context) &&
+                    conceptSchemaObj.TryGetPropertyValue("format", out var format))
+                {
+                    var formatStr = format!.GetValue<string>();
+                    if (!formatStr.EndsWith('?'))
+                    {
+                        conceptSchemaObj["format"] = formatStr + "?";
+                    }
                 }
             }
 

--- a/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
+++ b/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
@@ -91,7 +91,7 @@ public static class EventsShouldExtensions
 
         var schema = await eventTypesStorage.GetFor(eventTypeId, eventTypeGeneration);
         var complianceManager = fixture.Services.GetRequiredService<KernelCompliance.IJsonComplianceManager>();
-        var identifier = context.Subject?.IsSet == true ? context.Subject.Value : context.EventSourceId.Value;
+        var identifier = context.Subject?.IsSet is true ? context.Subject.Value : context.EventSourceId.Value;
 
         return await complianceManager.Release(context.EventStore, context.Namespace, schema.Schema, identifier, contentAsJson);
     }

--- a/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
+++ b/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
@@ -1,9 +1,16 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+extern alias KernelCore;
+extern alias KernelConcepts;
+
+using System.Text.Json.Nodes;
 using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Storage.EventTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using KernelCompliance = KernelCore::Cratis.Chronicle.Compliance;
+using KernelEventContext = KernelConcepts::Cratis.Chronicle.Concepts.Events.EventContext;
 
 namespace Cratis.Chronicle.XUnit.Integration.Events;
 
@@ -31,6 +38,7 @@ public static class EventsShouldExtensions
         Assert.Equal(@event.Context.SequenceNumber.Value, sequenceNumber.Value);
         Assert.Equal(@event.Context.EventType.Id.Value, eventType.Id.Value);
         var contentAsJson = System.Text.Json.JsonSerializer.SerializeToNode(@event.Content)!.AsObject();
+        contentAsJson = await TryDecryptEventContent(fixture, @event.Context, contentAsJson);
         var eventObject = await fixture.Services.GetRequiredService<IEventSerializer>().Deserialize(eventClrType, contentAsJson);
         Assert.IsType<TEvent>(eventObject);
         var theEvent = (TEvent)eventObject;
@@ -65,5 +73,26 @@ public static class EventsShouldExtensions
         var storedEventLog = fixture.GetEventLogStorage();
         var storedNumber = await storedEventLog.GetTailSequenceNumber();
         Assert.Equal(storedNumber.Value, sequenceNumber.Value);
+    }
+
+    static async Task<JsonObject> TryDecryptEventContent(
+        IChronicleSetupFixture fixture,
+        KernelEventContext context,
+        JsonObject contentAsJson)
+    {
+        var eventTypesStorage = fixture.Services.GetRequiredService<IEventTypesStorage>();
+        var eventTypeId = context.EventType.Id;
+        var eventTypeGeneration = context.EventType.Generation;
+
+        if (!await eventTypesStorage.HasFor(eventTypeId, eventTypeGeneration))
+        {
+            return contentAsJson;
+        }
+
+        var schema = await eventTypesStorage.GetFor(eventTypeId, eventTypeGeneration);
+        var complianceManager = fixture.Services.GetRequiredService<KernelCompliance.IJsonComplianceManager>();
+        var identifier = context.Subject?.IsSet == true ? context.Subject.Value : context.EventSourceId.Value;
+
+        return await complianceManager.Release(context.EventStore, context.Namespace, schema.Schema, identifier, contentAsJson);
     }
 }

--- a/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
+++ b/Source/Clients/XUnit.Integration/Events/EventsShouldExtensions.cs
@@ -6,7 +6,6 @@ extern alias KernelConcepts;
 
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Events;
-using Cratis.Chronicle.Storage.EventTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using KernelCompliance = KernelCore::Cratis.Chronicle.Compliance;
@@ -80,7 +79,7 @@ public static class EventsShouldExtensions
         KernelEventContext context,
         JsonObject contentAsJson)
     {
-        var eventTypesStorage = fixture.Services.GetRequiredService<IEventTypesStorage>();
+        var eventTypesStorage = fixture.EventStoreStorage.EventTypes;
         var eventTypeId = context.EventType.Id;
         var eventTypeGeneration = context.EventType.Generation;
 

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -529,14 +529,22 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
 
         logger.FromParentHierarchySinkDidNotFindRoot(childPropertyPath.Path, parentKey.Value?.ToString() ?? "null");
 
-        // All resolution strategies failed: event log, child creation event, and sink lookup all returned nothing.
-        // This is almost always a sign of a badly-defined projection (wrong parent key property, missing parent
-        // event type, or out-of-order events whose parent truly never exists). Creating a deferred future here
-        // would cause it to accumulate across every subsequent event in the batch without ever resolving, creating
-        // an ever-growing MongoDB read on each event. Signal this as permanently unresolvable instead so the
-        // event is silently skipped and no future is stored.
-        logger.FromParentHierarchyKeyUnresolvable(projection.Path, parentKey.Value?.ToString() ?? "null");
-        return new ParentEventResult(null, KeyResolverResult.Unresolvable());
+        // All resolution strategies failed — the parent does not yet exist in the event log or sink.
+        // This is a normal out-of-order scenario: the child event arrived before its parent was created.
+        // Create a deferred future so the event is re-processed once the parent materializes.
+        var parentIdentifierForFuture = parentProjection.HasParent
+            ? parentProjection.IdentifiedByProperty
+            : projection.IdentifiedByProperty;
+
+        var future = CreateDeferredFutureObject(
+            projection,
+            @event,
+            parentProjection.ChildrenPropertyPath,
+            identifiedByProperty,
+            parentIdentifierForFuture,
+            parentKey);
+
+        return new ParentEventResult(null, KeyResolverResult.Deferred(future));
     }
 
     ProjectionFuture CreateDeferredFutureObject(

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_no_subject.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventConverter/when_converting_event_to_appended_event/and_event_has_no_subject.cs
@@ -18,6 +18,6 @@ public class and_event_has_no_subject : given.an_event_converter
 
     async Task Because() => _result = await _converter.ToAppendedEvent(_event);
 
-    [Fact] void should_set_subject_to_not_set() => _result.Context.Subject.ShouldEqual(Subject.NotSet);
+    [Fact] void should_set_subject_to_event_source_id() => _result.Context.Subject.ShouldEqual(new Subject("test-source"));
     [Fact] void should_be_subject_is_event_source_id() => _result.Context.SubjectIsEventSourceId.ShouldBeTrue();
 }


### PR DESCRIPTION
## Fixed

- PII compliance metadata now applied correctly to \`ConceptAs<T>\` types adorned with \`[PII]\` in the JSON schema generator — previously the concept path bypassed the compliance metadata check entirely
- \`EventContext.Subject\` defaults to \`EventSourceId\` when deserialising an \`AppendedEvent\` back from a contract that carries no \`Subject\` field, preventing a null-dereference on \`SubjectIsEventSourceId\`
- \`ShouldHaveAppendedEvent\` integration test helper now decrypts PII fields before asserting on event content, matching the architecture where decryption no longer happens in \`EventConverter\` (#3120)
- Restored deferred-future creation in \`TryFindParentByFallback\` so out-of-order child projection events (arriving before their parent is appended) are correctly deferred and re-processed once the parent materialises — the previous change incorrectly used \`UnresolvableKey\` for this legitimate scenario