### PR TITLE
Fix Subject propagation in AppendMany and improve observer resilience

### DIFF
--- a/Source/Clients/DotNET/Reactors/Reactors.cs
+++ b/Source/Clients/DotNET/Reactors/Reactors.cs
@@ -312,6 +312,20 @@ public class Reactors : IReactors
                     var streamFailed = new ReactorObservationStreamFailed(handler.Id, ex);
                     _logger.RegisteringReactorFailed(handler.Id, streamFailed);
                     messages.Dispose();
+
+                    if (!handler.CancellationToken.IsCancellationRequested)
+                    {
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(2), handler.CancellationToken);
+                                _logger.ReconnectingReactor(handler.Id);
+                                RegisterReactor(handler);
+                            }
+                            catch (OperationCanceledException) { }
+                        });
+                    }
                 });
     }
 

--- a/Source/Clients/DotNET/Reactors/ReactorsLogMessages.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorsLogMessages.cs
@@ -28,4 +28,7 @@ internal static partial class ReactorsLogMessages
 
     [LoggerMessage(LogLevel.Error, "Failed to register Reactor '{Id}' — the reactive observation stream errored out")]
     internal static partial void RegisteringReactorFailed(this ILogger<Reactors> logger, ReactorId id, Exception exception);
+
+    [LoggerMessage(LogLevel.Information, "Reconnecting Reactor '{Id}' after stream failure")]
+    internal static partial void ReconnectingReactor(this ILogger<Reactors> logger, ReactorId id);
 }

--- a/Source/Clients/DotNET/Reducers/Reducers.cs
+++ b/Source/Clients/DotNET/Reducers/Reducers.cs
@@ -364,7 +364,26 @@ public class Reducers : IReducers
                 _logger.EventHandlingCompleted(handler.Id);
             }))
             .Concat()
-            .Subscribe(_ => { }, messages.Dispose);
+            .Subscribe(
+                _ => { },
+                ex =>
+                {
+                    messages.Dispose();
+
+                    if (!handler.CancellationToken.IsCancellationRequested)
+                    {
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await Task.Delay(TimeSpan.FromSeconds(2), handler.CancellationToken);
+                                _logger.ReconnectingReducer(handler.Id);
+                                RegisterReducer(handler);
+                            }
+                            catch (OperationCanceledException) { }
+                        });
+                    }
+                });
     }
 
     async Task ObserverMethod(BehaviorSubject<ReducerMessage> messages, IReducerHandler handler, ReduceOperationMessage operation)

--- a/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
+++ b/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
@@ -20,4 +20,7 @@ internal static partial class ReducersLogMessages
 
     [LoggerMessage(LogLevel.Trace, "Handling of events received for Reducer {ReducerId} completed")]
     internal static partial void EventHandlingCompleted(this ILogger<Reducers> logger, ReducerId reducerId);
+
+    [LoggerMessage(LogLevel.Information, "Reconnecting Reducer '{ReducerId}' after stream failure")]
+    internal static partial void ReconnectingReducer(this ILogger<Reducers> logger, ReducerId reducerId);
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
@@ -33,7 +33,9 @@ public class EncryptChangeset(
             return context;
         }
 
