### PR TITLE
Remove redundant projection replay rebuild path

### DIFF
--- a/Integration/MongoDB/MongoDBGiven.cs
+++ b/Integration/MongoDB/MongoDBGiven.cs
@@ -5,7 +5,7 @@ namespace Cratis.Chronicle.MongoDB.Integration;
 
 /// <summary>
 /// Base class for MongoDB integration specs that use a typed context.
-/// Equivalent to <see cref="Cratis.Chronicle.XUnit.Integration.Given{TSetup}"/> but without
+/// Equivalent to <see cref="Given{TSetup}"/> but without
 /// the <c>IChronicleSetupFixture</c> constraint so that lightweight MongoDB-only contexts
 /// can be used without starting an Orleans silo.
 /// </summary>

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/given/all_dependencies_with_configured_sink.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/given/all_dependencies_with_configured_sink.cs
@@ -47,7 +47,7 @@ public class all_dependencies_with_configured_sink : Specification
         _reducerObservers = Substitute.For<IReducerObservers>();
         _jsonSerializerOptions = new();
 
-        _schemaGenerator.Generate(Arg.Any<Type>()).Returns(new Cratis.Chronicle.Schemas.JsonSchema());
+        _schemaGenerator.Generate(Arg.Any<Type>()).Returns(new JsonSchema());
 
         _services = Substitute.For<IServices>();
 

