### PR TITLE
Fix key resolver infinite cycle and observer retry storm

### DIFF
--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_nested_event_within_grandchild_projection/and_child_creation_event_has_later_sequence_number_than_current_event.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_nested_event_within_grandchild_projection/and_child_creation_event_has_later_sequence_number_than_current_event.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_nested_event_within_grandchild_projection;
+
+/// <summary>
+/// When the candidate "child creation event" is at a later sequence number than the event being resolved,
+/// the cycle-detection guard must reject it and fall through to the sink lookup.
+/// A creation event that comes after the current event cannot be the anchor that establishes parentage
+/// for the current event; accepting it produces an infinite A→B→A resolution cycle.
+/// </summary>
+public class and_child_creation_event_has_later_sequence_number_than_current_event : given.a_three_level_hierarchy
+{
+    void Establish()
+    {
+        // Create a SliceAddedEvent at seq 5 — later than NestedCommandEvent (seq 3).
+        var creationEventAfterCurrentEvent = CreateEvent(5, SliceAddedEventType, SliceKey, new System.Dynamic.ExpandoObject());
+
+        Storage.GetHeadSequenceNumber(Arg.Any<IEnumerable<EventType>>(), (EventSourceId)SliceKey)
+            .Returns(new EventSequenceNumber(5));
+        var cursor = CreateCursorWith(creationEventAfterCurrentEvent);
+        Storage.GetRange(
+                Arg.Any<EventSequenceNumber>(),
+                Arg.Any<EventSequenceNumber>(),
+                (EventSourceId)SliceKey,
+                Arg.Any<IEnumerable<EventType>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cursor);
+
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), Arg.Any<object>())
+            .Returns(Option<Key>.None());
+    }
+
+    async Task Because() =>
+        await KeyResolvers.FromParentHierarchy(
+            SliceProjection,
+            KeyResolvers.FromEventSourceId,
+            KeyResolvers.FromEventSourceId,
+            "sliceId")(Storage, Sink, NestedCommandEvent);
+
+    [Fact] void should_not_use_the_creation_event_as_an_anchor() =>
+        Sink.Received().TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), Arg.Any<object>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_nested_event_within_grandchild_projection/and_child_creation_event_has_same_sequence_number_as_current_event.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_nested_event_within_grandchild_projection/and_child_creation_event_has_same_sequence_number_as_current_event.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_nested_event_within_grandchild_projection;
+
+/// <summary>
+/// When the only "child creation event" in the event sequence has the same sequence number as the
+/// event being resolved, the cycle-detection guard must reject it and fall through to the sink lookup.
+/// Accepting an event at the same position would indicate we are processing the creation event itself
+/// as its own resolver anchor — an infinite cycle.
+/// </summary>
+public class and_child_creation_event_has_same_sequence_number_as_current_event : given.a_three_level_hierarchy
+{
+    void Establish()
+    {
+        // Create a SliceAddedEvent at the same sequence number as NestedCommandEvent (seq 3).
+        var creationEventAtSameSequence = CreateEvent(3, SliceAddedEventType, SliceKey, new System.Dynamic.ExpandoObject());
+
+        Storage.GetHeadSequenceNumber(Arg.Any<IEnumerable<EventType>>(), (EventSourceId)SliceKey)
+            .Returns(new EventSequenceNumber(3));
+        var cursor = CreateCursorWith(creationEventAtSameSequence);
+        Storage.GetRange(
+                Arg.Any<EventSequenceNumber>(),
+                Arg.Any<EventSequenceNumber>(),
+                (EventSourceId)SliceKey,
+                Arg.Any<IEnumerable<EventType>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cursor);
+
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), Arg.Any<object>())
+            .Returns(Option<Key>.None());
+    }
+
+    async Task Because() =>
+        await KeyResolvers.FromParentHierarchy(
+            SliceProjection,
+            KeyResolvers.FromEventSourceId,
+            KeyResolvers.FromEventSourceId,
+            "sliceId")(Storage, Sink, NestedCommandEvent);
+
+    [Fact] void should_not_use_the_creation_event_as_an_anchor() =>
+        Sink.Received().TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), Arg.Any<object>());
+}

--- a/Source/Kernel/Core/Observation/Observer.Failing.cs
+++ b/Source/Kernel/Core/Observation/Observer.Failing.cs
@@ -22,13 +22,15 @@ public partial class Observer
         logger.PartitionFailed(partition, sequenceNumber, exceptionMessages, exceptionStackTrace);
         var failure = failures.State.RegisterAttempt(partition, sequenceNumber, exceptionMessages, exceptionStackTrace);
         var config = await configurationProvider.GetFor(_observerKey);
-        if (config.MaxRetryAttempts == 0 || failure.Attempts.Count() <= config.MaxRetryAttempts)
+        var attemptCount = failure.Attempts.Count();
+        if (config.MaxRetryAttempts == 0 || attemptCount <= config.MaxRetryAttempts)
         {
             await this.RegisterOrUpdateReminder(partition.ToString(), GetNextRetryDelay(failure, config), TimeSpan.FromHours(48));
         }
         else
         {
-            logger.GivingUpOnRecoveringFailedPartition(partition);
+            logger.GivingUpOnRecoveringFailedPartition(partition, attemptCount, config.MaxRetryAttempts);
+            await RemoveReminder(partition);
         }
 
         await failures.WriteStateAsync();
