### PR TITLE
Add Snappier package reference for MongoDB storage

### DIFF
--- a/Source/Kernel/Storage.MongoDB/Storage.MongoDB.csproj
+++ b/Source/Kernel/Storage.MongoDB/Storage.MongoDB.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Orleans.Providers.MongoDB" />
         <PackageReference Include="Cratis.Arc.Core" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+        <PackageReference Include="Snappier" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changed
- Add an explicit Snappier package reference in MongoDB storage project dependencies.
