### PR TITLE
Support [EventStore] on Reactor and Reducer classes for outbox→inbox subscriptions

### DIFF
--- a/Docker/Production/Dockerfile
+++ b/Docker/Production/Dockerfile
@@ -1,19 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ####################################
-# Cratis Chronicle Server
-# Build runtime image
+# Cratis Chronicle Server - Preparation stage
 ####################################
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
-ARG CONFIGURATION=Release
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS prep
 ARG VERSION
 
 WORKDIR /app
-
-RUN echo Configuration = ${CONFIGURATION}
-RUN echo Version = ${VERSION}
-
-EXPOSE 8080 11111 30000 35000
 
 COPY Docker/copy-server-files.sh ./copy-server-files.sh
 RUN chmod +x ./copy-server-files.sh
@@ -21,10 +14,20 @@ RUN chmod +x ./copy-server-files.sh
 COPY ./Source/Kernel/Server/out ./out
 COPY ./Source/Workbench/wwwroot wwwroot
 
-RUN echo $PWD
 RUN ./copy-server-files.sh
 
-RUN rm appsettings.Development.json
-RUN rm ./chronicle.json
+RUN rm appsettings.Development.json && rm ./chronicle.json
+
+####################################
+# Cratis Chronicle Server - Runtime stage
+####################################
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled
+
+WORKDIR /app
+
+EXPOSE 8080 11111 30000 35000
+
+# Copy prepared files from prep stage
+COPY --from=prep /app/. ./
 
 ENTRYPOINT ["./Cratis.Chronicle.Server"]

--- a/Documentation/code-analysis/CHR0013.md
+++ b/Documentation/code-analysis/CHR0013.md
@@ -1,0 +1,45 @@
+# CHR0013: Reactor cannot combine EventStore with explicit event sequence
+
+## Rule Description
+
+A reactor that declares `[EventStore("...")]` must use implicit inbox routing. It cannot also define an explicit event sequence.
+
+## Severity
+
+Error
+
+## Example
+
+### Violation
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+[EventStore("identity-service")]
+[Reactor(eventSequence: "custom-sequence")]
+public class UserSyncReactor : IReactor
+{
+}
+```
+
+### Fix
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+[EventStore("identity-service")]
+[Reactor]
+public class UserSyncReactor : IReactor
+{
+}
+```
+
+## Why This Rule Exists
+
+`[EventStore]` on a reactor is intended to drive outbox-to-inbox routing. Combining it with explicit event sequence configuration creates ambiguous routing intent.
+
+## Related Rules
+
+- [CHR0014](CHR0014.md): Reducer cannot combine EventStore with explicit event sequence

--- a/Documentation/code-analysis/CHR0014.md
+++ b/Documentation/code-analysis/CHR0014.md
@@ -1,0 +1,45 @@
+# CHR0014: Reducer cannot combine EventStore with explicit event sequence
+
+## Rule Description
+
+A reducer that declares `[EventStore("...")]` must use implicit inbox routing. It cannot also define an explicit event sequence.
+
+## Severity
+
+Error
+
+## Example
+
+### Violation
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+[EventStore("identity-service")]
+[Reducer(eventSequence: "custom-sequence")]
+public class UserSummaryReducer : IReducer
+{
+}
+```
+
+### Fix
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+[EventStore("identity-service")]
+[Reducer]
+public class UserSummaryReducer : IReducer
+{
+}
+```
+
+## Why This Rule Exists
+
+`[EventStore]` on a reducer is intended to drive outbox-to-inbox routing. Combining it with explicit event sequence configuration creates ambiguous routing intent.
+
+## Related Rules
+
+- [CHR0013](CHR0013.md): Reactor cannot combine EventStore with explicit event sequence

--- a/Documentation/code-analysis/index.md
+++ b/Documentation/code-analysis/index.md
@@ -16,6 +16,8 @@ All rules follow the identifier format `CHR####` where the numbers are sequentia
 | [CHR0006](CHR0006.md) | Reducer method signature must match allowed signatures | Warning | Reducer methods must follow allowed signatures |
 | [CHR0007](CHR0007.md) | Reducer event parameter must have [EventType] attribute | Error | Event parameters in reducer methods must be marked with [EventType] attribute |
 | [CHR0012](CHR0012.md) | Event types should avoid nullable properties | Warning | Nullable properties are supported on events but are often better modeled as separate event types |
+| [CHR0013](CHR0013.md) | Reactor cannot combine EventStore with explicit event sequence | Error | Reactors with [EventStore] must not also configure an explicit event sequence |
+| [CHR0014](CHR0014.md) | Reducer cannot combine EventStore with explicit event sequence | Error | Reducers with [EventStore] must not also configure an explicit event sequence |
 
 ## Quick Fixes
 

--- a/Documentation/code-analysis/toc.yml
+++ b/Documentation/code-analysis/toc.yml
@@ -16,3 +16,7 @@
   href: CHR0007.md
 - name: CHR0012 - Event types should avoid nullable properties
   href: CHR0012.md
+- name: CHR0013 - Reactor cannot combine EventStore with explicit event sequence
+  href: CHR0013.md
+- name: CHR0014 - Reducer cannot combine EventStore with explicit event sequence
+  href: CHR0014.md

