### PR TITLE
Fix ReadModelScenario parent-key resolution for child events

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/FeatureAddedSelfRef.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/FeatureAddedSelfRef.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+[EventType]
+public record FeatureAddedSelfRef(ModuleNodeId ModuleId, FeatureNodeId FeatureId, string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/FeatureNodeId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/FeatureNodeId.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+public record FeatureNodeId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    public static readonly FeatureNodeId NotSet = new(Guid.Empty);
+    public static implicit operator Guid(FeatureNodeId value) => value.Value;
+    public static implicit operator FeatureNodeId(Guid value) => new(value);
+    public static implicit operator EventSourceId(FeatureNodeId value) => new(value.Value.ToString());
+    public static FeatureNodeId New() => new(Guid.NewGuid());
+}

--- a/Source/Clients/Testing.Specs/ReadModels/FeatureNodeSelfRef.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/FeatureNodeSelfRef.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+[FromEvent<FeatureAddedSelfRef>]
+[FromEvent<SubFeatureAddedSelfRef>(parentKey: nameof(SubFeatureAddedSelfRef.ParentFeatureId))]
+public record FeatureNodeSelfRef(
+    [Key] FeatureNodeId Id,
+    string Name,
+    [ChildrenFrom<SubFeatureAddedSelfRef>(key: nameof(SubFeatureAddedSelfRef.FeatureId), identifiedBy: nameof(FeatureNodeSelfRef.Id), parentKey: nameof(SubFeatureAddedSelfRef.ParentFeatureId))]
+    IEnumerable<FeatureNodeSelfRef> SubFeatures);

--- a/Source/Clients/Testing.Specs/ReadModels/ModuleCreatedSelfRef.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleCreatedSelfRef.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+[EventType]
+public record ModuleCreatedSelfRef(string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/ModuleDashboardSelfRef.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleDashboardSelfRef.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+[Passive]
+[FromEvent<ModuleCreatedSelfRef>]
+public record ModuleDashboardSelfRef(
+    ModuleNodeId Id,
+    string Name,
+    [ChildrenFrom<FeatureAddedSelfRef>(key: nameof(FeatureAddedSelfRef.FeatureId), identifiedBy: nameof(FeatureNodeSelfRef.Id), parentKey: nameof(FeatureAddedSelfRef.ModuleId))]
+    IEnumerable<FeatureNodeSelfRef> Features);

--- a/Source/Clients/Testing.Specs/ReadModels/ModuleNodeId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleNodeId.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+public record ModuleNodeId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    public static readonly ModuleNodeId NotSet = new(Guid.Empty);
+    public static implicit operator Guid(ModuleNodeId value) => value.Value;
+    public static implicit operator ModuleNodeId(Guid value) => new(value);
+    public static implicit operator EventSourceId(ModuleNodeId value) => new(value.Value.ToString());
+    public static ModuleNodeId New() => new(Guid.NewGuid());
+}