--- a/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
@@ -88,8 +88,8 @@ public class ChronicleOrleansInProcessWebApplicationFactory<TStartup>(
                 // Keep every host-level Chronicle client registration pointed at the
                 // shared test event store so reconnect does not create a second unnamed
                 // event store with its own failing OnConnected registration.
-                services.PostConfigure<Cratis.Chronicle.ChronicleClientOptions>(options => options.EventStore = Constants.EventStore);
-                services.PostConfigure<Microsoft.AspNetCore.Builder.ChronicleAspNetCoreOptions>(options => options.EventStore = Constants.EventStore);
+                services.PostConfigure<ChronicleClientOptions>(options => options.EventStore = Constants.EventStore);
+                services.PostConfigure<ChronicleAspNetCoreOptions>(options => options.EventStore = Constants.EventStore);
 
                 // Register test services directly in DI so the first test works normally,
                 // and also capture them in the MutableServiceRegistry so subsequent tests

--- a/Source/Infrastructure.Specs/Changes/for_Changeset/when_clearing_nested/and_nested_property_is_cleared.cs
+++ b/Source/Infrastructure.Specs/Changes/for_Changeset/when_clearing_nested/and_nested_property_is_cleared.cs
@@ -5,7 +5,7 @@ using Cratis.Chronicle.Properties;
 
 namespace Cratis.Chronicle.Changes.for_Changeset.when_clearing_nested;
 
-public class and_nested_property_is_cleared : for_Changeset.when_adding_changes.given.a_changeset
+public class and_nested_property_is_cleared : when_adding_changes.given.a_changeset
 {
     PropertyPath _nestedProperty;
 

--- a/Source/Kernel/Core.Specs/Jobs/for_JobStepThrottle/when_observer_partition_limit_is_lower_than_job_step_limit.cs
+++ b/Source/Kernel/Core.Specs/Jobs/for_JobStepThrottle/when_observer_partition_limit_is_lower_than_job_step_limit.cs
@@ -18,7 +18,7 @@ public class when_observer_partition_limit_is_lower_than_job_step_limit : Specif
         _options = new ChronicleOptions
         {
             Jobs = new Configuration.Jobs { MaxParallelSteps = 8 },
-            Observers = new Configuration.Observers { MaxConcurrentPartitions = 1 }
+            Observers = new Observers { MaxConcurrentPartitions = 1 }
         };
         _throttle = new JobStepThrottle(Options.Create(_options), NullLogger<JobStepThrottle>.Instance);
         _completedTasks = 0;

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayHandler/when_beginning_replay/and_projection_exists.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayHandler/when_beginning_replay/and_projection_exists.cs
@@ -18,4 +18,5 @@ public class and_projection_exists : given.a_projection_replay_handler_with_proj
     Task Because() => _handler.BeginReplayFor(_observerDetails);
 
     [Fact] void should_begin_replay() => _replayContexts.Received(1).Establish(_readModelType, _readModelName);
+    [Fact] void should_not_get_the_projection_definition() => _projectionGrain.DidNotReceive().GetDefinition();
 }

--- a/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler.cs
+++ b/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Observation;
-using Cratis.Chronicle.Projections.Engine;
 using Cratis.Chronicle.Projections.Engine.Pipelines;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Storage;
@@ -27,10 +26,9 @@ public class a_projection_replay_handler : Specification
     protected IReplayContexts _replayContexts;
     protected IReplayedReadModelsStorage _replayedModels;
     protected IProjectionPipeline _projectionPipeline;
-    protected IProjectionFactory _projectionFactory;
     protected ObserverDetails _observerDetails;
     protected IGrainFactory _grainFactory;
-    protected global::Cratis.Chronicle.Projections.IProjection _projectionGrain;
+    protected IProjection _projectionGrain;
     protected IReadModelDefinitionsStorage _readModelDefinitions;
     protected IEventTypesStorage _eventTypesStorage;
     protected IReadModelReplayManager _readModelReplayManager;
@@ -52,17 +50,16 @@ public class a_projection_replay_handler : Specification
         _replayedModels = Substitute.For<IReplayedReadModelsStorage>();
         _eventStoreNamespaceStorage.ReplayedReadModels.Returns(_replayedModels);
         _grainFactory = Substitute.For<IGrainFactory>();
-        _projectionGrain = Substitute.For<global::Cratis.Chronicle.Projections.IProjection>();
+        _projectionGrain = Substitute.For<IProjection>();
         _readModelReplayManager = Substitute.For<IReadModelReplayManager>();
-        _grainFactory.GetGrain<global::Cratis.Chronicle.Projections.IProjection>(Arg.Any<string>()).Returns(_projectionGrain);
+        _grainFactory.GetGrain<IProjection>(Arg.Any<string>()).Returns(_projectionGrain);
         _grainFactory.GetGrain<IReadModelReplayManager>(Arg.Any<string>()).Returns(_readModelReplayManager);
-        _projectionFactory = Substitute.For<IProjectionFactory>();
 
         _readModelDefinitions = Substitute.For<IReadModelDefinitionsStorage>();
         _eventTypesStorage = Substitute.For<IEventTypesStorage>();
         _eventStoreStorage.ReadModels.Returns(_readModelDefinitions);
         _eventStoreStorage.EventTypes.Returns(_eventTypesStorage);
-        _eventTypesStorage.GetLatestForAllEventTypes().Returns(Task.FromResult<IEnumerable<EventTypeSchema>>([]));
+        _eventTypesStorage.GetLatestForAllEventTypes().Returns(_ => Task.FromResult<IEnumerable<EventTypeSchema>>([]));
 
         _projectionPipelineManager = Substitute.For<IProjectionPipelineManager>();
         _projectionPipeline = Substitute.For<IProjectionPipeline>();
@@ -76,7 +73,6 @@ public class a_projection_replay_handler : Specification
             _grainFactory,
             _storage,
             _projectionPipelineManager,
-            _projectionFactory,
             NullLogger<ProjectionReplayHandler>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler_with_projection.cs
+++ b/Source/Kernel/Core.Specs/Projections/given/a_projection_replay_handler_with_projection.cs
@@ -1,15 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.Json.Nodes;
-using Cratis.Chronicle.Concepts.Events;
-using Cratis.Chronicle.Concepts.EventSequences;
-using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Projections;
-using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
-using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.ReadModels;
@@ -19,15 +13,12 @@ namespace Cratis.Chronicle.Projections.for_ProjectionReplayHandler.given;
 public class a_projection_replay_handler_with_projection : a_projection_replay_handler
 {
     protected Engine.IProjection _projection;
-    protected ProjectionDefinition _projectionDefinition;
     protected ReadModelDefinition _readModel;
     protected ReadModelType _readModelType = new("TheReadModelType", ReadModelGeneration.First);
     protected ReadModelContainerName _readModelName = "TheReadModel";
 
     void Establish()
     {
-        var projectionDefinition = CreateProjectionDefinition();
-
         _projection = Substitute.For<Engine.IProjection>();
         _readModel = new ReadModelDefinition(
             _readModelType.Identifier,
@@ -41,41 +32,7 @@ public class a_projection_replay_handler_with_projection : a_projection_replay_h
             new Dictionary<ReadModelGeneration, JsonSchema> { { ReadModelGeneration.First, new JsonSchema() } },
             []);
         _projection.ReadModel.Returns(_readModel);
-        _projectionFactory.Create(
-            _observerDetails.Key.EventStore,
-            _observerDetails.Key.Namespace,
-            projectionDefinition,
-            _readModel,
-            Arg.Any<IEnumerable<EventTypeSchema>>()).Returns(_projection);
-
-        _projectionDefinition = new ProjectionDefinition(
-            ProjectionOwner.Client,
-            EventSequenceId.Log,
-            (ProjectionId)_observerDetails.Key.ObserverId,
-            _readModelType.Identifier,
-            true,
-            true,
-            new JsonObject(),
-            new Dictionary<EventType, FromDefinition>(),
-            new Dictionary<EventType, JoinDefinition>(),
-            new Dictionary<PropertyPath, ChildrenDefinition>(),
-            [],
-            new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
-            new Dictionary<EventType, RemovedWithDefinition>(),
-            new Dictionary<EventType, RemovedWithJoinDefinition>(),
-            null,
-            DateTimeOffset.UtcNow,
-            null,
-            AutoMap.Enabled);
-
-        _projectionGrain.GetDefinition().Returns(Task.FromResult(_projectionDefinition));
         _readModelDefinitions.Get(_readModelType.Identifier).Returns(Task.FromResult(_readModel));
-        _projectionFactory.Create(
-            _observerDetails.Key.EventStore,
-            _observerDetails.Key.Namespace,
-            _projectionDefinition,
-            _readModel,
-            Arg.Any<IEnumerable<EventTypeSchema>>()).Returns(Task.FromResult(_projection));
 
         _projections.TryGet(
             _observerDetails.Key.EventStore,
@@ -87,10 +44,6 @@ public class a_projection_replay_handler_with_projection : a_projection_replay_h
                 return true;
             });
 
-        var projectionGrainMock = Substitute.For<global::Cratis.Chronicle.Projections.IProjection>();
-        projectionGrainMock.GetDefinition().Returns(projectionDefinition);
-        _grainFactory.GetGrain<global::Cratis.Chronicle.Projections.IProjection>(Arg.Any<string>()).Returns(projectionGrainMock);
-
         var readModelDefinitions = Substitute.For<IReadModelDefinitionsStorage>();
         readModelDefinitions.Get(_readModelType.Identifier).Returns(_readModel);
         _eventStoreStorage.ReadModels.Returns(readModelDefinitions);
@@ -99,24 +52,4 @@ public class a_projection_replay_handler_with_projection : a_projection_replay_h
         eventTypesStorage.GetLatestForAllEventTypes().Returns([]);
         _eventStoreStorage.EventTypes.Returns(eventTypesStorage);
     }
-
-    ProjectionDefinition CreateProjectionDefinition() => new(
-        ProjectionOwner.Client,
-        Concepts.EventSequences.EventSequenceId.Log,
-        _observerDetails.Key.ObserverId.Value,
-        _readModelType.Identifier,
-        true,
-        true,
-        new System.Text.Json.Nodes.JsonObject(),
-        new Dictionary<Concepts.Events.EventType, FromDefinition>(),
-        new Dictionary<Concepts.Events.EventType, JoinDefinition>(),
-        new Dictionary<PropertyPath, ChildrenDefinition>(),
-        [],
-        new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
-        new Dictionary<Concepts.Events.EventType, RemovedWithDefinition>(),
-        new Dictionary<Concepts.Events.EventType, RemovedWithJoinDefinition>(),
-        null,
-        DateTimeOffset.UtcNow,
-        null,
-        AutoMap.Enabled);
 }

