### PR TITLE
Make integration specs reliable

### DIFF
--- a/.github/scripts/run-tests-with-retry.sh
+++ b/.github/scripts/run-tests-with-retry.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Runs an integration test project and, on failure, re-runs ONLY the failed
+# tests up to a number of attempts. This absorbs transient flakiness in the
+# Chronicle pipeline (a projection/reactor partition that occasionally does not
+# materialize a read model within the polling deadline) without masking real
+# regressions: a deterministically failing test fails on every attempt and the
+# job still goes red.
+#
+# Usage:
+#   run-tests-with-retry.sh <project> <test-filter> [extra dotnet test args...]
+#
+# <test-filter> is passed verbatim to `dotnet test --filter` for the first run,
+# so it can be a bare namespace expression (FullyQualifiedName~Ns) or a sharded
+# OR-expression (FullyQualifiedName~Ns.A.|FullyQualifiedName~Ns.B.).
+#
+# Environment:
+#   TEST_MAX_ATTEMPTS    Total attempts including the first run (default: 3).
+#   TEST_MAX_RETRY_TESTS Maximum number of failed tests that will be retried. Above
+#                        this the failure is treated as systemic (a broken image or a
+#                        fixture/container start error fails every test in a class) and
+#                        the job fails fast instead of re-running a huge set 3 times
+#                        (default: 20).
+
+set -uo pipefail
+
+PROJECT="$1"
+TEST_FILTER="$2"
+shift 2
+EXTRA_ARGS=("$@")
+
+MAX_ATTEMPTS="${TEST_MAX_ATTEMPTS:-3}"
+MAX_RETRY_TESTS="${TEST_MAX_RETRY_TESTS:-20}"
+RESULTS_DIR="$(mktemp -d)"
+
+# Extracts the fully-qualified names of failed tests from a TRX result file.
+extract_failed() {
+    local trx="$1"
+    python3 - "$trx" <<'PY'
+import sys, xml.etree.ElementTree as ET
+ns = '{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}'
+try:
+    tree = ET.parse(sys.argv[1])
+except Exception:
+    sys.exit(0)
+names = sorted({
+    r.get('testName')
+    for r in tree.iter(f'{ns}UnitTestResult')
+    if r.get('outcome') == 'Failed' and r.get('testName')
+})
+if names:
+    print('\n'.join(names))
+PY
+}
+
+run() {
+    local filter="$1"
+    local trx="$2"
+    dotnet test "$PROJECT" \
+        --no-restore \
+        --filter "$filter" \
+        --logger "console;verbosity=normal" \
+        --logger "trx;LogFileName=$trx" \
+        --results-directory "$RESULTS_DIR" \
+        --configuration Release \
+        "${EXTRA_ARGS[@]}"
+}
+
+attempt=1
+echo "::group::Test attempt ${attempt}/${MAX_ATTEMPTS} (full filter)"
+run "${TEST_FILTER}" "attempt-${attempt}.trx"
+status=$?
+echo "::endgroup::"
+
+if [ $status -eq 0 ]; then
+    echo "All tests passed on attempt ${attempt}."
+    exit 0
+fi
+
+while [ $attempt -lt "$MAX_ATTEMPTS" ]; do
+    failed=()
+    while IFS= read -r line; do
+        [ -n "$line" ] && failed+=("$line")
+    done < <(extract_failed "${RESULTS_DIR}/attempt-${attempt}.trx")
+
+    if [ "${#failed[@]}" -eq 0 ]; then
+        # Test run failed but no individual failed test was recorded (e.g. a
+        # crash, build, or fixture/container start error). Retrying the whole
+        # subset is meaningless and would hide an infrastructure failure — fail.
+        echo "Attempt ${attempt} failed but no failed tests were recorded in the TRX. Treating as a hard failure."
+        exit 1
+    fi
+
+    if [ "${#failed[@]}" -gt "$MAX_RETRY_TESTS" ]; then
+        # A large failed set is systemic, not flaky — a broken image or a failing
+        # class fixture fails every test in the affected class(es). Re-running it
+        # would just multiply the wasted time, so fail fast instead.
+        echo "Attempt ${attempt} had ${#failed[@]} failed tests (> ${MAX_RETRY_TESTS}). Treating as a systemic failure; not retrying."
+        exit 1
+    fi
+
+    attempt=$((attempt + 1))
+
+    echo "::group::Test attempt ${attempt}/${MAX_ATTEMPTS} (re-running ${#failed[@]} failed test(s))"
+    printf '  - %s\n' "${failed[@]}"
+
+    filter=""
+    for name in "${failed[@]}"; do
+        [ -n "$filter" ] && filter+="|"
+        filter+="FullyQualifiedName=${name}"
+    done
+
+    run "$filter" "attempt-${attempt}.trx"
+    status=$?
+    echo "::endgroup::"
+
+    if [ $status -eq 0 ]; then
+        echo "Previously failed tests passed on attempt ${attempt} — treating as flaky, not a regression."
+        exit 0
+    fi
+done
+
+echo "Tests still failing after ${MAX_ATTEMPTS} attempts."
+exit 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -138,12 +138,14 @@ jobs:
           # to do and its anonymous Docker Hub manifest call at session
           # init is a frequent source of flakiness. Disable it on CI.
           TESTCONTAINERS_RYUK_DISABLED: true
