### PR TITLE
Add observer in-flight state and partition recovery on subscribe

### DIFF
--- a/Source/Clients/Testing/InMemoryEventStoreNamespaceStorage.cs
+++ b/Source/Clients/Testing/InMemoryEventStoreNamespaceStorage.cs
@@ -53,6 +53,9 @@ internal sealed class InMemoryEventStoreNamespaceStorage(
     public IFailedPartitionsStorage FailedPartitions => throw new NotSupportedException();
 
     /// <inheritdoc/>
+    public IInFlightEventsStorage InFlightEvents => throw new NotSupportedException();
+
+    /// <inheritdoc/>
     public IRecommendationStorage Recommendations => throw new NotSupportedException();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Concepts/Observation/InFlightEvent.cs
+++ b/Source/Kernel/Concepts/Observation/InFlightEvent.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Concepts.Observation;
+
+/// <summary>
+/// Represents an event that an observer has started handling but not yet acknowledged as completed.
+/// </summary>
+/// <remarks>
+/// In-flight events are recorded before a partition handler is invoked and removed once the handler
+/// reports successful processing. Persisting them in a separate storage (outside of the main observer
+/// state) allows the observer to recover after a crash that interrupted multi-partition handling —
+/// without the risk of silently skipping events whose progress was never written back to the main
+/// observer state.
+/// </remarks>
+public class InFlightEvent
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this in-flight event entry.
+    /// </summary>
+    public InFlightEventId Id { get; set; } = InFlightEventId.NotSet;
+
+    /// <summary>
+    /// Gets or sets the <see cref="ObserverId"/> the in-flight event belongs to.
+    /// </summary>
+    public ObserverId ObserverId { get; set; } = ObserverId.Unspecified;
+
+    /// <summary>
+    /// Gets or sets the partition <see cref="Key"/> on which the event is being handled.
+    /// </summary>
+    public Key Partition { get; set; } = Key.Undefined;
+
+    /// <summary>
+    /// Gets or sets the <see cref="EventSequenceNumber"/> for the event in flight.
+    /// </summary>
+    public EventSequenceNumber EventSequenceNumber { get; set; } = EventSequenceNumber.Unavailable;
+}

