### PR TITLE
Fix AppendMany causation fallback behavior

### DIFF
--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_appending/many_events_for_different_event_source_ids.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_appending/many_events_for_different_event_source_ids.cs
@@ -16,6 +16,7 @@ public class many_events_for_different_event_source_ids : given.an_event_sequenc
     List<EventForEventSourceId> _events;
     EventType _eventType;
     JsonObject _eventContext;
+    Causation _eventCausation;
     IEnumerable<Causation> _causation;
     Identity _causedBy;
     AppendManyRequest _command;
@@ -30,6 +31,7 @@ public class many_events_for_different_event_source_ids : given.an_event_sequenc
 
         var causation1 = new Causation(DateTimeOffset.UtcNow, "type1", new Dictionary<string, string> { { "key", "1" } });
         var causation2 = new Causation(DateTimeOffset.UtcNow, "type2", new Dictionary<string, string> { { "key", "2" } });
+        _eventCausation = causation1;
 
         _events =
         [
@@ -70,7 +72,7 @@ public class many_events_for_different_event_source_ids : given.an_event_sequenc
     [Fact] void should_append_correct_number_of_events() => _command.Events.Count.ShouldEqual(_events.Count);
     [Fact] void should_append_events_with_correct_event_source_ids() => _command.Events.Select(e => (EventSourceId)e.EventSourceId).ShouldEqual(_events.Select(e => e.EventSourceId));
     [Fact] void should_append_events_with_correct_event_type() => _command.Events.All(e => e.EventType.ToClient().Equals(_eventType)).ShouldBeTrue();
-    [Fact] void should_append_events_with_correct_causations() => _command.Causation.ToClient().ShouldEqual(_causation);
+    [Fact] void should_append_events_with_correct_causations() => _command.Causation.ToClient().ShouldEqual([_eventCausation]);
     [Fact] void should_append_events_with_correct_caused_by() => _command.CausedBy.ToClient().ShouldEqual(_causedBy);
     [Fact] void should_return_result_with_sequence_numbers() => _result.SequenceNumbers.Select(_ => _.Value).ShouldEqual(_response.SequenceNumbers);
 }

--- a/Source/Clients/DotNET/EventSequences/EventForEventSourceId.cs
+++ b/Source/Clients/DotNET/EventSequences/EventForEventSourceId.cs
@@ -11,8 +11,8 @@ namespace Cratis.Chronicle.EventSequences;
 /// </summary>
 /// <param name="EventSourceId"><see cref="EventSourceId"/> the event is for.</param>
 /// <param name="Event">The actual event.</param>
-/// <param name="Causation">The causation for the event.</param>
-public record EventForEventSourceId(EventSourceId EventSourceId, object Event, Causation Causation)
+/// <param name="Causation">Optional causation for the event. If not set, the current causation chain is used.</param>
+public record EventForEventSourceId(EventSourceId EventSourceId, object Event, Causation? Causation = default)
 {
     /// <summary>
     /// Gets or inits the <see cref="EventStreamType"/> for the event. Defaults to <see cref="EventStreamType.All"/>.

--- a/Source/Clients/DotNET/EventSequences/EventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/EventSequence.cs
@@ -202,7 +202,7 @@ public class EventSequence(
         var resolvedCorrelationId = correlationId ?? correlationIdAccessor.Current;
         var causation = causationManager.GetCurrentChain();
         var identity = identityProvider.GetCurrent();
-        var result = await AppendManyImplementation(eventsToAppend, resolvedCorrelationId, concurrencyScopes);
+        var result = await AppendManyImplementation(eventsToAppend, resolvedCorrelationId, concurrencyScopes, causation);
         NotifyAppendMany(
             eventsList,
             resolvedCorrelationId,
@@ -225,8 +225,16 @@ public class EventSequence(
         IDictionary<EventSourceId, ConcurrencyScope>? concurrencyScopes = default)
     {
         var eventsList = events.ToList();
-        var eventsToAppend = eventsList.ConvertAll(@event =>
+        var eventsToAppend = new List<Contracts.Events.EventToAppend>(eventsList.Count);
+        IImmutableList<Causation>? causation = null;
+
+        foreach (var @event in eventsList)
         {
+            if (causation is null && @event.Causation is not null)
+            {
+                causation = [@event.Causation];
+            }
+
             var eventClrType = @event.Event.GetType();
             var eventType = eventTypes.GetEventTypeFor(eventClrType);
 
@@ -234,22 +242,23 @@ public class EventSequence(
             var staticTags = eventClrType.GetTags();
             var allTags = staticTags.Concat(tags ?? []).Distinct().ToList();
 
-            return new Contracts.Events.EventToAppend
+            eventsToAppend.Add(new Contracts.Events.EventToAppend
             {
                 EventSourceType = @event.EventSourceType,
                 EventSourceId = @event.EventSourceId,
                 EventStreamType = @event.EventStreamType,
                 EventStreamId = @event.EventStreamId,
                 EventType = eventType.ToContract(),
-                Content = eventSerializer.Serialize(@event.Event).GetAwaiter().GetResult().ToString(),
+                Content = (await eventSerializer.Serialize(@event.Event)).ToString(),
                 Tags = allTags,
                 Occurred = @event.Occurred
-            };
-        });
+            });
+        }
 
-        var causation = causationManager.GetCurrentChain();
+        causation ??= causationManager.GetCurrentChain();
+
         var resolvedCorrelationId = correlationId ?? correlationIdAccessor.Current;
-        var result = await AppendManyImplementation(eventsToAppend, resolvedCorrelationId, concurrencyScopes ?? new Dictionary<EventSourceId, ConcurrencyScope>());
+        var result = await AppendManyImplementation(eventsToAppend, resolvedCorrelationId, concurrencyScopes ?? new Dictionary<EventSourceId, ConcurrencyScope>(), causation);
 
         if (_appendedEventsRaised is not null)
         {
@@ -446,9 +455,12 @@ public class EventSequence(
         };
     }
 
-    async Task<AppendManyResult> AppendManyImplementation(IList<Contracts.Events.EventToAppend> eventsToAppend, CorrelationId correlationId, IDictionary<EventSourceId, ConcurrencyScope> concurrencyScopes)
+    async Task<AppendManyResult> AppendManyImplementation(
+        IList<Contracts.Events.EventToAppend> eventsToAppend,
+        CorrelationId correlationId,
+        IDictionary<EventSourceId, ConcurrencyScope> concurrencyScopes,
+        IImmutableList<Causation> causation)
     {
-        var causationChain = causationManager.GetCurrentChain().ToContract();
         var identity = identityProvider.GetCurrent();
         var request = new AppendManyRequest()
         {
@@ -457,7 +469,7 @@ public class EventSequence(
             EventSequenceId = eventSequenceId,
             CorrelationId = correlationId,
             Events = eventsToAppend,
-            Causation = causationChain,
+            Causation = causation.ToContract(),
             CausedBy = identity.ToContract(),
             ConcurrencyScopes = concurrencyScopes
                 .Where(kvp => kvp.Value is not null)


### PR DESCRIPTION
## Changed
- Event batch append now accepts optional causation on `EventForEventSourceId` and uses event-provided causation when set.
- Batch causation resolution now runs once per append operation and only falls back to the current causation chain when no event-level causation is provided.

## Fixed
- Removed unnecessary per-event causation chain lookups in `AppendMany`, reducing overhead while preserving causation behavior.