+        # On failure, only the failed tests are re-run (up to TEST_MAX_ATTEMPTS), so a
+        # transient pipeline/container flake does not redden the whole job. A systemic
+        # failure (many tests failing, e.g. a fixture/container start error) fails fast
+        # without retrying, and a deterministic failure stays red on every attempt.
         run: |
-          dotnet test Integration/Client/Client.csproj \
-            --no-restore \
-            --filter "FullyQualifiedName~${{ matrix.namespace }}" \
-            --logger "console;verbosity=normal" \
-            --configuration Release \
+          .github/scripts/run-tests-with-retry.sh \
+            Integration/Client/Client.csproj \
+            "FullyQualifiedName~${{ matrix.namespace }}" \
             -p:DisableDockerBuild=true \
             -p:EnableDevelopmentSymbol=true
 
@@ -188,11 +190,10 @@ jobs:
         env:
           # See client-integration-specs for the rationale.
           TESTCONTAINERS_RYUK_DISABLED: true
+        # See client-integration-specs for the retry rationale. The kernel project
+        # does not have Client's Docker build target.
         run: |
-          # Kernel project does not have Client's Docker build target.
-          dotnet test Integration/Kernel/Kernel.csproj \
-            --no-restore \
-            --filter "FullyQualifiedName~${{ matrix.namespace }}" \
-            --logger "console;verbosity=normal" \
-            --configuration Release \
+          .github/scripts/run-tests-with-retry.sh \
+            Integration/Kernel/Kernel.csproj \
+            "FullyQualifiedName~${{ matrix.namespace }}" \
             -p:EnableDevelopmentSymbol=true

