### PR TITLE
Fix stack overflow on self-referential model-bound projections

### DIFF
--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjections/RecursiveProjection.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjections/RecursiveProjection.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjections;
+
+public record RecursiveProjection(string Name, [ChildrenFrom<TestEvent>] IReadOnlyList<RecursiveProjection> Children);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjections/when_discovering/with_self_referential_children.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjections/when_discovering/with_self_referential_children.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjections.when_discovering;
+
+public class with_self_referential_children : given.a_model_bound_projections
+{
+    IDictionary<Type, ProjectionDefinition> _result;
+
+    void Establish() =>
+        _clientArtifactsProvider.ModelBoundProjections.Returns([typeof(RecursiveProjection)]);
+
+    void Because() => _result = projections.Discover();
+
+    [Fact] void should_include_recursive_projection_as_root() => _result.Keys.ShouldContainOnly([typeof(RecursiveProjection)]);
+}

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -50,11 +50,13 @@ static class ChildrenDefinitionExtensions
             definition,
             parentModelType);
 
+        var visited = parentModelType is null ? new HashSet<Type>() : new HashSet<Type> { parentModelType };
+
         // Recursively process nested children on the child type
         var childType = GetChildType(memberType);
         if (childType is not null)
         {
-            ProcessNestedChildren(childType, getOrCreateEventType, namingPolicy, processMember, definition, childrenDef);
+            ProcessNestedChildren(childType, getOrCreateEventType, namingPolicy, processMember, definition, childrenDef, visited);
         }
     }
 
@@ -71,6 +73,7 @@ static class ChildrenDefinitionExtensions
     /// <param name="processMember">The action to process child members recursively.</param>
     /// <param name="definition">The root projection definition for processing member attributes.</param>
     /// <param name="parentModelType">The type of the parent model that contains this children collection.</param>
+    /// <param name="visitedChildTypes">Set of child types already visited in the current recursion chain, used to break cycles for self-referential or mutually recursive types.</param>
     internal static void ProcessChildrenFromAttributeForNestedChildren(
         this ChildrenDefinition parentChildrenDef,
         Func<Type, EventType> getOrCreateEventType,
@@ -81,7 +84,8 @@ static class ChildrenDefinitionExtensions
         Type eventType,
         Action<MemberInfo, ProjectionDefinition, List<Attribute>, bool, Type?, ChildrenDefinition?> processMember,
         ProjectionDefinition definition,
-        Type? parentModelType = null)
+        Type? parentModelType = null,
+        HashSet<Type>? visitedChildTypes = null)
     {
         var childrenDef = ProcessChildrenFromAttributeCore(
             parentChildrenDef.Children,
@@ -99,7 +103,7 @@ static class ChildrenDefinitionExtensions
         var childType = GetChildType(memberType);
         if (childType is not null)
         {
-            ProcessNestedChildren(childType, getOrCreateEventType, namingPolicy, processMember, definition, childrenDef);
+            ProcessNestedChildren(childType, getOrCreateEventType, namingPolicy, processMember, definition, childrenDef, visitedChildTypes ?? []);
         }
     }
 
@@ -346,8 +350,14 @@ static class ChildrenDefinitionExtensions
         INamingPolicy namingPolicy,
         Action<MemberInfo, ProjectionDefinition, List<Attribute>, bool, Type?, ChildrenDefinition?> processMember,
         ProjectionDefinition definition,
-        ChildrenDefinition parentChildrenDef)
+        ChildrenDefinition parentChildrenDef,
+        HashSet<Type> visitedChildTypes)
     {
+        if (!visitedChildTypes.Add(childType))
+        {
+            return;
+        }
+
         // Process constructor parameters for ChildrenFrom and Nested attributes
         var primaryConstructor = childType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
             .OrderByDescending(c => c.GetParameters().Length)
@@ -372,7 +382,8 @@ static class ChildrenDefinitionExtensions
                         eventType,
                         processMember,
                         definition,
-                        childType);
+                        childType,
+                        visitedChildTypes);
                 }
 
                 if (parameter.IsDefined(typeof(NestedAttribute), inherit: false))
@@ -409,7 +420,8 @@ static class ChildrenDefinitionExtensions
                     eventType,
                     processMember,
                     definition,
-                    childType);
+                    childType,
+                    visitedChildTypes);
             }
 
             if (Attribute.IsDefined(property, typeof(NestedAttribute)))

--- a/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjections.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjections.cs
@@ -50,7 +50,13 @@ internal class ModelBoundProjections(
 
         foreach (var type in candidateTypes)
         {
-            CollectChildTypesFromType(type, referencedTypes);
+            var referencedByType = new HashSet<Type>();
+            CollectChildTypesFromType(type, referencedByType);
+            referencedByType.Remove(type);
+            foreach (var referenced in referencedByType)
+            {
+                referencedTypes.Add(referenced);
+            }
         }
 
         return referencedTypes;
@@ -89,15 +95,13 @@ internal class ModelBoundProjections(
         if (hasChildrenFromAttribute)
         {
             var childType = GetChildType(parameter.ParameterType);
-            if (childType is not null)
+            if (childType is not null && referencedTypes.Add(childType))
             {
-                referencedTypes.Add(childType);
                 CollectChildTypesFromType(childType, referencedTypes);
             }
         }
-        else if (IsComplexType(parameter.ParameterType))
+        else if (IsComplexType(parameter.ParameterType) && referencedTypes.Add(parameter.ParameterType))
         {
-            referencedTypes.Add(parameter.ParameterType);
             CollectChildTypesFromType(parameter.ParameterType, referencedTypes);
         }
     }
@@ -111,15 +115,13 @@ internal class ModelBoundProjections(
         if (hasChildrenFromAttribute)
         {
             var childType = GetChildType(property.PropertyType);
-            if (childType is not null)
+            if (childType is not null && referencedTypes.Add(childType))
             {
-                referencedTypes.Add(childType);
                 CollectChildTypesFromType(childType, referencedTypes);
             }
         }
-        else if (IsComplexType(property.PropertyType))
+        else if (IsComplexType(property.PropertyType) && referencedTypes.Add(property.PropertyType))
         {
-            referencedTypes.Add(property.PropertyType);
             CollectChildTypesFromType(property.PropertyType, referencedTypes);
         }
     }


### PR DESCRIPTION
## Fixed
- Model-bound projections that reference their own type via `[ChildrenFrom]` (self-referential or mutually recursive children) no longer crash the client with `StackOverflowException` during projection discovery.