### PR TITLE
Fix bugs related to enum handling and projection registration

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/ModuleCustomerInfo.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleCustomerInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Nested record populated from <see cref="ModuleOpened"/> via property-level <see cref="SetFromAttribute{TEvent}"/>.
+/// </summary>
+/// <param name="Name">Customer name.</param>
+/// <param name="Email">Customer email.</param>
+public record ModuleCustomerInfo(
+    [SetFrom<ModuleOpened>(nameof(ModuleOpened.CustomerName))]
+    string Name,
+    [SetFrom<ModuleOpened>(nameof(ModuleOpened.CustomerEmail))]
+    string Email);

--- a/Source/Clients/Testing.Specs/ReadModels/ModuleOpened.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleOpened.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for opening a module — carries module identity plus customer fields used by a nested record.
+/// </summary>
+/// <param name="Name">Module name.</param>
+/// <param name="CustomerName">Name of the customer the module is opened for.</param>
+/// <param name="CustomerEmail">Email of the customer the module is opened for.</param>
+[EventType]
+public record ModuleOpened(string Name, string CustomerName, string CustomerEmail);

--- a/Source/Clients/Testing.Specs/ReadModels/ModuleSummary.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleSummary.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test read model that exercises a single event type registered through three mechanisms simultaneously —
+/// class-level <see cref="FromEventAttribute{TEvent}"/>, property-level <see cref="SetFromContextAttribute{TEvent}"/>,
+/// and a <see cref="NestedAttribute"/> child whose properties use <see cref="SetFromAttribute{TEvent}"/>.
+/// </summary>
+/// <param name="Id">Identifier.</param>
+/// <param name="Name">Module name — auto-mapped from <see cref="ModuleOpened.Name"/>.</param>
+/// <param name="Customer">Nested customer details populated from the same <see cref="ModuleOpened"/> event.</param>
+/// <param name="OpenedAt">When the module was opened — captured from <see cref="EventContext.Occurred"/> for the same event.</param>
+[Passive]
+[FromEvent<ModuleOpened>]
+public record ModuleSummary(
+    Guid Id,
+    string Name,
+
+    [Nested]
+    ModuleCustomerInfo? Customer,
+
+    [SetFromContext<ModuleOpened>(nameof(EventContext.Occurred))]
+    DateTimeOffset? OpenedAt);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_event_is_used_at_class_property_and_nested_level.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_event_is_used_at_class_property_and_nested_level.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies the projection factory tolerates the same event type registered through multiple mechanisms on
+/// one projection — class-level [FromEvent], property-level [SetFromContext], and a [Nested] child's [SetFrom].
+/// Previously this raised 'An item with the same key has already been added. Key: ModuleOpened+1' from the
+/// operation-types dictionary build.
+/// </summary>
+public class when_event_is_used_at_class_property_and_nested_level : Specification
+{
+    ReadModelScenario<ModuleSummary> _scenario;
+    EventSourceId _moduleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ModuleSummary>();
+        _moduleId = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_moduleId)
+            .Events(new ModuleOpened("Reporting", "Equinor ASA", "billing@equinor.com"));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_map_module_name_from_event() => _scenario.Instance!.Name.ShouldEqual("Reporting");
+    [Fact] void should_populate_nested_customer() => _scenario.Instance!.Customer.ShouldNotBeNull();
+    [Fact] void should_map_nested_customer_name_from_same_event() => _scenario.Instance!.Customer!.Name.ShouldEqual("Equinor ASA");
+    [Fact] void should_map_nested_customer_email_from_same_event() => _scenario.Instance!.Customer!.Email.ShouldEqual("billing@equinor.com");
+    [Fact] void should_capture_opened_at_from_event_context() => _scenario.Instance!.OpenedAt.ShouldNotBeNull();
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// In production, MongoDB sets <c>_id</c> = projection key value and the BSON deserializer maps
+/// <c>_id</c> back onto the read model's identifier property. The in-memory test harness skips
+/// MongoDB, so it must mirror that mapping itself; otherwise <see cref="ReadModelScenario{T}.Instance"/>
+/// returns a read model whose identifier property is <see langword="null"/> for any model whose ID
+/// is sourced from the event-source ID (the common case).
+/// </summary>
+public class when_read_model_identifier_is_only_set_by_event_source : Specification
+{
+    [Passive]
+    [FromEvent<KeyedSampleCreated>]
+    public record KeyedSample([Key] Guid Id, string Name);
+
+    [EventType]
+    public record KeyedSampleCreated(string Name);
+
+    ReadModelScenario<KeyedSample> _scenario;
+    Guid _sampleGuid;
+    EventSourceId _sampleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<KeyedSample>();
+        _sampleGuid = Guid.NewGuid();
+        _sampleId = _sampleGuid.ToString();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sampleId)
+            .Events(new KeyedSampleCreated("Example"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_populate_keyed_identifier_from_event_source() => _scenario.Instance!.Id.ShouldEqual(_sampleGuid);
+    [Fact] void should_still_populate_event_mapped_properties() => _scenario.Instance!.Name.ShouldEqual("Example");
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// In production, MongoDB sets <c>_id</c> = projection key value and the BSON deserializer maps
+/// <c>_id</c> back onto the read model's identifier property. The in-memory test harness skips
+/// MongoDB, so it must mirror that mapping itself; otherwise <see cref="ReadModelScenario{T}.Instance"/>
+/// returns a read model whose identifier property is <see langword="null"/> for any model whose ID
+/// is sourced from the event-source ID (the common case).
+/// </summary>
+public class when_read_model_identifier_is_only_set_by_event_source : Specification
+{
+    [Passive]
+    [FromEvent<KeyedSampleCreated>]
+    public record KeyedSample([Key] Guid Id, string Name);
+
+    [EventType]
+    public record KeyedSampleCreated(string Name);
+
+    ReadModelScenario<KeyedSample> _scenario;
+    Guid _sampleGuid;
+    EventSourceId _sampleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<KeyedSample>();
+        _sampleGuid = Guid.NewGuid();
+        _sampleId = _sampleGuid.ToString();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sampleId)
+            .Events(new KeyedSampleCreated("Example"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_populate_keyed_identifier_from_event_source() => _scenario.Instance!.Id.ShouldEqual(_sampleGuid);
+    [Fact] void should_still_populate_event_mapped_properties() => _scenario.Instance!.Name.ShouldEqual("Example");
+}
+
+/// <summary>
+/// Variant of the same scenario where the identifier is marked with <see cref="SubjectAttribute"/> instead
+/// of <see cref="KeyAttribute"/> — both should populate from the event source ID in the test harness.
+/// </summary>
+public class when_read_model_identifier_is_only_set_by_event_source_via_subject_attribute : Specification
+{
+    [Passive]
+    [FromEvent<SubjectedSampleCreated>]
+    public record SubjectedSample([Subject] Guid Id, string Name);
+
+    [EventType]
+    public record SubjectedSampleCreated(string Name);
+
+    ReadModelScenario<SubjectedSample> _scenario;
+    Guid _sampleGuid;
+    EventSourceId _sampleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SubjectedSample>();
+        _sampleGuid = Guid.NewGuid();
+        _sampleId = _sampleGuid.ToString();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sampleId)
+            .Events(new SubjectedSampleCreated("Example"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_populate_subjected_identifier_from_event_source() => _scenario.Instance!.Id.ShouldEqual(_sampleGuid);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source_via_subject_attribute.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_read_model_identifier_is_only_set_by_event_source_via_subject_attribute.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Variant of <see cref="when_read_model_identifier_is_only_set_by_event_source"/> where the identifier
+/// is marked with <see cref="SubjectAttribute"/> instead of <see cref="Keys.KeyAttribute"/> — both
+/// should populate from the event source ID in the test harness, matching MongoDB's _id-mapping
+/// precedence ([Key] → [Subject] → property named "Id").
+/// </summary>
+public class when_read_model_identifier_is_only_set_by_event_source_via_subject_attribute : Specification
+{
+    [Passive]
+    [FromEvent<SubjectedSampleCreated>]
+    public record SubjectedSample([Subject] Guid Id, string Name);
+
+    [EventType]
+    public record SubjectedSampleCreated(string Name);
+
+    ReadModelScenario<SubjectedSample> _scenario;
+    Guid _sampleGuid;
+    EventSourceId _sampleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SubjectedSample>();
+        _sampleGuid = Guid.NewGuid();
+        _sampleId = _sampleGuid.ToString();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sampleId)
+            .Events(new SubjectedSampleCreated("Example"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_populate_subjected_identifier_from_event_source() => _scenario.Instance!.Id.ShouldEqual(_sampleGuid);
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -5,15 +5,18 @@ extern alias KernelConcepts;
 extern alias KernelCore;
 
 using System.Dynamic;
+using System.Reflection;
 using System.Text.Json;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Dynamic;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Keys;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Chronicle.Testing.EventSequences;
 using Cratis.Json;
+using Cratis.Serialization;
 using Microsoft.Extensions.Logging;
 using FrameworkNullLoggerFactory = Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory;
 using KernelAppendedEvent = KernelConcepts::Cratis.Chronicle.Concepts.Events.AppendedEvent;
@@ -158,11 +161,21 @@ internal static class ProjectionReadModelProcessor
             ? initialState.AsExpandoObject(false)
             : CreateInitialStateFromSchema(schema);
 
+        // Capture the first non-deferred key resolved for the root projection. In production, MongoDB
+        // upserts each read model document with `_id` = this key value, and the BSON deserializer maps
+        // `_id` back onto the read model's identifier property (the property marked [Key] / [Subject]
+        // or conventionally named "Id"). The in-memory test harness skips the MongoDB round-trip, so
+        // we mirror that mapping ourselves before serializing the state — otherwise identifier
+        // properties whose only source is the event-source ID surface as null in _scenario.Instance.
+        KernelKey? rootKey = null;
+
         // Process events, retrying any that return DeferredKey once all other events have been processed.
         var deferredEvents = new Queue<KernelAppendedEvent>();
         foreach (var @event in appendedEvents)
         {
-            state = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, @event, state, deferredEvents);
+            var (newState, eventKey) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, @event, state, deferredEvents);
+            state = newState;
+            rootKey ??= eventKey;
         }
 
         // Retry deferred events once; if still deferred, throw a descriptive exception.
@@ -180,6 +193,7 @@ internal static class ProjectionReadModelProcessor
             }
 
             var key = (keyResult as KernelProjectionEngine::ResolvedKey)!.Key;
+            rootKey ??= key;
             var context = new KernelProjectionEngine::ProjectionEventContext(
                 key,
                 @event,
@@ -191,8 +205,75 @@ internal static class ProjectionReadModelProcessor
             state = ApplyActualChanges(key, changeset.Changes, state);
         }
 
+        InjectIdentifierFromKey<TReadModel>(state, rootKey);
+
         var json = JsonSerializer.Serialize(state);
         return JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
+    }
+
+    /// <summary>
+    /// Mirrors MongoDB's `_id` → identifier property mapping for the in-memory test harness.
+    /// Finds the read model's identifier property (preferring <c>[Key]</c>, then <c>[Subject]</c>,
+    /// then a property named "Id" by convention) and writes the resolved projection key value into
+    /// the state under that property's camel-cased name — unless an event mapping has already
+    /// populated that property.
+    /// </summary>
+    /// <typeparam name="TReadModel">The read model type being projected.</typeparam>
+    /// <param name="state">The projection state ExpandoObject to inject into.</param>
+    /// <param name="key">The resolved projection key, or <see langword="null"/> if no event resolved one.</param>
+    static void InjectIdentifierFromKey<TReadModel>(ExpandoObject state, KernelKey? key)
+        where TReadModel : class
+    {
+        if (key is null || key.Value is null) return;
+
+        var identifierProperty = FindIdentifierProperty(typeof(TReadModel));
+        if (identifierProperty is null) return;
+
+        var propertyName = AcronymFriendlyJsonCamelCaseNamingPolicy.Instance.ConvertName(identifierProperty.Name);
+        var stateDict = (IDictionary<string, object?>)state;
+
+        // Don't overwrite an explicit projection mapping (e.g. [SetFrom<T>] or [SetFromContext<T>]
+        // that wrote to the identifier property). The MongoDB analogue is: if the projection
+        // updates `_id`, that update wins; we only fill in `_id` when no update touched it.
+        if (stateDict.TryGetValue(propertyName, out var existing) && existing is not null)
+        {
+            return;
+        }
+
+        stateDict[propertyName] = key.Value;
+    }
+
+    /// <summary>
+    /// Locates the property a read model uses as its document identifier, following the same
+    /// precedence MongoDB uses to map to `_id`:
+    /// <list type="number">
+    /// <item><description><see cref="KeyAttribute"/> on a property or record positional parameter</description></item>
+    /// <item><description><see cref="SubjectAttribute"/> on a property or record positional parameter</description></item>
+    /// <item><description>A property literally named <c>Id</c> (MongoDB default-id convention)</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="readModelType">The read model CLR type to inspect.</param>
+    static PropertyInfo? FindIdentifierProperty(Type readModelType)
+    {
+        var properties = readModelType.GetProperties();
+        var primaryCtor = readModelType.GetConstructors().FirstOrDefault();
+        var parameters = primaryCtor?.GetParameters() ?? [];
+
+        return FindByAttribute<KeyAttribute>(properties, parameters)
+            ?? FindByAttribute<SubjectAttribute>(properties, parameters)
+            ?? properties.FirstOrDefault(p => string.Equals(p.Name, "Id", StringComparison.Ordinal));
+    }
+
+    static PropertyInfo? FindByAttribute<TAttribute>(PropertyInfo[] properties, ParameterInfo[] parameters)
+        where TAttribute : Attribute
+    {
+        var taggedProperty = properties.FirstOrDefault(p => Attribute.IsDefined(p, typeof(TAttribute)));
+        if (taggedProperty is not null) return taggedProperty;
+
+        var taggedParameter = parameters.FirstOrDefault(p => Attribute.IsDefined(p, typeof(TAttribute)));
+        return taggedParameter is null
+            ? null
+            : properties.FirstOrDefault(p => string.Equals(p.Name, taggedParameter.Name, StringComparison.Ordinal));
     }
 
     static ExpandoObject CreateInitialStateFromSchema(JsonSchema schema)
@@ -246,7 +327,7 @@ internal static class ProjectionReadModelProcessor
         return schemas;
     }
 
-    static async Task<ExpandoObject> ProcessSingleEvent(
+    static async Task<(ExpandoObject State, KernelKey? Key)> ProcessSingleEvent(
         KernelProjectionEngine::IProjection projection,
         InMemoryEventSequenceStorage eventSequenceStorage,
         KernelAppendedEvent @event,
@@ -259,7 +340,7 @@ internal static class ProjectionReadModelProcessor
         if (keyResult is KernelProjectionEngine::DeferredKey)
         {
             deferredEvents.Enqueue(@event);
-            return state;
+            return (state, null);
         }
 
         var key = (keyResult as KernelProjectionEngine::ResolvedKey)!.Key;
@@ -271,7 +352,7 @@ internal static class ProjectionReadModelProcessor
             false);
 
         HandleEventFor(projection, context);
-        return ApplyActualChanges(key, changeset.Changes, state);
+        return (ApplyActualChanges(key, changeset.Changes, state), key);
     }
 
     static KernelReadModels::ReadModelDefinition BuildKernelReadModelDefinition(Type readModelType, JsonSchema schema)

--- a/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_converting_object_with_enum_property_to_expando.cs
+++ b/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_converting_object_with_enum_property_to_expando.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Dynamic.for_ExpandoObjectExtensions;
+
+public class when_converting_object_with_enum_property_to_expando : Specification
+{
+    public enum Status
+    {
+        Pending = 0,
+        Active = 1,
+        Archived = 2
+    }
+
+    public record SomethingWithStatus(string Name, Status Status);
+
+    SomethingWithStatus _source;
+    ExpandoObject _result;
+    object _statusValue;
+
+    void Establish() => _source = new("Example", Status.Active);
+
+    void Because()
+    {
+        _result = _source.AsExpandoObject();
+        _statusValue = ((IDictionary<string, object?>)_result)["Status"]!;
+    }
+
+    [Fact] void should_store_enum_value_as_the_enum_type_not_a_nested_expando() =>
+        _statusValue.ShouldBeOfExactType<Status>();
+
+    [Fact] void should_preserve_the_enum_value() =>
+        ((Status)_statusValue).ShouldEqual(Status.Active);
+}

--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -315,6 +315,7 @@ public static class ExpandoObjectExtensions
     {
         var valueType = value.GetType();
         if (!valueType.IsPrimitive &&
+            !valueType.IsEnum &&
             valueType != typeof(string) &&
             valueType != typeof(Guid) &&
             valueType != typeof(DateOnly) &&

--- a/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
@@ -617,12 +617,18 @@ public class ProjectionFactory(
         // Collect event types from all nested definitions (nested objects use the same key resolver as the parent)
         var nestedEventTypes = CollectNestedEventTypes(projection, projectionDefinition.Nested, actualIdentifiedByProperty, hasParent);
 
-        var operationTypes = fromEventTypes.ToDictionary(_ => _.EventType, _ => ProjectionOperationType.From)
-            .Concat(joinEventTypes.ToDictionary(_ => _.EventType, _ => ProjectionOperationType.Join))
-            .Concat(removedWithEventTypes.ToDictionary(_ => _.EventType, _ => ProjectionOperationType.Remove))
-            .Concat(removedWithJoinEventTypes.ToDictionary(_ => _.EventType, _ => ProjectionOperationType.Join | ProjectionOperationType.Remove))
-            .Concat(nestedEventTypes.ToDictionary(_ => _.EventType, _ => ProjectionOperationType.From))
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        // Combine all operation-type contributions per event type. The same event type can be registered
+        // through multiple mechanisms simultaneously — e.g. class-level [FromEvent<T>] on the parent +
+        // a nested definition that also projects T via [SetFrom<T>] on its properties. We OR the
+        // ProjectionOperationType flags together so a single event type can carry multiple operation
+        // semantics (From + Remove, From + Join, etc.) without colliding on dictionary insert.
+        var operationTypes = fromEventTypes.Select(_ => (_.EventType, Op: ProjectionOperationType.From))
+            .Concat(joinEventTypes.Select(_ => (_.EventType, Op: ProjectionOperationType.Join)))
+            .Concat(removedWithEventTypes.Select(_ => (_.EventType, Op: ProjectionOperationType.Remove)))
+            .Concat(removedWithJoinEventTypes.Select(_ => (_.EventType, Op: ProjectionOperationType.Join | ProjectionOperationType.Remove)))
+            .Concat(nestedEventTypes.Select(_ => (_.EventType, Op: ProjectionOperationType.From)))
+            .GroupBy(t => t.EventType)
+            .ToDictionary(g => g.Key, g => g.Aggregate(ProjectionOperationType.None, (acc, x) => acc | x.Op));
 
         List<EventTypeWithKeyResolver> eventsForProjection = [.. fromEventTypes, .. joinEventTypes, .. removedWithEventTypes, .. removedWithJoinEventTypes, .. nestedEventTypes];
         if (projectionDefinition.FromDerivatives is not null)

--- a/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
@@ -93,7 +93,6 @@ public static class OpenIddictServiceCollectionExtensions
                 var identityProviderHasSecureCertificate = identityProviderCertificate.Enabled && !string.IsNullOrEmpty(identityProviderCertificate.CertificatePath);
 
                 // Allow HTTP connections when Workbench TLS is disabled (e.g. behind ingress/reverse proxy)
-#if DEVELOPMENT
                 if (!identityProviderHasSecureCertificate)
                 {
                     options.UseAspNetCore()
@@ -105,19 +104,6 @@ public static class OpenIddictServiceCollectionExtensions
                     options.UseAspNetCore()
                            .EnableTokenEndpointPassthrough();
                 }
-#else
-                if (!identityProviderHasSecureCertificate)
-                {
-                    options.UseAspNetCore()
-                           .EnableTokenEndpointPassthrough()
-                           .DisableTransportSecurityRequirement();
-                }
-                else
-                {
-                    options.UseAspNetCore()
-                           .EnableTokenEndpointPassthrough();
-                }
-#endif
 
                 if (!string.IsNullOrWhiteSpace(chronicleOptions.Authentication.Authority))
                 {


### PR DESCRIPTION
# Summary

Fixes three `ReadModelScenario<T>` bugs that surfaced read models as `null` or threw on `_scenario.Instance` for common, documented read-model patterns — enum properties, shared event types across class/property/nested mappings, and identifiers sourced from the event source ID.

## Added

- Spec coverage for enum properties round-tripping through `AsExpandoObject`.
- Spec coverage for projections that register a single event type through class-level `[FromEvent<T>]` + property-level `[SetFromContext<T>]` + a `[Nested]` child's `[SetFrom<T>]` simultaneously.
- Spec coverage for `ReadModelScenario<T>` populating `[Key]` and `[Subject]` identifier properties from the event source ID.

## Fixed

- `ReadModelScenario<T>.Instance` no longer throws `JsonException: Unexpected token StartObject when parsing an Enum` for read models with enum properties.
- `ProjectionFactory.ResolveEventsForProjection` no longer throws `ArgumentException: An item with the same key has already been added. Key: <EventType>+1` when one event type is registered through class-level `[FromEvent<T>]`, property-level `[SetFromContext<T>]`, and a `[Nested]` child's `[SetFrom<T>]` on the same projection.
- `ReadModelScenario<T>.Instance` now populates the read model's identifier property (`[Key]`, `[Subject]`, or conventionally-named `Id`) from the resolved projection key, matching the production MongoDB `_id`-to-identifier behavior.