--- a/Source/Kernel/Core.Specs/Services/Projections/for_Projections/when_registering/and_registration_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/Projections/for_Projections/when_registering/and_registration_fails.cs
@@ -15,12 +15,12 @@ public class and_registration_fails : Specification
     void Establish()
     {
         var grainFactory = Substitute.For<IGrainFactory>();
-        var projectionsManager = Substitute.For<Cratis.Chronicle.Projections.IProjectionsManager>();
-        grainFactory.GetGrain<Cratis.Chronicle.Projections.IProjectionsManager>(Arg.Any<string>()).Returns(projectionsManager);
+        var projectionsManager = Substitute.For<Chronicle.Projections.IProjectionsManager>();
+        grainFactory.GetGrain<Chronicle.Projections.IProjectionsManager>(Arg.Any<string>()).Returns(projectionsManager);
         projectionsManager.Register(Arg.Any<IEnumerable<Concepts.Projections.Definitions.ProjectionDefinition>>())
             .Returns(Task.FromException(new InvalidOperationException("Failed to compile projection definition")));
 
-        _service = new Services.Projections.Projections(
+        _service = new Projections(
             grainFactory,
             Substitute.For<IExpandoObjectConverter>(),
             Substitute.For<ILanguageService>(),
@@ -44,7 +44,7 @@ public class and_registration_fails : Specification
         ]
     }));
 