@@ -69,8 +71,21 @@ public partial class Observer
     /// <inheritdoc/>
     public async Task TryRecoverAllFailedPartitions()
     {
+        var config = await configurationProvider.GetFor(_observerKey);
         foreach (var partition in Failures.Partitions)
         {
+            var attemptCount = partition.Attempts.Count();
+            if (config.MaxRetryAttempts > 0 && attemptCount > config.MaxRetryAttempts)
+            {
+                logger.SkippingRecoveryMaxAttemptsExceeded(partition.Partition, attemptCount, config.MaxRetryAttempts);
+                continue;
+            }
+
+            if (attemptCount > 0)
+            {
+                logger.StartingRecoveryWithExistingAttempts(partition.Partition, attemptCount, config.MaxRetryAttempts);
+            }
+
             await StartRecoverJobForFailedPartition(partition);
         }
     }

--- a/Source/Kernel/Core/Observation/ObserverLogging.cs
+++ b/Source/Kernel/Core/Observation/ObserverLogging.cs
@@ -26,8 +26,14 @@ internal static partial class ObserverLogMessages
     [LoggerMessage(LogLevel.Debug, "Trying to recover partition {Partition}")]
     internal static partial void TryingToRecoverFailedPartition(this ILogger<Observer> logger, Key partition);
 
-    [LoggerMessage(LogLevel.Warning, "Giving up on trying to recover failed partition {Partition} automatically")]
-    internal static partial void GivingUpOnRecoveringFailedPartition(this ILogger<Observer> logger, Key partition);
+    [LoggerMessage(LogLevel.Warning, "Giving up on trying to recover failed partition {Partition} automatically after {AttemptCount} attempts (max {MaxRetryAttempts})")]
+    internal static partial void GivingUpOnRecoveringFailedPartition(this ILogger<Observer> logger, Key partition, int attemptCount, int maxRetryAttempts);
+
+    [LoggerMessage(LogLevel.Warning, "Skipping recovery of partition {Partition} — already exceeded max retry attempts ({AttemptCount}/{MaxRetryAttempts}). Partition requires manual intervention or server restart to retry")]
+    internal static partial void SkippingRecoveryMaxAttemptsExceeded(this ILogger<Observer> logger, Key partition, int attemptCount, int maxRetryAttempts);
+
+    [LoggerMessage(LogLevel.Warning, "Starting recovery for partition {Partition} which has already failed {AttemptCount} times (max {MaxRetryAttempts}). This is a startup retry — the subscriber may be stuck")]
+    internal static partial void StartingRecoveryWithExistingAttempts(this ILogger<Observer> logger, Key partition, int attemptCount, int maxRetryAttempts);
 
     [LoggerMessage(LogLevel.Debug, "Attempting to replay partition {Partition} to event sequence number {ToEventSequenceNumber}")]
     internal static partial void AttemptReplayPartition(this ILogger<Observer> logger, Key partition, EventSequenceNumber toEventSequenceNumber);

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -454,6 +454,16 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
             return null;
         }
 
+        // A creation event must precede the event being resolved in sequence order.
+        // If the found event is at a later (or equal) sequence number, it is NOT a creation event —
+        // it is a modification event that came after. Accepting it would cause an infinite cycle
+        // (e.g. StateChangeSliceAdded_42 → CommandSetForSlice_43 → StateChangeSliceAdded_42 → ∞).
+        if (childCreationEvent.Context.SequenceNumber >= @event.Context.SequenceNumber)
+        {
+            logger.FromParentHierarchyChildCreationEventNotEarlier(childCreationEvent.Context.SequenceNumber.Value, @event.Context.SequenceNumber.Value);
+            return null;
+        }
+
         var parentEventType = parentProjection.EventTypes.FirstOrDefault(et => et.Id == childCreationEvent.Context.EventType.Id);
         if (parentEventType == default)
         {

--- a/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
@@ -135,4 +135,7 @@ internal static partial class KeyResolversLogMessages
 
     [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: all resolution strategies exhausted for child projection '{Path}' with parent key '{ParentKey}' — event will be skipped (no future created). This typically indicates a badly-defined projection.")]
     internal static partial void FromParentHierarchyKeyUnresolvable(this ILogger<KeyResolvers> logger, string path, string parentKey);
+
+    [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: child creation event at seq {CreationSeq} is not earlier than the current event at seq {CurrentSeq} — rejecting to prevent an infinite resolution cycle")]
+    internal static partial void FromParentHierarchyChildCreationEventNotEarlier(this ILogger<KeyResolvers> logger, ulong creationSeq, ulong currentSeq);
 }


### PR DESCRIPTION
## Fixed

- Infinite resolution loop in `TryResolveViaChildCreationEvent` when sibling event types for the same entity source create a A→B→A cycle during parent hierarchy key resolution. The guard enforces that a child creation event must have a lower sequence number than the event being resolved.
- `TryRecoverAllFailedPartitions` now respects `MaxRetryAttempts` — partitions that have exhausted their retry budget are skipped on server startup rather than triggering an unbounded retry storm with no backoff.
- Stale Orleans reminder is now removed when a partition gives up after exceeding `MaxRetryAttempts`, preventing one extra spurious retry on the next reminder tick.

## Added

- Warning-level diagnostics when a failed partition is skipped at startup (`MaxRetryAttempts` exceeded), when a startup retry is attempted for a partition with prior failures, and when the cycle-detection guard fires in the key resolver.