### PR TITLE
Fix null concurrency scopes handling in ToChronicle converter

### DIFF
--- a/Source/Kernel/Core.Specs/Services/EventSequences/Concurrency/for_ConcurrencyScopeConverters/when_converting_null_scopes.cs
+++ b/Source/Kernel/Core.Specs/Services/EventSequences/Concurrency/for_ConcurrencyScopeConverters/when_converting_null_scopes.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Services.EventSequences.Concurrency.for_ConcurrencyScopeConverters;
+
+public class when_converting_null_scopes : Specification
+{
+    Concepts.EventSequences.Concurrency.ConcurrencyScopes _result;
+
+    void Because()
+    {
+        IDictionary<string, Contracts.EventSequences.Concurrency.ConcurrencyScope> scopes = null!;
+        _result = scopes.ToChronicle();
+    }
+
+    [Fact] void should_return_a_result() => _result.ShouldNotBeNull();
+    [Fact] void should_have_no_scopes() => _result.Scopes.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core/Services/EventSequences/Concurrency/ConcurrencyScopeConverters.cs
+++ b/Source/Kernel/Core/Services/EventSequences/Concurrency/ConcurrencyScopeConverters.cs
@@ -32,10 +32,14 @@ internal static class ConcurrencyScopeConverters
     /// <param name="scopes"><see cref="IDictionary{TKey,TValue}"/> of <see cref="string"/> and <see cref="Contracts.EventSequences.Concurrency.ConcurrencyScope"/> to convert.</param>
     /// <returns>A converted <see cref="ConcurrencyScope"/>.</returns>
     public static ConcurrencyScopes ToChronicle(
-        this IDictionary<string, Contracts.EventSequences.Concurrency.ConcurrencyScope> scopes) =>
-        new(scopes.ToDictionary(
-            eventSourceIdAndScope => new EventSourceId(eventSourceIdAndScope.Key),
-            eventSourceIdAndScope => eventSourceIdAndScope.Value.ToChronicle()));
+        this IDictionary<string, Contracts.EventSequences.Concurrency.ConcurrencyScope>? scopes) =>
+        new((scopes ?? new Dictionary<string, Contracts.EventSequences.Concurrency.ConcurrencyScope>())
+            .Where(eventSourceIdAndScope =>
+                !string.IsNullOrWhiteSpace(eventSourceIdAndScope.Key) &&
+                eventSourceIdAndScope.Value is not null)
+            .ToDictionary(
+                eventSourceIdAndScope => new EventSourceId(eventSourceIdAndScope.Key),
+                eventSourceIdAndScope => eventSourceIdAndScope.Value.ToChronicle()));
 
     static T? ToMaybeConcept<T>(string? value, Func<string, T> toConcept)
         where T : ConceptAs<string>


### PR DESCRIPTION
## Fixed

- Handle null scopes and filter out null or whitespace keys in concurrency scope conversion to prevent runtime errors