--- a/Documentation/integration/implicit-subscriptions.md
+++ b/Documentation/integration/implicit-subscriptions.md
@@ -179,43 +179,12 @@ using var app = builder.Build();
 // are automatically routed to the inbox
 ```
 
-## Automatic Inbox Routing
+## Automatic Inbox Routing for Observers
 
-When an observer (reactor, projection, or reducer) handles event types all annotated with the same `[EventStore]` name, Chronicle automatically routes that observer to the corresponding inbox sequence — `inbox-{eventStoreName}`. No explicit subscription or event sequence configuration is needed.
+Automatic inbox routing is documented per observer type:
 
-### Reactors
-
-```csharp
-// No explicit event sequence needed
-public class FulfillmentReactor : IReactor
-{
-    public Task ShipmentDispatched(ShipmentDispatched @event, EventContext context)
-        => HandleDispatchedAsync(@event.OrderId, @event.TrackingNumber);
-
-    public Task ShipmentFailed(ShipmentFailed @event, EventContext context)
-        => HandleFailureAsync(@event.OrderId, @event.Reason);
-
-    Task HandleDispatchedAsync(Guid id, string tracking) => Task.CompletedTask;
-    Task HandleFailureAsync(Guid id, string reason) => Task.CompletedTask;
-}
-```
-
-### Reducers
-
-```csharp
-public class FulfillmentStatusReducer : IReducerFor<FulfillmentStatus>
-{
-    public FulfillmentStatus Reduce(ShipmentDispatched @event, FulfillmentStatus? current)
-        => (current ?? new FulfillmentStatus()) with 
-        { 
-            Status = "Dispatched", 
-            TrackingNumber = @event.TrackingNumber 
-        };
-
-    public FulfillmentStatus Reduce(ShipmentFailed @event, FulfillmentStatus? current)
-        => (current ?? new FulfillmentStatus()) with { Status = "Failed" };
-}
-```
+- Reactors: [Subscribe Reactors to External Event Stores](../reactors/external-event-store-subscriptions.md)
+- Reducers: [Subscribe Reducers to External Event Stores](../reducers/external-event-store-subscriptions.md)
 
 ### Projections
 

--- a/Documentation/reactors/event-sequence.md
+++ b/Documentation/reactors/event-sequence.md
@@ -10,7 +10,7 @@ Apply `[EventSequence]` directly to your reactor class to pin it to a specific e
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Reactors;
 
-[EventSequence("outbox")]
+[EventSequence("fulfillment-events")]
 public class ShipmentReactor : IReactor
 {
     public Task ShipmentDispatched(ShipmentDispatched @event, EventContext context)
@@ -29,7 +29,7 @@ When you are already using the `[Reactor]` attribute to set a custom identifier 
 ```csharp
 using Cratis.Chronicle.Reactors;
 
-[Reactor(id: "shipment-reactor", eventSequence: "outbox")]
+[Reactor(id: "shipment-reactor", eventSequence: "fulfillment-events")]
 public class ShipmentReactor : IReactor
 {
     public Task ShipmentDispatched(ShipmentDispatched @event, EventContext context)
@@ -63,11 +63,9 @@ public class LocalAuditReactor : IReactor
 }
 ```
 
-## Automatic Inbox Routing
+## External Event Store Inbox Routing
 
-When the event types handled by a reactor carry a `[EventStore]` attribute pointing to a **different** event store than the one the reactor is registered in, Chronicle automatically routes the reactor to the corresponding inbox sequence. No `[EventSequence]` annotation is needed in that case.
-
-When the `[EventStore]` attribute points to the **same** event store as the current one, Chronicle routes to the event log instead.
+For outbox-to-inbox subscriptions between event stores, including automatic inbox routing and observer-level `[EventStore]` usage, see [Subscribe Reactors to External Event Stores](external-event-store-subscriptions.md).
 
 ## When to Use `[EventSequence]` Explicitly
 

--- a/Documentation/reactors/external-event-store-subscriptions.md
+++ b/Documentation/reactors/external-event-store-subscriptions.md
@@ -1,0 +1,74 @@
+# Subscribe Reactors to External Event Stores
+
+## Automatic Inbox Routing
+
+When all event types handled by a reactor come from the same source event store, Chronicle routes the reactor to the matching inbox sequence automatically:
+
+- Source event store: `fulfillment-service`
+- Inbox sequence observed by the reactor: `inbox-fulfillment-service`
+
+This works when the source is declared on event types (or assembly) using `[EventStore("...")]`, and no explicit event sequence is configured on the reactor.
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+[EventType]
+[EventStore("fulfillment-service")]
+public record ShipmentDispatched(Guid OrderId, string TrackingNumber);
+
+public class FulfillmentReactor : IReactor
+{
+    public Task ShipmentDispatched(ShipmentDispatched @event, EventContext context) => Task.CompletedTask;
+}
+```
+
+## Observer-Level EventStore for Missing Event Metadata
+
+When event contracts cannot carry `[EventStore]` metadata, apply `[EventStore]` directly on the reactor.
+
+Chronicle resolves the reactor to the inbox for that source event store and implicitly creates or reuses the outbox-to-inbox subscription.
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+[EventType]
+public record ExternalUserInvited(Guid UserId);
+
+[EventStore("identity-service")]
+[Reactor]
+public class ExternalUserInvitedReactor : IReactor
+{
+    public Task On(ExternalUserInvited @event, EventContext context) => Task.CompletedTask;
+}
+```
+
+## Implicit Combined Event Type Filtering
+
+For each source event store, Chronicle combines all reactor and reducer event types into one implicit subscription filter.
+
+This means:
+
+- You get one subscription per source event store.
+- The filter is the union of handled event types from all participating observers.
+- Only those event types are forwarded from source outbox to target inbox.
+
+## Explicit Event Sequence Is Not Allowed with Observer EventStore
+
+When a reactor has `[EventStore("...")]`, do not combine it with:
+
+- `[EventSequence("...")]`
+- `[EventLog]`
+- `[Reactor(eventSequence: "...")]`
+
+This is invalid and fails:
+
+- At runtime with `EventStoreCannotBeCombinedWithExplicitEventSequence`.
+- At compile time with analyzer rule `CHR0013`.
+
+## See Also
+
+- [Implicit Event Store Subscriptions](../integration/implicit-subscriptions.md)
+- [Explicit Event Store Subscriptions](../integration/explicit-subscriptions.md)
+- [Event Sequence](event-sequence.md)

--- a/Documentation/reactors/index.md
+++ b/Documentation/reactors/index.md
@@ -41,6 +41,7 @@ public class EmailNotificationsReactor : IReactor
 ## Topics
 
 - [Getting Started](getting-started.md)
+- [Subscribe to External Event Stores](external-event-store-subscriptions.md)
 - [Event Processing](event-processing.md)
 - [Event Sequence](event-sequence.md)
 - [Once-Only Processing](once-only.md)

--- a/Documentation/reactors/toc.yml
+++ b/Documentation/reactors/toc.yml
@@ -6,6 +6,8 @@
   href: event-processing.md
 - name: Event Sequence
   href: event-sequence.md
+- name: Subscribe to External Event Stores
+  href: external-event-store-subscriptions.md
 - name: OnceOnly
   href: once-only.md
 - name: Filtering by appended event metadata

--- a/Documentation/reducers/event-sequence.md
+++ b/Documentation/reducers/event-sequence.md
@@ -10,7 +10,7 @@ Apply `[EventSequence]` directly to your reducer class to pin it to a specific e
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Reducers;
 
-[EventSequence("outbox")]
+[EventSequence("fulfillment-events")]
 public class ShipmentSummaryReducer : IReducerFor<ShipmentSummary>
 {
     public ShipmentSummary OnShipmentDispatched(ShipmentDispatched @event, ShipmentSummary? current, EventContext context)
@@ -30,7 +30,7 @@ When you are already using the `[Reducer]` attribute to set a custom identifier 
 ```csharp
 using Cratis.Chronicle.Reducers;
 
