### PR TITLE
Fix memory leak, race condition and hanging observable in Kernel

### DIFF
--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/two_subscribed_subscribers_with_an_event_type.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/two_subscribed_subscribers_with_an_event_type.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_AppendedEventsQueue.given;
+
+public class two_subscribed_subscribers_with_an_event_type : two_subscribed_subscribers
+{
+    protected EventType _eventType = new("Some event", 1);
+    protected AppendedEvent _appendedEvent;
+    protected EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _appendedEvent = AppendedEvent.Empty();
+        _eventSourceId = Guid.NewGuid();
+        _appendedEvent = _appendedEvent with
+        {
+            Context = EventContext.Empty with
+            {
+                EventType = _eventType,
+                EventSourceId = _eventSourceId
+            }
+        };
+    }
+
+    protected override IEnumerable<EventType> EventTypes => [_eventType];
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_first_of_two_subscribers_unsubscribed.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_first_of_two_subscribers_unsubscribed.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.EventSequences.for_AppendedEventsQueue.when_enqueuing;
+
+public class with_first_of_two_subscribers_unsubscribed : given.two_subscribed_subscribers_with_an_event_type
+{
+    void Establish() => _queue.Unsubscribe(_firstObserverKey);
+
+    async Task Because()
+    {
+        await _queue.Enqueue([_appendedEvent]);
+        await _queue.AwaitQueueDepletion();
+    }
+
+    [Fact] void should_not_deliver_event_to_unsubscribed_first_observer() => _firstObserverHandledEventsPerPartition.Count.ShouldEqual(0);
+    [Fact] void should_deliver_event_to_remaining_second_observer() => _secondObserverHandledEventsPerPartition.Count.ShouldEqual(1);
+    [Fact] void should_deliver_correct_event_to_second_observer() => _secondObserverHandledEventsPerPartition[_eventSourceId][0].Events.ShouldContainOnly(_appendedEvent);
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_lazy_enumerable.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_lazy_enumerable.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_AppendedEventsQueue.when_enqueuing;
+
+public class with_lazy_enumerable : given.a_single_subscriber_with_an_event_type
+{
+    AppendedEvent _appendedEvent;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _appendedEvent = AppendedEvent.Empty();
+        _eventSourceId = Guid.NewGuid();
+        _appendedEvent = _appendedEvent with
+        {
+            Context = EventContext.Empty with
+            {
+                EventType = _eventType,
+                EventSourceId = _eventSourceId
+            }
+        };
+    }
+
+    async Task Because()
+    {
+        var lazyEvents = new[] { _appendedEvent }.Where(_ => true);
+        await _queue.Enqueue(lazyEvents);
+        await _queue.AwaitQueueDepletion();
+    }
+
+    [Fact] void should_handle_event_once() => _handledEventsPerPartition[_eventSourceId].Count.ShouldEqual(1);
+    [Fact] void should_handle_correct_event() => _handledEventsPerPartition[_eventSourceId][0].Events.ShouldContainOnly(_appendedEvent);
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/Reducers/for_Reducers/when_observing/and_get_definition_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/Reducers/for_Reducers/when_observing/and_get_definition_fails.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Contracts.Observation.Reducers;
+using Cratis.Chronicle.Contracts.Primitives;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Observation.Reducers.Clients;
+using Cratis.Chronicle.ReadModels;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Services.Observation.Reducers.for_Reducers.when_observing;
+
+public class and_get_definition_fails : Specification
+{
+    Subject<ReducerMessage> _messages;
+    IReadModel _readModelGrain;
+    Reducers _reducers;
+    Exception _observedError;
+
+    void Establish()
+    {
+        var grainFactory = Substitute.For<IGrainFactory>();
+        _readModelGrain = Substitute.For<IReadModel>();
+        grainFactory.GetGrain<IReadModel>(Arg.Any<string>()).Returns(_readModelGrain);
+        _readModelGrain.GetDefinition()
+            .Returns(Task.FromException<ReadModelDefinition>(new InvalidOperationException("Read model definition unavailable")));
+
+        _reducers = new Reducers(
+            grainFactory,
+            Substitute.For<IReducerMediator>(),
+            Substitute.For<IExpandoObjectConverter>(),
+            new JsonSerializerOptions(),
+            NullLogger<Reducers>.Instance);
+
+        _messages = new Subject<ReducerMessage>();
+    }
+
+    async Task Because()
+    {
+        var errorSeen = new TaskCompletionSource();
+        var observable = _reducers.Observe(_messages, default);
+        observable.Subscribe(
+            _ => { },
+            ex =>
+            {
+                _observedError = ex;
+                errorSeen.TrySetResult();
+            },
+            () => { });
+
+        _messages.OnNext(new ReducerMessage(new OneOf<RegisterReducer, ReducerResult>(new RegisterReducer
+        {
+            ConnectionId = "test-connection",
+            EventStore = "test-store",
+            Namespace = "test-namespace",
+            Reducer = new ReducerDefinition
+            {
+                ReducerId = "test-reducer",
+                EventSequenceId = "event-log",
+                ReadModel = "test-read-model"
+            }
+        })));
+
+        await errorSeen.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact] void should_surface_an_error_on_the_observable() => _observedError.ShouldNotBeNull();
+}

--- a/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
@@ -24,12 +24,13 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     readonly IGrainFactory _grainFactory;
     readonly IMeter<AppendedEventsQueue> _meter;
     readonly ILogger<AppendedEventsQueue> _logger;
-    readonly ConcurrentQueue<IEnumerable<AppendedEvent>> _queue = new();
+    readonly ConcurrentQueue<IReadOnlyList<AppendedEvent>> _queue = new();
     readonly AsyncManualResetEvent _queueEvent = new();
     readonly AsyncManualResetEvent _queueEmptyEvent = new();
+    readonly Lock _subscriptionsLock = new();
+    readonly List<AppendedEventsQueueObserverSubscription> _subscriptions = [];
     Task _queueTask = Task.CompletedTask;
     bool _isDisposed;
-    ConcurrentBag<AppendedEventsQueueObserverSubscription> _subscriptions = [];
     IMeterScope<AppendedEventsQueue>? _metrics;
 
     /// <summary>
@@ -70,16 +71,21 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     /// <inheritdoc/>
     public Task Enqueue(IEnumerable<AppendedEvent> appendedEvents)
     {
-        _queue.Enqueue(appendedEvents);
+        var batch = appendedEvents as IReadOnlyList<AppendedEvent> ?? appendedEvents.ToList();
+        _queue.Enqueue(batch);
         _queueEvent.Set();
-        _metrics?.EventsEnqueued(appendedEvents.Count());
+        _metrics?.EventsEnqueued(batch.Count);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
     public Task Subscribe(ObserverKey observerKey, IEnumerable<EventType> eventTypes, ObserverFilters? filters = null)
     {
-        _subscriptions.Add(new(observerKey, eventTypes.Select(eventType => eventType.Id).ToArray(), filters));
+        lock (_subscriptionsLock)
+        {
+            _subscriptions.Add(new(observerKey, eventTypes.Select(eventType => eventType.Id).ToArray(), filters));
+        }
+
         return Task.CompletedTask;
     }
 
@@ -91,10 +97,9 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
             return Task.CompletedTask;
         }
 
-        var subscription = _subscriptions.SingleOrDefault(subscription => subscription.ObserverKey == observerKey);
-        if (subscription != null)
+        lock (_subscriptionsLock)
         {
-            _subscriptions = [.. _subscriptions.Except([subscription])];
+            _subscriptions.RemoveAll(subscription => subscription.ObserverKey == observerKey);
         }
 
         return Task.CompletedTask;
@@ -195,6 +200,14 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         return true;
     }
 