-        var identifier = context.Event.Context.Subject.Value;
+        var identifier = context.Event.Context.Subject?.IsSet == true
+            ? context.Event.Context.Subject.Value
+            : context.Event.Context.EventSourceId.Value;
 
         var schema = projection.TargetReadModelSchema;
         var currentState = context.Changeset.CurrentState;

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
@@ -109,8 +109,12 @@ public class ProjectionObserverSubscriber(
     {
         if (_pipeline is null)
         {
-            logger.PipelineDisconnected(_key);
-            return ObserverSubscriberResult.Disconnected();
+            logger.PipelineNotReady(_key);
+            return new(
+                ObserverSubscriberState.Failed,
+                EventSequenceNumber.Unavailable,
+                ["Projection pipeline is not yet ready — will be retried."],
+                string.Empty);
         }
 
         AppendedEvent? lastSuccessfullyObservedEvent = default;

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriberLogging.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriberLogging.cs
@@ -11,8 +11,8 @@ namespace Cratis.Chronicle.Projections;
 /// </summary>
 internal static partial class ProjectionObserverSubscriberLogging
 {
-    [LoggerMessage(LogLevel.Warning, "Projection pipeline for key {Key} is disconnected")]
-    internal static partial void PipelineDisconnected(this ILogger<ProjectionObserverSubscriber> logger, ObserverSubscriberKey key);
+    [LoggerMessage(LogLevel.Warning, "Projection pipeline for key {Key} is not yet ready — event will be retried as a failed partition")]
+    internal static partial void PipelineNotReady(this ILogger<ProjectionObserverSubscriber> logger, ObserverSubscriberKey key);
 
     [LoggerMessage(LogLevel.Warning, "An error occurred while handling to projection pipeline for key {Key}. Last successfully observed event was {LastObservedEventSequenceNumber}")]
     internal static partial void ErrorHandling(this ILogger<ProjectionObserverSubscriber> logger, Exception ex, ObserverSubscriberKey key, ulong lastObservedEventSequenceNumber);

--- a/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
@@ -218,6 +218,10 @@ public class EventSequenceStorage(
                 var schema = await eventTypesStorage.GetFor(eventToAppend.EventType.Id, eventToAppend.EventType.Generation);
                 var jsonObject = expandoObjectConverter.ToJsonObject(eventToAppend.Content, schema.Schema);
                 var document = BsonDocument.Parse(JsonSerializer.Serialize(jsonObject, jsonSerializerOptions));
+                var resolvedSubject = eventToAppend.Subject?.IsSet == true
+                    ? eventToAppend.Subject
+                    : new Concepts.Events.Subject(eventToAppend.EventSourceId.Value);
+
                 var @event = new Event(
                     eventToAppend.SequenceNumber,
                     eventToAppend.CorrelationId,
@@ -238,7 +242,8 @@ public class EventSequenceStorage(
                     {
                         { eventToAppend.EventType.Generation.ToString(), eventToAppend.Hash.Value }
                     },
-                    []);
+                    [],
+                    Subject: eventToAppend.Subject?.IsSet == true ? eventToAppend.Subject : null);
 
                 eventsToInsert.Add(@event);
 
@@ -257,7 +262,8 @@ public class EventSequenceStorage(
                         eventToAppend.Causation,
                         await identityStorage.GetFor(eventToAppend.CausedByChain),
                         eventToAppend.Tags,
-                        eventToAppend.Hash),
+                        eventToAppend.Hash,
+                        Subject: resolvedSubject),
                     eventToAppend.Content));
             }
 

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/EventSequenceStorage.cs
@@ -130,6 +130,7 @@ public class EventSequenceStorage(
 
             var eventHash = contentHashes.TryGetValue(eventType.Generation, out var hash) ? hash : EventHash.NotSet;
 
+            var resolvedSubject = subject?.IsSet == true ? subject : new Subject(eventSourceId.Value);
             var eventContext = new EventContext(
                 eventType,
                 eventSourceType,
@@ -144,7 +145,8 @@ public class EventSequenceStorage(
                 causation,
                 await identityStorage.GetFor(causedByChain),
                 tags,
-                eventHash);
+                eventHash,
+                Subject: resolvedSubject);
 
             return new AppendedEvent(eventContext, returnContent);
         }
@@ -230,6 +232,9 @@ public class EventSequenceStorage(
 
                 scope.DbContext.Events.Add(eventEntry);
 
+                var resolvedSubject = eventToAppend.Subject?.IsSet == true
+                    ? eventToAppend.Subject
+                    : new Subject(eventToAppend.EventSourceId.Value);
                 var eventContext = new EventContext(
                     eventToAppend.EventType,
                     eventToAppend.EventSourceType,
@@ -244,7 +249,8 @@ public class EventSequenceStorage(
                     eventToAppend.Causation,
                     await identityStorage.GetFor(eventToAppend.CausedByChain),
                     eventToAppend.Tags,
-                    eventToAppend.Hash);
+                    eventToAppend.Hash,
+                    Subject: resolvedSubject);
 
                 appendedEvents.Add(new AppendedEvent(eventContext, eventToAppend.Content));
             }


### PR DESCRIPTION
## Fixed
- `NullReferenceException` in `EncryptChangeset` caused by `Subject` not being propagated to `AppendedEvent` when appending events via `AppendMany` in both MongoDB and SQL storage — affected every projection processing batched events
- SQL `Append` path also omitted `Subject` from the returned `AppendedEvent`
- `ProjectionObserverSubscriber` no longer transitions the observer to `Disconnected` when the pipeline is not yet initialised; the affected partition is now recorded as a failed partition and retried automatically

## Changed
- Reactor and reducer observation streams now reconnect automatically after a stream failure, retrying every 2 seconds until the application shuts down
- `EncryptChangeset` falls back to `EventSourceId` when `Subject` is null (defensive guard for events stored before this fix)