-    [Fact] void should_throw_projection_registration_failure() => _exception.ShouldBeOfExactType<Services.Projections.ProjectionRegistrationFailed>();
+    [Fact] void should_throw_projection_registration_failure() => _exception.ShouldBeOfExactType<ProjectionRegistrationFailed>();
     [Fact] void should_include_projection_identifier_in_message() => _exception.Message.ShouldContain("EmployeeListProjection");
     [Fact] void should_include_event_store_in_message() => _exception.Message.ShouldContain("event-store");
 }

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_read_model_has_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_read_model_has_pii_property.cs
@@ -58,7 +58,7 @@ public class and_read_model_has_pii_property : given.all_dependencies
         _subscriptionHandle.UnsubscribeAsync().Returns(Task.CompletedTask);
 
         // Set up all SubscribeAsync overloads — the exact one called depends on which Orleans extension is used
-        Task<StreamSubscriptionHandle<ProjectionChangeset>> SubscribeHandler(NSubstitute.Core.CallInfo ci)
+        Task<StreamSubscriptionHandle<ProjectionChangeset>> SubscribeHandler(CallInfo ci)
         {
             _capturedObserver = ci.Arg<IAsyncObserver<ProjectionChangeset>>();
             _observerCaptured.SetResult();

--- a/Source/Kernel/Core/Observation/ProjectionReplayHandler.cs
+++ b/Source/Kernel/Core/Observation/ProjectionReplayHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Observation;
-using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Projections.Engine;
 using Cratis.Chronicle.Projections.Engine.Pipelines;
 using Cratis.Chronicle.ReadModels;
@@ -20,14 +19,12 @@ namespace Cratis.Chronicle.Observation;
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="storage"><see cref="IStorage"/> for working with storage.</param>
 /// <param name="projectionPipelineManager"><see cref="IProjectionPipelineManager"/> for managing projection pipelines.</param>
-/// <param name="projectionFactory"><see cref="IProjectionFactory"/> for creating projections.</param>
 /// <param name="logger">The logger.</param>
 public class ProjectionReplayHandler(
     IProjectionsManager projections,
     IGrainFactory grainFactory,
     IStorage storage,
     IProjectionPipelineManager projectionPipelineManager,
-    IProjectionFactory projectionFactory,
     ILogger<ProjectionReplayHandler> logger) : ICanHandleReplayForObserver
 {
     /// <inheritdoc/>
@@ -90,20 +87,7 @@ public class ProjectionReplayHandler(
                 return Result<ICanHandleReplayForObserver.Error>.Success();
             }
 
-            // CRITICAL: The cached projection may have a stale definition if the projection was
-            // recently re-registered with a new definition. The Projection grain is authoritative
-            // and always has the current definition persisted. To ensure replay uses the most
-            // up-to-date definition, always rebuild the projection from the authoritative source.
-            var projectionGrain = grainFactory.GetGrain<global::Cratis.Chronicle.Projections.IProjection>(new ProjectionKey(observerDetails.Key.ObserverId, observerDetails.Key.EventStore));
-            var currentDefinition = await projectionGrain.GetDefinition();
-
-            // Always rebuild the projection from the current definition to ensure freshness
-            var readModelDefinition = await storage.GetEventStore(observerDetails.Key.EventStore).ReadModels.Get(currentDefinition.ReadModel);
-            var eventStoreStorage = storage.GetEventStore(observerDetails.Key.EventStore);
-            var eventTypeSchemas = await eventStoreStorage.EventTypes.GetLatestForAllEventTypes();
-            projection = await projectionFactory.Create(observerDetails.Key.EventStore, observerDetails.Key.Namespace, currentDefinition, readModelDefinition, eventTypeSchemas);
-
-            // CRITICAL: Evict the pipeline cache so that the fresh projection is used when
+            // Evict the pipeline cache so that the current projection definition is used when
             // the pipeline is built. The pipeline manager caches pipelines by projection ID,
             // but doesn't include the definition version in the key, so it would otherwise
             // return a stale pipeline built with the old definition.

--- a/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/EventSequenceStorage.cs
@@ -110,7 +110,7 @@ public class EventSequenceStorage(
         DateTimeOffset occurred,
         IDictionary<EventTypeGeneration, ExpandoObject> content,
         IDictionary<EventTypeGeneration, EventHash> contentHashes,
-        Concepts.Events.Subject? subject = null)
+        Subject? subject = null)
     {
         try
         {
@@ -158,7 +158,7 @@ public class EventSequenceStorage(
 
             var eventHash = contentHashes.TryGetValue(eventType.Generation, out var hash) ? hash : EventHash.NotSet;
 
-            var resolvedSubject = subject?.IsSet == true ? subject : new Concepts.Events.Subject(eventSourceId.Value);
+            var resolvedSubject = subject?.IsSet == true ? subject : new Subject(eventSourceId.Value);
             return Result<AppendedEvent, DuplicateEventSequenceNumber>.Success(new AppendedEvent(
                 new(
                     eventType,
@@ -220,7 +220,7 @@ public class EventSequenceStorage(
                 var document = BsonDocument.Parse(JsonSerializer.Serialize(jsonObject, jsonSerializerOptions));
                 var resolvedSubject = eventToAppend.Subject?.IsSet == true
                     ? eventToAppend.Subject
-                    : new Concepts.Events.Subject(eventToAppend.EventSourceId.Value);
+                    : new Subject(eventToAppend.EventSourceId.Value);
 
                 var @event = new Event(
                     eventToAppend.SequenceNumber,

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKey.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKey.cs
@@ -14,7 +14,7 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Encryption;
 public class EncryptionKey
 {
     /// <summary>
-    /// Gets or sets the <see cref="Cratis.Chronicle.Compliance.EncryptionKeyIdentifier"/> value the key is for.
+    /// Gets or sets the <see cref="Chronicle.Compliance.EncryptionKeyIdentifier"/> value the key is for.
     /// </summary>
     [Key]
     [Column(Order = 0)]
@@ -22,7 +22,7 @@ public class EncryptionKey
     public string Identifier { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the <see cref="Cratis.Chronicle.Compliance.EncryptionKeyRevision"/> of the key.
+    /// Gets or sets the <see cref="Chronicle.Compliance.EncryptionKeyRevision"/> of the key.
     /// </summary>
     [Key]
     [Column(Order = 1)]


### PR DESCRIPTION
## Changed
- Simplify projection replay handling by removing redundant rebuild logic and relying on the active projection path.
- Clean up type qualification and namespace usage in related storage and specification code.

## Fixed
- Prevent replay from fetching projection definitions through the projection grain during begin-replay, reducing unnecessary indirection in the replay path.