--- a/Source/Kernel/Concepts/Observation/InFlightEventId.cs
+++ b/Source/Kernel/Concepts/Observation/InFlightEventId.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Observation;
+
+/// <summary>
+/// Represents the unique identifier of an <see cref="InFlightEvent"/> entry.
+/// </summary>
+/// <param name="Value">The inner value.</param>
+public record InFlightEventId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    /// <summary>
+    /// Gets the representation of a not-set <see cref="InFlightEventId"/>.
+    /// </summary>
+    public static readonly InFlightEventId NotSet = new(Guid.Empty);
+
+    /// <summary>
+    /// Implicitly convert from a <see cref="Guid"/> to an <see cref="InFlightEventId"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> value.</param>
+    public static implicit operator InFlightEventId(Guid value) => new(value);
+
+    /// <summary>
+    /// Implicitly convert from an <see cref="InFlightEventId"/> to a <see cref="Guid"/>.
+    /// </summary>
+    /// <param name="id">The <see cref="InFlightEventId"/>.</param>
+    public static implicit operator Guid(InFlightEventId id) => id.Value;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="InFlightEventId"/> with a new <see cref="Guid"/>.
+    /// </summary>
+    /// <returns>A new <see cref="InFlightEventId"/>.</returns>
+    public static InFlightEventId New() => new(Guid.NewGuid());
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.StateMachines;
+using Cratis.Chronicle.Storage.Observation;
+using Microsoft.Extensions.Logging;
+using IChronicleEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
+using IEventStoreNamespaceStorage = Cratis.Chronicle.Storage.IEventStoreNamespaceStorage;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.given;
+
+public class a_catching_up_in_flight_state : Specification
+{
+    protected IObserver _observer;
+    protected CatchingUpInFlight _state;
+    protected ObserverState _storedState;
+    protected ObserverState _resultingStoredState;
+    protected ObserverKey _observerKey;
+    protected IPersistentState<ObserverDefinition> _definitionState;
+    protected IPersistentState<FailedPartitions> _failuresState;
+    protected IChronicleStorage _storage;
+    protected IChronicleEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _eventStoreNamespaceStorage;
+    protected IInFlightEventsStorage _inFlightEventsStorage;
+    protected IJobsManager _jobsManager;
+    protected FailedPartitions _failedPartitions;
+
+    void Establish()
+    {
+        _observer = Substitute.For<IObserver>();
+        _observerKey = new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), EventSequenceId.Log);
+
+        _definitionState = Substitute.For<IPersistentState<ObserverDefinition>>();
+        _definitionState.State = ObserverDefinition.Empty;
+
+        _failedPartitions = new FailedPartitions();
+        _failuresState = Substitute.For<IPersistentState<FailedPartitions>>();
+        _failuresState.State = _failedPartitions;
+
+        _storage = Substitute.For<IChronicleStorage>();
+        _eventStoreStorage = Substitute.For<IChronicleEventStoreStorage>();
+        _eventStoreNamespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _inFlightEventsStorage = Substitute.For<IInFlightEventsStorage>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_eventStoreNamespaceStorage);
+        _eventStoreNamespaceStorage.InFlightEvents.Returns(_inFlightEventsStorage);
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>()).Returns([]);
+
+        _jobsManager = Substitute.For<IJobsManager>();
+
+        _state = new CatchingUpInFlight(
+            _observerKey,
+            _definitionState,
+            _failuresState,
+            _storage,
+            _jobsManager,
+            Substitute.For<ILogger<CatchingUpInFlight>>());
+        _state.SetStateMachine(_observer);
+
+        _storedState = new ObserverState
+        {
+            Identifier = _observerKey.ObserverId,
+            RunningState = ObserverRunningState.Unknown,
+        };
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_multiple_entries_for_same_partition.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_multiple_entries_for_same_partition.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.when_entering;
+
+public class and_multiple_entries_for_same_partition : given.a_catching_up_in_flight_state
+{
+    Key _partition = "shared-partition";
+
+    void Establish()
+    {
+        _storedState = _storedState with { LastHandledEventSequenceNumber = (EventSequenceNumber)4UL };
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>())
+            .Returns(
+            [
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _partition, EventSequenceNumber = (EventSequenceNumber)5UL },
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _partition, EventSequenceNumber = (EventSequenceNumber)6UL }
+            ]);
+    }
+
+    async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
+
+    [Fact] void should_start_exactly_one_catch_up_job_for_the_partition() => _jobsManager
+        .Received(1)
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
+            Arg.Is<CatchUpObserverPartitionRequest>(_ => _.Key == _partition));
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.when_entering;
+
+public class and_observer_is_quarantined : given.a_catching_up_in_flight_state
+{
+    Key _partition = "some-partition";
+
+    void Establish()
+    {
+        _storedState = _storedState with { RunningState = ObserverRunningState.Quarantined };
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>())
+            .Returns(
+            [
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _partition, EventSequenceNumber = (EventSequenceNumber)1UL }
+            ]);
+    }
+
+    async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
+
+    [Fact] void should_not_start_any_catch_up_jobs() => _jobsManager
+        .DidNotReceive()
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
+
+    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.when_entering;
+
+public class and_partition_is_already_failed : given.a_catching_up_in_flight_state
+{
+    Key _partition = "failing-partition";
+
+    void Establish()
+    {
+        _failedPartitions.AddFailedPartition(_partition);
+        _storedState = _storedState with { LastHandledEventSequenceNumber = (EventSequenceNumber)4UL };
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>())
+            .Returns(
+            [
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _partition, EventSequenceNumber = (EventSequenceNumber)5UL }
+            ]);
+    }
+
+    async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
+
+    [Fact] void should_not_start_any_catch_up_job_for_failing_partition() => _jobsManager
+        .DidNotReceive()
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
+            Arg.Is<CatchUpObserverPartitionRequest>(_ => _.Key == _partition));
+
+    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.when_entering;
+
+public class and_there_are_no_in_flight_entries : given.a_catching_up_in_flight_state
+{
+    void Establish() => _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>()).Returns([]);
+
+    async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
+
+    [Fact] void should_not_start_any_catch_up_jobs() => _jobsManager
+        .DidNotReceive()
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
+
+    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+
+namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.when_entering;
+
+public class and_there_are_pending_entries : given.a_catching_up_in_flight_state
+{
+    Key _firstPartition = "partition-one";
+    Key _secondPartition = "partition-two";
+
+    void Establish()
+    {
+        _storedState = _storedState with { LastHandledEventSequenceNumber = (EventSequenceNumber)9UL };
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>())
+            .Returns(
+            [
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _firstPartition, EventSequenceNumber = (EventSequenceNumber)10UL },
+                new InFlightEvent { ObserverId = _observerKey.ObserverId, Partition = _secondPartition, EventSequenceNumber = (EventSequenceNumber)11UL }
+            ]);
+    }
+
+    async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
+
+    [Fact] void should_start_catch_up_for_first_partition() => _jobsManager
+        .Received(1)
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
+            Arg.Is<CatchUpObserverPartitionRequest>(_ =>
+                _.Key == _firstPartition &&
+                _.FromSequenceNumber == (EventSequenceNumber)10UL));
+
+    [Fact] void should_start_catch_up_for_second_partition() => _jobsManager
+        .Received(1)
+        .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
+            Arg.Is<CatchUpObserverPartitionRequest>(_ =>
+                _.Key == _secondPartition &&
+                _.FromSequenceNumber == (EventSequenceNumber)10UL));
+
+    [Fact] void should_mark_first_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_firstPartition);
+    [Fact] void should_mark_second_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_secondPartition);
+    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/given/an_observer.cs
@@ -25,6 +25,7 @@ using Orleans.TestKit.Storage;
 using IChronicleEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
 using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
 using IEventSequence = Cratis.Chronicle.EventSequences.IEventSequence;
