### PR TITLE
Optimize development Docker image layering and MongoDB setup

### DIFF
--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -57,8 +57,7 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc \
         ${MONGO_PACKAGE}-database-tools-extra=$MONGO_VERSION \
     && rm -rf /var/lib/apt/lists/*
 
-# Create MongoDB data directories. Replica set initialisation is deferred to
-# entrypoint.sh at runtime — no need to bake 200+ MB of journal files into the image.
+# Create MongoDB data directories.
 RUN mkdir -p /data/db /data/configdb \
     && chown -R mongodb:mongodb /data/db /data/configdb
 

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -1,46 +1,50 @@
 # syntax=docker/dockerfile:1
 
 ####################################
-# Cratis Chronicle Server
-# Build runtime image.
+# Cratis Chronicle Server - Preparation stage
+####################################
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS prep
+
+WORKDIR /app
+
+COPY Docker/copy-server-files.sh ./copy-server-files.sh
+RUN chmod +x ./copy-server-files.sh
+
+COPY ./Source/Kernel/Server/out ./out
+COPY ./Source/Workbench/wwwroot wwwroot
+
+RUN ./copy-server-files.sh && rm -f appsettings.Development.json
+
+####################################
+# Cratis Chronicle Server - Runtime stage
 ####################################
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
 ARG VERSION
 ARG MONGO_VERSION=8.0.8
 ARG MONGO_PACKAGE=mongodb-org
-
 ARG ENTRYPOINT=entrypoint.sh
 
-RUN echo Version = ${VERSION}
-RUN echo Mongo Version = ${VERSION}
-RUN echo ${ENTRYPOINT}
-
-# Install Tools
+# Install tools and tini
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    nano \
-    iputils-ping \
-    netcat-traditional \
-    wget \
-    curl \
-    gnupg \
-    apt-transport-https \
-    ca-certificates \
+        nano \
+        iputils-ping \
+        netcat-traditional \
+        curl \
+        gnupg \
+        ca-certificates \
+    && curl -fsSL https://github.com/krallin/tini/releases/download/v0.19.0/tini-$(dpkg --print-architecture) \
+        -o /usr/bin/tini \
+    && chmod +x /usr/bin/tini \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-        amd64)  SSL_PKG_URL="http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb" ;; \
-        arm64)  SSL_PKG_URL="http://launchpadlibrarian.net/475575244/libssl1.1_1.1.1f-1ubuntu2_arm64.deb" ;; \
-        *)      echo "Unsupported architecture: $ARCH" && exit 1 ;; \
-    esac && \
-    wget $SSL_PKG_URL -O libssl1.1.deb && \
-    dpkg -i libssl1.1.deb && \
-    rm libssl1.1.deb
-
-# Install MongoDB
-RUN wget --no-check-certificate -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | apt-key add - \
-    && echo "deb [ arch=$(dpkg --print-architecture) ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/8.0 multiverse" > /etc/apt/sources.list.d/mongodb-org-8.0.list \
+# Install MongoDB using the noble repository with the modern signed-by key method.
+# The libssl1.1 workaround and focal repo are no longer needed — MongoDB 8.0 has
+# native noble (24.04) packages that link against the OpenSSL 3 already in the base image.
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc \
+        | gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg \
+    && echo "deb [ arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" \
+        > /etc/apt/sources.list.d/mongodb-org-8.0.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         ${MONGO_PACKAGE}=$MONGO_VERSION \
@@ -52,37 +56,22 @@ RUN wget --no-check-certificate -qO - https://www.mongodb.org/static/pgp/server-
         ${MONGO_PACKAGE}-database-tools-extra=$MONGO_VERSION \
     && rm -rf /var/lib/apt/lists/*
 
-# Setup MongoDB as single-node replicaset
+# Create MongoDB data directories. Replica set initialisation is deferred to
+# entrypoint.sh at runtime — no need to bake 200+ MB of journal files into the image.
 RUN mkdir -p /data/db /data/configdb \
-    && chown -R mongodb:mongodb /data/db /data/configdb \
-    && mongod --logpath /var/log/mongodb/initdb.log --replSet "rs0" --bind_ip 0.0.0.0 --fork \
-    && mongosh --eval 'rs.initiate({_id: "rs0", members: [{ _id: 0, host: "localhost:27017"}]})' \
-    && mongod --shutdown
+    && chown -R mongodb:mongodb /data/db /data/configdb
 
 VOLUME /data/db /data/configdb
 
-# Add Tini to get a real init process
-RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini-$(dpkg --print-architecture) --output /usr/bin/tini
-RUN chmod +x /usr/bin/tini
-
-
 WORKDIR /app
 
-# Create entrypoint that runs both MongoDB and Runtime
 COPY Docker/${ENTRYPOINT} ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
-COPY Docker/copy-server-files.sh ./copy-server-files.sh
-RUN chmod +x ./copy-server-files.sh
-
-COPY ./Source/Kernel/Server/out ./out
-COPY ./Source/Workbench/wwwroot wwwroot
-
-RUN echo $PWD
-RUN ./copy-server-files.sh
-
+# Copy prepared application files — the large out/ directory stays in the prep
+# stage and is never baked into this image.
+COPY --from=prep /app/. ./
 COPY ./Docker/Development/appsettings.json ./appsettings.json
-RUN rm -f appsettings.Development.json
 
 EXPOSE 8080 11111 30000 35000
 ENTRYPOINT ["/usr/bin/tini", "--", "/bin/bash", "/app/entrypoint.sh"]

--- a/Docker/Development/Dockerfile
+++ b/Docker/Development/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# Development image — self-contained, includes Chronicle server + embedded MongoDB.
 
 ####################################
 # Cratis Chronicle Server - Preparation stage

--- a/Source/Kernel/Server/Kernel.cs
+++ b/Source/Kernel/Server/Kernel.cs
@@ -3,7 +3,6 @@
 
 namespace Cratis.Chronicle.Server;
 
-
 /// <summary>
 /// Class used for logging purposes. We use this to have a logger specific to the server assembly.
 /// </summary>

--- a/Source/Kernel/Server/Kernel.cs
+++ b/Source/Kernel/Server/Kernel.cs
@@ -3,6 +3,7 @@
 
 namespace Cratis.Chronicle.Server;
 
+
 /// <summary>
 /// Class used for logging purposes. We use this to have a logger specific to the server assembly.
 /// </summary>


### PR DESCRIPTION
## Changed
- Optimize the development container build to reduce image size by moving server file preparation to a separate prep stage.
- Update MongoDB package installation to use the Ubuntu noble repository with modern signed-key configuration.

## Fixed
- Remove redundant build-time replica set initialization to avoid baking unnecessary MongoDB data into the image.
- Remove legacy and obsolete package workarounds that are no longer required for MongoDB 8 on Ubuntu noble.