### PR TITLE
Support append metadata for reactor side-effect events

### DIFF
--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceIdValuesProvider/when_providing/with_interface_implementation.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceIdValuesProvider/when_providing/with_interface_implementation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventSourceIdValuesProvider.when_providing;
+
+public class with_interface_implementation : Specification
+{
+    EventSourceIdValuesProvider _provider;
+    ReactorContextValues _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _provider = new EventSourceIdValuesProvider();
+        _eventSourceId = "the-source";
+    }
+
+    void Because() => _result = _provider.Provide(new ReactorWithEventSourceId(_eventSourceId), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_event_source_id_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventSourceId).ShouldBeTrue();
+    [Fact] void should_have_the_provided_event_source_id() => ((EventSourceId)_result[WellKnownReactorContextKeys.EventSourceId]).ShouldEqual(_eventSourceId);
+
+    class ReactorWithEventSourceId(EventSourceId eventSourceId) : IReactor, ICanProvideEventSourceId
+    {
+        public EventSourceId GetEventSourceId() => eventSourceId;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceIdValuesProvider/when_providing/without_interface_implementation.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceIdValuesProvider/when_providing/without_interface_implementation.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventSourceIdValuesProvider.when_providing;
+
+public class without_interface_implementation : Specification
+{
+    EventSourceIdValuesProvider _provider;
+    ReactorContextValues _result;
+    EventSourceId _eventSourceId;
+
+    void Establish()
+    {
+        _provider = new EventSourceIdValuesProvider();
+        _eventSourceId = EventSourceId.New();
+    }
+
+    void Because() => _result = _provider.Provide(new PlainReactor(), EventContext.EmptyWithEventSourceId(_eventSourceId));
+
+    [Fact] void should_return_event_source_id_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventSourceId).ShouldBeTrue();
+    [Fact] void should_fall_back_to_the_event_context_event_source_id() => ((EventSourceId)_result[WellKnownReactorContextKeys.EventSourceId]).ShouldEqual(_eventSourceId);
+
+    class PlainReactor : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceTypeValuesProvider/when_providing/with_event_source_type_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceTypeValuesProvider/when_providing/with_event_source_type_attribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventSourceTypeValuesProvider.when_providing;
+
+public class with_event_source_type_attribute : Specification
+{
+    EventSourceTypeValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventSourceTypeValuesProvider();
+
+    void Because() => _result = _provider.Provide(new ReactorWithAttribute(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_event_source_type_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventSourceType).ShouldBeTrue();
+    [Fact] void should_have_the_attribute_event_source_type() => ((EventSourceType)_result[WellKnownReactorContextKeys.EventSourceType]).ShouldEqual((EventSourceType)"Customer");
+
+    [EventSourceType("Customer")]
+    class ReactorWithAttribute : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceTypeValuesProvider/when_providing/without_event_source_type.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventSourceTypeValuesProvider/when_providing/without_event_source_type.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventSourceTypeValuesProvider.when_providing;
+
+public class without_event_source_type : Specification
+{
+    EventSourceTypeValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventSourceTypeValuesProvider();
+
+    void Because() => _result = _provider.Provide(new PlainReactor(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_not_return_any_values() => _result.ShouldBeEmpty();
+
+    class PlainReactor : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/with_event_stream_id_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/with_event_stream_id_attribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventStreamIdValuesProvider.when_providing;
+
+public class with_event_stream_id_attribute : Specification
+{
+    EventStreamIdValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventStreamIdValuesProvider();
+
+    void Because() => _result = _provider.Provide(new ReactorWithAttribute(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_event_stream_id_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventStreamId).ShouldBeTrue();
+    [Fact] void should_have_the_attribute_event_stream_id() => ((EventStreamId)_result[WellKnownReactorContextKeys.EventStreamId]).ShouldEqual((EventStreamId)"Yearly");
+
+    [EventStreamId("Yearly")]
+    class ReactorWithAttribute : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/with_interface_implementation.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/with_interface_implementation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventStreamIdValuesProvider.when_providing;
+
+public class with_interface_implementation : Specification
+{
+    EventStreamIdValuesProvider _provider;
+    ReactorContextValues _result;
+    EventStreamId _eventStreamId;
+
+    void Establish()
+    {
+        _provider = new EventStreamIdValuesProvider();
+        _eventStreamId = "Yearly";
+    }
+
+    void Because() => _result = _provider.Provide(new ReactorWithEventStreamId(_eventStreamId), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_event_stream_id_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventStreamId).ShouldBeTrue();
+    [Fact] void should_have_the_provided_event_stream_id() => ((EventStreamId)_result[WellKnownReactorContextKeys.EventStreamId]).ShouldEqual(_eventStreamId);
+
+    class ReactorWithEventStreamId(EventStreamId eventStreamId) : IReactor, ICanProvideEventStreamId
+    {
+        public EventStreamId GetEventStreamId() => eventStreamId;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/without_event_stream_id.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamIdValuesProvider/when_providing/without_event_stream_id.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventStreamIdValuesProvider.when_providing;
+
+public class without_event_stream_id : Specification
+{
+    EventStreamIdValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventStreamIdValuesProvider();
+
+    void Because() => _result = _provider.Provide(new PlainReactor(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_not_return_any_values() => _result.ShouldBeEmpty();
+
+    class PlainReactor : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamTypeValuesProvider/when_providing/with_event_stream_type_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamTypeValuesProvider/when_providing/with_event_stream_type_attribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventStreamTypeValuesProvider.when_providing;
+
+public class with_event_stream_type_attribute : Specification
+{
+    EventStreamTypeValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventStreamTypeValuesProvider();
+
+    void Because() => _result = _provider.Provide(new ReactorWithAttribute(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_event_stream_type_value() => _result.ContainsKey(WellKnownReactorContextKeys.EventStreamType).ShouldBeTrue();
+    [Fact] void should_have_the_attribute_event_stream_type() => ((EventStreamType)_result[WellKnownReactorContextKeys.EventStreamType]).ShouldEqual((EventStreamType)"Audit");
+
+    [EventStreamType("Audit")]
+    class ReactorWithAttribute : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamTypeValuesProvider/when_providing/without_event_stream_type.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventStreamTypeValuesProvider/when_providing/without_event_stream_type.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventStreamTypeValuesProvider.when_providing;
+
+public class without_event_stream_type : Specification
+{
+    EventStreamTypeValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new EventStreamTypeValuesProvider();
+
+    void Because() => _result = _provider.Provide(new PlainReactor(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_not_return_any_values() => _result.ShouldBeEmpty();
+
+    class PlainReactor : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_ReactorContextValuesBuilder/when_building/with_multiple_providers.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_ReactorContextValuesBuilder/when_building/with_multiple_providers.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_ReactorContextValuesBuilder.when_building;
+
+public class with_multiple_providers : Specification
+{
+    ReactorContextValuesBuilder _builder;
+    ReactorContextValues _result;
+    EventStreamId _eventStreamId;
+    Subject _subject;
+
+    void Establish()
+    {
+        _eventStreamId = "Yearly";
+        _subject = new Subject("my-subject");
+        _builder = new ReactorContextValuesBuilder(new KnownInstancesOf<IReactorContextValuesProvider>(
+        [
+            new EventSourceIdValuesProvider(),
+            new EventStreamIdValuesProvider(),
+            new SubjectValuesProvider()
+        ]));
+    }
+
+    void Because() => _result = _builder.Build(new MultiProvidingReactor(_eventStreamId, _subject), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_include_event_source_id() => _result.ContainsKey(WellKnownReactorContextKeys.EventSourceId).ShouldBeTrue();
+    [Fact] void should_include_event_stream_id() => ((EventStreamId)_result[WellKnownReactorContextKeys.EventStreamId]).ShouldEqual(_eventStreamId);
+    [Fact] void should_include_subject() => ((Subject)_result[WellKnownReactorContextKeys.Subject]).ShouldEqual(_subject);
+
+    class MultiProvidingReactor(EventStreamId eventStreamId, Subject subject) : IReactor, ICanProvideEventStreamId, ICanProvideSubject
+    {
+        public EventStreamId GetEventStreamId() => eventStreamId;
+        public Subject GetSubject() => subject;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_SubjectValuesProvider/when_providing/with_interface_implementation.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_SubjectValuesProvider/when_providing/with_interface_implementation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_SubjectValuesProvider.when_providing;
+
+public class with_interface_implementation : Specification
+{
+    SubjectValuesProvider _provider;
+    ReactorContextValues _result;
+    Subject _subject;
+
+    void Establish()
+    {
+        _provider = new SubjectValuesProvider();
+        _subject = new Subject("my-subject");
+    }
+
+    void Because() => _result = _provider.Provide(new ReactorWithSubject(_subject), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_return_subject_value() => _result.ContainsKey(WellKnownReactorContextKeys.Subject).ShouldBeTrue();
+    [Fact] void should_have_the_provided_subject() => ((Subject)_result[WellKnownReactorContextKeys.Subject]).ShouldEqual(_subject);
+
+    class ReactorWithSubject(Subject subject) : IReactor, ICanProvideSubject
+    {
+        public Subject GetSubject() => subject;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_SubjectValuesProvider/when_providing/without_subject.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_SubjectValuesProvider/when_providing/without_subject.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_SubjectValuesProvider.when_providing;
+
+public class without_subject : Specification
+{
+    SubjectValuesProvider _provider;
+    ReactorContextValues _result;
+
+    void Establish() => _provider = new SubjectValuesProvider();
+
+    void Because() => _result = _provider.Provide(new PlainReactor(), EventContext.EmptyWithEventSourceId(EventSourceId.New()));
+
+    [Fact] void should_not_return_any_values() => _result.ShouldBeEmpty();
+
+    class PlainReactor : IReactor;
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/ReactorContextValuesBuilders.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/ReactorContextValuesBuilders.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Reactors.SideEffects;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// Helper for constructing a <see cref="ReactorContextValuesBuilder"/> wired with all built-in providers for specifications.
+/// </summary>
+internal static class ReactorContextValuesBuilders
+{
+    /// <summary>
+    /// Creates a <see cref="ReactorContextValuesBuilder"/> with all built-in reactor context values providers.
+    /// </summary>
+    /// <returns>A <see cref="ReactorContextValuesBuilder"/> for use in specifications.</returns>
+    public static ReactorContextValuesBuilder ForSpecifications() =>
+        new(new KnownInstancesOf<IReactorContextValuesProvider>(
+        [
+            new EventSourceIdValuesProvider(),
+            new EventStreamIdValuesProvider(),
+            new EventStreamTypeValuesProvider(),
+            new EventSourceTypeValuesProvider(),
+            new SubjectValuesProvider()
+        ]));
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideEventSourceId.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideEventSourceId.cs
@@ -41,7 +41,8 @@ public class handler_method_returning_event_from_reactor_implementing_ICanProvid
             new ActivatedArtifact(reactor, typeof(ReactorWithCustomEventSourceId), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideEventStreamId.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideEventStreamId.cs
@@ -41,7 +41,8 @@ public class handler_method_returning_event_from_reactor_implementing_ICanProvid
             new ActivatedArtifact(reactor, typeof(ReactorWithCustomEventStreamId), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideSubject.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_implementing_ICanProvideSubject.cs
@@ -41,7 +41,8 @@ public class handler_method_returning_event_from_reactor_implementing_ICanProvid
             new ActivatedArtifact(reactor, typeof(ReactorWithSubjectProvider), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_with_event_source_type_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_with_event_source_type_attribute.cs
@@ -39,7 +39,8 @@ public class handler_method_returning_event_from_reactor_with_event_source_type_
             new ActivatedArtifact(reactor, typeof(ReactorWithEventSourceTypeAttribute), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_with_event_stream_type_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_event_from_reactor_with_event_stream_type_attribute.cs
@@ -39,7 +39,8 @@ public class handler_method_returning_event_from_reactor_with_event_stream_type_
             new ActivatedArtifact(reactor, typeof(ReactorWithEventStreamTypeAttribute), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_task_of_event.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/handler_method_returning_task_of_event.cs
@@ -39,7 +39,8 @@ public class handler_method_returning_task_of_event : Specification
             new ActivatedArtifact(reactor, typeof(ReactorWithTaskOfEventReturnType), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/sync_handler_method_returning_event.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/sync_handler_method_returning_event.cs
@@ -39,7 +39,8 @@ public class sync_handler_method_returning_event : Specification
             new ActivatedArtifact(reactor, typeof(ReactorWithSyncEventReturnType), Substitute.For<ILogger<ActivatedArtifact>>()),
             Substitute.For<ILogger<ReactorInvoker>>(),
             sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            ReactorContextValuesBuilders.ForSpecifications());
 
         _eventContext = EventContext.EmptyWithEventSourceId(EventSourceId.New());
     }

--- a/Source/Clients/DotNET.Specs/Reactors/for_Reactors/given/all_dependencies.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_Reactors/given/all_dependencies.cs
@@ -26,6 +26,7 @@ public class all_dependencies : Specification
     protected ICausationManager _causationManager;
     protected IActivitySource<Reactors> _activitySource;
     protected IReactorSideEffectHandlers _sideEffectHandlers;
+    protected IReactorContextValuesBuilder _reactorContextValuesBuilder;
     protected ILogger<Reactors> _logger;
     protected ILoggerFactory _loggerFactory;
     protected IChronicleServicesAccessor _servicesAccessor;
@@ -53,6 +54,7 @@ public class all_dependencies : Specification
         _causationManager = Substitute.For<ICausationManager>();
         _activitySource = Substitute.For<IActivitySource<Reactors>>();
         _sideEffectHandlers = Substitute.For<IReactorSideEffectHandlers>();
+        _reactorContextValuesBuilder = Substitute.For<IReactorContextValuesBuilder>();
         _logger = Substitute.For<ILogger<Reactors>>();
         _loggerFactory = Substitute.For<ILoggerFactory>();
 
@@ -86,6 +88,7 @@ public class all_dependencies : Specification
             _identityProvider,
             _activitySource,
             _sideEffectHandlers,
+            _reactorContextValuesBuilder,
             _logger,
             _loggerFactory);
 

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -19,6 +19,7 @@ using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.Reactors.SideEffects;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Reducers;
 using Cratis.Chronicle.Schemas;
@@ -27,6 +28,7 @@ using Cratis.Chronicle.Transactions;
 using Cratis.Chronicle.Webhooks;
 using Cratis.Serialization;
 using Cratis.Traces;
+using Cratis.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -154,6 +156,7 @@ public class EventStore : IEventStore
             identityProvider,
             serviceProvider.GetRequiredKeyedService<IActivitySource<Reactors.Reactors>>(ClientActivity.SourceName),
             reactorSideEffectHandlers,
+            new ReactorContextValuesBuilder(new InstancesOf<IReactorContextValuesProvider>(Types.Types.Instance, serviceProvider)),
             loggerFactory.CreateLogger<Reactors.Reactors>(),
             loggerFactory);
 

--- a/Source/Clients/DotNET/Events/ICanProvideEventSourceId.cs
+++ b/Source/Clients/DotNET/Events/ICanProvideEventSourceId.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Events;
-
-namespace Cratis.Chronicle.Reactors;
+namespace Cratis.Chronicle.Events;
 
 /// <summary>
 /// Defines a reactor (or any object) that can provide the <see cref="EventSourceId"/> to use when

--- a/Source/Clients/DotNET/Events/ICanProvideEventStreamId.cs
+++ b/Source/Clients/DotNET/Events/ICanProvideEventStreamId.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Events;
-
-namespace Cratis.Chronicle.Reactors;
+namespace Cratis.Chronicle.Events;
 
 /// <summary>
 /// Defines a reactor that can dynamically provide the <see cref="EventStreamId"/> to use when
@@ -11,7 +9,7 @@ namespace Cratis.Chronicle.Reactors;
 /// </summary>
 /// <remarks>
 /// Implement this interface on a reactor class to supply a runtime stream ID. For a fixed compile-time
-/// value, apply the <see cref="Events.EventStreamIdAttribute"/> to the reactor type instead.
+/// value, apply the <see cref="EventStreamIdAttribute"/> to the reactor type instead.
 /// When both this interface and the attribute are present on the same reactor type, the interface
 /// takes priority and the attribute value is ignored.
 /// </remarks>

--- a/Source/Clients/DotNET/Events/ICanProvideSubject.cs
+++ b/Source/Clients/DotNET/Events/ICanProvideSubject.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Chronicle.Reactors;
+namespace Cratis.Chronicle.Events;
 
 /// <summary>
 /// Defines a reactor that can provide the <see cref="Subject"/> to associate with side-effect events

--- a/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
@@ -30,6 +30,10 @@ namespace Cratis.Chronicle.Reactors;
 /// Optional <see cref="IEventStore"/> supplied to side effect handlers when appending events.
 /// When <see langword="null"/>, any return values are silently discarded even if handlers are registered.
 /// </param>
+/// <param name="reactorContextValuesBuilder">
+/// Optional <see cref="IReactorContextValuesBuilder"/> used to resolve append-metadata for side-effect events.
+/// When <see langword="null"/>, no values are resolved and append-metadata falls back to the triggering event.
+/// </param>
 public class ReactorInvoker(
     IEventTypes eventTypes,
     IReactorMiddlewares middlewares,
@@ -37,7 +41,8 @@ public class ReactorInvoker(
     ActivatedArtifact activatedReactor,
     ILogger<ReactorInvoker> logger,
     IReactorSideEffectHandlers? sideEffectHandlers = null,
-    IEventStore? eventStore = null) : IReactorInvoker
+    IEventStore? eventStore = null,
+    IReactorContextValuesBuilder? reactorContextValuesBuilder = null) : IReactorInvoker
 {
     static readonly ConcurrentDictionary<Type, Dictionary<Type, MethodInfo>> _methodsByEventTypeCache = [];
     readonly Dictionary<Type, MethodInfo> _methodsByEventType = MethodsByEventType.Get(targetType, eventTypes.AllClrTypes);
@@ -136,7 +141,7 @@ public class ReactorInvoker(
                 return;
             }
 
-            var reactorContext = new ReactorContext(eventContext, activatedReactor.Instance);
+            var reactorContext = new ReactorContext(eventContext, activatedReactor.Instance, BuildValues(eventContext));
             if (sideEffectHandlers.CanHandle(reactorContext, result))
             {
                 await sideEffectHandlers.Handle(reactorContext, eventStore, result);
@@ -151,12 +156,15 @@ public class ReactorInvoker(
             return;
         }
 
-        var syncReactorContext = new ReactorContext(eventContext, activatedReactor.Instance);
+        var syncReactorContext = new ReactorContext(eventContext, activatedReactor.Instance, BuildValues(eventContext));
         if (sideEffectHandlers.CanHandle(syncReactorContext, returnValue))
         {
             await sideEffectHandlers.Handle(syncReactorContext, eventStore, returnValue);
         }
     }
+
+    ReactorContextValues BuildValues(EventContext eventContext) =>
+        reactorContextValuesBuilder?.Build(activatedReactor.Instance, eventContext) ?? ReactorContextValues.Empty;
 
     static class MethodsByEventType
     {

--- a/Source/Clients/DotNET/Reactors/Reactors.cs
+++ b/Source/Clients/DotNET/Reactors/Reactors.cs
@@ -41,6 +41,7 @@ public class Reactors : IReactors
     readonly IIdentityProvider _identityProvider;
     readonly IActivitySource<Reactors> _activitySource;
     readonly IReactorSideEffectHandlers _sideEffectHandlers;
+    readonly IReactorContextValuesBuilder _reactorContextValuesBuilder;
     readonly ILogger<Reactors> _logger;
     readonly ILoggerFactory _loggerFactory;
     readonly IDictionary<Type, IReactorHandler> _handlers = new Dictionary<Type, IReactorHandler>();
@@ -62,6 +63,7 @@ public class Reactors : IReactors
     /// <param name="identityProvider"><see cref="IIdentityProvider"/> for managing identity context.</param>
     /// <param name="activitySource"><see cref="IActivitySource{T}"/> for tracing reactor event handling.</param>
     /// <param name="sideEffectHandlers"><see cref="IReactorSideEffectHandlers"/> for processing return values as side effects.</param>
+    /// <param name="reactorContextValuesBuilder"><see cref="IReactorContextValuesBuilder"/> for resolving append-metadata for side-effect events.</param>
     /// <param name="logger"><see cref="ILogger"/> for logging.</param>
     /// <param name="loggerFactory"><see cref="ILoggerFactory"/> for creating loggers.</param>
     public Reactors(
@@ -76,6 +78,7 @@ public class Reactors : IReactors
         IIdentityProvider identityProvider,
         IActivitySource<Reactors> activitySource,
         IReactorSideEffectHandlers sideEffectHandlers,
+        IReactorContextValuesBuilder reactorContextValuesBuilder,
         ILogger<Reactors> logger,
         ILoggerFactory loggerFactory)
     {
@@ -91,6 +94,7 @@ public class Reactors : IReactors
         _identityProvider = identityProvider;
         _activitySource = activitySource;
         _sideEffectHandlers = sideEffectHandlers;
+        _reactorContextValuesBuilder = reactorContextValuesBuilder;
         _logger = logger;
         _loggerFactory = loggerFactory;
         _eventStore.Connection.Lifecycle.OnDisconnected += () =>
@@ -423,7 +427,8 @@ public class Reactors : IReactors
             activatedReactor,
             _loggerFactory.CreateLogger<ReactorInvoker>(),
             _sideEffectHandlers,
-            _eventStore);
+            _eventStore,
+            _reactorContextValuesBuilder);
 
         foreach (var @event in events.Events)
         {

--- a/Source/Clients/DotNET/Reactors/SideEffects/EventSourceIdValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/EventSourceIdValuesProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesProvider"/> that provides the event source id.
+/// </summary>
+/// <remarks>
+/// Resolution order: the reactor implementing <see cref="ICanProvideEventSourceId"/> takes priority,
+/// otherwise the <see cref="EventSourceId"/> from the triggering <see cref="EventContext"/> is used.
+/// </remarks>
+public class EventSourceIdValuesProvider : IReactorContextValuesProvider
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Provide(object reactor, EventContext eventContext)
+    {
+        var eventSourceId = reactor is ICanProvideEventSourceId provider
+            ? provider.GetEventSourceId()
+            : eventContext.EventSourceId;
+
+        return new ReactorContextValues
+        {
+            { WellKnownReactorContextKeys.EventSourceId, eventSourceId }
+        };
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/EventSourceTypeValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/EventSourceTypeValuesProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesProvider"/> that provides the event source type.
+/// </summary>
+/// <remarks>
+/// Reads the <see cref="EventSourceTypeAttribute"/> from the reactor type. No value is provided when the attribute is absent.
+/// </remarks>
+public class EventSourceTypeValuesProvider : IReactorContextValuesProvider
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Provide(object reactor, EventContext eventContext)
+    {
+        var attribute = Attribute.GetCustomAttribute(reactor.GetType(), typeof(EventSourceTypeAttribute)) as EventSourceTypeAttribute;
+        if (attribute is not null)
+        {
+            return new ReactorContextValues
+            {
+                { WellKnownReactorContextKeys.EventSourceType, attribute.EventSourceType }
+            };
+        }
+
+        return [];
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/EventStreamIdValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/EventStreamIdValuesProvider.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesProvider"/> that provides the event stream id.
+/// </summary>
+/// <remarks>
+/// Resolution order: the reactor implementing <see cref="ICanProvideEventStreamId"/> takes priority,
+/// otherwise the <see cref="EventStreamIdAttribute"/> value is used when it is not <see cref="EventStreamId.NotSet"/>.
+/// When neither is present, no value is provided.
+/// </remarks>
+public class EventStreamIdValuesProvider : IReactorContextValuesProvider
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Provide(object reactor, EventContext eventContext)
+    {
+        if (reactor is ICanProvideEventStreamId provider)
+        {
+            return new ReactorContextValues
+            {
+                { WellKnownReactorContextKeys.EventStreamId, provider.GetEventStreamId() }
+            };
+        }
+
+        var attribute = Attribute.GetCustomAttribute(reactor.GetType(), typeof(EventStreamIdAttribute)) as EventStreamIdAttribute;
+        if (attribute is not null && attribute.Value != EventStreamId.NotSet)
+        {
+            return new ReactorContextValues
+            {
+                { WellKnownReactorContextKeys.EventStreamId, attribute.Value }
+            };
+        }
+
+        return [];
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/EventStreamTypeValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/EventStreamTypeValuesProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesProvider"/> that provides the event stream type.
+/// </summary>
+/// <remarks>
+/// Reads the <see cref="EventStreamTypeAttribute"/> from the reactor type. No value is provided when the attribute is absent.
+/// </remarks>
+public class EventStreamTypeValuesProvider : IReactorContextValuesProvider
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Provide(object reactor, EventContext eventContext)
+    {
+        var attribute = Attribute.GetCustomAttribute(reactor.GetType(), typeof(EventStreamTypeAttribute)) as EventStreamTypeAttribute;
+        if (attribute is not null)
+        {
+            return new ReactorContextValues
+            {
+                { WellKnownReactorContextKeys.EventStreamType, attribute.EventStreamType }
+            };
+        }
+
+        return [];
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/IReactorContextValuesBuilder.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/IReactorContextValuesBuilder.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Defines a builder for creating instances of <see cref="ReactorContextValues"/>.
+/// </summary>
+public interface IReactorContextValuesBuilder
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="ReactorContextValues"/>.
+    /// </summary>
+    /// <param name="reactor">The reactor instance whose side-effect events are being appended.</param>
+    /// <param name="eventContext">The <see cref="EventContext"/> of the triggering event.</param>
+    /// <returns>A new instance of <see cref="ReactorContextValues"/>.</returns>
+    ReactorContextValues Build(object reactor, EventContext eventContext);
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/IReactorContextValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/IReactorContextValuesProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Provides values for a <see cref="ReactorContext"/>.
+/// </summary>
+public interface IReactorContextValuesProvider
+{
+    /// <summary>
+    /// Gets the reactor context values.
+    /// </summary>
+    /// <param name="reactor">The reactor instance whose side-effect events are being appended.</param>
+    /// <param name="eventContext">The <see cref="EventContext"/> of the triggering event.</param>
+    /// <returns>The reactor context values.</returns>
+    ReactorContextValues Provide(object reactor, EventContext eventContext);
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/ReactorContext.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/ReactorContext.cs
@@ -11,4 +11,5 @@ namespace Cratis.Chronicle.Reactors.SideEffects;
 /// </summary>
 /// <param name="EventContext">The <see cref="Events.EventContext"/> of the event that triggered the reactor.</param>
 /// <param name="Reactor">The reactor instance that handled the event.</param>
-public record ReactorContext(EventContext EventContext, object Reactor);
+/// <param name="Values">The <see cref="ReactorContextValues"/> carrying append-metadata resolved for the side-effect.</param>
+public record ReactorContext(EventContext EventContext, object Reactor, ReactorContextValues Values);

--- a/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextExtensions.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextExtensions.cs
@@ -6,111 +6,58 @@ using Cratis.Chronicle.Events;
 namespace Cratis.Chronicle.Reactors.SideEffects;
 
 /// <summary>
-/// Extension methods for <see cref="ReactorContext"/> that resolve append-metadata from the
-/// reactor instance, its type attributes, and the incoming <see cref="EventContext"/>.
+/// Extension methods for <see cref="ReactorContext"/> that read append-metadata from the
+/// <see cref="ReactorContext.Values"/> populated by the registered <see cref="IReactorContextValuesProvider"/> instances.
 /// </summary>
 public static class ReactorContextExtensions
 {
     /// <summary>
-    /// Resolves the <see cref="EventSourceId"/> to use when appending side-effect events.
+    /// Gets the <see cref="EventSourceId"/> to use when appending side-effect events.
     /// </summary>
-    /// <remarks>
-    /// Resolution order:
-    /// <list type="number">
-    ///   <item>Reactor implements <see cref="ICanProvideEventSourceId"/> — calls <see cref="ICanProvideEventSourceId.GetEventSourceId"/>.</item>
-    ///   <item>Falls back to <see cref="EventContext.EventSourceId"/> of the triggering event.</item>
-    /// </list>
-    /// </remarks>
     /// <param name="reactorContext">The reactor context.</param>
-    /// <returns>The resolved <see cref="EventSourceId"/>.</returns>
-    public static EventSourceId GetEventSourceId(this ReactorContext reactorContext)
-    {
-        if (reactorContext.Reactor is ICanProvideEventSourceId provider)
-        {
-            return provider.GetEventSourceId();
-        }
-
-        return reactorContext.EventContext.EventSourceId;
-    }
+    /// <returns>The resolved <see cref="EventSourceId"/>, or the <see cref="EventSourceId"/> of the triggering event when none was provided.</returns>
+    public static EventSourceId GetEventSourceId(this ReactorContext reactorContext) =>
+        reactorContext.Values.TryGetValue(WellKnownReactorContextKeys.EventSourceId, out var value) && value is EventSourceId eventSourceId
+            ? eventSourceId
+            : reactorContext.EventContext.EventSourceId;
 
     /// <summary>
-    /// Resolves the <see cref="EventStreamType"/> to use when appending side-effect events.
+    /// Gets the <see cref="EventStreamType"/> to use when appending side-effect events.
     /// </summary>
-    /// <remarks>
-    /// Reads the <see cref="EventStreamTypeAttribute"/> from the reactor type.
-    /// Returns <see langword="null"/> when the attribute is absent.
-    /// </remarks>
     /// <param name="reactorContext">The reactor context.</param>
-    /// <returns>The <see cref="EventStreamType"/> from the reactor's attribute, or <see langword="null"/>.</returns>
-    public static EventStreamType? GetEventStreamType(this ReactorContext reactorContext)
-    {
-        var attribute = Attribute.GetCustomAttribute(reactorContext.Reactor.GetType(), typeof(EventStreamTypeAttribute)) as EventStreamTypeAttribute;
-        return attribute?.EventStreamType;
-    }
+    /// <returns>The <see cref="EventStreamType"/>, or <see langword="null"/> when none was provided.</returns>
+    public static EventStreamType? GetEventStreamType(this ReactorContext reactorContext) =>
+        reactorContext.Values.TryGetValue(WellKnownReactorContextKeys.EventStreamType, out var value) && value is EventStreamType eventStreamType
+            ? eventStreamType
+            : null;
 
     /// <summary>
-    /// Resolves the <see cref="EventStreamId"/> to use when appending side-effect events.
+    /// Gets the <see cref="EventStreamId"/> to use when appending side-effect events.
     /// </summary>
-    /// <remarks>
-    /// Resolution order:
-    /// <list type="number">
-    ///   <item>Reactor implements <see cref="ICanProvideEventStreamId"/> — calls <see cref="ICanProvideEventStreamId.GetEventStreamId"/>. Takes priority over the attribute.</item>
-    ///   <item>Reactor type has <see cref="EventStreamIdAttribute"/> with a value other than <see cref="EventStreamId.NotSet"/> (the sentinel for "not configured").</item>
-    ///   <item>Returns <see langword="null"/>.</item>
-    /// </list>
-    /// </remarks>
     /// <param name="reactorContext">The reactor context.</param>
-    /// <returns>The resolved <see cref="EventStreamId"/>, or <see langword="null"/>.</returns>
-    public static EventStreamId? GetEventStreamId(this ReactorContext reactorContext)
-    {
-        if (reactorContext.Reactor is ICanProvideEventStreamId provider)
-        {
-            return provider.GetEventStreamId();
-        }
-
-        var attribute = Attribute.GetCustomAttribute(reactorContext.Reactor.GetType(), typeof(EventStreamIdAttribute)) as EventStreamIdAttribute;
-        if (attribute is not null && attribute.Value != EventStreamId.NotSet)
-        {
-            return attribute.Value;
-        }
-
-        return null;
-    }
+    /// <returns>The resolved <see cref="EventStreamId"/>, or <see langword="null"/> when none was provided.</returns>
+    public static EventStreamId? GetEventStreamId(this ReactorContext reactorContext) =>
+        reactorContext.Values.TryGetValue(WellKnownReactorContextKeys.EventStreamId, out var value) && value is EventStreamId eventStreamId
+            ? eventStreamId
+            : null;
 
     /// <summary>
-    /// Resolves the <see cref="EventSourceType"/> to use when appending side-effect events.
+    /// Gets the <see cref="EventSourceType"/> to use when appending side-effect events.
     /// </summary>
-    /// <remarks>
-    /// Reads the <see cref="EventSourceTypeAttribute"/> from the reactor type.
-    /// Returns <see langword="null"/> when the attribute is absent.
-    /// </remarks>
     /// <param name="reactorContext">The reactor context.</param>
-    /// <returns>The <see cref="EventSourceType"/> from the reactor's attribute, or <see langword="null"/>.</returns>
-    public static EventSourceType? GetEventSourceType(this ReactorContext reactorContext)
-    {
-        var attribute = Attribute.GetCustomAttribute(reactorContext.Reactor.GetType(), typeof(EventSourceTypeAttribute)) as EventSourceTypeAttribute;
-        return attribute?.EventSourceType;
-    }
+    /// <returns>The <see cref="EventSourceType"/>, or <see langword="null"/> when none was provided.</returns>
+    public static EventSourceType? GetEventSourceType(this ReactorContext reactorContext) =>
+        reactorContext.Values.TryGetValue(WellKnownReactorContextKeys.EventSourceType, out var value) && value is EventSourceType eventSourceType
+            ? eventSourceType
+            : null;
 
     /// <summary>
-    /// Resolves the <see cref="Subject"/> to use when appending side-effect events.
+    /// Gets the <see cref="Subject"/> to use when appending side-effect events.
     /// </summary>
-    /// <remarks>
-    /// Resolution order:
-    /// <list type="number">
-    ///   <item>Reactor implements <see cref="ICanProvideSubject"/> — calls <see cref="ICanProvideSubject.GetSubject"/>.</item>
-    ///   <item>Returns <see langword="null"/>.</item>
-    /// </list>
-    /// </remarks>
     /// <param name="reactorContext">The reactor context.</param>
-    /// <returns>The <see cref="Subject"/> from the reactor, or <see langword="null"/>.</returns>
-    public static Subject? GetSubject(this ReactorContext reactorContext)
-    {
-        if (reactorContext.Reactor is ICanProvideSubject provider)
-        {
-            return provider.GetSubject();
-        }
-
-        return null;
-    }
+    /// <returns>The <see cref="Subject"/>, or <see langword="null"/> when none was provided.</returns>
+    public static Subject? GetSubject(this ReactorContext reactorContext) =>
+        reactorContext.Values.TryGetValue(WellKnownReactorContextKeys.Subject, out var value) && value is Subject subject
+            ? subject
+            : null;
 }

--- a/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextValues.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextValues.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents a set of values associated with a <see cref="ReactorContext"/>.
+/// </summary>
+public class ReactorContextValues : Dictionary<string, object>
+{
+    /// <summary>
+    /// Gets an empty set of reactor context values.
+    /// </summary>
+    public static readonly ReactorContextValues Empty = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReactorContextValues"/> class.
+    /// </summary>
+    public ReactorContextValues()
+        : base(StringComparer.OrdinalIgnoreCase)
+    {
+    }
+
+    /// <summary>
+    /// Merges another set of reactor context values into this instance.
+    /// </summary>
+    /// <param name="other">The other set of reactor context values to merge.</param>
+    public void Merge(ReactorContextValues other)
+    {
+        foreach (var kvp in other)
+        {
+            this[kvp.Key] = kvp.Value;
+        }
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextValuesBuilder.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/ReactorContextValuesBuilder.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Types;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesBuilder"/>.
+/// </summary>
+/// <param name="providers">The instances of <see cref="IReactorContextValuesProvider"/> to use when building the values.</param>
+[Singleton]
+public class ReactorContextValuesBuilder(IInstancesOf<IReactorContextValuesProvider> providers) : IReactorContextValuesBuilder
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Build(object reactor, EventContext eventContext)
+    {
+        var values = new ReactorContextValues();
+        foreach (var provider in providers)
+        {
+            values.Merge(provider.Provide(reactor, eventContext));
+        }
+
+        return values;
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/SubjectValuesProvider.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/SubjectValuesProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Represents an implementation of <see cref="IReactorContextValuesProvider"/> that provides the subject for event appends.
+/// </summary>
+/// <remarks>
+/// Resolves the <see cref="Subject"/> from a reactor implementing <see cref="ICanProvideSubject"/>.
+/// No value is provided when the reactor does not implement the interface.
+/// </remarks>
+public class SubjectValuesProvider : IReactorContextValuesProvider
+{
+    /// <inheritdoc/>
+    public ReactorContextValues Provide(object reactor, EventContext eventContext)
+    {
+        if (reactor is ICanProvideSubject provider)
+        {
+            return new ReactorContextValues
+            {
+                { WellKnownReactorContextKeys.Subject, provider.GetSubject() }
+            };
+        }
+
+        return [];
+    }
+}

--- a/Source/Clients/DotNET/Reactors/SideEffects/WellKnownReactorContextKeys.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/WellKnownReactorContextKeys.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Reactors.SideEffects;
+
+/// <summary>
+/// Well known keys for reactor context values.
+/// </summary>
+public static class WellKnownReactorContextKeys
+{
+    /// <summary>
+    /// The key for the event source id in the reactor context values.
+    /// </summary>
+    public const string EventSourceId = "eventSourceId";
+
+    /// <summary>
+    /// The key for the event source type in the reactor context values.
+    /// </summary>
+    public const string EventSourceType = "eventSourceType";
+
+    /// <summary>
+    /// The key for the event stream type in the reactor context values.
+    /// </summary>
+    public const string EventStreamType = "eventStreamType";
+
+    /// <summary>
+    /// The key for the event stream id in the reactor context values.
+    /// </summary>
+    public const string EventStreamId = "eventStreamId";
+
+    /// <summary>
+    /// The key for the subject in the reactor context values.
+    /// </summary>
+    public const string Subject = "subject";
+}

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -167,6 +167,14 @@ public class EventStoreForTesting : IEventStore
             new BaseIdentityProvider(),
             new ActivitySource<ReactorsImpl>(),
             new ReactorSideEffectHandlers(new KnownInstancesOf<IReactorSideEffectHandler>([new EventResultHandler(_eventTypes), new EventsResultHandler(_eventTypes)])),
+            new ReactorContextValuesBuilder(new KnownInstancesOf<IReactorContextValuesProvider>(
+            [
+                new EventSourceIdValuesProvider(),
+                new EventStreamIdValuesProvider(),
+                new EventStreamTypeValuesProvider(),
+                new EventSourceTypeValuesProvider(),
+                new SubjectValuesProvider()
+            ])),
             NullLogger<ReactorsImpl>.Instance,
             new NullLoggerFactory()));
         _webhooks = new Lazy<IWebhooks>(() => new WebhooksImpl(_eventTypes, this, NullLogger<WebhooksImpl>.Instance));

--- a/Source/Clients/Testing/Reactors/ReactorScenario.cs
+++ b/Source/Clients/Testing/Reactors/ReactorScenario.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reactors.SideEffects;
 using Cratis.Execution;
+using Cratis.Types;
 
 namespace Cratis.Chronicle.Testing.Reactors;
 
@@ -95,7 +96,15 @@ public class ReactorScenario<TReactor>(
             activatedReactor,
             NullLogger<ReactorInvoker>.Instance,
             sideEffectHandlers,
-            eventStore);
+            eventStore,
+            new ReactorContextValuesBuilder(new KnownInstancesOf<IReactorContextValuesProvider>(
+            [
+                new EventSourceIdValuesProvider(),
+                new EventStreamIdValuesProvider(),
+                new EventStreamTypeValuesProvider(),
+                new EventSourceTypeValuesProvider(),
+                new SubjectValuesProvider()
+            ])));
 
         foreach (var @event in events)
         {

--- a/Source/Infrastructure/Json/ExpandoObjectConverter.cs
+++ b/Source/Infrastructure/Json/ExpandoObjectConverter.cs
@@ -58,7 +58,7 @@ public class ExpandoObjectConverter(ITypeFormats typeFormats) : IExpandoObjectCo
             }
 
             var name = property.Name;
-            var schemaProperty = schemaProperties.FirstOrDefault(_ => _.Name == name);
+            var schemaProperty = schemaProperties.Find(_ => _.Name == name);
             if (schemaProperty is null)
             {
                 ConvertUnknownSchemaTypeToJsonValue(keyValue.Value);


### PR DESCRIPTION
## Added

- Reactors can now control the append metadata of the side-effect events they return — event source id, event stream id and type, event source type, and subject — through the `ICanProvideEventSourceId`, `ICanProvideEventStreamId` and `ICanProvideSubject` interfaces and the `[EventStreamId]`, `[EventStreamType]` and `[EventSourceType]` attributes.

## Changed

- Moved `ICanProvideEventSourceId`, `ICanProvideEventStreamId` and `ICanProvideSubject` to the `Cratis.Chronicle.Events` namespace so they are shared by reactors and commands.