-[Reducer(id: "shipment-summary", eventSequence: "outbox")]
+[Reducer(id: "shipment-summary", eventSequence: "fulfillment-events")]
 public class ShipmentSummaryReducer : IReducerFor<ShipmentSummary>
 {
     public ShipmentSummary OnShipmentDispatched(ShipmentDispatched @event, ShipmentSummary? current, EventContext context)
@@ -64,11 +64,9 @@ public class LocalOrderSummaryReducer : IReducerFor<LocalOrderSummary>
 }
 ```
 
-## Automatic Inbox Routing
+## External Event Store Inbox Routing
 
-When the event types handled by a reducer carry a `[EventStore]` attribute pointing to a **different** event store than the one the reducer is registered in, Chronicle automatically routes the reducer to the corresponding inbox sequence. No `[EventSequence]` annotation is needed in that case.
-
-When the `[EventStore]` attribute points to the **same** event store as the current one, Chronicle routes to the event log instead.
+For outbox-to-inbox subscriptions between event stores, including automatic inbox routing and observer-level `[EventStore]` usage, see [Subscribe Reducers to External Event Stores](external-event-store-subscriptions.md).
 
 ## When to Use `[EventSequence]` Explicitly
 

--- a/Documentation/reducers/external-event-store-subscriptions.md
+++ b/Documentation/reducers/external-event-store-subscriptions.md
@@ -1,0 +1,80 @@
+# Subscribe Reducers to External Event Stores
+
+## Automatic Inbox Routing
+
+When all event types reduced by a reducer come from the same source event store, Chronicle routes the reducer to the matching inbox sequence automatically:
+
+- Source event store: `fulfillment-service`
+- Inbox sequence observed by the reducer: `inbox-fulfillment-service`
+
+This works when the source is declared on event types (or assembly) using `[EventStore("...")]`, and no explicit event sequence is configured on the reducer.
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+[EventType]
+[EventStore("fulfillment-service")]
+public record ShipmentDispatched(Guid OrderId, string TrackingNumber);
+
+public record FulfillmentStatus(string Status, string TrackingNumber);
+
+public class FulfillmentStatusReducer : IReducerFor<FulfillmentStatus>
+{
+    public FulfillmentStatus Reduce(ShipmentDispatched @event, FulfillmentStatus? current, EventContext context) =>
+        new("Dispatched", @event.TrackingNumber);
+}
+```
+
+## Observer-Level EventStore for Missing Event Metadata
+
+When event contracts cannot carry `[EventStore]` metadata, apply `[EventStore]` directly on the reducer.
+
+Chronicle resolves the reducer to the inbox for that source event store and implicitly creates or reuses the outbox-to-inbox subscription.
+
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+[EventType]
+public record ExternalUserInvited(Guid UserId);
+
+public record ExternalUserTotals(int Count);
+
+[EventStore("identity-service")]
+[Reducer]
+public class ExternalUserTotalsReducer : IReducerFor<ExternalUserTotals>
+{
+    public ExternalUserTotals Reduce(ExternalUserInvited @event, ExternalUserTotals? current, EventContext context) =>
+        new((current?.Count ?? 0) + 1);
+}
+```
+
+## Implicit Combined Event Type Filtering
+
+For each source event store, Chronicle combines all reducer and reactor event types into one implicit subscription filter.
+
+This means:
+
+- You get one subscription per source event store.
+- The filter is the union of handled event types from all participating observers.
+- Only those event types are forwarded from source outbox to target inbox.
+
+## Explicit Event Sequence Is Not Allowed with Observer EventStore
+
+When a reducer has `[EventStore("...")]`, do not combine it with:
+
+- `[EventSequence("...")]`
+- `[EventLog]`
+- `[Reducer(eventSequence: "...")]`
+
+This is invalid and fails:
+
+- At runtime with `EventStoreCannotBeCombinedWithExplicitEventSequence`.
+- At compile time with analyzer rule `CHR0014`.
+
+## See Also
+
+- [Implicit Event Store Subscriptions](../integration/implicit-subscriptions.md)
+- [Explicit Event Store Subscriptions](../integration/explicit-subscriptions.md)
+- [Event Sequence](event-sequence.md)

--- a/Documentation/reducers/index.md
+++ b/Documentation/reducers/index.md
@@ -44,6 +44,7 @@ public class AccountBalanceReducer : IReducerFor<AccountBalance>
 ## Topics
 
 - [Getting Started](getting-started.md) - Learn how to create your first reducer
+- [Subscribe to External Event Stores](external-event-store-subscriptions.md) - Configure outbox-to-inbox subscriptions for reducers
 - [Passive Reducers](passive-reducers.md) - Control when reducers actively observe events
 - [Event Processing](event-processing.md) - Understand how reducers process events
 - [Event Sequence](event-sequence.md) - Specify which event sequence a reducer observes

--- a/Documentation/reducers/toc.yml
+++ b/Documentation/reducers/toc.yml
@@ -8,6 +8,8 @@
   href: event-processing.md
 - name: Event Sequence
   href: event-sequence.md
+- name: Subscribe to External Event Stores
+  href: external-event-store-subscriptions.md
 - name: Filtering by appended event metadata
   href: filtering.md
   items:

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/given/a_reactor_event_store_and_event_sequence_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/given/a_reactor_event_store_and_event_sequence_analyzer.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReactorEventStoreAndEventSequenceAnalyzer.given;
+
+public class a_reactor_event_store_and_event_sequence_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Events;",
+            "using Cratis.Chronicle.EventSequences;",
+            "using Cratis.Chronicle.Reactors;",
+            "",
+            "namespace Cratis.Chronicle.Events",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false)]",
+            "    public sealed class EventStoreAttribute(string eventStore) : Attribute { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.EventSequences",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public class EventSequenceAttribute(string sequence) : Attribute { }",
+            "",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class EventLogAttribute() : EventSequenceAttribute(\"event-log\") { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Reactors",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]",
+            "    public sealed class ReactorAttribute(string id = \"\", string? eventSequence = default) : Attribute { }",
+            "",
+            "    public interface IReactor",
+            "    {",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/when_analyzing_reactor_types/and_event_store_and_reactor_event_sequence_are_combined.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/when_analyzing_reactor_types/and_event_store_and_reactor_event_sequence_are_combined.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReactorEventStoreAndEventSequenceAnalyzer.when_analyzing_reactor_types;
+
+public class and_event_store_and_reactor_event_sequence_are_combined : given.a_reactor_event_store_and_event_sequence_analyzer
+{
+    const string Usage = """
+    {|#0:[EventStore("external-store")]
+    [Reactor(eventSequence: "custom-sequence")]
+    public class InvalidReactor : IReactor
+    {
+    }|}
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReactorEventStoreAndEventSequenceAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReactorCannotCombineEventStoreWithExplicitEventSequence, DiagnosticSeverity.Error, "InvalidReactor", "external-store"));
+
+    [Fact] Task should_report_event_store_and_explicit_event_sequence_conflict() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/when_analyzing_reactor_types/and_only_event_store_is_set.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReactorEventStoreAndEventSequenceAnalyzer/when_analyzing_reactor_types/and_only_event_store_is_set.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReactorEventStoreAndEventSequenceAnalyzer.when_analyzing_reactor_types;
+
+public class and_only_event_store_is_set : given.a_reactor_event_store_and_event_sequence_analyzer
+{
+    const string Usage = """
+    [EventStore("external-store")]
+    [Reactor]
+    public class ValidReactor : IReactor
+    {
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReactorEventStoreAndEventSequenceAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/given/a_reducer_event_store_and_event_sequence_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/given/a_reducer_event_store_and_event_sequence_analyzer.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerEventStoreAndEventSequenceAnalyzer.given;
+
+public class a_reducer_event_store_and_event_sequence_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Events;",
+            "using Cratis.Chronicle.EventSequences;",
+            "using Cratis.Chronicle.Reducers;",
+            "",
+            "namespace Cratis.Chronicle.Events",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false)]",
+            "    public sealed class EventStoreAttribute(string eventStore) : Attribute { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.EventSequences",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public class EventSequenceAttribute(string sequence) : Attribute { }",
+            "",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class EventLogAttribute() : EventSequenceAttribute(\"event-log\") { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Reducers",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]",
+            "    public sealed class ReducerAttribute(string id = \"\", string? eventSequence = default, bool isActive = true) : Attribute { }",
+            "",
+            "    public interface IReducer",
+            "    {",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/when_analyzing_reducer_types/and_event_store_and_reducer_event_sequence_are_combined.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/when_analyzing_reducer_types/and_event_store_and_reducer_event_sequence_are_combined.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerEventStoreAndEventSequenceAnalyzer.when_analyzing_reducer_types;
+
+public class and_event_store_and_reducer_event_sequence_are_combined : given.a_reducer_event_store_and_event_sequence_analyzer
+{
+    const string Usage = """
+    {|#0:[EventStore("external-store")]
+    [Reducer(eventSequence: "custom-sequence")]
+    public class InvalidReducer : IReducer
+    {
+    }|}
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerEventStoreAndEventSequenceAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReducerCannotCombineEventStoreWithExplicitEventSequence, DiagnosticSeverity.Error, "InvalidReducer", "external-store"));
+
+    [Fact] Task should_report_event_store_and_explicit_event_sequence_conflict() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/when_analyzing_reducer_types/and_only_event_store_is_set.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerEventStoreAndEventSequenceAnalyzer/when_analyzing_reducer_types/and_only_event_store_is_set.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerEventStoreAndEventSequenceAnalyzer.when_analyzing_reducer_types;
+
+public class and_only_event_store_is_set : given.a_reducer_event_store_and_event_sequence_analyzer
+{
+    const string Usage = """
+    [EventStore("external-store")]
+    [Reducer]
+    public class ValidReducer : IReducer
+    {
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerEventStoreAndEventSequenceAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReactorEventStoreAndEventSequenceAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReactorEventStoreAndEventSequenceAnalyzer.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that checks if a reactor combines <c>[EventStore]</c> with explicit event sequence configuration.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReactorEventStoreAndEventSequenceAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.ReactorCannotCombineEventStoreWithExplicitEventSequence,
+        title: "Reactor cannot combine EventStore with explicit event sequence",
+        messageFormat: "Reactor '{0}' declares [EventStore(\"{1}\")] and explicit event sequence configuration. Remove [EventSequence]/[EventLog] or Reactor(eventSequence: ...) to use EventStore inbox routing.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A reactor with [EventStore] must use implicit inbox routing and cannot also define an explicit event sequence.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!WellKnownTypes.ImplementsIReactor(namedTypeSymbol, context.Compilation))
+        {
+            return;
+        }
+
+        var eventStoreAttribute = namedTypeSymbol
+            .GetAttributes()
+            .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventStoreAttributeName);
+
+        if (eventStoreAttribute is null)
+        {
+            return;
+        }
+
+        var hasEventSequenceAttribute = namedTypeSymbol.GetAttributes().Any(attr =>
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventSequenceAttributeName ||
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventLogAttributeName);
+
+        var reactorAttribute = namedTypeSymbol.GetAttributes().FirstOrDefault(attr =>
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.ReactorAttributeName);
+
+        var hasEventSequenceOnReactorAttribute = reactorAttribute?.ConstructorArguments.Length > 1 &&
+            reactorAttribute.ConstructorArguments[1].Value is string;
+
+        if (!hasEventSequenceAttribute && !hasEventSequenceOnReactorAttribute)
+        {
+            return;
+        }
+
+        var eventStoreName = eventStoreAttribute.ConstructorArguments.FirstOrDefault().Value as string ?? string.Empty;
+
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            namedTypeSymbol.Locations.FirstOrDefault(),
+            namedTypeSymbol.Name,
+            eventStoreName);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerEventStoreAndEventSequenceAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerEventStoreAndEventSequenceAnalyzer.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that checks if a reducer combines <c>[EventStore]</c> with explicit event sequence configuration.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReducerEventStoreAndEventSequenceAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.ReducerCannotCombineEventStoreWithExplicitEventSequence,
+        title: "Reducer cannot combine EventStore with explicit event sequence",
+        messageFormat: "Reducer '{0}' declares [EventStore(\"{1}\")] and explicit event sequence configuration. Remove [EventSequence]/[EventLog] or Reducer(eventSequence: ...) to use EventStore inbox routing.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A reducer with [EventStore] must use implicit inbox routing and cannot also define an explicit event sequence.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!WellKnownTypes.ImplementsIReducer(namedTypeSymbol, context.Compilation))
+        {
+            return;
+        }
+
+        var eventStoreAttribute = namedTypeSymbol
+            .GetAttributes()
+            .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventStoreAttributeName);
+
+        if (eventStoreAttribute is null)
+        {
+            return;
+        }
+
+        var hasEventSequenceAttribute = namedTypeSymbol.GetAttributes().Any(attr =>
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventSequenceAttributeName ||
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.EventLogAttributeName);
+
+        var reducerAttribute = namedTypeSymbol.GetAttributes().FirstOrDefault(attr =>
+            attr.AttributeClass?.ToDisplayString() == WellKnownTypes.ReducerAttributeName);
+
+        var hasEventSequenceOnReducerAttribute = reducerAttribute?.ConstructorArguments.Length > 1 &&
+            reducerAttribute.ConstructorArguments[1].Value is string;
+
+        if (!hasEventSequenceAttribute && !hasEventSequenceOnReducerAttribute)
+        {
+            return;
+        }
+
+        var eventStoreName = eventStoreAttribute.ConstructorArguments.FirstOrDefault().Value as string ?? string.Empty;
+
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            namedTypeSymbol.Locations.FirstOrDefault(),
+            namedTypeSymbol.Name,
+            eventStoreName);
+
+        context.ReportDiagnostic(diagnostic);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -67,4 +67,14 @@ public static class DiagnosticIds
     /// Event types should avoid nullable properties.
     /// </summary>
     public const string EventTypeShouldAvoidNullableProperties = "CHR0012";
+
+    /// <summary>
+    /// Reactor cannot combine EventStore attribute with an explicit event sequence.
+    /// </summary>
+    public const string ReactorCannotCombineEventStoreWithExplicitEventSequence = "CHR0013";
+
+    /// <summary>
+    /// Reducer cannot combine EventStore attribute with an explicit event sequence.
+    /// </summary>
+    public const string ReducerCannotCombineEventStoreWithExplicitEventSequence = "CHR0014";
 }

--- a/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
@@ -26,6 +26,26 @@ public static class WellKnownTypes
     public const string EventStoreAttributeName = "Cratis.Chronicle.Events.EventStoreAttribute";
 
     /// <summary>
+    /// The full name of the EventSequence attribute.
+    /// </summary>
+    public const string EventSequenceAttributeName = "Cratis.Chronicle.EventSequences.EventSequenceAttribute";
+
+    /// <summary>
+    /// The full name of the EventLog attribute.
+    /// </summary>
+    public const string EventLogAttributeName = "Cratis.Chronicle.EventSequences.EventLogAttribute";
+
+    /// <summary>
+    /// The full name of the Reactor attribute.
+    /// </summary>
+    public const string ReactorAttributeName = "Cratis.Chronicle.Reactors.ReactorAttribute";
+
+    /// <summary>
+    /// The full name of the Reducer attribute.
+    /// </summary>
+    public const string ReducerAttributeName = "Cratis.Chronicle.Reducers.ReducerAttribute";
+
+    /// <summary>
     /// The sentinel value representing the default event store.
     /// </summary>
     public const string DefaultEventStoreName = "";

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactorTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reactor_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactorTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reactor_attribute.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ReactorTypeExtensions.when_getting_event_sequence_id;
+
+public class and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reactor_attribute : Specification
+{
+    [EventType]
+    class EventWithoutEventStore;
+
+    [EventStore("some-event-store")]
+    [Reactor(eventSequence: "custom-sequence")]
+    class InvalidReactor : IReactor
+    {
+        public Task Handle(EventWithoutEventStore @event) => Task.CompletedTask;
+    }
+
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() => typeof(InvalidReactor).GetEventSequenceId());
+
+    [Fact] void should_throw_event_store_cannot_be_combined_with_explicit_event_sequence() =>
+        _exception.ShouldBeOfExactType<EventStoreCannotBeCombinedWithExplicitEventSequence>();
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactorTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_on_reactor.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactorTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_on_reactor.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Reactors.for_ReactorTypeExtensions.when_getting_event_sequence_id;
+
+public class and_event_store_attribute_is_set_on_reactor : Specification
+{
+    const string SourceEventStore = "some-event-store";
+
+    [EventType]
+    class EventWithoutEventStore;
+
+    [EventStore(SourceEventStore)]
+    [Reactor]
+    class ReactorWithEventStoreAttribute : IReactor
+    {
+        public Task Handle(EventWithoutEventStore @event) => Task.CompletedTask;
+    }
+
+    EventSequenceId _result;
+
+    void Because() => _result = typeof(ReactorWithEventStoreAttribute).GetEventSequenceId();
+
+    [Fact] void should_return_the_inbox_event_sequence_for_the_source_event_store() =>
+        _result.ShouldEqual(new EventSequenceId($"{EventSequenceId.InboxPrefix}{SourceEventStore}"));
+}

--- a/Source/Clients/DotNET.Specs/Reducers/for_ReducerTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reducer_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reducers/for_ReducerTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reducer_attribute.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reducers.for_ReducerTypeExtensions.when_getting_event_sequence_id;
+
+public class and_event_store_attribute_is_set_and_event_sequence_is_explicitly_set_on_reducer_attribute : Specification
+{
+    record ReadModel;
+
+    [EventType]
+    class EventWithoutEventStore;
+
+    [EventStore("some-event-store")]
+    [Reducer(eventSequence: "custom-sequence")]
+    class InvalidReducer : IReducerFor<ReadModel>
+    {
+        public ReadModel Reduce(EventWithoutEventStore @event, ReadModel? current) => new();
+    }
+
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() => typeof(InvalidReducer).GetEventSequenceId());
+
+    [Fact] void should_throw_event_store_cannot_be_combined_with_explicit_event_sequence() =>
+        _exception.ShouldBeOfExactType<EventStoreCannotBeCombinedWithExplicitEventSequence>();
+}

--- a/Source/Clients/DotNET.Specs/Reducers/for_ReducerTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_on_reducer.cs
+++ b/Source/Clients/DotNET.Specs/Reducers/for_ReducerTypeExtensions/when_getting_event_sequence_id/and_event_store_attribute_is_set_on_reducer.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Reducers.for_ReducerTypeExtensions.when_getting_event_sequence_id;
+
+public class and_event_store_attribute_is_set_on_reducer : Specification
+{
+    const string SourceEventStore = "some-event-store";
+
+    record ReadModel;
+
+    [EventType]
+    class EventWithoutEventStore;
+
+    [EventStore(SourceEventStore)]
+    [Reducer]
+    class ReducerWithEventStoreAttribute : IReducerFor<ReadModel>
+    {
+        public ReadModel Reduce(EventWithoutEventStore @event, ReadModel? current) => new();
+    }
+
+    EventSequenceId _result;
+
+    void Because() => _result = typeof(ReducerWithEventStoreAttribute).GetEventSequenceId();
+
+    [Fact] void should_return_the_inbox_event_sequence_for_the_source_event_store() =>
+        _result.ShouldEqual(new EventSequenceId($"{EventSequenceId.InboxPrefix}{SourceEventStore}"));
+}

--- a/Source/Clients/DotNET.Specs/for_EventStore/when_registering_external_event_store_subscriptions/and_observers_with_event_store_attribute_are_combined_into_single_filter.cs
+++ b/Source/Clients/DotNET.Specs/for_EventStore/when_registering_external_event_store_subscriptions/and_observers_with_event_store_attribute_are_combined_into_single_filter.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventStoreSubscriptions;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Chronicle.Specs.for_EventStore.when_registering_external_event_store_subscriptions;
+
+public class and_observers_with_event_store_attribute_are_combined_into_single_filter : Specification
+{
+    const string SourceEventStore = "StudioAdmin";
+
+    static readonly MethodInfo _registerExternalSubscriptionsMethod =
+        typeof(EventStore).GetMethod("RegisterExternalEventStoreSubscriptionsAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    EventStore _eventStore;
+    IEventStoreSubscriptions _subscriptions;
+    Action<IEventStoreSubscriptionBuilder>? _configure;
+    EventTypeId _invitedEventTypeId;
+    EventTypeId _acceptedEventTypeId;
+
+    void Establish()
+    {
+        _subscriptions = Substitute.For<IEventStoreSubscriptions>();
+        _subscriptions
+            .Subscribe(Arg.Any<EventStoreSubscriptionId>(), Arg.Any<string>(), Arg.Any<Action<IEventStoreSubscriptionBuilder>>())
+            .Returns(Task.CompletedTask)
+            .AndDoes(callInfo => _configure = callInfo.Arg<Action<IEventStoreSubscriptionBuilder>>());
+
+        var projections = Substitute.For<IProjections>();
+        projections.GetExternalEventStoreSubscriptions().Returns([]);
+
+        var clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
+        clientArtifactsProvider.Reactors.Returns([typeof(external_user_invited_reactor), typeof(external_user_accepted_reactor)]);
+        clientArtifactsProvider.Reducers.Returns([typeof(external_user_status_reducer)]);
+
+        var eventTypes = new EventTypesForSpecifications([typeof(external_user_invited), typeof(external_user_accepted)]);
+        _invitedEventTypeId = eventTypes.GetEventTypeFor(typeof(external_user_invited)).Id;
+        _acceptedEventTypeId = eventTypes.GetEventTypeFor(typeof(external_user_accepted)).Id;
+
+        _eventStore = (EventStore)RuntimeHelpers.GetUninitializedObject(typeof(EventStore));
+        SetField("_eventStoreName", new EventStoreName("Lobby"));
+        SetField("_clientArtifactsProvider", clientArtifactsProvider);
+        SetAutoProperty("EventTypes", eventTypes);
+        SetAutoProperty("Projections", projections);
+        SetAutoProperty("Subscriptions", _subscriptions);
+    }
+
+    async Task Because() => await (Task)_registerExternalSubscriptionsMethod.Invoke(_eventStore, [])!;
+
+    [Fact] void should_register_a_single_subscription_for_the_observer_event_store() =>
+        _subscriptions.Received(1).Subscribe(
+            Arg.Is<EventStoreSubscriptionId>(id => id.Value == SourceEventStore),
+            SourceEventStore,
+            Arg.Any<Action<IEventStoreSubscriptionBuilder>>());
+
+    [Fact] void should_combine_all_observer_event_types_into_the_subscription_filter()
+    {
+        var builder = Substitute.For<IEventStoreSubscriptionBuilder>();
+        builder.WithEventType(Arg.Any<EventTypeId>()).Returns(builder);
+
+        _configure.ShouldNotBeNull();
+        _configure!(builder);
+
+        builder.Received(1).WithEventType(_invitedEventTypeId);
+        builder.Received(1).WithEventType(_acceptedEventTypeId);
+    }
+
+    void SetField(string fieldName, object value)
+    {
+        var field = typeof(EventStore).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(_eventStore, value);
+    }
+
+    void SetAutoProperty(string propertyName, object value)
+    {
+        var field = typeof(EventStore).GetField($"<{propertyName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(_eventStore, value);
+    }
+
+    [EventType("f6d8a40f-db16-4474-9f1e-d7ce6f263a2f")]
+    record external_user_invited;
+
+    [EventType("7bc5b4c8-f957-44e7-b0bc-cf80ef6dbf7c")]
+    record external_user_accepted;
+
+    [EventStore(SourceEventStore)]
+    [Reactor]
+    class external_user_invited_reactor : IReactor
+    {
+        Task On(external_user_invited @event) => Task.CompletedTask;
+    }
+
+    [EventStore(SourceEventStore)]
+    [Reactor]
+    class external_user_accepted_reactor : IReactor
+    {
+        Task On(external_user_accepted @event) => Task.CompletedTask;
+    }
+
+    [EventStore(SourceEventStore)]
+    [Reducer]
+    class external_user_status_reducer : IReducerFor<object>
+    {
+        public object Reduce(external_user_invited @event, object? current) => new();
+    }
+}

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
+using System.Reflection;
 using System.Text.Json;
 using Cratis.Chronicle.Auditing;
 using Cratis.Chronicle.Connections;
@@ -331,30 +332,64 @@ public class EventStore : IEventStore
     {
         var currentStoreName = _eventStoreName?.Value;
 
-        // Collect external event types from reactors (skip reactors with explicit event sequences and skip same-store types)
-        var reactorExternalEventTypes = _clientArtifactsProvider.Reactors
+        static string? ResolveSourceStoreForObserver(Type observerType)
+        {
+            var observerEventStore = observerType.GetCustomAttributes(typeof(EventStoreAttribute), inherit: true)
+                .OfType<EventStoreAttribute>()
+                .FirstOrDefault();
+            if (observerEventStore is not null)
+            {
+                return observerEventStore.EventStore;
+            }
+
+            var eventStores = observerType
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => !m.IsSpecialName)
+                .Select(m => m.GetParameters().FirstOrDefault()?.ParameterType)
+                .OfType<Type>()
+                .Where(t => Attribute.IsDefined(t, typeof(EventTypeAttribute), inherit: true))
+                .Select(t => t.GetEventStoreName())
+                .Where(name => name is not null)
+                .Select(name => name!)
+                .Distinct()
+                .ToList();
+
+            if (eventStores.Count == 1)
+            {
+                return eventStores[0];
+            }
+
+            return null;
+        }
+
+        static IEnumerable<EventTypeId> ResolveObserverEventTypeIds(Type observerType, IEventTypes eventTypes) =>
+            observerType
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => !m.IsSpecialName)
+                .Select(m => m.GetParameters().FirstOrDefault()?.ParameterType)
+                .OfType<Type>()
+                .Where(t => Attribute.IsDefined(t, typeof(EventTypeAttribute), inherit: true))
+                .Select(t => eventTypes.GetEventTypeFor(t).Id)
+                .Distinct()
+                .ToArray();
+
+        var observerExternalSubscriptions = _clientArtifactsProvider.Reactors
             .Where(r => !ReactorTypeExtensions.HasExplicitEventSequence(r))
-            .SelectMany(ReactorTypeExtensions.GetHandlerEventTypes)
-            .Where(t => t.GetEventStoreName() is { } s && s != currentStoreName);
-
-        // Collect external event types from reducers (skip reducers with explicit event sequences and skip same-store types)
-        var reducerExternalEventTypes = _clientArtifactsProvider.Reducers
-            .Where(r => !ReducerTypeExtensions.HasExplicitEventSequence(r))
-            .SelectMany(ReducerTypeExtensions.GetHandlerEventTypes)
-            .Where(t => t.GetEventStoreName() is { } s && s != currentStoreName);
-
-        // Group reactor/reducer external event types by event store name
-        var observersByStore = reactorExternalEventTypes
-            .Concat(reducerExternalEventTypes)
-            .Select(t => (EventType: t, StoreName: t.GetEventStoreName()!))
-            .GroupBy(x => x.StoreName, x => x.EventType)
+            .Concat(_clientArtifactsProvider.Reducers.Where(r => !ReducerTypeExtensions.HasExplicitEventSequence(r)))
+            .Select(observerType =>
+            {
+                var sourceStore = ResolveSourceStoreForObserver(observerType);
+                return (observerType, sourceStore);
+            })
+            .Where(item => item.sourceStore is not null && item.sourceStore != currentStoreName)
+            .GroupBy(item => item.sourceStore!, item => item.observerType)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(t => EventTypes.GetEventTypeFor(t).Id).Distinct().ToList());
+                g => g.SelectMany(observerType => ResolveObserverEventTypeIds(observerType, EventTypes)).Distinct().ToList());
 
         // Merge with projection external event store references (already filtered by GetExternalEventStoreSubscriptions)
         var allByStore = new Dictionary<string, HashSet<EventTypeId>>();
-        foreach (var kvp in observersByStore)
+        foreach (var kvp in observerExternalSubscriptions)
         {
             allByStore[kvp.Key] = [.. kvp.Value];
         }

--- a/Source/Clients/DotNET/Events/EventStoreCannotBeCombinedWithExplicitEventSequence.cs
+++ b/Source/Clients/DotNET/Events/EventStoreCannotBeCombinedWithExplicitEventSequence.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Events;
+
+/// <summary>
+/// The exception that is thrown when an observer combines <see cref="EventStoreAttribute"/> with an explicit event sequence.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="EventStoreCannotBeCombinedWithExplicitEventSequence"/> class.
+/// </remarks>
+/// <param name="observerType">The observer type.</param>
+/// <param name="eventStore">The event store declared on the observer.</param>
+/// <param name="eventSequenceId">The explicit event sequence id.</param>
+public class EventStoreCannotBeCombinedWithExplicitEventSequence(Type observerType, string eventStore, EventSequenceId eventSequenceId)
+    : Exception($"Observer '{observerType.FullName}' combines [EventStore(\"{eventStore}\")] with explicit event sequence '{eventSequenceId}'. Remove the explicit event sequence configuration to use EventStore-based inbox routing.");

--- a/Source/Clients/DotNET/Reactors/ReactorTypeExtensions.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorTypeExtensions.cs
@@ -42,19 +42,38 @@ public static class ReactorTypeExtensions
     /// </param>
     /// <returns>The <see cref="EventSequenceId"/> for the type.</returns>
     /// <exception cref="MultipleEventStoresDefined">Thrown when the reactor handles event types from multiple event stores.</exception>
+    /// <exception cref="EventStoreCannotBeCombinedWithExplicitEventSequence">Thrown when <see cref="EventStoreAttribute"/> is combined with explicit event sequence configuration.</exception>
     public static EventSequenceId GetEventSequenceId(this Type type, string? currentEventStoreName = null)
     {
         TypeMustImplementReactor.ThrowIfTypeDoesNotImplementReactor(type);
 
-        // [EventSequence] / [EventLog] on the class takes highest priority
+        var eventStoreAttribute = type.GetCustomAttribute<EventStoreAttribute>();
+
         var eventSequenceAttr = type.GetCustomAttribute<EventSequenceAttribute>();
+        var reactorAttribute = type.GetCustomAttribute<ReactorAttribute>();
+
+        if (eventStoreAttribute is not null)
+        {
+            if (eventSequenceAttr is not null)
+            {
+                throw new EventStoreCannotBeCombinedWithExplicitEventSequence(type, eventStoreAttribute.EventStore, eventSequenceAttr.Sequence);
+            }
+
+            if (reactorAttribute?.EventSequenceId is not null)
+            {
+                throw new EventStoreCannotBeCombinedWithExplicitEventSequence(type, eventStoreAttribute.EventStore, reactorAttribute.EventSequenceId);
+            }
+
+            return new EventSequenceId($"{EventSequenceId.InboxPrefix}{eventStoreAttribute.EventStore}");
+        }
+
+        // [EventSequence] / [EventLog] on the class takes highest priority
         if (eventSequenceAttr is not null)
         {
             return eventSequenceAttr.Sequence;
         }
 
         // [Reactor(eventSequence: "...")] is the second priority
-        var reactorAttribute = type.GetCustomAttribute<ReactorAttribute>();
         if (reactorAttribute?.EventSequenceId is not null)
         {
             return reactorAttribute.EventSequenceId;

--- a/Source/Clients/DotNET/Reducers/ReducerTypeExtensions.cs
+++ b/Source/Clients/DotNET/Reducers/ReducerTypeExtensions.cs
@@ -112,18 +112,36 @@ public static class ReducerTypeExtensions
     /// </param>
     /// <returns>The <see cref="EventSequenceId"/> for the type.</returns>
     /// <exception cref="MultipleEventStoresDefined">Thrown when the reducer handles event types from multiple event stores.</exception>
+    /// <exception cref="EventStoreCannotBeCombinedWithExplicitEventSequence">Thrown when <see cref="EventStoreAttribute"/> is combined with explicit event sequence configuration.</exception>
     public static EventSequenceId GetEventSequenceId(this Type type, string? currentEventStoreName = null)
     {
         TypeMustImplementReducer.ThrowIfTypeDoesNotImplementReducer(type);
 
-        // [EventSequence] / [EventLog] on the class takes highest priority
+        var eventStoreAttribute = type.GetCustomAttribute<EventStoreAttribute>();
+
         var eventSequenceAttr = type.GetCustomAttribute<EventSequenceAttribute>();
+        var reducerAttribute = type.GetCustomAttribute<ReducerAttribute>();
+
+        if (eventStoreAttribute is not null)
+        {
+            if (eventSequenceAttr is not null)
+            {
+                throw new EventStoreCannotBeCombinedWithExplicitEventSequence(type, eventStoreAttribute.EventStore, eventSequenceAttr.Sequence);
+            }
+
+            if (reducerAttribute?.EventSequenceId is not null)
+            {
+                throw new EventStoreCannotBeCombinedWithExplicitEventSequence(type, eventStoreAttribute.EventStore, reducerAttribute.EventSequenceId);
+            }
+
+            return new EventSequenceId($"{EventSequenceId.InboxPrefix}{eventStoreAttribute.EventStore}");
+        }
+
+        // [EventSequence] / [EventLog] on the class takes highest priority
         if (eventSequenceAttr is not null)
         {
             return eventSequenceAttr.Sequence;
         }
-
-        var reducerAttribute = type.GetCustomAttribute<ReducerAttribute>();
 
         if (reducerAttribute?.EventSequenceId is not null)
         {


### PR DESCRIPTION
## Added

- `[EventStore("name")]` can now be placed on a Reactor or Reducer class to automatically subscribe to the `inbox-<name>` event sequence of that event store, without requiring explicit event sequence configuration.
- All observers sharing the same source event store are grouped into a single combined inbox subscription with a merged event type filter, reducing the number of subscriptions created.
- CHR0013 (Error) Roslyn analyzer: reports a build error when a Reactor has `[EventStore]` combined with an explicit event sequence attribute or `Reactor(eventSequenceId:...)`.
- CHR0014 (Error) Roslyn analyzer: same rule for Reducers.
- Documentation pages for reactors and reducers covering the outbox→inbox subscription pattern, including automatic inbox routing via the class-level `[EventStore]` attribute.
- CHR0013 and CHR0014 rule reference pages in the code analysis documentation.