--- a/Integration/Client/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
+++ b/Integration/Client/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
@@ -23,6 +23,32 @@ public class a_projection_and_events_appended_to_it<TProjection, TReadModel>(Chr
     protected IProjectionHandler Projection;
     protected bool WaitForEachEvent;
 
+    /// <summary>
+    /// Gets the bounded window the final result read polls for the instance to become visible.
+    /// </summary>
+    /// <remarks>
+    /// The window only needs to cover the read-after-write gap between the observer reporting it
+    /// reached the tail and the sink committing the instance — a short, fixed window is enough and
+    /// is deliberately not the (much larger) end-to-end pipeline timeout, so scenarios that
+    /// legitimately end without an instance do not stall for long.
+    /// </remarks>
+    protected static readonly TimeSpan ReadModelVisibilityTimeout = TimeSpanFactory.FromSeconds(30);
+
+    /// <summary>
+    /// Gets a value indicating whether the primary read model (keyed by <see cref="ReadModelId"/>)
+    /// is expected to materialize once the projection has reached the tail.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see langword="true"/>, which makes the final result read poll (within
+    /// <see cref="ReadModelVisibilityTimeout"/>) until the instance is visible — closing the
+    /// read-after-write gap between the observer reporting it reached the tail and the sink
+    /// committing the instance. Scenarios whose instance lives under a different key space than
+    /// <see cref="ReadModelId"/> (e.g. composite-key projections), or that intentionally end with
+    /// the instance removed, override this to <see langword="false"/> so the read is performed once
+    /// without waiting for an instance that, by design, never appears at that id.
+    /// </remarks>
+    protected virtual bool ExpectsPrimaryReadModel => true;
+
     protected override void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton(new TProjection());
@@ -71,16 +97,47 @@ public class a_projection_and_events_appended_to_it<TProjection, TReadModel>(Chr
 
         if (appendResult is not null)
         {
-            await WaitForProjectionAndSetResult(LastEventSequenceNumber);
+            await WaitForProjectionAndSetResult(LastEventSequenceNumber, requireMaterialized: true);
         }
     }
 
     protected virtual Task<TReadModel> GetReadModelResult() => GetReadModel(ReadModelId);
 
-    protected async Task WaitForProjectionAndSetResult(EventSequenceNumber eventSequenceNumber)
+    /// <summary>
+    /// Waits for the projection to reach the given sequence number and reads the resulting instance into <see cref="Result"/>.
+    /// </summary>
+    /// <param name="eventSequenceNumber">The <see cref="EventSequenceNumber"/> the projection observer must reach first.</param>
+    /// <param name="requireMaterialized">
+    /// When <see langword="true"/> (the final read after all events are appended), the read is retried
+    /// within <see cref="ReadModelVisibilityTimeout"/> until the instance is visible — closing the
+    /// read-after-write gap that otherwise leaves <see cref="Result"/> null and surfaces as a confusing
+    /// <see cref="NullReferenceException"/> in a downstream assertion. The wait is best-effort: if the
+    /// instance never appears (a scenario may legitimately end with it removed) the read simply returns
+    /// null. When <see langword="false"/> (per-event intermediate reads), the instance may legitimately
+    /// not exist yet, so it is read once without waiting.
+    /// </param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    protected async Task WaitForProjectionAndSetResult(EventSequenceNumber eventSequenceNumber, bool requireMaterialized = false)
     {
         await Projection.WaitTillReachesEventSequenceNumber(eventSequenceNumber);
-        Result = await GetReadModelResult();
+
+        if (!requireMaterialized || !ExpectsPrimaryReadModel)
+        {
+            Result = await GetReadModelResult();
+            return;
+        }
+
+        var deadline = DateTime.UtcNow.Add(ReadModelVisibilityTimeout);
+        while (true)
+        {
+            Result = await GetReadModelResult();
+            if (Result is not null || DateTime.UtcNow >= deadline)
+            {
+                return;
+            }
+
+            await Task.Delay(50);
+        }
     }
 
     protected async Task<TReadModel> GetReadModel(EventSourceId eventSourceId) =>

--- a/Integration/Client/Projections/Scenarios/when_projecting_properties/using_composite_key_from_property_and_context_property.cs
+++ b/Integration/Client/Projections/Scenarios/when_projecting_properties/using_composite_key_from_property_and_context_property.cs
@@ -17,6 +17,9 @@ public class using_composite_key_from_property_and_context_property(context cont
         public CompositeKey CompositeId;
         public ReadModelWithCompositeKey ReadModel;
 
+        /// <inheritdoc/>
+        protected override bool ExpectsPrimaryReadModel => false; // keyed by a composite key, never appears at ReadModelId
+
         void Establish()
         {
             CompositeId = new(Guid.NewGuid().ToString(), 0);

--- a/Integration/Client/Projections/Scenarios/when_projecting_with_join_for_children/and_event_joined_has_happened_first.cs
+++ b/Integration/Client/Projections/Scenarios/when_projecting_with_join_for_children/and_event_joined_has_happened_first.cs
@@ -17,9 +17,6 @@ public class and_event_joined_has_happened_first(context context) : Given<contex
 
     public class context(ChronicleFixture chronicleFixture) : given.a_projection_and_events_appended_to_it<UserProjection, User>(chronicleFixture)
     {
-        const int ReadModelAvailabilityTimeoutSeconds = 5;
-        const int ReadModelPollingIntervalMilliseconds = 50;
-
         public UserId UserId;
         public EventSourceId GroupId;
         public override IEnumerable<Type> EventTypes => [typeof(UserCreated), typeof(GroupCreated), typeof(UserAddedToGroup)];
@@ -34,30 +31,6 @@ public class and_event_joined_has_happened_first(context context) : Given<contex
             EventsWithEventSourceIdToAppend.Add(new(GroupId, new GroupCreated(GroupName)));
             EventsWithEventSourceIdToAppend.Add(new(UserId.ToString(), new UserCreated(UserName)));
             EventsWithEventSourceIdToAppend.Add(new(GroupId, new UserAddedToGroup(UserId)));
-        }
-
-        protected override async Task<User> GetReadModelResult()
-        {
-            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(ReadModelAvailabilityTimeoutSeconds));
-            while (!timeout.IsCancellationRequested)
-            {
-                var result = await base.GetReadModelResult();
-                if (result is not null)
-                {
-                    return result;
-                }
-
-                try
-                {
-                    await Task.Delay(ReadModelPollingIntervalMilliseconds, timeout.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
-            }
-
-            throw new TimeoutException($"Read model was not available within {ReadModelAvailabilityTimeoutSeconds} seconds.");
         }
     }
 

--- a/Integration/Client/Projections/Scenarios/when_removing/root_level.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing/root_level.cs
@@ -14,6 +14,9 @@ public class root_level(context context) : Given<context>(context)
     {
         public override IEnumerable<Type> EventTypes => [typeof(EventWithPropertiesForAllSupportedTypes), typeof(RemoveRoot)];
 
+        /// <inheritdoc/>
+        protected override bool ExpectsPrimaryReadModel => false; // root is removed, so no instance remains
+
         void Establish()
         {
             EventsToAppend.Add(EventWithPropertiesForAllSupportedTypes.CreateWithRandomValues());


### PR DESCRIPTION
CI / test-infrastructure change only — no framework behavior changes.

## Fixed
- Projection integration specs no longer fail intermittently with a confusing `NullReferenceException` when a read model is read fractionally before the projection sink commits it — the final read now briefly polls until the instance is visible (best-effort, non-throwing, so scenarios that intentionally end with no instance still pass).

## Changed
- A failing integration test job now re-runs only the failed tests (up to 3 attempts) so a transient pipeline/container flake no longer reddens an otherwise-green run. A systemic failure (many tests failing at once) fails fast without retrying, and a deterministic failure stays red.

# Summary

Targets the flaky integration specs. The flakiness was a read-after-write gap where the projection observer reported reaching the tail before the sink committed the read model; the final read now polls until the instance is visible. A failed-test rerun pass absorbs residual transient flakiness without masking real regressions.

Scope note: this PR is deliberately reliability-only. An earlier revision also sharded the Projections matrix and split the Docker image build for speed, but on a runner-bound setup that increased the job count and bunched container starts, causing more container-startup flakes and longer runs — so those changes were dropped. Build speed will be addressed separately.