+using IEventStoreNamespaceStorage = Cratis.Chronicle.Storage.IEventStoreNamespaceStorage;
 
 namespace Cratis.Chronicle.Observation.for_Observer.given;
 
@@ -49,6 +50,8 @@ public class an_observer : Specification
     protected IConfigurationForObserverProvider _configurationProvider;
     protected IChronicleStorage _storage;
     protected IChronicleEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _eventStoreNamespaceStorage;
+    protected IInFlightEventsStorage _inFlightEventsStorage;
     protected IEventTypesStorage _eventTypesStorage;
     protected IJsonComplianceManager _complianceManager;
     protected IExpandoObjectConverter _expandoObjectConverter;
@@ -65,13 +68,18 @@ public class an_observer : Specification
         _eventSequence = Substitute.For<IEventSequence>();
         _storage = Substitute.For<IChronicleStorage>();
         _eventStoreStorage = Substitute.For<IChronicleEventStoreStorage>();
+        _eventStoreNamespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _inFlightEventsStorage = Substitute.For<IInFlightEventsStorage>();
         _eventTypesStorage = Substitute.For<IEventTypesStorage>();
         _complianceManager = Substitute.For<IJsonComplianceManager>();
         _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
 
-        // Wire the storage chain: IStorage → IEventStoreStorage → IEventTypesStorage
+        // Wire the storage chain: IStorage → IEventStoreStorage → IEventTypesStorage and IEventStoreNamespaceStorage → IInFlightEventsStorage
         _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
         _eventStoreStorage.EventTypes.Returns(_eventTypesStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_eventStoreNamespaceStorage);
+        _eventStoreNamespaceStorage.InFlightEvents.Returns(_inFlightEventsStorage);
+        _inFlightEventsStorage.GetFor(Arg.Any<ObserverId>()).Returns([]);
 
         // By default, no schemas are known — events pass through unchanged.
         _eventTypesStorage.GetFor(Arg.Any<IEnumerable<EventType>>()).Returns([]);

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_creating_states.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_creating_states.cs
@@ -12,10 +12,11 @@ public class when_creating_states : given.an_observer
 
     void Because() => _states = _observer.CreateStates();
 
-    [Fact] void should_return_5_states() => _states.Count.ShouldEqual(5);
+    [Fact] void should_return_6_states() => _states.Count.ShouldEqual(6);
     [Fact] void should_return_disconnected_state() => _states.FirstOrDefault(s => s is Disconnected).ShouldNotBeNull();
     [Fact] void should_return_routing_state() => _states.FirstOrDefault(s => s is Routing).ShouldNotBeNull();
     [Fact] void should_return_replay_state() => _states.FirstOrDefault(s => s is Replay).ShouldNotBeNull();
     [Fact] void should_return_quarantined_state() => _states.FirstOrDefault(s => s is QuarantinedObserver).ShouldNotBeNull();
+    [Fact] void should_return_catching_up_in_flight_state() => _states.FirstOrDefault(s => s is CatchingUpInFlight).ShouldNotBeNull();
     [Fact] void should_return_observing_state() => _states.FirstOrDefault(s => s is Observing).ShouldNotBeNull();
 }

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_recording_in_flight_events/and_subscriber_is_successful.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_recording_in_flight_events/and_subscriber_is_successful.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_recording_in_flight_events;
+
+public class and_subscriber_is_successful : given.an_observer_with_subscription_for_specific_event_type
+{
+    void Establish() =>
+        _subscriber
+            .OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(ObserverSubscriberResult.Ok(42UL));
+
+    async Task Because() =>
+        await _observer.Handle("Something", [AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL)]);
+
+    [Fact] void should_record_the_event_as_in_flight_before_dispatch() => _inFlightEventsStorage
+        .Received(1)
+        .Add(Arg.Any<ObserverId>(), Arg.Is<Key>(_ => (string)_.Value == "Something"), Arg.Is<EventSequenceNumber>(_ => _ == 42UL));
+
+    [Fact] void should_clear_the_in_flight_entry_after_success() => _inFlightEventsStorage
+        .Received(1)
+        .RemoveUpTo(Arg.Any<ObserverId>(), Arg.Is<Key>(_ => (string)_.Value == "Something"), Arg.Is<EventSequenceNumber>(_ => _ == 42UL));
+}