+    AppendedEventsQueueObserverSubscription[] GetSubscriptionsSnapshot()
+    {
+        lock (_subscriptionsLock)
+        {
+            return [.. _subscriptions];
+        }
+    }
+
     void StartQueueHandler()
     {
         if (_isDisposed)
@@ -225,8 +238,8 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
                     {
                         try
                         {
-                            var count = events.Count();
-                            Func<IEnumerable<AppendedEvent>, Task> handler = count == 1 ?
+                            var count = events.Count;
+                            Func<IReadOnlyList<AppendedEvent>, Task> handler = count == 1 ?
                                 HandleSingle :
                                 HandlePartitioned;
 
@@ -258,10 +271,10 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         }
     }
 
-    async Task HandleSingle(IEnumerable<AppendedEvent> events)
+    async Task HandleSingle(IReadOnlyList<AppendedEvent> events)
     {
-        var @event = events.First();
-        foreach (var subscription in _subscriptions)
+        var @event = events[0];
+        foreach (var subscription in GetSubscriptionsSnapshot())
         {
             if (!subscription.EventTypeIds.Contains(@event.Context.EventType.Id))
             {
@@ -279,7 +292,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         }
     }
 
-    async Task HandlePartitioned(IEnumerable<AppendedEvent> events)
+    async Task HandlePartitioned(IReadOnlyList<AppendedEvent> events)
     {
         // Sort events by sequence number and deliver consecutive same-partition batches.
         // This prevents a race condition where processing one partition's events first
@@ -300,7 +313,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
             var partitionEvents = sorted.GetRange(start, index - start);
 
             var tasks = new List<Task>();
-            foreach (var subscription in _subscriptions)
+            foreach (var subscription in GetSubscriptionsSnapshot())
             {
                 var actualEvents = partitionEvents
                     .Where(@event => subscription.EventTypeIds.Contains(@event.Context.EventType.Id) && MatchesFilters(subscription, @event))

--- a/Source/Kernel/Core/Jobs/JobStep.cs
+++ b/Source/Kernel/Core/Jobs/JobStep.cs
@@ -83,6 +83,7 @@ public abstract class JobStep<TRequest, TResult, TState>(
         state.State.Name = Name;
         state.State.Id = Identifier;
         state.State.Type = grainType;
+        _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = new();
     }
 
@@ -164,9 +165,10 @@ public abstract class JobStep<TRequest, TResult, TState>(
             }
 
             logger.Stopping();
-            var cancelTokenTask = _cancellationTokenSource?.CancelAsync() ?? Task.CompletedTask;
-            await cancelTokenTask;
+            var cts = _cancellationTokenSource;
             _cancellationTokenSource = null;
+            await (cts?.CancelAsync() ?? Task.CompletedTask);
+            cts?.Dispose();
             if (_currentlyRunning)
             {
                 return Result.Success<JobStepError>();

--- a/Source/Kernel/Core/Services/Observation/Reducers/Reducers.cs
+++ b/Source/Kernel/Core/Services/Observation/Reducers/Reducers.cs
@@ -79,11 +79,18 @@ internal sealed class Reducers(
                         register.Reducer.EventSequenceId,
                         register.ConnectionId);
 
-                    var readModel = grainFactory.GetReadModel(register.Reducer.ReadModel, register.EventStore).GetDefinition().ContinueWith(
+                    grainFactory.GetReadModel(register.Reducer.ReadModel, register.EventStore).GetDefinition().ContinueWith(
                         result =>
                         {
-                            model = result.Result;
-                            registrationTcs.SetResult(register);
+                            if (result.IsFaulted)
+                            {
+                                registrationTcs.TrySetException(result.Exception!.InnerExceptions);
+                            }
+                            else
+                            {
+                                model = result.Result;
+                                registrationTcs.TrySetResult(register);
+                            }
                         },
                         TaskScheduler.Current);
                     break;


### PR DESCRIPTION
## Fixed
- `CancellationTokenSource` leaked on every grain reactivation and after `Stop()` in `JobStep` — old instance was never disposed before being replaced or nulled (#3167)
- Race condition in `AppendedEventsQueue.Unsubscribe` where a concurrent `Subscribe` call could silently lose a subscription due to non-atomic read-modify-write on the collection (#3171)
- `IEnumerable<AppendedEvent>` passed to `AppendedEventsQueue.Enqueue` was enumerated multiple times (once for `Count()`, once for `First()`), causing incorrect behavior with lazy sequences (#3170)
- Faulted `GetDefinition()` in the reducer registration path left `registrationTcs` permanently unresolved, hanging the client gRPC stream indefinitely (#3172)