### PR TITLE
Fix subscription reactivation for persisted event-store subscriptions

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/a_new_subscription.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/a_new_subscription.cs
@@ -69,4 +69,7 @@ public class a_new_subscription : given.an_event_store_subscriptions_service
         _subscriptionsManager.Received(1).WaitUntilSubscribed(
             Arg.Is<EventStoreSubscriptionId>(id => id.Value == "test-subscription-id"),
             Arg.Any<TimeSpan>());
+
+    [Fact] void should_trigger_subscription_reactivation_for_the_source_event_store() =>
+        _subscriptionsManager.Received(1).SourceEventStoreAdded(Arg.Is<Concepts.EventStoreName>(name => name.Value == "source-event-store"));
 }

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/when_adding/an_existing_subscription.cs
@@ -61,6 +61,11 @@ public class an_existing_subscription : given.an_event_store_subscriptions_servi
             Arg.Any<EventStreamType>(),
             Arg.Any<EventStreamId>());
 
-    [Fact] void should_not_wait_until_subscription_is_ready() =>
-        _subscriptionsManager.DidNotReceive().WaitUntilSubscribed(Arg.Any<EventStoreSubscriptionId>(), Arg.Any<TimeSpan>());
+    [Fact] void should_trigger_subscription_reactivation_for_the_source_event_store() =>
+        _subscriptionsManager.Received(1).SourceEventStoreAdded(Arg.Is<EventStoreName>(name => name.Value == "source-event-store"));
+
+    [Fact] void should_wait_until_subscription_is_ready() =>
+        _subscriptionsManager.Received(1).WaitUntilSubscribed(
+            Arg.Is<EventStoreSubscriptionId>(id => id.Value == "test-subscription-id"),
+            Arg.Any<TimeSpan>());
 }

--- a/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
+++ b/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
@@ -49,20 +49,24 @@ internal sealed class EventStoreSubscriptions(
                 await eventSequence.Append(subscription.Identifier, new EventStoreSubscriptionAdded(
                     definition.SourceEventStore,
                     definition.EventTypes));
+            }
 
-                // Wait for the subscription to be ready before returning to the client
-                // This ensures that events are not lost if the client immediately starts publishing
-                try
-                {
-                    await subscriptionsManager.WaitUntilSubscribed(
-                        new EventStoreSubscriptionId(subscription.Identifier),
-                        TimeSpan.FromSeconds(5));
-                }
-                catch (TimeoutException)
-                {
-                    // Log but don't fail - the subscription may still activate asynchronously
-                    // This prevents blocking the client indefinitely if there are issues
-                }
+            // Existing matching definitions still need to be reactivated after reconnects and server restarts.
+            // Without this, subscriptions can remain persisted but disconnected indefinitely.
+            await subscriptionsManager.SourceEventStoreAdded(definition.SourceEventStore);
+
+            // Wait for the subscription to be ready before returning to the client.
+            // This ensures that events are not lost if the client immediately starts publishing.
+            try
+            {
+                await subscriptionsManager.WaitUntilSubscribed(
+                    new EventStoreSubscriptionId(subscription.Identifier),
+                    TimeSpan.FromSeconds(5));
+            }
+            catch (TimeoutException)
+            {
+                // Log but don't fail - the subscription may still activate asynchronously.
+                // This prevents blocking the client indefinitely if there are issues.
             }
         }
     }


### PR DESCRIPTION
## Fixed
- Event-store subscriptions persisted in MongoDB are now properly reactivated after service restart. Previously, subscriptions were skipped if their definition matched an existing entry, leaving them disconnected and unable to forward events.

## Details
When a subscription definition already exists (from a previous run), the `Add()` service was treating it as "already configured" and skipping the reactivation step. This caused subscriptions to remain disconnected after service restarts or client reconnects, preventing forwarded events from reaching their targets.

The fix ensures `SourceEventStoreAdded()` is called unconditionally for all subscriptions, triggering immediate reactivation of the subscription on the source event store.

## Testing
- Added specs validating that `SourceEventStoreAdded` is called for both new and existing subscription definitions
- All existing tests pass
- Build validates with zero errors and zero warnings