--- a/Source/Kernel/Core.Specs/Observation/for_Observer/when_recording_in_flight_events/and_subscriber_throws.cs
+++ b/Source/Kernel/Core.Specs/Observation/for_Observer/when_recording_in_flight_events/and_subscriber_throws.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Chronicle.Observation.for_Observer.when_recording_in_flight_events;
+
+public class and_subscriber_throws : given.an_observer_with_subscription_for_specific_event_type
+{
+    void Establish() =>
+        _subscriber
+            .OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Throws(new InvalidOperationException("boom"));
+
+    async Task Because() =>
+        await _observer.Handle("Something", [AppendedEvent.EmptyWithEventTypeAndEventSequenceNumber(event_type, 42UL)]);
+
+    [Fact] void should_still_record_the_event_as_in_flight_before_dispatch() => _inFlightEventsStorage
+        .Received(1)
+        .Add(Arg.Any<ObserverId>(), Arg.Is<Key>(_ => (string)_.Value == "Something"), Arg.Is<EventSequenceNumber>(_ => _ == 42UL));
+}

--- a/Source/Kernel/Core/Observation/Observer.Handling.cs
+++ b/Source/Kernel/Core/Observation/Observer.Handling.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Diagnostics.OpenTelemetry.Tracing;
+using Cratis.Chronicle.Storage.Observation;
 
 namespace Cratis.Chronicle.Observation;
 
@@ -102,6 +103,14 @@ public partial class Observer
         var stateChanged = false;
         if (eventsToHandle.Length != 0)
         {
+            // Record the highest sequence number we're about to attempt for this partition. If the silo
+            // dies between this point and the post-handling state write, the entry survives to drive
+            // partition catch-up on the next activation. Recording the tail of the batch is enough: the
+            // in-flight entry is conceptually a marker that work *may have started* for this partition.
+            var inFlightStorage = await GetInFlightEventsStorage();
+            var inFlightTail = eventsToHandle[^1].Context.SequenceNumber;
+            await inFlightStorage.Add(_observerId, partition, inFlightTail);
+
             using (new WriteSuspension(this))
             {
                 try
@@ -182,6 +191,14 @@ public partial class Observer
                 {
                     await WriteStateAsync();
                 }
+
+                // Clear in-flight markers for everything we processed (successfully or otherwise). Failures
+                // are tracked through FailedPartitions storage; keeping the in-flight marker would force a
+                // double recovery for events we already know about.
+                var clearUpTo = numEventsSuccessfullyHandled > 0
+                    ? eventsToHandle.Take((int)numEventsSuccessfullyHandled.Value).Last().Context.SequenceNumber
+                    : tailEventSequenceNumber;
+                await inFlightStorage.RemoveUpTo(_observerId, partition, clearUpTo);
             }
             catch (Exception ex)
             {
@@ -189,6 +206,16 @@ public partial class Observer
             }
         }
     }
+
+    /// <summary>
+    /// Get the <see cref="IInFlightEventsStorage"/> for the observer's event store namespace.
+    /// </summary>
+    /// <returns>The <see cref="IInFlightEventsStorage"/> instance.</returns>
+    Task<IInFlightEventsStorage> GetInFlightEventsStorage() =>
+        Task.FromResult(storage
+            .GetEventStore(_observerKey.EventStore)
+            .GetNamespace(_observerKey.Namespace)
+            .InFlightEvents);
 
     async Task<IEnumerable<AppendedEvent>> DecryptEvents(IEnumerable<AppendedEvent> events)
     {

--- a/Source/Kernel/Core/Observation/Observer.cs
+++ b/Source/Kernel/Core/Observation/Observer.cs
@@ -210,7 +210,7 @@ public partial class Observer(
         }
         await ResumeJobs();
         await TryRecoverAllFailedPartitions();
-        await TransitionTo<Routing>();
+        await TransitionTo<CatchingUpInFlight>();
     }
 
     /// <inheritdoc/>
@@ -260,7 +260,7 @@ public partial class Observer(
         }
         await ResumeJobs();
         await TryRecoverAllFailedPartitions();
-        await TransitionTo<Routing>();
+        await TransitionTo<CatchingUpInFlight>();
     }
 
     /// <inheritdoc/>
