### PR TITLE
Fix JsonSchemaGenerator crash for records with non-primitive struct defaults

### DIFF
--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_record_with_struct_default_values.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_record_with_struct_default_values.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+public class when_generating_schema_for_record_with_struct_default_values : given.a_json_schema_generator
+{
+    record TypeWithStructDefaults(DateTimeOffset OccurredAt = default, Guid Id = default);
+
+    Exception? _error;
+    JsonSchema _result = null!;
+
+    void Because() => _error = Catch.Exception(() => _result = _generator.Generate(typeof(TypeWithStructDefaults)));
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_generate_a_schema() => _result.ShouldNotBeNull();
+    [Fact] void should_have_occurred_at_property() => _result.ActualProperties.ContainsKey("OccurredAt").ShouldBeTrue();
+    [Fact] void should_have_id_property() => _result.ActualProperties.ContainsKey("Id").ShouldBeTrue();
+    [Fact] void should_inject_date_time_offset_format_for_occurred_at() => _result.ActualProperties["OccurredAt"].Format.ShouldEqual("date-time-offset");
+    [Fact] void should_inject_guid_format_for_id() => _result.ActualProperties["Id"].Format.ShouldEqual("guid");
+}

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -19,6 +19,8 @@ namespace Cratis.Chronicle.Schemas;
 [Singleton]
 public class JsonSchemaGenerator : IJsonSchemaGenerator
 {
+    static FieldInfo? _paramDefaultValueField;
+
     readonly JsonSerializerOptions _serializerOptions;
     readonly JsonSchemaExporterOptions _exporterOptions;
     readonly IComplianceMetadataResolver _metadataResolver;
@@ -34,10 +36,13 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
         _metadataResolver = metadataResolver;
         _typeFormats = new TypeFormats();
 
+        var resolver = new DefaultJsonTypeInfoResolver();
+        resolver.Modifiers.Add(FixStructDefaultValues);
+
         _serializerOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = namingPolicy.JsonPropertyNamingPolicy,
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+            TypeInfoResolver = resolver,
             Converters =
             {
                 new EnumerableConceptAsJsonConverterFactory(),
@@ -57,6 +62,47 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     {
         var node = _serializerOptions.GetJsonSchemaAsNode(type, _exporterOptions);
         return new JsonSchema(node.AsObject());
+    }
+
+    static FieldInfo GetParameterDefaultValueField(JsonParameterInfo paramInfo)
+    {
+        if (_paramDefaultValueField is not null) return _paramDefaultValueField;
+
+        var type = paramInfo.GetType();
+        while (type is not null)
+        {
+            var field = type.GetField(
+                "<DefaultValue>k__BackingField",
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+            if (field is not null)
+            {
+                _paramDefaultValueField = field;
+                return field;
+            }
+
+            type = type.BaseType;
+        }
+
+        throw new InvalidOperationException("Could not find DefaultValue backing field on JsonParameterInfo.");
+    }
+
+    static void FixStructDefaultValues(JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object) return;
+
+        foreach (var property in typeInfo.Properties)
+        {
+            if (property.AssociatedParameter is not { HasDefaultValue: true, DefaultValue: null } paramInfo)
+                continue;
+            if (!paramInfo.ParameterType.IsValueType)
+                continue;
+            if (Nullable.GetUnderlyingType(paramInfo.ParameterType) is not null)
+                continue;
+
+            var field = GetParameterDefaultValueField(paramInfo);
+            field.SetValue(paramInfo, Activator.CreateInstance(paramInfo.ParameterType));
+        }
     }
 
     static void AddComplianceMetadata(JsonObject schema, IEnumerable<ComplianceMetadata> metadata)


### PR DESCRIPTION
## Fixed
- `JsonSchemaGenerator.Generate()` no longer crashes with a `JsonException` when called on a record type that has non-primitive struct properties with default values (e.g. `DateTimeOffset OccurredAt = default`, `Guid Id = default`) under .NET 10.