--- a/Source/Clients/Testing.Specs/ReadModels/SubFeatureAddedSelfRef.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SubFeatureAddedSelfRef.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+[EventType]
+public record SubFeatureAddedSelfRef(FeatureNodeId ParentFeatureId, FeatureNodeId FeatureId, string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_self_referencing_children_are_on_separate_event_sources.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_self_referencing_children_are_on_separate_event_sources.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_self_referencing_children_are_on_separate_event_sources : Specification
+{
+    ReadModelScenario<ModuleDashboardSelfRef> _scenario;
+    ModuleNodeId _moduleId;
+    FeatureNodeId _featureId;
+    FeatureNodeId _subFeatureId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ModuleDashboardSelfRef>();
+        _moduleId = ModuleNodeId.New();
+        _featureId = FeatureNodeId.New();
+        _subFeatureId = FeatureNodeId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_moduleId)
+            .Events(new ModuleCreatedSelfRef("Catalog"));
+
+        await _scenario.Given
+            .ForEventSource(_featureId)
+            .Events(new FeatureAddedSelfRef(_moduleId, _featureId, "Products"));
+
+        await _scenario.Given
+            .ForEventSource(_subFeatureId)
+            .Events(new SubFeatureAddedSelfRef(_featureId, _subFeatureId, "Inventory"));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_project_both_feature_events() => _scenario.Instance!.Features.Count().ShouldEqual(2);
+    [Fact] void should_contain_sub_feature_event_name() => _scenario.Instance!.Features.Any(_ => _.Name == "Inventory").ShouldBeTrue();
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -13,7 +13,7 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Keys;
 using Cratis.Chronicle.Schemas;
-using Cratis.Chronicle.Storage.Sinks;
+using Cratis.Chronicle.Storage.Sinks.InMemory;
 using Cratis.Chronicle.Testing.EventSequences;
 using Cratis.Json;
 using Cratis.Serialization;
@@ -169,11 +169,13 @@ internal static class ProjectionReadModelProcessor
         // properties whose only source is the event-source ID surface as null in _scenario.Instance.
         KernelKey? rootKey = null;
 
+        using var inMemorySink = new InMemorySink(kernelReadModelDefinition, _typeFormats);
+
         // Process events, retrying any that return DeferredKey once all other events have been processed.
         var deferredEvents = new Queue<KernelAppendedEvent>();
         foreach (var @event in appendedEvents)
         {
-            var (newState, eventKey) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, @event, state, deferredEvents);
+            var (newState, eventKey) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents);
             state = newState;
             rootKey ??= eventKey;
         }
@@ -183,7 +185,7 @@ internal static class ProjectionReadModelProcessor
         {
             var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
             var keyResolver = engineProjection.GetKeyResolverFor(@event.Context.EventType);
-            var keyResult = await keyResolver(inMemoryEventSequenceStorage, NullSink.Instance, @event);
+            var keyResult = await keyResolver(inMemoryEventSequenceStorage, inMemorySink, @event);
 
             if (keyResult is KernelProjectionEngine::DeferredKey)
             {
@@ -203,6 +205,7 @@ internal static class ProjectionReadModelProcessor
 
             HandleEventFor(engineProjection, context);
             state = ApplyActualChanges(key, changeset.Changes, state);
+            await inMemorySink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
         }
 
         InjectIdentifierFromKey<TReadModel>(state, rootKey);
@@ -330,12 +333,13 @@ internal static class ProjectionReadModelProcessor
     static async Task<(ExpandoObject State, KernelKey? Key)> ProcessSingleEvent(
         KernelProjectionEngine::IProjection projection,
         InMemoryEventSequenceStorage eventSequenceStorage,
+        InMemorySink sink,
         KernelAppendedEvent @event,
         ExpandoObject state,
         Queue<KernelAppendedEvent> deferredEvents)
     {
         var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
-        var keyResult = await projection.GetKeyResolverFor(@event.Context.EventType)(eventSequenceStorage, NullSink.Instance, @event);
+        var keyResult = await projection.GetKeyResolverFor(@event.Context.EventType)(eventSequenceStorage, sink, @event);
 
         if (keyResult is KernelProjectionEngine::DeferredKey)
         {
@@ -352,7 +356,9 @@ internal static class ProjectionReadModelProcessor
             false);
 
         HandleEventFor(projection, context);
-        return (ApplyActualChanges(key, changeset.Changes, state), key);
+        var updatedState = ApplyActualChanges(key, changeset.Changes, state);
+        await sink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
+        return (updatedState, key);
     }
 
     static KernelReadModels::ReadModelDefinition BuildKernelReadModelDefinition(Type readModelType, JsonSchema schema)


### PR DESCRIPTION
## Fixed
- Resolved ReadModelScenario parent-key resolution for child events on separate event sources by using an in-memory sink during projection and deferred retries.
- Added regression coverage for self-referencing child-event projections to prevent unresolved parent-key failures in the testing pipeline.