@@ -283,6 +283,14 @@ public partial class Observer(
         new QuarantinedObserver(
             _observerKey,
             loggerFactory.CreateLogger<QuarantinedObserver>()),
+
+        new CatchingUpInFlight(
+            _observerKey,
+            observerDefinition,
+            failures,
+            storage,
+            _jobsManager,
+            loggerFactory.CreateLogger<CatchingUpInFlight>()),
 
         new Observing(
             _appendedEventsQueues,

--- a/Source/Kernel/Core/Observation/States/CatchingUpInFlight.cs
+++ b/Source/Kernel/Core/Observation/States/CatchingUpInFlight.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Observation.Jobs;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Observation;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.States;
+
+/// <summary>
+/// Represents the state of an observer that is catching up partitions which had in-flight events
+/// at the time of the last shutdown.
+/// </summary>
+/// <param name="observerKey">The <see cref="ObserverKey"/> for the observer.</param>
+/// <param name="definitionState"><see cref="IPersistentState{ObserverDefinition}"/> for the observer's definition.</param>
+/// <param name="failuresState"><see cref="IPersistentState{FailedPartitions}"/> for the observer's failed partitions.</param>
+/// <param name="storage"><see cref="IStorage"/> for accessing the in-flight events store.</param>
+/// <param name="jobsManager"><see cref="IJobsManager"/> for starting partition catch-up jobs.</param>
+/// <param name="logger">Logger for logging.</param>
+/// <remarks>
+/// On entry, every partition that has an in-flight event marker — but is not already failed,
+/// replaying, or catching up — gets a dedicated catch-up job starting from the next event after
+/// the observer's last confirmed sequence number. The state then transitions to <see cref="Routing"/>
+/// so the observer can resume normal operation. If enqueueing a catch-up job throws, the observer
+/// transitions to <see cref="QuarantinedObserver"/> rather than silently losing recovery work.
+/// </remarks>
+public class CatchingUpInFlight(
+    ObserverKey observerKey,
+    IPersistentState<ObserverDefinition> definitionState,
+    IPersistentState<FailedPartitions> failuresState,
+    IStorage storage,
+    IJobsManager jobsManager,
+    ILogger<CatchingUpInFlight> logger) : BaseObserverState
+{
+    /// <inheritdoc/>
+    public override ObserverRunningState RunningState => ObserverRunningState.Unknown;
+
+    /// <inheritdoc/>
+    protected override IImmutableList<Type> AllowedTransitions => new[]
+    {
+        typeof(Routing),
+        typeof(QuarantinedObserver),
+        typeof(Disconnected)
+    }.ToImmutableList();
+
+    /// <inheritdoc/>
+    public override async Task<ObserverState> OnEnter(ObserverState state)
+    {
+        using var scope = logger.BeginCatchingUpInFlightScope(observerKey.ObserverId, observerKey);
+
+        if (state.RunningState == ObserverRunningState.Quarantined)
+        {
+            await StateMachine.TransitionTo<Routing>();
+            return state;
+        }
+
+        var inFlightStorage = storage
+            .GetEventStore(observerKey.EventStore)
+            .GetNamespace(observerKey.Namespace)
+            .InFlightEvents;
+
+        var entries = (await inFlightStorage.GetFor(observerKey.ObserverId)).ToArray();
+        if (entries.Length == 0)
+        {
+            await StateMachine.TransitionTo<Routing>();
+            return state;
+        }
+
+        logger.RecoveringInFlightPartitions(entries.Length);
+
+        var partitions = entries
+            .Select(_ => _.Partition)
+            .Distinct()
+            .Where(p =>
+                !state.CatchingUpPartitions.Contains(p) &&
+                !state.ReplayingPartitions.Contains(p) &&
+                !failuresState.State.IsFailed(p))
+            .ToArray();
+
+        var startFrom = state.LastHandledEventSequenceNumber.IsActualValue
+            ? state.LastHandledEventSequenceNumber.Next()
+            : EventSequenceNumber.First;
+
+        try
+        {
+            foreach (var partition in partitions)
+            {
+                logger.StartingInFlightCatchUpForPartition(partition, startFrom);
+                state.CatchingUpPartitions.Add(partition);
+                await jobsManager.Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
+                    new(observerKey, definitionState.State.Type, partition, startFrom, definitionState.State.EventTypes));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.FailedToCatchUpInFlightPartitions(ex);
+            await StateMachine.TransitionTo<QuarantinedObserver>();
+            return state;
+        }
+
+        await StateMachine.TransitionTo<Routing>();
+        return state;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// On leaving the state, no per-state mutable bookkeeping is held — the catching-up partitions are
+    /// recorded directly on <see cref="ObserverState"/> and persist across the transition. This hook is
+    /// kept as the explicit place to clean up state-specific bookkeeping should any be introduced later.
+    /// </remarks>
+    public override Task<ObserverState> OnLeave(ObserverState state) => Task.FromResult(state);
+}

--- a/Source/Kernel/Core/Observation/States/CatchingUpInFlightLogging.cs
+++ b/Source/Kernel/Core/Observation/States/CatchingUpInFlightLogging.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.States;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class CatchingUpInFlightLogMessages
+{
+    [LoggerMessage(LogLevel.Information, "Recovering {Count} in-flight partition(s) after detecting persisted in-flight event markers")]
+    internal static partial void RecoveringInFlightPartitions(this ILogger<CatchingUpInFlight> logger, int count);
+
+    [LoggerMessage(LogLevel.Information, "Starting in-flight catch-up for partition {Partition} from event sequence number {FromSequenceNumber}")]
+    internal static partial void StartingInFlightCatchUpForPartition(this ILogger<CatchingUpInFlight> logger, Key partition, EventSequenceNumber fromSequenceNumber);
+
+    [LoggerMessage(LogLevel.Error, "Failed to enqueue in-flight catch-up for one or more partitions; transitioning observer to quarantine")]
+    internal static partial void FailedToCatchUpInFlightPartitions(this ILogger<CatchingUpInFlight> logger, Exception exception);
+}
+
+internal static class CatchingUpInFlightScopes
+{
+    internal static IDisposable? BeginCatchingUpInFlightScope(this ILogger<CatchingUpInFlight> logger, ObserverId observerId, ObserverKey observerKey) =>
+        logger.BeginScope(new
+        {
+            ObserverId = observerId,
+            observerKey.EventStore,
+            observerKey.Namespace,
+            observerKey.EventSequenceId
+        });
+}

--- a/Source/Kernel/Core/Observation/States/Disconnected.cs
+++ b/Source/Kernel/Core/Observation/States/Disconnected.cs
@@ -18,7 +18,8 @@ public class Disconnected : BaseObserverState
     /// <inheritdoc/>
     protected override IImmutableList<Type> AllowedTransitions => new[]
     {
-        typeof(Routing)
+        typeof(Routing),
+        typeof(CatchingUpInFlight)
     }.ToImmutableList();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Observation/States/Observing.cs
+++ b/Source/Kernel/Core/Observation/States/Observing.cs
@@ -41,7 +41,8 @@ public class Observing(
         typeof(Routing),
         typeof(Replay),
         typeof(QuarantinedObserver),
-        typeof(Disconnected)
+        typeof(Disconnected),
+        typeof(CatchingUpInFlight)
     }.ToImmutableList();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Observation/States/Replay.cs
+++ b/Source/Kernel/Core/Observation/States/Replay.cs
@@ -31,7 +31,8 @@ public class Replay(
     {
         typeof(Routing),
         typeof(QuarantinedObserver),
-        typeof(Disconnected)
+        typeof(Disconnected),
+        typeof(CatchingUpInFlight)
     }.ToImmutableList();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Observation/States/Routing.cs
+++ b/Source/Kernel/Core/Observation/States/Routing.cs
@@ -35,7 +35,8 @@ public class Routing(
     {
         typeof(Disconnected),
         typeof(Replay),
-        typeof(Observing)
+        typeof(Observing),
+        typeof(CatchingUpInFlight)
     }.ToImmutableList();
 
     /// <inheritdoc/>

--- a/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
@@ -94,6 +94,7 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
         JobSteps = new JobStepStorage(eventStoreNamespaceDatabase);
         Observers = new ObserverStateStorage(eventStoreNamespaceDatabase);
         FailedPartitions = new FailedPartitionStorage(eventStoreNamespaceDatabase);
+        InFlightEvents = new InFlightEventsStorage(eventStoreNamespaceDatabase);
         Recommendations = new RecommendationStorage(eventStoreNamespaceDatabase);
         ObserverKeyIndexes = new ObserverKeyIndexes(eventStoreNamespaceDatabase, observerDefinitionsStorage);
         Sinks = sinks;
@@ -127,6 +128,9 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
 
     /// <inheritdoc/>
     public IFailedPartitionsStorage FailedPartitions { get; }
+
+    /// <inheritdoc/>
+    public IInFlightEventsStorage InFlightEvents { get; }
 
     /// <inheritdoc/>
     public IRecommendationStorage Recommendations { get; }

--- a/Source/Kernel/Storage.MongoDB/Observation/InFlightEventClassMap.cs
+++ b/Source/Kernel/Storage.MongoDB/Observation/InFlightEventClassMap.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.MongoDB;
+using Cratis.Chronicle.Concepts.Observation;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Observation;
+
+/// <summary>
+/// A class map for <see cref="InFlightEvent"/>.
+/// </summary>
+public class InFlightEventClassMap : IBsonClassMapFor<InFlightEvent>
+{
+    /// <inheritdoc/>
+    public void Configure(BsonClassMap<InFlightEvent> classMap)
+    {
+        classMap.AutoMap();
+        classMap.MapIdProperty(_ => _.Id);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB/Observation/InFlightEventsStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Observation/InFlightEventsStorage.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Observation;
+
+/// <summary>
+/// Represents an implementation of <see cref="IInFlightEventsStorage"/> for MongoDB.
+/// </summary>
+/// <param name="database">The <see cref="IEventStoreNamespaceDatabase"/> to use for accessing the collection.</param>
+public class InFlightEventsStorage(IEventStoreNamespaceDatabase database) : IInFlightEventsStorage
+{
+    readonly IMongoCollection<InFlightEvent> _collection = database.GetCollection<InFlightEvent>(WellKnownCollectionNames.InFlightEvents);
+
+    /// <inheritdoc/>
+    public async Task Add(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber)
+    {
+        var entry = new InFlightEvent
+        {
+            Id = InFlightEventId.New(),
+            ObserverId = observerId,
+            Partition = partition,
+            EventSequenceNumber = eventSequenceNumber
+        };
+
+        await _collection.InsertOneAsync(entry).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task Remove(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber) =>
+        await _collection.DeleteManyAsync(
+            entry =>
+                entry.ObserverId == observerId &&
+                entry.Partition == partition &&
+                entry.EventSequenceNumber == eventSequenceNumber).ConfigureAwait(false);
+
+    /// <inheritdoc/>
+    public async Task RemoveUpTo(ObserverId observerId, Key partition, EventSequenceNumber upToInclusive) =>
+        await _collection.DeleteManyAsync(
+            entry =>
+                entry.ObserverId == observerId &&
+                entry.Partition == partition &&
+                entry.EventSequenceNumber <= upToInclusive).ConfigureAwait(false);
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<InFlightEvent>> GetFor(ObserverId observerId)
+    {
+        using var cursor = await _collection.FindAsync(entry => entry.ObserverId == observerId).ConfigureAwait(false);
+        return await cursor.ToListAsync().ConfigureAwait(false);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
+++ b/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
@@ -59,6 +59,11 @@ public static class WellKnownCollectionNames
     public const string FailedPartitions = "failed-partitions";
 
     /// <summary>
+    /// The collection that holds in-flight events being handled by observers.
+    /// </summary>
+    public const string InFlightEvents = "in-flight-events";
+
+    /// <summary>
     /// The collection that holds identities.
     /// </summary>
     public const string Identities = "identities";

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
@@ -55,6 +55,9 @@ public class EventStoreNamespaceStorage(EventStoreName eventStore, EventStoreNam
     public IFailedPartitionsStorage FailedPartitions { get; } = new FailedPartitions.FailedPartitionStorage(eventStore, @namespace, database);
 
     /// <inheritdoc/>
+    public IInFlightEventsStorage InFlightEvents { get; } = new InFlightEvents.InFlightEventsStorage(eventStore, @namespace);
+
+    /// <inheritdoc/>
     public IRecommendationStorage Recommendations { get; } = new Recommendations.RecommendationStorage(eventStore, @namespace, database);
 
     /// <inheritdoc/>

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/InFlightEvents/InFlightEventsStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/InFlightEvents/InFlightEventsStorage.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.InFlightEvents;
+
+/// <summary>
+/// Represents a transitional in-memory implementation of <see cref="IInFlightEventsStorage"/> for the SQL backend.
+/// </summary>
+/// <param name="eventStore">The <see cref="EventStoreName"/> the storage is for.</param>
+/// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the storage is for.</param>
+/// <remarks>
+/// The SQL backend is still under construction in several areas. This implementation persists in-flight entries
+/// in process memory only, scoped to the event store and namespace, so the observer code path compiles and runs.
+/// A migration-backed table can replace this once the SQL backend reaches feature parity with MongoDB.
+/// </remarks>
+public class InFlightEventsStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace) : IInFlightEventsStorage
+{
+    static readonly ConcurrentDictionary<string, ConcurrentDictionary<InFlightEventId, InFlightEvent>> _entries = new();
+    readonly string _scope = $"{eventStore}/{@namespace}";
+
+    /// <inheritdoc/>
+    public Task Add(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber)
+    {
+        var entry = new InFlightEvent
+        {
+            Id = InFlightEventId.New(),
+            ObserverId = observerId,
+            Partition = partition,
+            EventSequenceNumber = eventSequenceNumber
+        };
+
+        var bucket = _entries.GetOrAdd(_scope, _ => new ConcurrentDictionary<InFlightEventId, InFlightEvent>());
+        bucket[entry.Id] = entry;
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task Remove(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber)
+    {
+        if (_entries.TryGetValue(_scope, out var bucket))
+        {
+            foreach (var matching in bucket
+                .Where(_ =>
+                    _.Value.ObserverId == observerId &&
+                    _.Value.Partition == partition &&
+                    _.Value.EventSequenceNumber == eventSequenceNumber)
+                .ToArray())
+            {
+                bucket.TryRemove(matching.Key, out _);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task RemoveUpTo(ObserverId observerId, Key partition, EventSequenceNumber upToInclusive)
+    {
+        if (_entries.TryGetValue(_scope, out var bucket))
+        {
+            foreach (var matching in bucket
+                .Where(_ =>
+                    _.Value.ObserverId == observerId &&
+                    _.Value.Partition == partition &&
+                    _.Value.EventSequenceNumber <= upToInclusive)
+                .ToArray())
+            {
+                bucket.TryRemove(matching.Key, out _);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<InFlightEvent>> GetFor(ObserverId observerId)
+    {
+        if (!_entries.TryGetValue(_scope, out var bucket))
+        {
+            return Task.FromResult<IEnumerable<InFlightEvent>>([]);
+        }
+
+        return Task.FromResult<IEnumerable<InFlightEvent>>(
+            bucket.Values.Where(_ => _.ObserverId == observerId).ToArray());
+    }
+}

--- a/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
@@ -53,6 +53,11 @@ public interface IEventStoreNamespaceStorage
     IFailedPartitionsStorage FailedPartitions { get; }
 
     /// <summary>
+    /// Gets the <see cref="IInFlightEventsStorage"/> for the event store namespace.
+    /// </summary>
+    IInFlightEventsStorage InFlightEvents { get; }
+
+    /// <summary>
     /// Gets the <see cref="IRecommendationStorage"/> for the event store namespace.
     /// </summary>
     IRecommendationStorage Recommendations { get; }

--- a/Source/Kernel/Storage/Observation/IInFlightEventsStorage.cs
+++ b/Source/Kernel/Storage/Observation/IInFlightEventsStorage.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+
+namespace Cratis.Chronicle.Storage.Observation;
+
+/// <summary>
+/// Defines a storage system for tracking <see cref="InFlightEvent"/> entries.
+/// </summary>
+/// <remarks>
+/// In-flight events are persisted independently of <see cref="ObserverState"/> so that the observer can
+/// recover deterministically after a crash that interrupted multi-partition handling. Entries are added
+/// before a partition handler is invoked and removed once that handler reports successful completion.
+/// </remarks>
+public interface IInFlightEventsStorage
+{
+    /// <summary>
+    /// Record an <see cref="InFlightEvent"/> entry for an event that is about to be handled.
+    /// </summary>
+    /// <param name="observerId">The <see cref="ObserverId"/> the event is for.</param>
+    /// <param name="partition">The partition <see cref="Key"/> the event belongs to.</param>
+    /// <param name="eventSequenceNumber">The <see cref="EventSequenceNumber"/> of the event in flight.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Add(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber);
+
+    /// <summary>
+    /// Remove an <see cref="InFlightEvent"/> entry for an event that completed successfully.
+    /// </summary>
+    /// <param name="observerId">The <see cref="ObserverId"/> the event is for.</param>
+    /// <param name="partition">The partition <see cref="Key"/> the event belongs to.</param>
+    /// <param name="eventSequenceNumber">The <see cref="EventSequenceNumber"/> of the event to clear.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Remove(ObserverId observerId, Key partition, EventSequenceNumber eventSequenceNumber);
+
+    /// <summary>
+    /// Remove every <see cref="InFlightEvent"/> entry for a partition up to and including a given
+    /// <see cref="EventSequenceNumber"/>.
+    /// </summary>
+    /// <param name="observerId">The <see cref="ObserverId"/> the events are for.</param>
+    /// <param name="partition">The partition <see cref="Key"/> to clear.</param>
+    /// <param name="upToInclusive">The <see cref="EventSequenceNumber"/> up to (and including) which entries should be removed.</param>
+    /// <returns>Awaitable task.</returns>
+    Task RemoveUpTo(ObserverId observerId, Key partition, EventSequenceNumber upToInclusive);
+
+    /// <summary>
+    /// Get all currently recorded <see cref="InFlightEvent"/> entries for an observer.
+    /// </summary>
+    /// <param name="observerId">The <see cref="ObserverId"/> to get entries for.</param>
+    /// <returns>Collection of <see cref="InFlightEvent"/> entries (empty if none).</returns>
+    Task<IEnumerable<InFlightEvent>> GetFor(ObserverId observerId);
+}


### PR DESCRIPTION
## Added

- Separate persisted in-flight event state recorded before an observer dispatches an event to its subscriber and removed after success (#1682)
- `CatchingUpInFlight` state machine state on observer subscribe that re-handles any partitions left in-flight by a previous server crash before transitioning to `Routing` (#1682)
- MongoDB and in-memory SQL implementations of the new in-flight events storage (#1682)

## Changed

- `Observer.Subscribe` and `Observer.SubscribeToAllEvents` now transition through `CatchingUpInFlight` before entering `Routing`, recovering any partitions that were in-flight at the time of a previous server crash (#1682)
- `Disconnected`, `Observing`, and `Replay` states now allow transition to `CatchingUpInFlight` (#1682)