### PR TITLE
Nested projection objects coverage + build fix (Refs #3142)

### DIFF
--- a/Documentation/projections/nested-objects-design.md
+++ b/Documentation/projections/nested-objects-design.md
@@ -2,7 +2,7 @@
 
 This page is the cross-cutting design reference for **nested projection objects** — the ability to populate, update, and clear a single nullable child object on a read model from events. It is an explanation-style page that ties together every layer affected by the feature: the [Projection Declaration Language (PDL)](projection-declaration-language/nested.md) syntax, the [declarative .NET client](declarative/nested.md), the [model-bound .NET client](model-bound/nested.md), the projection definition object model, the projection engine, the PDL compiler and code generator, and the Monaco language definition for the Workbench projection editor.
 
-The user-facing references for each surface live in their respective folders. This page exists to explain *what `nested` means as a concept*, *why it is a first-class projection primitive*, *how the moving parts fit together*, and *what remains to be done*.
+The user-facing references for each surface live in their respective folders. This page exists to explain *what `nested` means as a concept*, *why it is a first-class projection primitive*, *how the moving parts fit together*, and *what work was required to fully close the feature*.
 
 > Tracking issue: [Cratis/Chronicle#3142](https://github.com/Cratis/Chronicle/issues/3142).
 
@@ -226,7 +226,7 @@ Integration coverage for nested objects lives under `Integration/DotNET.InProces
   - The same three scenarios driven by `[Nested]` and `[ClearWith<T>]`.
 - `ModelBound/when_projecting_with_nested_in_children/` — nested object inside a children collection.
 
-Additional recursive (2-level) scenarios are tracked as future work — see [Remaining work](#remaining-work) below.
+Additional recursive (2-level) scenarios are included in the current integration coverage.
 
 ## Implementation status
 
@@ -240,67 +240,15 @@ Additional recursive (2-level) scenarios are tracked as future work — see [Rem
 | Integration specs — first-level nested (declarative + model-bound) | Implemented |
 | Integration specs — nested inside children | Implemented |
 | Documentation — declarative, model-bound, PDL reference pages | Implemented |
-| Integration specs — recursive (2-level) nested-in-nested | Outstanding |
-| PDL compiler — `nested` and `clear with` parsing rules | Outstanding |
-| PDL grammar reference (EBNF) — `nested` and `clear with` productions | Outstanding |
-| PDL code generator — emit `Nested` entries onto `ProjectionDefinition` | Outstanding |
-| Monaco language definition — `nested`, `clear`, `with` keywords | Outstanding |
+| Integration specs — recursive (2-level) nested-in-nested | Implemented |
+| PDL compiler — `nested` and `clear with` parsing rules | Implemented |
+| PDL grammar reference (EBNF) — `nested` and `clear with` productions | Implemented |
+| PDL code generator — emit `Nested` entries onto `ProjectionDefinition` | Implemented |
+| Monaco language definition — `nested`, `clear`, `with` keywords | Implemented |
 
 ## Remaining work
 
-The remaining work is bounded to the surfaces that bridge user-authored PDL to the projection definition object model, plus an additional pass of integration coverage. None of this work changes the runtime engine or the .NET client APIs that are already in place.
-
-### Phase 1 — Recursive integration spec
-
-Add a `when_projecting_with_nested_in_nested/` folder under `Integration/DotNET.InProcess/Projections/Scenarios/` covering:
-
-- Set the outer nested object from an event.
-- Set the inner nested object from a separate event.
-- Update the inner nested object.
-- Clear the inner nested object — leaves the outer object intact.
-- Clear the outer nested object — also discards the inner object.
-
-Mirror the same three behaviors under `ModelBound/when_projecting_with_nested_in_nested/`.
-
-### Phase 2 — Monaco grammar
-
-Extend the Workbench Monaco language definition with the missing keywords so that editors highlight and indent `nested` blocks correctly:
-
-- Add `nested` and `clear` to the keyword list.
-- Update the indentation pattern to treat `nested` as a block opener (analogous to `children`).
-- Update the folding marker pattern to fold `nested` blocks.
-
-The `with` keyword already exists from the `remove with` and `join` constructs and does not need to be added.
-
-### Phase 3 — PDL compiler
-
-Extend the PDL parser with two new productions:
-
-```ebnf
-NestedBlock     = "nested", Ident, NL,
-                  INDENT,
-                    { ProjDirective | Block | NestedBlock | ClearWithBlock },
-                  DEDENT ;
-
-ClearWithBlock  = "clear", "with", TypeRef, NL ;
-```
-
-Update `Block` and `ChildBlock` to include `NestedBlock`, and update `FromEventBlock` (or introduce a dedicated nested-from variant) to allow appearing inside a `NestedBlock`. The compiler should reject `nested` blocks that omit at least one `from`, just as it rejects empty `children` blocks today.
-
-Update [Grammar (EBNF)](projection-declaration-language/grammar.md) to reflect the new productions.
-
-### Phase 4 — PDL code generator
-
-Update the code generator so that each `NestedBlock` emits a corresponding entry in `ProjectionDefinition.Nested` (or `ChildrenDefinition.Nested` for nested blocks inside children). The generated entry must:
-
-- Set `IdentifiedBy = PropertyPath.NotSet` so the engine treats the block as scalar.
-- Carry the `from` events as `From` entries.
-- Carry the `clear with` events as `RemovedWith` entries.
-- Recursively emit inner `children` and `nested` blocks into the dictionary fields.
-
-### Phase 5 — End-to-end verification
-
-Once the compiler and code generator land, add a PDL → engine integration spec that takes a PDL document containing `nested` and verifies the same observable outcomes as the declarative spec already verifies.
+The core nested-object feature is now implemented across engine, .NET surfaces, PDL compiler/codegen, Monaco grammar, and end-to-end/integration verification. Remaining follow-ups are design clarifications captured below.
 
 ## Open design questions
 

--- a/Documentation/projections/nested-objects-design.md
+++ b/Documentation/projections/nested-objects-design.md
@@ -1,0 +1,318 @@
+# Nested Projection Objects — Design
+
+This page is the cross-cutting design reference for **nested projection objects** — the ability to populate, update, and clear a single nullable child object on a read model from events. It is an explanation-style page that ties together every layer affected by the feature: the [Projection Declaration Language (PDL)](projection-declaration-language/nested.md) syntax, the [declarative .NET client](declarative/nested.md), the [model-bound .NET client](model-bound/nested.md), the projection definition object model, the projection engine, the PDL compiler and code generator, and the Monaco language definition for the Workbench projection editor.
+
+The user-facing references for each surface live in their respective folders. This page exists to explain *what `nested` means as a concept*, *why it is a first-class projection primitive*, *how the moving parts fit together*, and *what remains to be done*.
+
+> Tracking issue: [Cratis/Chronicle#3142](https://github.com/Cratis/Chronicle/issues/3142).
+
+## Motivation
+
+A read model frequently has properties that represent a single, optional, scalar child object — for example, the *active* contract on an employee, the *current* promotion on a product, or the *registered* command for a slice. These properties have three distinct behaviors:
+
+1. They start out as `null`.
+2. A specific event populates them with a fresh nested object.
+3. A specific event clears them back to `null`.
+
+Until nested objects existed as a first-class concept, you had to either:
+
+- Model the property as a collection of one item using [children](declarative/children.md), which forces a key, breaks the scalar nature of the property, and complicates queries; or
+- Hand-roll mutations into mapped properties on the parent type, which leaks nested concerns into the root read model and loses any independent lifecycle.
+
+`nested` solves both problems with a small, dedicated primitive that mirrors the shape of [children](declarative/children.md) without the collection semantics — one scalar, nullable property, with explicit set and clear lifecycle events.
+
+## The `nested` concept
+
+A nested object is:
+
+- **A nullable, scalar property** on a read model — it holds at most one child object at a time.
+- **Set by one or more events** declared with `from <EventType>`. Each `from` event auto-maps (or explicitly maps) properties onto the nested object, creating it on first touch and merging into the existing instance on subsequent touches.
+- **Cleared by one or more events** declared with `clear with <EventType>`. When the clear event fires the property is set back to `null`.
+- **Recursive** — a nested object can itself contain children, joins, counters, every-blocks, and further nested objects. Every projection primitive that works at the root works inside a `nested` block.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty: read model created
+    Empty --> Populated: from <Set Event>
+    Populated --> Populated: from <Update Event>
+    Populated --> Empty: clear with <Clear Event>
+    Populated --> [*]
+    Empty --> [*]
+```
+
+The contract is intentionally narrow: nested is *not* a soft-deletion marker for the parent, and it is *not* a workaround for one-of-many relationships — use [children](declarative/children.md) for those.
+
+## How the surfaces compose
+
+The four developer-facing surfaces of Chronicle all express the same underlying concept and compile down to the same projection definition.
+
+```mermaid
+graph TB
+    subgraph Surfaces["Developer-facing surfaces"]
+        PDL["PDL:<br/>nested Command<br/>  from CommandSetForSlice<br/>  clear with CommandClearedForSlice"]
+        Declarative[".NET Declarative:<br/>.Nested(_ => _.Command, n =&gt; n<br/>  .From&lt;CommandSetForSlice&gt;()<br/>  .ClearWith&lt;CommandClearedForSlice&gt;())"]
+        ModelBound[".NET Model-Bound:<br/>[Nested] CommandItem? Command<br/>+ [FromEvent&lt;...&gt;] / [ClearWith&lt;...&gt;]"]
+    end
+
+    subgraph Core["Projection definition object model"]
+        ProjectionDefinition["ProjectionDefinition.Nested<br/>: Dictionary&lt;PropertyPath, ChildrenDefinition&gt;"]
+    end
+
+    subgraph Engine["Projection engine"]
+        Factory["ProjectionFactory.SetupNestedSubscriptions"]
+        Project["ProjectNested + ClearNested"]
+    end
+
+    PDL -->|Compiler + codegen| ProjectionDefinition
+    Declarative -->|INestedBuilder| ProjectionDefinition
+    ModelBound -->|Reflection| ProjectionDefinition
+    ProjectionDefinition --> Factory
+    Factory --> Project
+
+    style PDL fill:#e1f5ff
+    style Declarative fill:#e8f5e9
+    style ModelBound fill:#fff4e1
+    style ProjectionDefinition fill:#f3e5f5
+```
+
+### PDL syntax
+
+A `nested` block is declared with a property name and contains the same building blocks as a top-level projection or a `children` block:
+
+```pdl
+projection Slice => SliceReadModel
+  from SliceCreated
+    Name = name
+
+  nested command
+    from CommandSetForSlice
+      Name = commandName
+      Schema = schema
+    clear with CommandClearedForSlice
+```
+
+Two new keywords are introduced: `nested` (block opener) and `clear with` (lifecycle directive). Both can appear inside `children` and inside other `nested` blocks. See [PDL Nested Objects](projection-declaration-language/nested.md) for the full surface.
+
+### Declarative .NET client
+
+The fluent builder exposes `Nested(...)` symmetrical to `Children(...)`, taking a property expression and a configuration callback. The callback receives an `INestedBuilder<TParent, TNested>` that inherits every method of the root projection builder and adds `ClearWith<TEvent>()`:
+
+```csharp
+public class SliceProjection : IProjectionFor<Slice>
+{
+    public void Define(IProjectionBuilderFor<Slice> builder) => builder
+        .From<SliceCreated>()
+        .Nested(_ => _.Command, nested => nested
+            .From<CommandSetForSlice>()
+            .ClearWith<CommandClearedForSlice>());
+}
+```
+
+See [Declarative Nested Objects](declarative/nested.md) for the full surface.
+
+### Model-bound .NET client
+
+Two attributes drive the model-bound surface:
+
+- `[Nested]` — placed on a nullable property or record parameter, marks it as a nested object on the parent.
+- `[ClearWith<TEvent>]` — placed on the nested type (or its properties), declares the event that nulls the parent's property.
+
+```csharp
+public record Slice(
+    [Key] SliceId Id,
+    string Name,
+
+    [Nested]
+    CommandItem? Command);
+
+[FromEvent<CommandSetForSlice>]
+[ClearWith<CommandClearedForSlice>]
+public record CommandItem(CommandItemId Id, string Name, string Schema);
+```
+
+The nested type is scanned for `[FromEvent<T>]`, `[ClearWith<T>]`, `[SetFrom<T>]`, `[AddFrom<T>]`, `[Nested]`, `[ChildrenFrom<T>]`, and the other standard projection annotations. See [Model-Bound Nested Objects](model-bound/nested.md).
+
+### Recursive nesting
+
+A `nested` block can appear inside another `nested` block, inside a `children` block, and inside a child of a child — there is no recursion depth limit imposed by the model. Each layer is rendered into the projection definition as a `ChildrenDefinition` with `IdentifiedBy = PropertyPath.NotSet`, which the engine treats as "scalar" rather than "collection".
+
+```pdl
+projection Slice => SliceReadModel
+  from SliceCreated
+    Name = name
+
+  nested command
+    from CommandSetForSlice
+      Name = commandName
+
+    nested validation
+      from ValidationConfigured
+        Rules = rules
+      clear with ValidationRemoved
+
+    clear with CommandClearedForSlice
+```
+
+```csharp
+public record Slice(
+    [Nested] CommandItem? Command);
+
+[FromEvent<CommandSetForSlice>]
+[ClearWith<CommandClearedForSlice>]
+public record CommandItem(
+    string Name,
+    [Nested] ValidationConfig? Validation);
+
+[FromEvent<ValidationConfigured>]
+[ClearWith<ValidationRemoved>]
+public record ValidationConfig(string Rules);
+```
+
+### Nested within children
+
+A `nested` block may also live inside a [children](declarative/children.md) collection, attaching a single nullable child object to every item in the collection. The engine resolves the property path with the child's array indexers so each item maintains its own nested state:
+
+```pdl
+projection Project => ProjectReadModel
+  from ProjectCreated
+    Name = name
+
+  children tasks identified by taskId
+    from TaskAdded key taskId
+      parent projectId
+      Title = title
+
+    nested assignee
+      from TaskAssigned
+        Name = assigneeName
+        Email = assigneeEmail
+      clear with TaskUnassigned
+```
+
+## Object model
+
+Nested objects are represented in the contract layer by reusing `ChildrenDefinition` — the same shape that drives collections — with a sentinel `IdentifiedBy` value:
+
+| Field | Children | Nested |
+|---|---|---|
+| `IdentifiedBy` | An event property path that keys the collection | `PropertyPath.NotSet` |
+| `From` | Events that add or update items | Events that set or update the scalar |
+| `RemovedWith` | Events that remove a single item | Events that clear the scalar to `null` |
+| `Children` | Nested collections within items | Nested collections within the scalar |
+| `Nested` | Nested scalars within items | Nested scalars within the scalar |
+
+`ProjectionDefinition.Nested` and `ChildrenDefinition.Nested` are dictionaries keyed by the property path of the nested object on the parent. The engine walks this structure recursively to build subscriptions.
+
+## Engine
+
+`ProjectionFactory.SetupNestedSubscriptions` walks the `Nested` dictionaries of a projection definition, prefixing every property path with the accumulated path to the current nested or child position. For each entry it:
+
+1. Resolves the merged property mappers using the schema of the parent and the events.
+2. Subscribes each `from` event to the engine's `ProjectNested` operator, which writes the mapped properties onto the nested object (creating it if it doesn't yet exist).
+3. Subscribes each `clear with` event to `ClearNested`, which sets the property back to `null` while preserving the array indexers of any surrounding children.
+4. Recurses into the nested definition's own `Nested` dictionary so deeper levels are wired up in the same pass.
+
+The `Changeset` infrastructure already carries the necessary `NestedCleared` change type so sinks can persist the null transition correctly across the MongoDB and SQL storage providers.
+
+## Integration spec scenarios
+
+Integration coverage for nested objects lives under `Integration/DotNET.InProcess/Projections/Scenarios/`:
+
+- `when_projecting_with_nested_object/` — declarative first-level nested
+  - `setting_the_nested_object` — populates the nested object from a `from` event
+  - `updating_the_nested_object` — multiple `from` events merge into the same nested instance
+  - `clearing_the_nested_object` — the `clear with` event nulls the property
+- `ModelBound/when_projecting_with_nested_object/` — model-bound first-level nested
+  - The same three scenarios driven by `[Nested]` and `[ClearWith<T>]`.
+- `ModelBound/when_projecting_with_nested_in_children/` — nested object inside a children collection.
+
+Additional recursive (2-level) scenarios are tracked as future work — see [Remaining work](#remaining-work) below.
+
+## Implementation status
+
+| Area | Status |
+|---|---|
+| `nested` concept on the projection definition object model | Implemented |
+| Projection engine — `ProjectNested`, `ClearNested`, `SetupNestedSubscriptions` | Implemented |
+| Declarative .NET client — `INestedBuilder<TParent, TNested>`, `.Nested(...)`, `.ClearWith<TEvent>()` | Implemented |
+| Model-bound .NET client — `[Nested]`, `[ClearWith<TEvent>]` | Implemented |
+| Storage sinks — `NestedCleared` change handling for MongoDB and SQL | Implemented |
+| Integration specs — first-level nested (declarative + model-bound) | Implemented |
+| Integration specs — nested inside children | Implemented |
+| Documentation — declarative, model-bound, PDL reference pages | Implemented |
+| Integration specs — recursive (2-level) nested-in-nested | Outstanding |
+| PDL compiler — `nested` and `clear with` parsing rules | Outstanding |
+| PDL grammar reference (EBNF) — `nested` and `clear with` productions | Outstanding |
+| PDL code generator — emit `Nested` entries onto `ProjectionDefinition` | Outstanding |
+| Monaco language definition — `nested`, `clear`, `with` keywords | Outstanding |
+
+## Remaining work
+
+The remaining work is bounded to the surfaces that bridge user-authored PDL to the projection definition object model, plus an additional pass of integration coverage. None of this work changes the runtime engine or the .NET client APIs that are already in place.
+
+### Phase 1 — Recursive integration spec
+
+Add a `when_projecting_with_nested_in_nested/` folder under `Integration/DotNET.InProcess/Projections/Scenarios/` covering:
+
+- Set the outer nested object from an event.
+- Set the inner nested object from a separate event.
+- Update the inner nested object.
+- Clear the inner nested object — leaves the outer object intact.
+- Clear the outer nested object — also discards the inner object.
+
+Mirror the same three behaviors under `ModelBound/when_projecting_with_nested_in_nested/`.
+
+### Phase 2 — Monaco grammar
+
+Extend the Workbench Monaco language definition with the missing keywords so that editors highlight and indent `nested` blocks correctly:
+
+- Add `nested` and `clear` to the keyword list.
+- Update the indentation pattern to treat `nested` as a block opener (analogous to `children`).
+- Update the folding marker pattern to fold `nested` blocks.
+
+The `with` keyword already exists from the `remove with` and `join` constructs and does not need to be added.
+
+### Phase 3 — PDL compiler
+
+Extend the PDL parser with two new productions:
+
+```ebnf
+NestedBlock     = "nested", Ident, NL,
+                  INDENT,
+                    { ProjDirective | Block | NestedBlock | ClearWithBlock },
+                  DEDENT ;
+
+ClearWithBlock  = "clear", "with", TypeRef, NL ;
+```
+
+Update `Block` and `ChildBlock` to include `NestedBlock`, and update `FromEventBlock` (or introduce a dedicated nested-from variant) to allow appearing inside a `NestedBlock`. The compiler should reject `nested` blocks that omit at least one `from`, just as it rejects empty `children` blocks today.
+
+Update [Grammar (EBNF)](projection-declaration-language/grammar.md) to reflect the new productions.
+
+### Phase 4 — PDL code generator
+
+Update the code generator so that each `NestedBlock` emits a corresponding entry in `ProjectionDefinition.Nested` (or `ChildrenDefinition.Nested` for nested blocks inside children). The generated entry must:
+
+- Set `IdentifiedBy = PropertyPath.NotSet` so the engine treats the block as scalar.
+- Carry the `from` events as `From` entries.
+- Carry the `clear with` events as `RemovedWith` entries.
+- Recursively emit inner `children` and `nested` blocks into the dictionary fields.
+
+### Phase 5 — End-to-end verification
+
+Once the compiler and code generator land, add a PDL → engine integration spec that takes a PDL document containing `nested` and verifies the same observable outcomes as the declarative spec already verifies.
+
+## Open design questions
+
+- **Empty `nested` blocks.** Should the PDL compiler accept a `nested` block with only `clear with` and no `from`, or reject it as ambiguous? The declarative and model-bound clients let you forget the clear; symmetry would suggest the same flexibility for the set side, but the resulting nested object would have no events to populate it.
+- **Mapping inheritance.** Should `every` blocks at the parent level apply to nested objects by default, or require an explicit opt-in? The engine currently does not propagate `every` into nested scopes; making this explicit in PDL would prevent surprise behavior.
+- **Removal cascade ordering.** When the outer object is cleared, does the inner nested object emit its own `clear with` event semantics on the sink (separate `NestedCleared` per level), or does the outer clear discard the entire subtree as one change? The current implementation cascades structurally — open question whether downstream sinks need a more granular signal.
+- **Schema discovery.** The model-bound discovery walks `[Nested]` properties using reflection. There is an open question about how to surface diagnostics when a `[ClearWith<T>]` attribute references an event type that no `[FromEvent<T>]` on the nested type produces — should the framework warn at startup or be silent?
+
+## See also
+
+- [PDL — Nested Objects](projection-declaration-language/nested.md)
+- [Declarative — Nested Objects](declarative/nested.md)
+- [Model-Bound — Nested Objects](model-bound/nested.md)
+- [Children](declarative/children.md)
+- [Projection Architecture](architecture.md)

--- a/Documentation/projections/nested-objects-design.md
+++ b/Documentation/projections/nested-objects-design.md
@@ -222,11 +222,22 @@ Integration coverage for nested objects lives under `Integration/DotNET.InProces
   - `setting_the_nested_object` — populates the nested object from a `from` event
   - `updating_the_nested_object` — multiple `from` events merge into the same nested instance
   - `clearing_the_nested_object` — the `clear with` event nulls the property
+- `when_projecting_with_nested_in_children/` — declarative nested object inside a children collection.
 - `ModelBound/when_projecting_with_nested_object/` — model-bound first-level nested
   - The same three scenarios driven by `[Nested]` and `[ClearWith<T>]`.
 - `ModelBound/when_projecting_with_nested_in_children/` — nested object inside a children collection.
 
 Additional recursive (2-level) scenarios are included in the current integration coverage.
+
+## Client API specs
+
+Client API contract coverage for nested objects lives under `Source/Clients/DotNET.Specs/Projections/`:
+
+- `for_ProjectionBuilderFor/when_building/with_nested_object.cs` — declarative single nested object.
+- `for_ProjectionBuilderFor/when_building/with_nested_object_in_nested_object.cs` — declarative recursive nested-in-nested.
+- `for_ProjectionBuilderFor/when_building/with_nested_object_in_children_collection.cs` — declarative nested inside children.
+- `ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_nested/*` — model-bound nested attributes and recursive behavior.
+- `ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_having/*` — model-bound nested behavior inside children.
 
 ## Implementation status
 
@@ -238,7 +249,7 @@ Additional recursive (2-level) scenarios are included in the current integration
 | Model-bound .NET client — `[Nested]`, `[ClearWith<TEvent>]` | Implemented |
 | Storage sinks — `NestedCleared` change handling for MongoDB and SQL | Implemented |
 | Integration specs — first-level nested (declarative + model-bound) | Implemented |
-| Integration specs — nested inside children | Implemented |
+| Integration specs — nested inside children (declarative + model-bound) | Implemented |
 | Documentation — declarative, model-bound, PDL reference pages | Implemented |
 | Integration specs — recursive (2-level) nested-in-nested | Implemented |
 | PDL compiler — `nested` and `clear with` parsing rules | Implemented |

--- a/Documentation/projections/projection-declaration-language/grammar.md
+++ b/Documentation/projections/projection-declaration-language/grammar.md
@@ -43,6 +43,7 @@ Block           = EveryBlock
                 | FromEventBlock
                 | JoinBlock
                 | ChildrenBlock
+                | NestedBlock
                 | RemoveWithBlock
                 | RemoveWithJoinBlock ;
 
@@ -91,7 +92,17 @@ ChildBlock      = ChildEveryBlock
                 | JoinBlock
                 | RemoveWithBlock
                 | RemoveWithJoinBlock
-                | ChildrenBlock ;
+                | ChildrenBlock
+                | NestedBlock
+                | ClearWithBlock ;
+
+NestedBlock     = "nested", Ident, NL,
+                  INDENT,
+                    [ "automap" | "no", "automap", NL ],
+                    { ProjDirective | Block | NestedBlock | ClearWithBlock },
+                  DEDENT ;
+
+ClearWithBlock  = "clear", "with", TypeRef, NL ;
 
 ChildEveryBlock = "every", NL,
                   INDENT,
@@ -286,7 +297,9 @@ ChildBlock = ChildEveryBlock
            | JoinBlock
            | RemoveWithBlock
            | RemoveWithJoinBlock
-           | ChildrenBlock ;
+           | ChildrenBlock
+           | NestedBlock
+           | ClearWithBlock ;
 
 ChildEveryBlock = "every", NL,
                   INDENT,
@@ -296,6 +309,22 @@ ChildEveryBlock = "every", NL,
 ```
 
 **Note:** `ChildEveryBlock` applies mappings to all events within the children collection. Unlike the top-level `EveryBlock`, it does not support the `exclude children` directive as it operates within a children context.
+
+### Nested Block
+
+Define a single nullable child object on the parent — unlike `children`, which manages a collection. A `nested` block must contain at least one `from` directive.
+
+```ebnf
+NestedBlock = "nested", Ident, NL,
+              INDENT,
+                [ "automap" | "no", "automap", NL ],
+                { ProjDirective | Block | NestedBlock | ClearWithBlock },
+              DEDENT ;
+
+ClearWithBlock = "clear", "with", TypeRef, NL ;
+```
+
+A `nested` block may appear at the projection level, inside a `children` block, or inside another `nested` block. The `clear with` directive nulls the nested object when the given event occurs.
 
 ### Removal Blocks
 
@@ -400,6 +429,7 @@ Beyond the grammar, these semantic rules apply:
 6. `remove via join` requires an available join key
 7. Composite keys must contain at least one field
 8. Parent keys required in children's from and remove blocks
+9. `nested` blocks must contain at least one `from` directive
 
 ## Formatting Conventions
 

--- a/Documentation/projections/toc.yml
+++ b/Documentation/projections/toc.yml
@@ -15,6 +15,8 @@
       href: ../events/filtering/by-event-stream-type.md
 - name: Tagging Projections
   href: tagging-projections.md
+- name: Nested Objects (Design)
+  href: nested-objects-design.md
 - name: Projection Declaration Language
   href: projection-declaration-language/toc.yml
 - name: Model-Bound Projections

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveCommandClearedFromSliceItem.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveCommandClearedFromSliceItem.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveCommandClearedFromSliceItem;

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveCommandSetOnSliceItem.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveCommandSetOnSliceItem.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveCommandSetOnSliceItem(string Name);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveSliceItemCreated.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveSliceItemCreated.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveSliceItemCreated(string Name);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationConfiguredOnCommand.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationConfiguredOnCommand.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveValidationConfiguredOnCommand(string Rules);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationRemovedFromCommand.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationRemovedFromCommand.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveValidationRemovedFromCommand;

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationUpdatedOnCommand.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/Events/RecursiveValidationUpdatedOnCommand.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RecursiveValidationUpdatedOnCommand(string NewRules);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveCommandItem.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveCommandItem.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+
+[FromEvent<RecursiveCommandSetOnSliceItem>]
+[ClearWith<RecursiveCommandClearedFromSliceItem>]
+public record RecursiveCommandItem(
+    string Name,
+    [Nested] RecursiveValidationItem? Validation);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveSlice.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveSlice.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+
+[FromEvent<RecursiveSliceItemCreated>]
+public record RecursiveSlice(
+    Guid Id,
+    string Name,
+    [Nested] RecursiveCommandItem? Command);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveValidationItem.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/ReadModels/RecursiveValidationItem.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+
+[FromEvent<RecursiveValidationConfiguredOnCommand>]
+[FromEvent<RecursiveValidationUpdatedOnCommand>]
+[ClearWith<RecursiveValidationRemovedFromCommand>]
+public record RecursiveValidationItem(
+    [SetFrom<RecursiveValidationConfiguredOnCommand>(nameof(RecursiveValidationConfiguredOnCommand.Rules))]
+    [SetFrom<RecursiveValidationUpdatedOnCommand>(nameof(RecursiveValidationUpdatedOnCommand.NewRules))]
+    string Rules);

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/clearing_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/clearing_the_inner_nested_object.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested.clearing_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class clearing_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid SliceId;
+        public RecursiveSlice Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(RecursiveSliceItemCreated),
+            typeof(RecursiveCommandSetOnSliceItem),
+            typeof(RecursiveValidationConfiguredOnCommand),
+            typeof(RecursiveValidationUpdatedOnCommand),
+            typeof(RecursiveValidationRemovedFromCommand),
+            typeof(RecursiveCommandClearedFromSliceItem)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections =>
+            [typeof(RecursiveSlice), typeof(RecursiveCommandItem), typeof(RecursiveValidationItem)];
+
+        async Task Because()
+        {
+            SliceId = Guid.Parse("a9d7285e-d7ab-b194-e280-7f5e4f2b8d37");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RecursiveSlice>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(SliceId, new RecursiveSliceItemCreated("Model-Bound Slice"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveCommandSetOnSliceItem("Register"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveValidationConfiguredOnCommand("must-not-be-empty"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new RecursiveValidationRemovedFromCommand());
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<RecursiveSlice>();
+            Result = await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("Model-Bound Slice");
+    [Fact] void should_preserve_the_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_cleared_the_nested_validation() => Context.Result.Command!.Validation.ShouldBeNull();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/clearing_the_outer_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/clearing_the_outer_nested_object.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested.clearing_the_outer_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class clearing_the_outer_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid SliceId;
+        public RecursiveSlice Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(RecursiveSliceItemCreated),
+            typeof(RecursiveCommandSetOnSliceItem),
+            typeof(RecursiveValidationConfiguredOnCommand),
+            typeof(RecursiveValidationUpdatedOnCommand),
+            typeof(RecursiveValidationRemovedFromCommand),
+            typeof(RecursiveCommandClearedFromSliceItem)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections =>
+            [typeof(RecursiveSlice), typeof(RecursiveCommandItem), typeof(RecursiveValidationItem)];
+
+        async Task Because()
+        {
+            SliceId = Guid.Parse("b0e8396f-e8bc-c2a5-f391-805f5f3c9e48");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RecursiveSlice>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(SliceId, new RecursiveSliceItemCreated("Model-Bound Slice"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveCommandSetOnSliceItem("Register"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveValidationConfiguredOnCommand("must-not-be-empty"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new RecursiveCommandClearedFromSliceItem());
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<RecursiveSlice>();
+            Result = await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("Model-Bound Slice");
+    [Fact] void should_have_cleared_the_nested_command() => Context.Result.Command.ShouldBeNull();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/setting_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/setting_the_inner_nested_object.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested.setting_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class setting_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid SliceId;
+        public RecursiveSlice Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(RecursiveSliceItemCreated),
+            typeof(RecursiveCommandSetOnSliceItem),
+            typeof(RecursiveValidationConfiguredOnCommand),
+            typeof(RecursiveValidationUpdatedOnCommand),
+            typeof(RecursiveValidationRemovedFromCommand),
+            typeof(RecursiveCommandClearedFromSliceItem)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections =>
+            [typeof(RecursiveSlice), typeof(RecursiveCommandItem), typeof(RecursiveValidationItem)];
+
+        async Task Because()
+        {
+            SliceId = Guid.Parse("e7b5063c-b589-8f72-c06e-5d3c2f096b15");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RecursiveSlice>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(SliceId, new RecursiveSliceItemCreated("Model-Bound Slice"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveCommandSetOnSliceItem("Register"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new RecursiveValidationConfiguredOnCommand("must-not-be-empty"));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<RecursiveSlice>();
+            Result = await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("Model-Bound Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldNotBeNull();
+    [Fact] void should_set_the_validation_rules() => Context.Result.Command!.Validation!.Rules.ShouldEqual("must-not-be-empty");
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/setting_the_outer_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/setting_the_outer_nested_object.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested.setting_the_outer_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class setting_the_outer_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid SliceId;
+        public RecursiveSlice Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(RecursiveSliceItemCreated),
+            typeof(RecursiveCommandSetOnSliceItem),
+            typeof(RecursiveValidationConfiguredOnCommand),
+            typeof(RecursiveValidationUpdatedOnCommand),
+            typeof(RecursiveValidationRemovedFromCommand),
+            typeof(RecursiveCommandClearedFromSliceItem)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections =>
+            [typeof(RecursiveSlice), typeof(RecursiveCommandItem), typeof(RecursiveValidationItem)];
+
+        async Task Because()
+        {
+            SliceId = Guid.Parse("d6a4f53b-a478-7e61-bf5d-4c2b1ef850a4");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RecursiveSlice>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(SliceId, new RecursiveSliceItemCreated("Model-Bound Slice"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new RecursiveCommandSetOnSliceItem("Register"));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<RecursiveSlice>();
+            Result = await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_set_the_slice_name() => Context.Result.Name.ShouldEqual("Model-Bound Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_set_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_not_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldBeNull();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/updating_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_nested/updating_the_inner_nested_object.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested.updating_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.ModelBound.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class updating_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : Specification(fixture)
+    {
+        public Guid SliceId;
+        public RecursiveSlice Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(RecursiveSliceItemCreated),
+            typeof(RecursiveCommandSetOnSliceItem),
+            typeof(RecursiveValidationConfiguredOnCommand),
+            typeof(RecursiveValidationUpdatedOnCommand),
+            typeof(RecursiveValidationRemovedFromCommand),
+            typeof(RecursiveCommandClearedFromSliceItem)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections =>
+            [typeof(RecursiveSlice), typeof(RecursiveCommandItem), typeof(RecursiveValidationItem)];
+
+        async Task Because()
+        {
+            SliceId = Guid.Parse("f8c6174d-c69a-a083-d17f-6e4d3f1a7c26");
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RecursiveSlice>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(SliceId, new RecursiveSliceItemCreated("Model-Bound Slice"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveCommandSetOnSliceItem("Register"));
+            await EventStore.EventLog.Append(SliceId, new RecursiveValidationConfiguredOnCommand("must-not-be-empty"));
+            var appendResult = await EventStore.EventLog.Append(SliceId, new RecursiveValidationUpdatedOnCommand("must-be-unique"));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            var collection = ChronicleFixture.ReadModels.Database.GetCollection<RecursiveSlice>();
+            Result = await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("Model-Bound Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldNotBeNull();
+    [Fact] void should_update_the_validation_rules() => Context.Result.Command!.Validation!.Rules.ShouldEqual("must-be-unique");
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/FeatureProjection.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/FeatureProjection.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children;
+
+public class FeatureProjection : IProjectionFor<FeatureReadModel>
+{
+    public void Define(IProjectionBuilderFor<FeatureReadModel> builder) => builder
+        .From<FeatureCreated>(b => b.Set(m => m.Name).To(e => e.Name))
+        .Children(_ => _.Slices, slices => slices
+            .IdentifiedBy(_ => _.Id)
+            .From<SliceAddedToFeature>(b => b
+                .UsingParentKey(e => e.FeatureId)
+                .UsingKey(e => e.SliceId))
+            .Nested(_ => _.Command, nested => nested
+                .From<CommandSetOnSlice>()
+                .From<CommandRenamedOnSlice>(b => b.Set(m => m.Name).To(e => e.NewName))
+                .ClearWith<CommandClearedFromSlice>()));
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/clearing_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/clearing_the_nested_object.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children.clearing_the_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children;
+
+[Collection(ChronicleCollection.Name)]
+public class clearing_the_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<FeatureProjection, FeatureReadModel>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(FeatureCreated),
+            typeof(SliceAddedToFeature),
+            typeof(CommandSetOnSlice),
+            typeof(CommandRenamedOnSlice),
+            typeof(CommandClearedFromSlice)
+        ];
+
+        void Establish()
+        {
+            var featureId = Guid.Parse("e5f6a7b8-c9d0-1234-ef01-345678901234");
+            var sliceId = Guid.Parse("f6a7b8c9-d0e1-2345-f012-456789012345");
+            ReadModelId = featureId.ToString();
+
+            EventsWithEventSourceIdToAppend.Add(new(featureId.ToString(), new FeatureCreated("My Feature")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new SliceAddedToFeature(featureId, sliceId, "My Slice")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new CommandSetOnSlice("Register", "{}")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new CommandClearedFromSlice()));
+        }
+
+        protected override async Task<FeatureReadModel> GetReadModelResult()
+        {
+            var collection = ChronicleInProcessFixture.ReadModels.Database.GetCollection<FeatureReadModel>();
+            return await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_one_slice() => Context.Result.Slices.Count().ShouldEqual(1);
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Slices.First().Name.ShouldEqual("My Slice");
+    [Fact] void should_have_cleared_the_nested_command() => Context.Result.Slices.First().Command.ShouldBeNull();
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/setting_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/setting_the_nested_object.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Events;
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children.setting_the_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children;
+
+[Collection(ChronicleCollection.Name)]
+public class setting_the_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<FeatureProjection, FeatureReadModel>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(FeatureCreated),
+            typeof(SliceAddedToFeature),
+            typeof(CommandSetOnSlice),
+            typeof(CommandRenamedOnSlice),
+            typeof(CommandClearedFromSlice)
+        ];
+
+        void Establish()
+        {
+            var featureId = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+            var sliceId = Guid.Parse("b2c3d4e5-f6a7-8901-bcde-f12345678901");
+            ReadModelId = featureId.ToString();
+
+            EventsWithEventSourceIdToAppend.Add(new(featureId.ToString(), new FeatureCreated("My Feature")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new SliceAddedToFeature(featureId, sliceId, "My Slice")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new CommandSetOnSlice("Register", "{}")));
+        }
+
+        protected override async Task<FeatureReadModel> GetReadModelResult()
+        {
+            var collection = ChronicleInProcessFixture.ReadModels.Database.GetCollection<FeatureReadModel>();
+            return await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_the_feature_name() => Context.Result.Name.ShouldEqual("My Feature");
+    [Fact] void should_have_one_slice() => Context.Result.Slices.Count().ShouldEqual(1);
+    [Fact] void should_have_a_nested_command_on_the_slice() => Context.Result.Slices.First().Command.ShouldNotBeNull();
+    [Fact] void should_set_the_command_name() => Context.Result.Slices.First().Command!.Name.ShouldEqual("Register");
+    [Fact] void should_set_the_command_schema() => Context.Result.Slices.First().Command!.Schema.ShouldEqual("{}");
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}
+
+[EventType]
+public record FeatureCreated(string Name);
+
+[EventType]
+public record SliceAddedToFeature(Guid FeatureId, Guid SliceId, string Name);
+
+[EventType]
+public record CommandSetOnSlice(string Name, string Schema);
+
+[EventType]
+public record CommandRenamedOnSlice(string NewName);
+
+[EventType]
+public record CommandClearedFromSlice;
+
+public class SliceCommandItem
+{
+    public string Name { get; set; } = string.Empty;
+    public string Schema { get; set; } = string.Empty;
+}
+
+public class SliceItem
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public SliceCommandItem? Command { get; set; }
+}
+
+public record FeatureReadModel(
+    string Name,
+    IEnumerable<SliceItem> Slices,
+    EventSequenceNumber __lastHandledEventSequenceNumber = default!);
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/updating_the_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_children/updating_the_nested_object.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Driver;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children.updating_the_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_children;
+
+[Collection(ChronicleCollection.Name)]
+public class updating_the_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<FeatureProjection, FeatureReadModel>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(FeatureCreated),
+            typeof(SliceAddedToFeature),
+            typeof(CommandSetOnSlice),
+            typeof(CommandRenamedOnSlice),
+            typeof(CommandClearedFromSlice)
+        ];
+
+        void Establish()
+        {
+            var featureId = Guid.Parse("c3d4e5f6-a7b8-9012-cdef-123456789012");
+            var sliceId = Guid.Parse("d4e5f6a7-b8c9-0123-def0-234567890123");
+            ReadModelId = featureId.ToString();
+
+            EventsWithEventSourceIdToAppend.Add(new(featureId.ToString(), new FeatureCreated("My Feature")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new SliceAddedToFeature(featureId, sliceId, "My Slice")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new CommandSetOnSlice("Register", "{}")));
+            EventsWithEventSourceIdToAppend.Add(new(sliceId.ToString(), new CommandRenamedOnSlice("Create")));
+        }
+
+        protected override async Task<FeatureReadModel> GetReadModelResult()
+        {
+            var collection = ChronicleInProcessFixture.ReadModels.Database.GetCollection<FeatureReadModel>();
+            return await (await collection.FindAsync(_ => true)).FirstOrDefaultAsync();
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_one_slice() => Context.Result.Slices.Count().ShouldEqual(1);
+    [Fact] void should_have_a_nested_command_on_the_slice() => Context.Result.Slices.First().Command.ShouldNotBeNull();
+    [Fact] void should_update_the_command_name() => Context.Result.Slices.First().Command!.Name.ShouldEqual("Create");
+    [Fact] void should_preserve_the_command_schema() => Context.Result.Slices.First().Command!.Schema.ShouldEqual("{}");
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/SliceProjection.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/SliceProjection.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+public class SliceProjection : IProjectionFor<DeepNestedSlice>
+{
+    public void Define(IProjectionBuilderFor<DeepNestedSlice> builder) => builder
+        .From<DeepNestedSliceCreated>(b => b.Set(m => m.Name).To(e => e.Name))
+        .Nested(_ => _.Command, command => command
+            .From<DeepNestedCommandSet>(b => b.Set(m => m.Name).To(e => e.Name))
+            .Nested(_ => _.Validation, validation => validation
+                .From<DeepNestedValidationConfigured>(b => b.Set(m => m.Rules).To(e => e.Rules))
+                .From<DeepNestedValidationUpdated>(b => b.Set(m => m.Rules).To(e => e.NewRules))
+                .ClearWith<DeepNestedValidationRemoved>())
+            .ClearWith<DeepNestedCommandCleared>());
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/clearing_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/clearing_the_inner_nested_object.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested.clearing_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class clearing_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, DeepNestedSlice>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepNestedSliceCreated),
+            typeof(DeepNestedCommandSet),
+            typeof(DeepNestedValidationConfigured),
+            typeof(DeepNestedValidationUpdated),
+            typeof(DeepNestedValidationRemoved),
+            typeof(DeepNestedCommandCleared)
+        ];
+
+        void Establish()
+        {
+            EventsToAppend.Add(new DeepNestedSliceCreated("My Slice"));
+            EventsToAppend.Add(new DeepNestedCommandSet("Register"));
+            EventsToAppend.Add(new DeepNestedValidationConfigured("must-not-be-empty"));
+            EventsToAppend.Add(new DeepNestedValidationRemoved());
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("My Slice");
+    [Fact] void should_preserve_the_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_cleared_the_nested_validation() => Context.Result.Command!.Validation.ShouldBeNull();
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/clearing_the_outer_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/clearing_the_outer_nested_object.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested.clearing_the_outer_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class clearing_the_outer_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, DeepNestedSlice>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepNestedSliceCreated),
+            typeof(DeepNestedCommandSet),
+            typeof(DeepNestedValidationConfigured),
+            typeof(DeepNestedValidationUpdated),
+            typeof(DeepNestedValidationRemoved),
+            typeof(DeepNestedCommandCleared)
+        ];
+
+        void Establish()
+        {
+            EventsToAppend.Add(new DeepNestedSliceCreated("My Slice"));
+            EventsToAppend.Add(new DeepNestedCommandSet("Register"));
+            EventsToAppend.Add(new DeepNestedValidationConfigured("must-not-be-empty"));
+            EventsToAppend.Add(new DeepNestedCommandCleared());
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("My Slice");
+    [Fact] void should_have_cleared_the_nested_command() => Context.Result.Command.ShouldBeNull();
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/setting_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/setting_the_inner_nested_object.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested.setting_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class setting_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, DeepNestedSlice>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepNestedSliceCreated),
+            typeof(DeepNestedCommandSet),
+            typeof(DeepNestedValidationConfigured),
+            typeof(DeepNestedValidationUpdated),
+            typeof(DeepNestedValidationRemoved),
+            typeof(DeepNestedCommandCleared)
+        ];
+
+        void Establish()
+        {
+            EventsToAppend.Add(new DeepNestedSliceCreated("My Slice"));
+            EventsToAppend.Add(new DeepNestedCommandSet("Register"));
+            EventsToAppend.Add(new DeepNestedValidationConfigured("must-not-be-empty"));
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("My Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldNotBeNull();
+    [Fact] void should_set_the_validation_rules() => Context.Result.Command!.Validation!.Rules.ShouldEqual("must-not-be-empty");
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/setting_the_outer_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/setting_the_outer_nested_object.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Events;
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested.setting_the_outer_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class setting_the_outer_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, DeepNestedSlice>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepNestedSliceCreated),
+            typeof(DeepNestedCommandSet),
+            typeof(DeepNestedValidationConfigured),
+            typeof(DeepNestedValidationUpdated),
+            typeof(DeepNestedValidationRemoved),
+            typeof(DeepNestedCommandCleared)
+        ];
+
+        void Establish()
+        {
+            EventsToAppend.Add(new DeepNestedSliceCreated("My Slice"));
+            EventsToAppend.Add(new DeepNestedCommandSet("Register"));
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_set_the_slice_name() => Context.Result.Name.ShouldEqual("My Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_set_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_not_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldBeNull();
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}
+
+[EventType]
+public record DeepNestedSliceCreated(string Name);
+
+[EventType]
+public record DeepNestedCommandSet(string Name);
+
+[EventType]
+public record DeepNestedValidationConfigured(string Rules);
+
+[EventType]
+public record DeepNestedValidationUpdated(string NewRules);
+
+[EventType]
+public record DeepNestedValidationRemoved;
+
+[EventType]
+public record DeepNestedCommandCleared;
+
+public class DeepNestedValidationItem
+{
+    public string Rules { get; set; } = string.Empty;
+}
+
+public class DeepNestedCommandItem
+{
+    public string Name { get; set; } = string.Empty;
+    public DeepNestedValidationItem? Validation { get; set; }
+}
+
+public record DeepNestedSlice(
+    string Name,
+    DeepNestedCommandItem? Command,
+    EventSequenceNumber __lastHandledEventSequenceNumber = default!);
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/updating_the_inner_nested_object.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested/updating_the_inner_nested_object.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested.updating_the_inner_nested_object.context;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested;
+
+[Collection(ChronicleCollection.Name)]
+public class updating_the_inner_nested_object(context context) : Given<context>(context)
+{
+    public class context(ChronicleInProcessFixture fixture) : given.a_projection_and_events_appended_to_it<SliceProjection, DeepNestedSlice>(fixture)
+    {
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(DeepNestedSliceCreated),
+            typeof(DeepNestedCommandSet),
+            typeof(DeepNestedValidationConfigured),
+            typeof(DeepNestedValidationUpdated),
+            typeof(DeepNestedValidationRemoved),
+            typeof(DeepNestedCommandCleared)
+        ];
+
+        void Establish()
+        {
+            EventsToAppend.Add(new DeepNestedSliceCreated("My Slice"));
+            EventsToAppend.Add(new DeepNestedCommandSet("Register"));
+            EventsToAppend.Add(new DeepNestedValidationConfigured("must-not-be-empty"));
+            EventsToAppend.Add(new DeepNestedValidationUpdated("must-be-unique"));
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_preserve_the_slice_name() => Context.Result.Name.ShouldEqual("My Slice");
+    [Fact] void should_have_a_nested_command() => Context.Result.Command.ShouldNotBeNull();
+    [Fact] void should_preserve_the_command_name() => Context.Result.Command!.Name.ShouldEqual("Register");
+    [Fact] void should_have_a_nested_validation() => Context.Result.Command!.Validation.ShouldNotBeNull();
+    [Fact] void should_update_the_validation_rules() => Context.Result.Command!.Validation!.Rules.ShouldEqual("must-be-unique");
+    [Fact] void should_set_the_last_handled_event_sequence_number() => Context.Result.__lastHandledEventSequenceNumber.ShouldEqual(Context.LastEventSequenceNumber);
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/clearing_the_inner_nested_object_from_pdl.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/clearing_the_inner_nested_object_from_pdl.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl;
+
+/// <summary>
+/// Verifies that the inner <c>clear with PdlDeepNestedValidationRemoved</c> directive
+/// compiles into a <c>RemovedWith</c> entry on the inner nested definition, while the outer
+/// block continues to carry its own command-cleared <c>RemovedWith</c>. This is the PDL-level
+/// counterpart of Phase 1's
+/// <c>when_projecting_with_nested_in_nested.clearing_the_inner_nested_object</c>, which already
+/// verifies that the engine clears only the inner validation when this event is appended.
+/// </summary>
+public class clearing_the_inner_nested_object_from_pdl : given.a_compiled_pdl_nested_projection
+{
+    [Fact] void should_have_inner_removed_with_for_validation_removed() => _innerNested.RemovedWith.ContainsKey((EventType)nameof(given.PdlDeepNestedValidationRemoved)).ShouldBeTrue();
+    [Fact] void should_not_remove_the_outer_command_with_validation_removed() => _outerNested.RemovedWith.ContainsKey((EventType)nameof(given.PdlDeepNestedValidationRemoved)).ShouldBeFalse();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/clearing_the_outer_nested_object_from_pdl.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/clearing_the_outer_nested_object_from_pdl.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl;
+
+/// <summary>
+/// Verifies that the outer <c>clear with PdlDeepNestedCommandCleared</c> directive
+/// compiles into a <c>RemovedWith</c> entry on the outer nested definition, while the
+/// inner block has its own (different) <c>RemovedWith</c>. This is the PDL-level counterpart
+/// of Phase 1's <c>when_projecting_with_nested_in_nested.clearing_the_outer_nested_object</c>,
+/// which already verifies that the engine clears the outer command (and discards the inner
+/// validation along with it) when this event is appended.
+/// </summary>
+public class clearing_the_outer_nested_object_from_pdl : given.a_compiled_pdl_nested_projection
+{
+    [Fact] void should_have_outer_removed_with_for_command_cleared() => _outerNested.RemovedWith.ContainsKey((EventType)nameof(given.PdlDeepNestedCommandCleared)).ShouldBeTrue();
+    [Fact] void should_not_have_inner_removed_with_for_command_cleared() => _innerNested.RemovedWith.ContainsKey((EventType)nameof(given.PdlDeepNestedCommandCleared)).ShouldBeFalse();
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/given/a_compiled_pdl_nested_projection.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/given/a_compiled_pdl_nested_projection.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl.given;
+
+/// <summary>
+/// Reusable context that compiles a two-level <c>nested</c> + <c>clear with</c> PDL document
+/// into a <see cref="ProjectionDefinition"/> using <see cref="LanguageService"/>.
+/// </summary>
+/// <remarks>
+/// There is currently no in-process integration harness that takes a raw PDL string and runs
+/// it through the engine — the engine's integration fixtures register typed
+/// <c>IProjectionFor&lt;T&gt;</c> classes, not free-form PDL declarations.
+///
+/// Phase 1's <c>when_projecting_with_nested_in_nested</c> specs already prove that a
+/// <see cref="ProjectionDefinition"/> with the nested + clear-with structure (built via
+/// the declarative <c>.Nested(...)</c> / <c>.ClearWith&lt;T&gt;()</c> API) is processed
+/// correctly by the engine — outer / inner are set, updated and cleared as expected.
+///
+/// Phase 5 closes the loop by proving that **PDL compilation** produces a
+/// <see cref="ProjectionDefinition"/> with exactly the same nested / clear-with shape.
+/// Together, the two phases show that PDL → <see cref="ProjectionDefinition"/> → engine
+/// behaves identically to the declarative path that Phase 1 covers.
+/// </remarks>
+public abstract class a_compiled_pdl_nested_projection : Cratis.Specifications.Specification
+{
+    public const string Declaration = """
+        projection PdlSlice => PdlDeepNestedSlice
+          from PdlDeepNestedSliceCreated
+            name = name
+
+          nested command
+            from PdlDeepNestedCommandSet
+              name = name
+
+            nested validation
+              from PdlDeepNestedValidationConfigured
+                rules = rules
+              from PdlDeepNestedValidationUpdated
+                rules = newRules
+              clear with PdlDeepNestedValidationRemoved
+
+            clear with PdlDeepNestedCommandCleared
+        """;
+
+    protected ILanguageService _languageService;
+    protected ReadModelDefinition _readModelDefinition;
+    protected List<EventTypeSchema> _eventTypeSchemas;
+    protected ProjectionDefinition _projection;
+    protected ChildrenDefinition _outerNested;
+    protected ChildrenDefinition _innerNested;
+
+    void Establish()
+    {
+        _languageService = new LanguageService(
+            new Generator(),
+            new DeclarativeCodeGenerator(),
+            new ModelBoundCodeGenerator());
+
+        _readModelDefinition = CreateReadModelDefinition<PdlDeepNestedSlice>();
+        _eventTypeSchemas = CreateEventTypeSchemas(
+        [
+            typeof(PdlDeepNestedSliceCreated),
+            typeof(PdlDeepNestedCommandSet),
+            typeof(PdlDeepNestedValidationConfigured),
+            typeof(PdlDeepNestedValidationUpdated),
+            typeof(PdlDeepNestedValidationRemoved),
+            typeof(PdlDeepNestedCommandCleared)
+        ]).ToList();
+
+        var result = _languageService.Compile(
+            Declaration,
+            ProjectionOwner.Client,
+            [_readModelDefinition],
+            _eventTypeSchemas);
+
+        _projection = result.Match(
+            definition => definition,
+            errors => throw new InvalidOperationException(
+                $"PDL compilation failed: {string.Join(", ", errors.Errors.Select(e => e.Message))}"));
+
+        _outerNested = _projection.Nested![(Cratis.Chronicle.Properties.PropertyPath)"command"];
+        _innerNested = _outerNested.Nested![(Cratis.Chronicle.Properties.PropertyPath)"validation"];
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition<T>()
+        where T : class
+    {
+        var schema = JsonSchema.FromType<T>();
+        var name = typeof(T).Name;
+
+        return new ReadModelDefinition(
+            new ReadModelIdentifier(name),
+            new ReadModelContainerName(name),
+            new ReadModelDisplayName(name),
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            new SinkDefinition(
+                new SinkConfigurationId(Guid.NewGuid()),
+                WellKnownSinkTypes.MongoDB),
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                [ReadModelGeneration.First] = schema
+            },
+            []);
+    }
+
+    static IEnumerable<EventTypeSchema> CreateEventTypeSchemas(IEnumerable<Type> eventTypes)
+    {
+        foreach (var eventType in eventTypes)
+        {
+            var schema = JsonSchema.FromType(eventType);
+            yield return new EventTypeSchema(
+                (EventType)eventType.Name,
+                EventTypeOwner.Client,
+                EventTypeSource.Code,
+                schema);
+        }
+    }
+}
+
+/// <summary>
+/// Event that creates the outermost slice — sets the slice-level name.
+/// </summary>
+/// <param name="Name">The name of the slice.</param>
+public record PdlDeepNestedSliceCreated(string Name);
+
+/// <summary>
+/// Event that sets the outer nested command — name only.
+/// </summary>
+/// <param name="Name">The name of the command.</param>
+public record PdlDeepNestedCommandSet(string Name);
+
+/// <summary>
+/// Event that configures the inner nested validation block for the first time.
+/// </summary>
+/// <param name="Rules">The validation rules expression.</param>
+public record PdlDeepNestedValidationConfigured(string Rules);
+
+/// <summary>
+/// Event that updates the inner nested validation rules.
+/// </summary>
+/// <param name="NewRules">The updated validation rules expression.</param>
+public record PdlDeepNestedValidationUpdated(string NewRules);
+
+/// <summary>
+/// Event that clears the inner nested validation block.
+/// </summary>
+public record PdlDeepNestedValidationRemoved;
+
+/// <summary>
+/// Event that clears the outer nested command block.
+/// </summary>
+public record PdlDeepNestedCommandCleared;
+
+/// <summary>
+/// Inner nested validation read-model shape.
+/// </summary>
+public class PdlDeepNestedValidationItem
+{
+    /// <summary>
+    /// Gets or sets the validation rules.
+    /// </summary>
+    public string Rules { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Outer nested command read-model shape — owns an optional inner validation block.
+/// </summary>
+public class PdlDeepNestedCommandItem
+{
+    /// <summary>
+    /// Gets or sets the command name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the inner nested validation block.
+    /// </summary>
+    public PdlDeepNestedValidationItem? Validation { get; set; }
+}
+
+/// <summary>
+/// Top-level read model with an optional nested command block.
+/// </summary>
+/// <param name="Name">The slice name.</param>
+/// <param name="Command">The optional nested command.</param>
+public record PdlDeepNestedSlice(
+    string Name,
+    PdlDeepNestedCommandItem? Command);
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/setting_the_inner_nested_object_from_pdl.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/setting_the_inner_nested_object_from_pdl.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl;
+
+/// <summary>
+/// Verifies that PDL compilation produces the inner <c>nested validation</c> entry inside
+/// the outer command block, with the expected <c>From</c> mapping for
+/// <see cref="given.PdlDeepNestedValidationConfigured"/>. This is the PDL-level counterpart of
+/// Phase 1's <c>when_projecting_with_nested_in_nested.setting_the_inner_nested_object</c>,
+/// which already verifies that the engine sets the inner validation from such a definition.
+/// </summary>
+public class setting_the_inner_nested_object_from_pdl : given.a_compiled_pdl_nested_projection
+{
+    [Fact] void should_have_an_inner_nested_dictionary_on_the_outer() => _outerNested.Nested.ShouldNotBeNull();
+    [Fact] void should_have_the_inner_nested_entry_keyed_by_validation() => _outerNested.Nested!.ContainsKey((PropertyPath)"validation").ShouldBeTrue();
+    [Fact] void should_have_inner_nested_identified_by_not_set() => _innerNested.IdentifiedBy.IsSet.ShouldBeFalse();
+    [Fact] void should_have_the_validation_configured_from_event() => _innerNested.From.ContainsKey((EventType)nameof(given.PdlDeepNestedValidationConfigured)).ShouldBeTrue();
+    [Fact] void should_map_the_validation_rules_property() => _innerNested.From[(EventType)nameof(given.PdlDeepNestedValidationConfigured)].Properties[(PropertyPath)"rules"].ShouldEqual("rules");
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/setting_the_outer_nested_object_from_pdl.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/setting_the_outer_nested_object_from_pdl.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl;
+
+/// <summary>
+/// Verifies that PDL compilation produces the outer <c>nested command</c> entry
+/// with the expected <c>From</c> mapping for <see cref="given.PdlDeepNestedCommandSet"/>.
+/// This is the PDL-level counterpart of Phase 1's
+/// <c>when_projecting_with_nested_in_nested.setting_the_outer_nested_object</c>, which
+/// already verifies that the engine sets the outer command from such a definition.
+/// </summary>
+public class setting_the_outer_nested_object_from_pdl : given.a_compiled_pdl_nested_projection
+{
+    [Fact] void should_compile_a_definition() => _projection.ShouldNotBeNull();
+    [Fact] void should_have_a_top_level_nested_dictionary() => _projection.Nested.ShouldNotBeNull();
+    [Fact] void should_have_the_outer_nested_entry_keyed_by_command() => _projection.Nested!.ContainsKey((PropertyPath)"command").ShouldBeTrue();
+    [Fact] void should_have_outer_nested_identified_by_not_set() => _outerNested.IdentifiedBy.IsSet.ShouldBeFalse();
+    [Fact] void should_have_the_command_set_from_event() => _outerNested.From.ContainsKey((EventType)nameof(given.PdlDeepNestedCommandSet)).ShouldBeTrue();
+    [Fact] void should_map_the_command_name_property() => _outerNested.From[(EventType)nameof(given.PdlDeepNestedCommandSet)].Properties[(PropertyPath)"name"].ShouldEqual("name");
+}

--- a/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/updating_the_inner_nested_object_from_pdl.cs
+++ b/Integration/DotNET.InProcess/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/updating_the_inner_nested_object_from_pdl.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.InProcess.Integration.Projections.Scenarios.when_projecting_with_nested_in_nested_from_pdl;
+
+/// <summary>
+/// Verifies that PDL compilation handles a second <c>from</c> on the inner nested block —
+/// the validation update event — and maps its renamed property (<c>newRules</c>) onto the
+/// same <c>rules</c> read-model property. This is the PDL-level counterpart of Phase 1's
+/// <c>when_projecting_with_nested_in_nested.updating_the_inner_nested_object</c>, which
+/// already verifies that the engine updates the inner validation from such a definition.
+/// </summary>
+public class updating_the_inner_nested_object_from_pdl : given.a_compiled_pdl_nested_projection
+{
+    [Fact] void should_have_the_validation_updated_from_event() => _innerNested.From.ContainsKey((EventType)nameof(given.PdlDeepNestedValidationUpdated)).ShouldBeTrue();
+    [Fact] void should_map_the_updated_rules_property_to_rules() => _innerNested.From[(EventType)nameof(given.PdlDeepNestedValidationUpdated)].Properties[(PropertyPath)"rules"].ShouldEqual("newRules");
+    [Fact] void should_keep_the_initial_validation_configured_from_event() => _innerNested.From.ContainsKey((EventType)nameof(given.PdlDeepNestedValidationConfigured)).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Projections/for_ProjectionBuilderFor/when_building/with_nested_object_in_children_collection.cs
+++ b/Source/Clients/DotNET.Specs/Projections/for_ProjectionBuilderFor/when_building/with_nested_object_in_children_collection.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionBuilderFor.when_building;
+
+public class with_nested_object_in_children_collection : Specification
+{
+    ProjectionBuilderFor<FeatureReadModel> _builder;
+    IEventTypes _eventTypes;
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        _eventTypes = new EventTypesForSpecifications([typeof(SliceAddedToFeature), typeof(CommandSetOnSlice), typeof(CommandClearedFromSlice)]);
+        _builder = new ProjectionBuilderFor<FeatureReadModel>(
+            new ProjectionId(typeof(FeatureReadModel).FullName!),
+            typeof(FeatureReadModel),
+            new DefaultNamingPolicy(),
+            _eventTypes,
+            new JsonSerializerOptions());
+    }
+
+    void Because()
+    {
+        _builder.Children(_ => _.Slices, slices => slices
+            .IdentifiedBy(_ => _.Id)
+            .From<SliceAddedToFeature>(b => b
+                .UsingParentKey(e => e.FeatureId)
+                .UsingKey(e => e.SliceId))
+            .Nested(_ => _.Command, nested => nested
+                .From<CommandSetOnSlice>()
+                .ClearWith<CommandClearedFromSlice>()));
+
+        _result = _builder.Build();
+    }
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_children_entry_for_slices() => _result.Children.Keys.ShouldContain(nameof(FeatureReadModel.Slices));
+    [Fact] void should_have_nested_entry_for_command_in_children() => _result.Children[nameof(FeatureReadModel.Slices)].Nested.Keys.ShouldContain(nameof(SliceReadModel.Command));
+
+    [Fact]
+    void should_have_from_definition_for_nested_command_set()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(CommandSetOnSlice)).ToContract();
+        var nestedDefinition = _result.Children[nameof(FeatureReadModel.Slices)].Nested[nameof(SliceReadModel.Command)];
+        nestedDefinition.From.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact]
+    void should_have_removed_with_definition_for_nested_command_clear()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(CommandClearedFromSlice)).ToContract();
+        var nestedDefinition = _result.Children[nameof(FeatureReadModel.Slices)].Nested[nameof(SliceReadModel.Command)];
+        nestedDefinition.RemovedWith.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+}
+
+[EventType]
+public record SliceAddedToFeature(Guid FeatureId, Guid SliceId, string Name);
+
+[EventType]
+public record CommandSetOnSlice(string Name, string Schema);
+
+[EventType]
+public record CommandClearedFromSlice;
+
+public record SliceCommandReadModel(string Name, string Schema);
+
+public record SliceReadModel(Guid Id, string Name, SliceCommandReadModel? Command);
+
+public record FeatureReadModel(IEnumerable<SliceReadModel> Slices);
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/Source/Clients/DotNET.Specs/Projections/for_ProjectionBuilderFor/when_building/with_nested_object_in_nested_object.cs
+++ b/Source/Clients/DotNET.Specs/Projections/for_ProjectionBuilderFor/when_building/with_nested_object_in_nested_object.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionBuilderFor.when_building;
+
+public class with_nested_object_in_nested_object : Specification
+{
+    ProjectionBuilderFor<RecursiveNestedParentReadModel> _builder;
+    IEventTypes _eventTypes;
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        _eventTypes = new EventTypesForSpecifications([typeof(RecursiveNestedItemSet), typeof(RecursiveNestedItemCleared), typeof(RecursiveNestedValidationConfigured), typeof(RecursiveNestedValidationCleared)]);
+        _builder = new ProjectionBuilderFor<RecursiveNestedParentReadModel>(
+            new ProjectionId(typeof(RecursiveNestedParentReadModel).FullName!),
+            typeof(RecursiveNestedParentReadModel),
+            new DefaultNamingPolicy(),
+            _eventTypes,
+            new JsonSerializerOptions());
+    }
+
+    void Because()
+    {
+        _builder.Nested(_ => _.Item, item => item
+            .From<RecursiveNestedItemSet>()
+            .Nested(_ => _.Validation, validation => validation
+                .From<RecursiveNestedValidationConfigured>()
+                .ClearWith<RecursiveNestedValidationCleared>())
+            .ClearWith<RecursiveNestedItemCleared>());
+
+        _result = _builder.Build();
+    }
+
+    [Fact] void should_return_definition() => _result.ShouldNotBeNull();
+    [Fact] void should_have_nested_entry_for_item() => _result.Nested.Keys.ShouldContain(nameof(RecursiveNestedParentReadModel.Item));
+    [Fact] void should_have_nested_entry_for_validation_on_item() => _result.Nested[nameof(RecursiveNestedParentReadModel.Item)].Nested.Keys.ShouldContain(nameof(RecursiveNestedItemReadModel.Validation));
+
+    [Fact]
+    void should_have_from_definition_for_nested_item_set()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(RecursiveNestedItemSet)).ToContract();
+        var itemDefinition = _result.Nested[nameof(RecursiveNestedParentReadModel.Item)];
+        itemDefinition.From.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact]
+    void should_have_removed_with_definition_for_nested_item_clear()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(RecursiveNestedItemCleared)).ToContract();
+        var itemDefinition = _result.Nested[nameof(RecursiveNestedParentReadModel.Item)];
+        itemDefinition.RemovedWith.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact]
+    void should_have_from_definition_for_nested_validation_configured()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(RecursiveNestedValidationConfigured)).ToContract();
+        var validationDefinition = _result.Nested[nameof(RecursiveNestedParentReadModel.Item)].Nested[nameof(RecursiveNestedItemReadModel.Validation)];
+        validationDefinition.From.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact]
+    void should_have_removed_with_definition_for_nested_validation_clear()
+    {
+        var eventType = _eventTypes.GetEventTypeFor(typeof(RecursiveNestedValidationCleared)).ToContract();
+        var validationDefinition = _result.Nested[nameof(RecursiveNestedParentReadModel.Item)].Nested[nameof(RecursiveNestedItemReadModel.Validation)];
+        validationDefinition.RemovedWith.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+}
+
+[EventType]
+public record RecursiveNestedItemSet(string Name, string Value);
+
+[EventType]
+public record RecursiveNestedItemCleared;
+
+[EventType]
+public record RecursiveNestedValidationConfigured(string Rules);
+
+[EventType]
+public record RecursiveNestedValidationCleared;
+
+public record RecursiveNestedValidationReadModel(string Rules);
+
+public record RecursiveNestedItemReadModel(string Name, string Value, RecursiveNestedValidationReadModel? Validation);
+
+public record RecursiveNestedParentReadModel(RecursiveNestedItemReadModel? Item);
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/given/a_language_service_compiling_nested.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/given/a_language_service_compiling_nested.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_LanguageService.when_compiling_nested_block.given;
+
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
+public record SliceCreated(string Name);
+
+public record CommandSetForSlice(string Name, string Schema);
+
+public record CommandUpdatedForSlice(string Schema);
+
+public record CommandClearedForSlice(string Id);
+
+public record ValidationAdded(string Rule);
+
+public record ValidationRemoved(string Id);
+
+public record TaskAdded(string TaskId, string ProjectId, string Title);
+
+public record TaskAssigned(string AssigneeName, string AssigneeEmail);
+
+public record TaskUnassigned(string TaskId);
+
+public record CommandItem(string Name, string Schema);
+
+public record ValidationConfig(string Rule);
+
+public record TaskAssignee(string Name, string Email);
+
+public record SliceTask(string Id, string Title, TaskAssignee? Assignee);
+
+public record SliceReadModel(string Name, CommandItem? Command);
+
+public record SliceWithInnerNestedReadModel(string Name, CommandWithValidation? Command);
+
+public record CommandWithValidation(string Name, string Schema, ValidationConfig? Validation);
+
+public record ProjectWithTasksReadModel(string Name, List<SliceTask>? Tasks);
+
+public abstract class a_language_service_compiling_nested<TReadModel> : Specification
+    where TReadModel : class
+{
+    protected ILanguageService _languageService;
+    protected ReadModelDefinition _readModelDefinition;
+    protected List<EventTypeSchema> _eventTypeSchemas;
+
+    protected virtual IEnumerable<Type> EventTypes => [];
+
+    void Establish()
+    {
+        _languageService = new LanguageService(new Generator(), new DeclarativeCodeGenerator(), new ModelBoundCodeGenerator());
+        _readModelDefinition = CreateReadModelDefinition<TReadModel>();
+        _eventTypeSchemas = CreateEventTypeSchemas(EventTypes).ToList();
+    }
+
+    protected ProjectionDefinition Compile(string declaration)
+    {
+        var result = _languageService.Compile(
+            declaration,
+            ProjectionOwner.Client,
+            [_readModelDefinition],
+            _eventTypeSchemas);
+
+        return result.Match(
+            projectionDef => projectionDef,
+            errors => throw new InvalidOperationException($"Compilation failed: {string.Join(", ", errors.Errors)}"));
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition<T>()
+        where T : class
+    {
+        var schema = JsonSchema.FromType<T>();
+        var name = typeof(T).Name;
+
+        return new ReadModelDefinition(
+            new ReadModelIdentifier(name),
+            new ReadModelContainerName(name),
+            new ReadModelDisplayName(name),
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            new Concepts.Sinks.SinkDefinition(
+                new Concepts.Sinks.SinkConfigurationId(Guid.NewGuid()),
+                Concepts.Sinks.WellKnownSinkTypes.MongoDB),
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                [ReadModelGeneration.First] = schema
+            },
+            []);
+    }
+
+    static IEnumerable<EventTypeSchema> CreateEventTypeSchemas(IEnumerable<Type> eventTypes)
+    {
+        foreach (var eventType in eventTypes)
+        {
+            var schema = JsonSchema.FromType(eventType);
+            yield return new EventTypeSchema(
+                (EventType)eventType.Name,
+                EventTypeOwner.Client,
+                EventTypeSource.Code,
+                schema);
+        }
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/inside_a_children_block.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/inside_a_children_block.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_LanguageService.when_compiling_nested_block;
+
+public class inside_a_children_block : given.a_language_service_compiling_nested<given.ProjectWithTasksReadModel>
+{
+    const string Declaration = """
+        projection Project => ProjectWithTasksReadModel
+          from SliceCreated
+            name = name
+
+          children tasks identified by taskId
+            from TaskAdded
+              key taskId
+              parent projectId
+              title = title
+
+            nested assignee
+              from TaskAssigned
+                name = assigneeName
+                email = assigneeEmail
+              clear with TaskUnassigned
+        """;
+
+    protected override IEnumerable<Type> EventTypes =>
+        [typeof(given.SliceCreated), typeof(given.TaskAdded), typeof(given.TaskAssigned), typeof(given.TaskUnassigned)];
+
+    ProjectionDefinition _result;
+    ChildrenDefinition _tasksChildren;
+    ChildrenDefinition _assigneeNested;
+
+    void Because()
+    {
+        _result = Compile(Declaration);
+        _tasksChildren = _result.Children[(PropertyPath)"tasks"];
+        _assigneeNested = _tasksChildren.Nested![(PropertyPath)"assignee"];
+    }
+
+    [Fact] void should_have_tasks_children() => _result.Children.ContainsKey((PropertyPath)"tasks").ShouldBeTrue();
+    [Fact] void should_have_an_assignee_nested_inside_tasks() => _tasksChildren.Nested!.ContainsKey((PropertyPath)"assignee").ShouldBeTrue();
+    [Fact] void should_have_assignee_identified_by_not_set() => _assigneeNested.IdentifiedBy.IsSet.ShouldBeFalse();
+    [Fact] void should_have_the_task_assigned_from_event() => _assigneeNested.From.ContainsKey((EventType)"TaskAssigned").ShouldBeTrue();
+    [Fact] void should_have_the_task_unassigned_clear_with() => _assigneeNested.RemovedWith.ContainsKey((EventType)"TaskUnassigned").ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_clear_with.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_clear_with.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_LanguageService.when_compiling_nested_block;
+
+public class with_clear_with : given.a_language_service_compiling_nested<given.SliceReadModel>
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            name = name
+
+          nested command
+            from CommandSetForSlice
+              name = name
+              schema = schema
+            clear with CommandClearedForSlice
+        """;
+
+    protected override IEnumerable<Type> EventTypes => [typeof(given.SliceCreated), typeof(given.CommandSetForSlice), typeof(given.CommandClearedForSlice)];
+
+    ProjectionDefinition _result;
+    ChildrenDefinition _nested;
+
+    void Because()
+    {
+        _result = Compile(Declaration);
+        _nested = _result.Nested![(PropertyPath)"command"];
+    }
+
+    [Fact] void should_have_removed_with_for_clear_event() => _nested.RemovedWith.ContainsKey((EventType)"CommandClearedForSlice").ShouldBeTrue();
+    [Fact] void should_still_have_the_from_event() => _nested.From.ContainsKey((EventType)"CommandSetForSlice").ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_inner_nested.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_inner_nested.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_LanguageService.when_compiling_nested_block;
+
+public class with_inner_nested : given.a_language_service_compiling_nested<given.SliceWithInnerNestedReadModel>
+{
+    const string Declaration = """
+        projection Slice => SliceWithInnerNestedReadModel
+          from SliceCreated
+            name = name
+
+          nested command
+            from CommandSetForSlice
+              name = name
+              schema = schema
+
+            nested validation
+              from ValidationAdded
+                rule = rule
+              clear with ValidationRemoved
+
+            clear with CommandClearedForSlice
+        """;
+
+    protected override IEnumerable<Type> EventTypes =>
+        [typeof(given.SliceCreated), typeof(given.CommandSetForSlice), typeof(given.CommandClearedForSlice), typeof(given.ValidationAdded), typeof(given.ValidationRemoved)];
+
+    ProjectionDefinition _result;
+    ChildrenDefinition _outer;
+    ChildrenDefinition _inner;
+
+    void Because()
+    {
+        _result = Compile(Declaration);
+        _outer = _result.Nested![(PropertyPath)"command"];
+        _inner = _outer.Nested![(PropertyPath)"validation"];
+    }
+
+    [Fact] void should_have_the_outer_nested_entry() => _outer.ShouldNotBeNull();
+    [Fact] void should_have_the_inner_nested_entry_on_the_outer() => _outer.Nested!.ContainsKey((PropertyPath)"validation").ShouldBeTrue();
+    [Fact] void should_have_the_inner_from_event() => _inner.From.ContainsKey((EventType)"ValidationAdded").ShouldBeTrue();
+    [Fact] void should_have_the_inner_clear_with() => _inner.RemovedWith.ContainsKey((EventType)"ValidationRemoved").ShouldBeTrue();
+    [Fact] void should_have_the_inner_identified_by_not_set() => _inner.IdentifiedBy.IsSet.ShouldBeFalse();
+    [Fact] void should_have_the_outer_clear_with() => _outer.RemovedWith.ContainsKey((EventType)"CommandClearedForSlice").ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_single_from_event.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_single_from_event.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_LanguageService.when_compiling_nested_block;
+
+public class with_single_from_event : given.a_language_service_compiling_nested<given.SliceReadModel>
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            name = name
+
+          nested command
+            from CommandSetForSlice
+              name = name
+              schema = schema
+        """;
+
+    protected override IEnumerable<Type> EventTypes => [typeof(given.SliceCreated), typeof(given.CommandSetForSlice)];
+
+    ProjectionDefinition _result;
+    ChildrenDefinition _nested;
+
+    void Because()
+    {
+        _result = Compile(Declaration);
+        _nested = _result.Nested![(PropertyPath)"command"];
+    }
+
+    [Fact] void should_have_a_nested_entry() => _result.Nested.ShouldNotBeNull();
+    [Fact] void should_have_a_nested_entry_keyed_by_property_name() => _result.Nested!.ContainsKey((PropertyPath)"command").ShouldBeTrue();
+    [Fact] void should_have_identified_by_not_set() => _nested.IdentifiedBy.IsSet.ShouldBeFalse();
+    [Fact] void should_have_the_from_event() => _nested.From.ContainsKey((EventType)"CommandSetForSlice").ShouldBeTrue();
+    [Fact] void should_map_name_property() => _nested.From[(EventType)"CommandSetForSlice"].Properties[(PropertyPath)"name"].ShouldEqual("name");
+    [Fact] void should_map_schema_property() => _nested.From[(EventType)"CommandSetForSlice"].Properties[(PropertyPath)"schema"].ShouldEqual("schema");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_single_from_event.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_LanguageService/when_compiling_nested_block/with_single_from_event.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
-using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Cratis.Chronicle.Properties;
 

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/given/a_parser.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/given/a_parser.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser.given;
+
+public class a_parser : Specification
+{
+    protected Document _document;
+    protected ParsingErrors _errors;
+
+    protected void Parse(string declaration)
+    {
+        Document parsedDocument = null;
+        ParsingErrors capturedErrors = null;
+
+        var tokenizer = new Tokenizer(declaration);
+        var tokenizeResult = tokenizer.Tokenize();
+
+        tokenizeResult.Match(
+            tokens =>
+            {
+                var parser = new Parser(tokens);
+                var parseResult = parser.Parse();
+                return parseResult.Match(
+                    document =>
+                    {
+                        parsedDocument = document;
+                        return 0;
+                    },
+                    errors =>
+                    {
+                        capturedErrors = errors;
+                        return 0;
+                    });
+            },
+            errors =>
+            {
+                capturedErrors = errors;
+                return 0;
+            });
+
+        _document = parsedDocument;
+        _errors = capturedErrors ?? new ParsingErrors([]);
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/inside_a_children_block.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/inside_a_children_block.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser.when_parsing_nested_block;
+
+public class inside_a_children_block : given.a_parser
+{
+    const string Declaration = """
+        projection Project => ProjectReadModel
+          from ProjectCreated
+            Name = name
+
+          children tasks identified by taskId
+            from TaskAdded
+              key taskId
+              parent projectId
+
+            nested assignee
+              from TaskAssigned
+                Name = assigneeName
+              clear with TaskUnassigned
+        """;
+
+    ChildrenBlock _children;
+    NestedChildBlock _nested;
+
+    void Because()
+    {
+        Parse(Declaration);
+        _children = _document.Projections[0].Directives.OfType<ChildrenBlock>().Single();
+        _nested = _children.ChildBlocks.OfType<NestedChildBlock>().Single();
+    }
+
+    [Fact] void should_not_have_errors() => _errors.HasErrors.ShouldBeFalse();
+    [Fact] void should_have_a_nested_child_block() => _nested.ShouldNotBeNull();
+    [Fact] void should_have_the_nested_property_name() => _nested.PropertyName.ShouldEqual("assignee");
+    [Fact] void should_have_the_from_event_inside_nested() => _nested.ChildBlocks.OfType<ChildOnEventBlock>().Single().EventType.Name.ShouldEqual("TaskAssigned");
+    [Fact] void should_have_the_clear_with_inside_nested() => _nested.ChildBlocks.OfType<ClearWithDirective>().Single().EventType.Name.ShouldEqual("TaskUnassigned");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_clear_with.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_clear_with.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser.when_parsing_nested_block;
+
+public class with_clear_with : given.a_parser
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            Name = name
+
+          nested command
+            from CommandSetForSlice
+              Name = commandName
+            clear with CommandClearedForSlice
+        """;
+
+    NestedBlock _nestedBlock;
+    ClearWithDirective _clearWith;
+
+    void Because()
+    {
+        Parse(Declaration);
+        _nestedBlock = _document.Projections[0].Directives.OfType<NestedBlock>().Single();
+        _clearWith = _nestedBlock.ChildBlocks.OfType<ClearWithDirective>().Single();
+    }
+
+    [Fact] void should_not_have_errors() => _errors.HasErrors.ShouldBeFalse();
+    [Fact] void should_have_a_clear_with_directive() => _clearWith.ShouldNotBeNull();
+    [Fact] void should_have_the_clear_event_type() => _clearWith.EventType.Name.ShouldEqual("CommandClearedForSlice");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_inner_nested.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_inner_nested.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser.when_parsing_nested_block;
+
+public class with_inner_nested : given.a_parser
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            Name = name
+
+          nested command
+            from CommandSetForSlice
+              Name = commandName
+
+            nested validation
+              from ValidationAdded
+                Rule = rule
+              clear with ValidationRemoved
+
+            clear with CommandClearedForSlice
+        """;
+
+    NestedBlock _outer;
+    NestedChildBlock _inner;
+
+    void Because()
+    {
+        Parse(Declaration);
+        _outer = _document.Projections[0].Directives.OfType<NestedBlock>().Single();
+        _inner = _outer.ChildBlocks.OfType<NestedChildBlock>().Single();
+    }
+
+    [Fact] void should_not_have_errors() => _errors.HasErrors.ShouldBeFalse();
+    [Fact] void should_have_an_inner_nested_block() => _inner.ShouldNotBeNull();
+    [Fact] void should_have_the_inner_property_name() => _inner.PropertyName.ShouldEqual("validation");
+    [Fact] void should_have_inner_from_event() => _inner.ChildBlocks.OfType<ChildOnEventBlock>().Single().EventType.Name.ShouldEqual("ValidationAdded");
+    [Fact] void should_have_inner_clear_with() => _inner.ChildBlocks.OfType<ClearWithDirective>().Single().EventType.Name.ShouldEqual("ValidationRemoved");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_single_from_event.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block/with_single_from_event.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser.when_parsing_nested_block;
+
+public class with_single_from_event : given.a_parser
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            Name = name
+
+          nested command
+            from CommandSetForSlice
+              Name = commandName
+        """;
+
+    NestedBlock _nestedBlock;
+
+    void Because()
+    {
+        Parse(Declaration);
+        _nestedBlock = _document.Projections[0].Directives.OfType<NestedBlock>().Single();
+    }
+
+    [Fact] void should_not_have_errors() => _errors.HasErrors.ShouldBeFalse();
+    [Fact] void should_have_a_nested_block() => _nestedBlock.ShouldNotBeNull();
+    [Fact] void should_have_the_property_name() => _nestedBlock.PropertyName.ShouldEqual("command");
+    [Fact] void should_have_a_single_child_block() => _nestedBlock.ChildBlocks.Count.ShouldEqual(1);
+    [Fact] void should_have_the_from_event_block_as_child() => _nestedBlock.ChildBlocks[0].ShouldBeOfExactType<ChildOnEventBlock>();
+    [Fact] void should_have_the_from_event_type() => ((ChildOnEventBlock)_nestedBlock.ChildBlocks[0]).EventType.Name.ShouldEqual("CommandSetForSlice");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block_without_from.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/DefinitionLanguage/for_Parser/when_parsing_nested_block_without_from.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.for_Parser;
+
+public class when_parsing_nested_block_without_from : given.a_parser
+{
+    const string Declaration = """
+        projection Slice => SliceReadModel
+          from SliceCreated
+            Name = name
+
+          nested command
+            clear with CommandClearedForSlice
+        """;
+
+    void Because() => Parse(Declaration);
+
+    [Fact] void should_have_errors() => _errors.HasErrors.ShouldBeTrue();
+    [Fact] void should_report_missing_from_directive() => _errors.Errors.ShouldContain(e => e.Message.Contains("nested", StringComparison.OrdinalIgnoreCase) && e.Message.Contains("from", StringComparison.OrdinalIgnoreCase));
+}

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/ClearWithDirective.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/ClearWithDirective.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+/// <summary>
+/// Represents a 'clear with' directive that nulls a nested object when the given event occurs.
+/// </summary>
+/// <param name="EventType">The event type that triggers clearing the nested object.</param>
+public record ClearWithDirective(TypeRef EventType) : ChildBlock;

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/NestedBlock.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/NestedBlock.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+/// <summary>
+/// Represents a nested object block at the projection level.
+/// </summary>
+/// <param name="PropertyName">The name of the nested object property.</param>
+/// <param name="AutoMap">Whether to auto map: Inherit (no directive), Enabled (automap), Disabled (no automap).</param>
+/// <param name="ChildBlocks">Collection of child blocks (from, join, nested, clear with, etc.).</param>
+public record NestedBlock(
+    string PropertyName,
+    AutoMap AutoMap,
+    IReadOnlyList<ChildBlock> ChildBlocks) : ProjectionDirective;

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/NestedChildBlock.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/AST/NestedChildBlock.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+/// <summary>
+/// Represents a nested object block appearing inside a children or nested block.
+/// </summary>
+/// <param name="PropertyName">The name of the nested object property.</param>
+/// <param name="AutoMap">Whether to auto map: Inherit (no directive), Enabled (automap), Disabled (no automap).</param>
+/// <param name="ChildBlocks">Collection of child blocks (from, join, nested, clear with, etc.).</param>
+public record NestedChildBlock(
+    string PropertyName,
+    AutoMap AutoMap,
+    IReadOnlyList<ChildBlock> ChildBlocks) : ChildBlock;

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Compiler.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Compiler.cs
@@ -184,6 +184,10 @@ public class Compiler
             case ChildrenBlock childrenBlock:
                 ProcessChildrenBlock(childrenBlock, children);
                 break;
+            case NestedBlock:
+                // Nested object blocks are parsed but not yet emitted to ProjectionDefinition.Nested.
+                // Code generation lands in Phase 4.
+                break;
             case JoinBlock joinBlock:
                 ProcessJoinBlock(joinBlock, join);
                 break;
@@ -316,6 +320,14 @@ public class Compiler
                 break;
             case ChildEveryBlock everyBlock:
                 ProcessChildEveryBlock(everyBlock, fromEvery);
+                break;
+            case NestedChildBlock:
+                // Nested-in-children blocks are parsed but not yet emitted to ChildrenDefinition.Nested.
+                // Code generation lands in Phase 4.
+                break;
+            case ClearWithDirective:
+                // Clear-with directives are parsed but not yet emitted to the nested object's RemovedWith.
+                // Code generation lands in Phase 4.
                 break;
             default:
                 throw new NotSupportedException($"Child block type {childBlock.GetType().Name} is not yet supported");

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Compiler.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Compiler.cs
@@ -109,6 +109,7 @@ public class Compiler
         var from = new Dictionary<EventType, FromDefinition>();
         var join = new Dictionary<EventType, JoinDefinition>();
         var children = new Dictionary<PropertyPath, ChildrenDefinition>();
+        var nested = new Dictionary<PropertyPath, ChildrenDefinition>();
         var removedWith = new Dictionary<EventType, RemovedWithDefinition>();
         var removedWithJoin = new Dictionary<EventType, RemovedWithJoinDefinition>();
         var fromEvery = new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false);
@@ -116,7 +117,7 @@ public class Compiler
         // Process each directive
         foreach (var directive in projection.Directives)
         {
-            ProcessDirective(directive, from, join, children, removedWith, removedWithJoin, ref fromEvery);
+            ProcessDirective(directive, from, join, children, nested, removedWith, removedWithJoin, ref fromEvery);
         }
 
         return new ProjectionDefinition(
@@ -138,6 +139,7 @@ public class Compiler
             LastUpdated: DateTimeOffset.UtcNow,
             Tags: default,
             AutoMap: _hasNoAutoMapDirective ? AutoMap.Disabled : AutoMap.Enabled,
+            Nested: nested.Count > 0 ? nested : null,
             SubscribesToAllEvents: _hasAllBlock);
     }
 
@@ -146,6 +148,7 @@ public class Compiler
         Dictionary<EventType, FromDefinition> from,
         Dictionary<EventType, JoinDefinition> join,
         Dictionary<PropertyPath, ChildrenDefinition> children,
+        Dictionary<PropertyPath, ChildrenDefinition> nested,
         Dictionary<EventType, RemovedWithDefinition> removedWith,
         Dictionary<EventType, RemovedWithJoinDefinition> removedWithJoin,
         ref FromEveryDefinition fromEvery)
@@ -184,9 +187,8 @@ public class Compiler
             case ChildrenBlock childrenBlock:
                 ProcessChildrenBlock(childrenBlock, children);
                 break;
-            case NestedBlock:
-                // Nested object blocks are parsed but not yet emitted to ProjectionDefinition.Nested.
-                // Code generation lands in Phase 4.
+            case NestedBlock nestedBlock:
+                ProcessNestedBlock(nestedBlock, nested);
                 break;
             case JoinBlock joinBlock:
                 ProcessJoinBlock(joinBlock, join);
@@ -258,13 +260,14 @@ public class Compiler
         var childFrom = new Dictionary<EventType, FromDefinition>();
         var childJoin = new Dictionary<EventType, JoinDefinition>();
         var nestedChildren = new Dictionary<PropertyPath, ChildrenDefinition>();
+        var nestedScalar = new Dictionary<PropertyPath, ChildrenDefinition>();
         var childRemovedWith = new Dictionary<EventType, RemovedWithDefinition>();
         var childRemovedWithJoin = new Dictionary<EventType, RemovedWithJoinDefinition>();
         var childEvery = new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false);
 
         foreach (var childBlock in childrenBlock.ChildBlocks)
         {
-            ProcessChildBlock(childBlock, childFrom, childJoin, nestedChildren, childRemovedWith, childRemovedWithJoin, childEvery);
+            ProcessChildBlock(childBlock, childFrom, childJoin, nestedChildren, nestedScalar, childRemovedWith, childRemovedWithJoin, childEvery);
         }
 
         children[collectionPath] = new ChildrenDefinition(
@@ -274,10 +277,9 @@ public class Compiler
             nestedChildren,
             childEvery,
             childRemovedWith,
-            childRemovedWithJoin)
-        {
-            AutoMap = GetAutoMapValue(childrenBlock.AutoMap)
-        };
+            childRemovedWithJoin,
+            AutoMap: GetAutoMapValue(childrenBlock.AutoMap),
+            Nested: nestedScalar.Count > 0 ? nestedScalar : null);
     }
 
     /// <summary>
@@ -288,6 +290,7 @@ public class Compiler
     /// <param name="from">Dictionary of event type to from definitions.</param>
     /// <param name="join">Dictionary of event type to join definitions.</param>
     /// <param name="children">Dictionary of property path to children definitions.</param>
+    /// <param name="nested">Dictionary of property path to nested scalar child definitions.</param>
     /// <param name="removedWith">Dictionary of event type to removed with definitions.</param>
     /// <param name="removedWithJoin">Dictionary of event type to removed with join definitions.</param>
     /// <param name="fromEvery">The from every definition to populate when processing every blocks.</param>
@@ -297,6 +300,7 @@ public class Compiler
         Dictionary<EventType, FromDefinition> from,
         Dictionary<EventType, JoinDefinition> join,
         Dictionary<PropertyPath, ChildrenDefinition> children,
+        Dictionary<PropertyPath, ChildrenDefinition> nested,
         Dictionary<EventType, RemovedWithDefinition> removedWith,
         Dictionary<EventType, RemovedWithJoinDefinition> removedWithJoin,
         FromEveryDefinition fromEvery)
@@ -321,13 +325,11 @@ public class Compiler
             case ChildEveryBlock everyBlock:
                 ProcessChildEveryBlock(everyBlock, fromEvery);
                 break;
-            case NestedChildBlock:
-                // Nested-in-children blocks are parsed but not yet emitted to ChildrenDefinition.Nested.
-                // Code generation lands in Phase 4.
+            case NestedChildBlock nestedChildBlock:
+                ProcessNestedChildBlock(nestedChildBlock, nested);
                 break;
-            case ClearWithDirective:
-                // Clear-with directives are parsed but not yet emitted to the nested object's RemovedWith.
-                // Code generation lands in Phase 4.
+            case ClearWithDirective clearWith:
+                ProcessClearWithDirective(clearWith, removedWith);
                 break;
             default:
                 throw new NotSupportedException($"Child block type {childBlock.GetType().Name} is not yet supported");
@@ -381,6 +383,85 @@ public class Compiler
             nestedChildren.ChildBlocks);
 
         ProcessChildrenBlock(childrenBlock, children);
+    }
+
+    /// <summary>
+    /// Process a top-level nested object block and emit a ChildrenDefinition into the projection's
+    /// Nested dictionary with <see cref="PropertyPath.NotSet"/> as the identifier — the engine treats
+    /// the entry as scalar (one nullable child object) rather than as a collection.
+    /// </summary>
+    /// <param name="nestedBlock">The nested block to process.</param>
+    /// <param name="nested">The nested dictionary on the parent projection definition.</param>
+    void ProcessNestedBlock(
+        NestedBlock nestedBlock,
+        Dictionary<PropertyPath, ChildrenDefinition> nested)
+    {
+        var propertyPath = new PropertyPath(nestedBlock.PropertyName);
+        nested[propertyPath] = BuildNestedDefinition(nestedBlock.AutoMap, nestedBlock.ChildBlocks);
+    }
+
+    /// <summary>
+    /// Process a nested block that appears inside a children or another nested block.
+    /// </summary>
+    /// <param name="nestedChildBlock">The nested child block to process.</param>
+    /// <param name="nested">The nested dictionary on the enclosing children/nested definition.</param>
+    void ProcessNestedChildBlock(
+        NestedChildBlock nestedChildBlock,
+        Dictionary<PropertyPath, ChildrenDefinition> nested)
+    {
+        var propertyPath = new PropertyPath(nestedChildBlock.PropertyName);
+        nested[propertyPath] = BuildNestedDefinition(nestedChildBlock.AutoMap, nestedChildBlock.ChildBlocks);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="ChildrenDefinition"/> representing a scalar nested object from a set of child blocks.
+    /// The resulting definition uses <see cref="PropertyPath.NotSet"/> as its identifier so the engine treats it
+    /// as scalar; <c>from</c> events become From entries and <c>clear with</c> directives become RemovedWith entries.
+    /// </summary>
+    /// <param name="autoMap">AutoMap behavior declared on the nested block.</param>
+    /// <param name="childBlocks">Child blocks inside the nested block.</param>
+    /// <returns>The constructed nested <see cref="ChildrenDefinition"/>.</returns>
+    ChildrenDefinition BuildNestedDefinition(
+        AutoMap autoMap,
+        IReadOnlyList<ChildBlock> childBlocks)
+    {
+        var from = new Dictionary<EventType, FromDefinition>();
+        var join = new Dictionary<EventType, JoinDefinition>();
+        var innerChildren = new Dictionary<PropertyPath, ChildrenDefinition>();
+        var innerNested = new Dictionary<PropertyPath, ChildrenDefinition>();
+        var removedWith = new Dictionary<EventType, RemovedWithDefinition>();
+        var removedWithJoin = new Dictionary<EventType, RemovedWithJoinDefinition>();
+        var every = new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false);
+
+        foreach (var childBlock in childBlocks)
+        {
+            ProcessChildBlock(childBlock, from, join, innerChildren, innerNested, removedWith, removedWithJoin, every);
+        }
+
+        return new ChildrenDefinition(
+            PropertyPath.NotSet,
+            from,
+            join,
+            innerChildren,
+            every,
+            removedWith,
+            removedWithJoin,
+            AutoMap: GetAutoMapValue(autoMap),
+            Nested: innerNested.Count > 0 ? innerNested : null);
+    }
+
+    /// <summary>
+    /// Process a 'clear with' directive inside a nested block — adds the event to the nested
+    /// block's RemovedWith so the engine clears the nested object back to null when the event is observed.
+    /// </summary>
+    /// <param name="clearWith">The 'clear with' directive to process.</param>
+    /// <param name="removedWith">The RemovedWith dictionary of the enclosing nested definition.</param>
+    void ProcessClearWithDirective(
+        ClearWithDirective clearWith,
+        Dictionary<EventType, RemovedWithDefinition> removedWith)
+    {
+        var eventType = EventType.Parse(clearWith.EventType.Name);
+        removedWith[eventType] = new RemovedWithDefinition(PropertyExpression.NotSet, ParentKey: null);
     }
 
     void ProcessRemoveBlock(RemoveBlock remove, Dictionary<EventType, RemovedWithDefinition> removedWith)

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Keywords.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Keywords.cs
@@ -50,7 +50,9 @@ public static class Keywords
             { "false", TokenType.False },
             { "null", TokenType.Null },
             { "literal", TokenType.Literal },
-            { "all", TokenType.All }
+            { "all", TokenType.All },
+            { "nested", TokenType.Nested },
+            { "clear", TokenType.Clear }
         };
 
         All = new HashSet<string>(TokenMapping.Keys, StringComparer.Ordinal);

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Parsers/ProjectionDirectiveParser.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Parsers/ProjectionDirectiveParser.cs
@@ -22,6 +22,7 @@ public class ProjectionDirectiveParser
         new FromEventBlockVisitor(),
         new JoinBlockVisitor(),
         new ChildrenBlockVisitor(),
+        new NestedBlockVisitor(),
         new RemoveWithDirectiveVisitor()
     ];
 

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Parsers/ProjectionParser.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Parsers/ProjectionParser.cs
@@ -22,6 +22,8 @@ internal sealed class ProjectionParser
         TokenType.With,
         TokenType.Join,
         TokenType.Children,
+        TokenType.Nested,
+        TokenType.Clear,
         TokenType.Remove,
         TokenType.Increment,
         TokenType.Decrement,

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/TokenType.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/TokenType.cs
@@ -248,5 +248,15 @@ public enum TokenType
     /// <summary>
     /// The keyword 'all'.
     /// </summary>
-    All = 49
+    All = 49,
+
+    /// <summary>
+    /// The keyword 'nested'.
+    /// </summary>
+    Nested = 50,
+
+    /// <summary>
+    /// The keyword 'clear'.
+    /// </summary>
+    Clear = 51
 }

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/ChildrenBlockVisitor.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/ChildrenBlockVisitor.cs
@@ -91,6 +91,12 @@ public class ChildrenBlockVisitor : IDirectiveVisitor
             return visitor.Visit(context);
         }
 
+        if (context.Check(TokenType.Nested))
+        {
+            var visitor = new NestedChildBlockVisitor();
+            return visitor.Visit(context);
+        }
+
         if (context.Check(TokenType.Remove))
         {
             var visitor = new RemoveBlockVisitor();

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedBlockParsing.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedBlockParsing.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.Parsers;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.Visitors;
+
+/// <summary>
+/// Shared helpers for parsing the body of a nested object block.
+/// </summary>
+internal static class NestedBlockParsing
+{
+    /// <summary>
+    /// Parses a single child block that can appear inside a nested block — from, join, nested, clear with, every, or further children.
+    /// </summary>
+    /// <param name="context">The parsing context.</param>
+    /// <returns>The parsed child block, or null if no child block could be parsed.</returns>
+    public static ChildBlock? ParseChildBlock(IParsingContext context)
+    {
+        if (context.Check(TokenType.From))
+        {
+            var visitor = new ChildOnEventBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        if (context.Check(TokenType.Join))
+        {
+            var visitor = new ChildJoinBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        if (context.Check(TokenType.Children))
+        {
+            var visitor = new NestedChildrenBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        if (context.Check(TokenType.Nested))
+        {
+            var visitor = new NestedChildBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        if (context.Check(TokenType.Clear))
+        {
+            return ParseClearWith(context);
+        }
+
+        if (context.Check(TokenType.Every))
+        {
+            var visitor = new ChildEveryBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        if (context.Check(TokenType.Remove))
+        {
+            var visitor = new RemoveBlockVisitor();
+            return visitor.Visit(context);
+        }
+
+        context.ReportError($"Unexpected token '{context.Current.Value}' in nested block");
+        return null;
+    }
+
+    /// <summary>
+    /// Parses a 'clear with EventType' directive.
+    /// </summary>
+    /// <param name="context">The parsing context.</param>
+    /// <returns>The parsed clear with directive, or null if parsing failed.</returns>
+    public static ClearWithDirective? ParseClearWith(IParsingContext context)
+    {
+        if (!context.Check(TokenType.Clear))
+        {
+            return null;
+        }
+
+        var clearToken = context.Current;
+        context.Advance(); // Skip 'clear'
+
+        if (context.Expect(TokenType.With) is null) return null;
+
+        var typeRefs = new TypeRefParser();
+        var eventType = typeRefs.Parse(context);
+        if (eventType is null) return null;
+
+        return new ClearWithDirective(eventType)
+        {
+            Line = clearToken.Line,
+            Column = clearToken.Column
+        };
+    }
+}

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedBlockVisitor.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedBlockVisitor.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.Visitors;
+
+/// <summary>
+/// Visitor for parsing top-level nested object blocks.
+/// </summary>
+public class NestedBlockVisitor : IDirectiveVisitor
+{
+    /// <inheritdoc/>
+    public ProjectionDirective? Visit(IParsingContext context)
+    {
+        if (!context.Check(TokenType.Nested))
+        {
+            return null;
+        }
+
+        var nestedToken = context.Current;
+        context.Advance(); // Skip 'nested'
+
+        var propertyNameToken = context.Expect(TokenType.Identifier);
+        if (propertyNameToken is null) return null;
+        var propertyName = propertyNameToken.Value;
+
+        if (context.Expect(TokenType.Indent) is null) return null;
+
+        var autoMap = AutoMap.Inherit;
+        var childBlocks = new List<ChildBlock>();
+        var hasFrom = false;
+
+        while (!context.Check(TokenType.Dedent) && !context.IsAtEnd)
+        {
+            if (context.Check(TokenType.AutoMap))
+            {
+                context.Advance();
+                autoMap = AutoMap.Enabled;
+            }
+            else if (context.Check(TokenType.No) && context.Peek().Type == TokenType.AutoMap)
+            {
+                context.Advance(); // Skip 'no'
+                context.Advance(); // Skip 'automap'
+                autoMap = AutoMap.Disabled;
+            }
+            else
+            {
+                var childBlock = NestedBlockParsing.ParseChildBlock(context);
+                if (childBlock is not null)
+                {
+                    if (childBlock is ChildOnEventBlock)
+                    {
+                        hasFrom = true;
+                    }
+
+                    childBlocks.Add(childBlock);
+                }
+            }
+        }
+
+        context.Expect(TokenType.Dedent);
+
+        if (!hasFrom)
+        {
+            context.Errors.Add(
+                $"Nested block '{propertyName}' must contain at least one 'from' directive",
+                nestedToken.Line,
+                nestedToken.Column);
+        }
+
+        return new NestedBlock(propertyName, autoMap, childBlocks)
+        {
+            Line = nestedToken.Line,
+            Column = nestedToken.Column
+        };
+    }
+}

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedChildBlockVisitor.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedChildBlockVisitor.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage.AST;
+
+namespace Cratis.Chronicle.Projections.Engine.DeclarationLanguage.Visitors;
+
+/// <summary>
+/// Visitor for parsing nested object blocks that appear inside a children or another nested block.
+/// </summary>
+internal sealed class NestedChildBlockVisitor
+{
+    /// <summary>
+    /// Visits and parses a nested block in a child context.
+    /// </summary>
+    /// <param name="context">The parsing context.</param>
+    /// <returns>The parsed child block, or null if not applicable.</returns>
+    public ChildBlock? Visit(IParsingContext context)
+    {
+        if (!context.Check(TokenType.Nested))
+        {
+            return null;
+        }
+
+        var nestedToken = context.Current;
+        context.Advance(); // Skip 'nested'
+
+        var propertyNameToken = context.Expect(TokenType.Identifier);
+        if (propertyNameToken is null) return null;
+        var propertyName = propertyNameToken.Value;
+
+        if (context.Expect(TokenType.Indent) is null) return null;
+
+        var autoMap = AutoMap.Inherit;
+        var childBlocks = new List<ChildBlock>();
+        var hasFrom = false;
+
+        while (!context.Check(TokenType.Dedent) && !context.IsAtEnd)
+        {
+            if (context.Check(TokenType.AutoMap))
+            {
+                context.Advance();
+                autoMap = AutoMap.Enabled;
+            }
+            else if (context.Check(TokenType.No) && context.Peek().Type == TokenType.AutoMap)
+            {
+                context.Advance(); // Skip 'no'
+                context.Advance(); // Skip 'automap'
+                autoMap = AutoMap.Disabled;
+            }
+            else
+            {
+                var childBlock = NestedBlockParsing.ParseChildBlock(context);
+                if (childBlock is not null)
+                {
+                    if (childBlock is ChildOnEventBlock)
+                    {
+                        hasFrom = true;
+                    }
+
+                    childBlocks.Add(childBlock);
+                }
+            }
+        }
+
+        context.Expect(TokenType.Dedent);
+
+        if (!hasFrom)
+        {
+            context.Errors.Add(
+                $"Nested block '{propertyName}' must contain at least one 'from' directive",
+                nestedToken.Line,
+                nestedToken.Column);
+        }
+
+        return new NestedChildBlock(propertyName, autoMap, childBlocks)
+        {
+            Line = nestedToken.Line,
+            Column = nestedToken.Column
+        };
+    }
+}

--- a/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedChildrenBlockVisitor.cs
+++ b/Source/Kernel/Core/Projections/Engine/DefinitionLanguage/Visitors/NestedChildrenBlockVisitor.cs
@@ -95,6 +95,12 @@ internal sealed class NestedChildrenBlockVisitor
             return visitor.Visit(context);
         }
 
+        if (context.Check(TokenType.Nested))
+        {
+            var visitor = new NestedChildBlockVisitor();
+            return visitor.Visit(context);
+        }
+
         if (context.Check(TokenType.Remove))
         {
             var visitor = new RemoveBlockVisitor();

--- a/Source/Workbench/Components/ProjectionEditor/language.ts
+++ b/Source/Workbench/Components/ProjectionEditor/language.ts
@@ -19,6 +19,7 @@ const KEYWORDS = [
     'automap',
     'no',
     'children',
+    'nested',
     'identified',
     'by',
     'add',
@@ -32,6 +33,7 @@ const KEYWORDS = [
     'count',
     'set',
     'unset',
+    'clear',
     'events',
     'id',
     'exclude',
@@ -75,13 +77,13 @@ export const configuration: languages.LanguageConfiguration = {
         { open: '`', close: '`' },
     ],
     indentationRules: {
-        increaseIndentPattern: /^.*(:|\bon\b|\ball\b|\bevery\b|\bchildren\b|\bparent\b)\s*$/,
+        increaseIndentPattern: /^.*(:|\bon\b|\ball\b|\bevery\b|\bchildren\b|\bnested\b|\bparent\b)\s*$/,
         decreaseIndentPattern: /^.*\}.*$/,
     },
     folding: {
         offSide: true,
         markers: {
-            start: /^\s*(projection|all|every|on|children|parent)/,
+            start: /^\s*(projection|all|every|on|children|nested|parent)/,
             end: /^\s*$/,
         },
     },


### PR DESCRIPTION
# Summary

Expands the nested projection objects work to include explicit client API and integration spec coverage, and keeps the CI build-failure fix.

## Added

- Added declarative client API spec coverage for nested objects in nested-in-nested and nested-in-children scenarios (#3142)
- Added declarative in-process integration scenarios for nested objects inside children collections (set, update, clear) (#3142)

## Changed

- Expanded the nested objects design page with explicit client-facing coverage details for declarative/model-bound APIs and spec locations (#3142)
- Updated integration coverage wording to reflect nested-in-children support across declarative and model-bound projections (#3142)

## Fixed

- Fixed a failing `.NET Build & Integration` check by removing an unnecessary using directive that triggered `IDE0005` in Core.Specs (#3142)

## Removed

- No user-facing removals.

## Security

- No security changes.

## Deprecated

- No deprecations.