### PR TITLE
Fix development container images aborting on missing encryption certificate

### DIFF
--- a/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
@@ -71,11 +71,13 @@ public static class OpenIddictServiceCollectionExtensions
                     options.AddEncryptionCertificate(cert)
                            .AddSigningCertificate(cert);
                 }
-                else if (IsDevelopmentEnvironment())
+#if DEVELOPMENT
+                else
                 {
                     options.AddEphemeralEncryptionKey()
                            .AddEphemeralSigningKey();
                 }
+#else
                 else
                 {
                     throw new InvalidOperationException(
@@ -83,6 +85,7 @@ public static class OpenIddictServiceCollectionExtensions
                         "Configure 'EncryptionCertificate:CertificatePath' and 'EncryptionCertificate:CertificatePassword' " +
                         "in your configuration. See the Chronicle documentation for more details on generating and configuring certificates.");
                 }
+#endif
 
                 // Determine if the identity provider has TLS enabled (token endpoint runs on the management port).
                 // Prefer IdentityProvider:Certificate when configured and fall back to top-level Tls for backward compatibility.
@@ -170,13 +173,5 @@ public static class OpenIddictServiceCollectionExtensions
             });
 
         return services;
-    }
-
-    static bool IsDevelopmentEnvironment()
-    {
-        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
-        var aspnetcoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        return string.Equals(dotnetEnvironment, "Development", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(aspnetcoreEnvironment, "Development", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -26,7 +26,6 @@ CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
 var builder = WebApplication.CreateBuilder(args);
-var isDevelopmentEnvironment = builder.Environment.IsDevelopment();
 
 #pragma warning disable ASP0000 // Do not call 'IServiceCollection.BuildServiceProvider' in 'ConfigureServices'
 var logger = builder.Logging.Services
@@ -65,13 +64,13 @@ else if (grpcCertificate is not null)
 {
     logger.TlsCertificateLoaded();
 }
-else if (isDevelopmentEnvironment)
-{
-    logger.TlsCertificateMissingDevelopment();
-}
 else
 {
+#if DEVELOPMENT
+    logger.TlsCertificateMissingDevelopment();
+#else
     logger.TlsCertificateMissingProduction();
+#endif
 }
 
 logger.ServerListening(chronicleOptions.ManagementPort, chronicleOptions.Port);
@@ -88,7 +87,8 @@ builder.WebHost.UseKestrel(options =>
         {
             listenOptions.UseHttps(workbenchCertificate);
         }
-        else if (!isDevelopmentEnvironment)
+#if !DEVELOPMENT
+        else
         {
             // In production, Workbench TLS can be explicitly disabled for deployments
             // behind an ingress/reverse proxy that terminates TLS upstream.
@@ -101,6 +101,7 @@ builder.WebHost.UseKestrel(options =>
                     "if TLS is terminated upstream by an ingress/reverse proxy.");
             }
         }
+#endif
     });
 
     // Listen on Port for gRPC (HTTP/2)
@@ -113,12 +114,14 @@ builder.WebHost.UseKestrel(options =>
         {
             listenOptions.UseHttps(grpcCertificate);
         }
-        else if (!isDevelopmentEnvironment && grpcTls.Enabled)
+#if !DEVELOPMENT
+        else if (grpcTls.Enabled)
         {
             throw new InvalidOperationException(
                 "No TLS certificate is configured for gRPC while TLS is enabled. " +
                 "Please provide a certificate path in configuration, or set Tls:Enabled to false.");
         }
+#endif
     });
 
     options.Limits.Http2.MaxStreamsPerConnection = 100;


### PR DESCRIPTION
## Fixed
- The `development` and `development-slim` container images no longer abort at startup demanding an encryption certificate and HTTPS. Development security relaxations (ephemeral OpenIddict keys, optional TLS) are once again gated on the compile-time `DEVELOPMENT` flag the images are built with, instead of a runtime environment-variable check the images never set. Production images still require an encryption certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)