### PR TITLE
Enforce unique constraints within a single AppendMany batch

### DIFF
--- a/Integration/Client/for_EventSequence/when_appending/many_for_different_sources_with_distinct_unique_values.cs
+++ b/Integration/Client/for_EventSequence/when_appending/many_for_different_sources_with_distinct_unique_values.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending.many_for_different_sources_with_distinct_unique_values.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending;
+
+[Collection(ChronicleCollection.Name)]
+public class many_for_different_sources_with_distinct_unique_values(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification<ChronicleFixture>(chronicleFixture)
+    {
+        public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
+        public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];
+
+        public IAppendResult Result { get; private set; }
+
+        public async Task Because() =>
+            Result = await EventStore.EventLog.AppendMany(
+            [
+                new EventForEventSourceId(Guid.NewGuid().ToString(), new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString())),
+                new EventForEventSourceId(Guid.NewGuid().ToString(), new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()))
+            ]);
+    }
+
+    [Fact] void should_be_successful() => Context.Result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_constraint_violations() => Context.Result.HasConstraintViolations.ShouldBeFalse();
+    [Fact] async Task should_commit_both_events() => (await Context.EventStore.EventLog.GetFromSequenceNumber(EventSequenceNumber.First)).Count.ShouldEqual(2);
+}

--- a/Integration/Client/for_EventSequence/when_appending/many_for_different_sources_with_same_unique_value.cs
+++ b/Integration/Client/for_EventSequence/when_appending/many_for_different_sources_with_same_unique_value.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending.many_for_different_sources_with_same_unique_value.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending;
+
+[Collection(ChronicleCollection.Name)]
+public class many_for_different_sources_with_same_unique_value(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification<ChronicleFixture>(chronicleFixture)
+    {
+        public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
+        public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];
+
+        public UserOnboardingStarted Event { get; private set; }
+
+        public IAppendResult Result { get; private set; }
+
+        public void Establish() => Event = new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+
+        public async Task Because() =>
+            Result = await EventStore.EventLog.AppendMany(
+            [
+                new EventForEventSourceId(Guid.NewGuid().ToString(), Event),
+                new EventForEventSourceId(Guid.NewGuid().ToString(), Event)
+            ]);
+    }
+
+    [Fact] void should_not_be_successful() => Context.Result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_constraint_violations() => Context.Result.HasConstraintViolations.ShouldBeTrue();
+    [Fact] async Task should_not_commit_any_of_the_two_events() => (await Context.EventStore.EventLog.GetFromSequenceNumber(EventSequenceNumber.First)).Count.ShouldEqual(0);
+}

--- a/Integration/Client/for_EventSequence/when_appending/many_with_duplicate_unique_value_among_distinct_events.cs
+++ b/Integration/Client/for_EventSequence/when_appending/many_with_duplicate_unique_value_among_distinct_events.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending.many_with_duplicate_unique_value_among_distinct_events.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending;
+
+[Collection(ChronicleCollection.Name)]
+public class many_with_duplicate_unique_value_among_distinct_events(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification<ChronicleFixture>(chronicleFixture)
+    {
+        public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueUserConstraint)];
+        public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];
+
+        public UserOnboardingStarted Distinct { get; private set; }
+        public UserOnboardingStarted Duplicate { get; private set; }
+
+        public IAppendResult Result { get; private set; }
+
+        public void Establish()
+        {
+            Distinct = new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            Duplicate = new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+        }
+
+        public async Task Because()
+        {
+            // The duplicate appears as the second and third event for different sources, never as the first —
+            // so the violation can only be caught by reconciling against the other events in the same batch.
+            Result = await EventStore.EventLog.AppendMany(
+            [
+                new EventForEventSourceId(Guid.NewGuid().ToString(), Distinct),
+                new EventForEventSourceId(Guid.NewGuid().ToString(), Duplicate),
+                new EventForEventSourceId(Guid.NewGuid().ToString(), Duplicate)
+            ]);
+        }
+    }
+
+    [Fact] void should_not_be_successful() => Context.Result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_have_constraint_violations() => Context.Result.HasConstraintViolations.ShouldBeTrue();
+    [Fact] async Task should_not_commit_any_events() => (await Context.EventStore.EventLog.GetFromSequenceNumber(EventSequenceNumber.First)).Count.ShouldEqual(0);
+}

--- a/Source/Kernel/Core/EventSequences/EventSequence.cs
+++ b/Source/Kernel/Core/EventSequences/EventSequence.cs
@@ -271,13 +271,17 @@ public class EventSequence(
         {
             events = events as IList<EventToAppend> ?? events.ToList();
 
-            var tasks = events.Select(async e =>
+            // Validate sequentially with a shared set of batch claims so that two events in the same batch
+            // cannot both claim the same unique constraint value — the persisted index is only updated after
+            // the whole batch has been appended, so without this earlier events in the batch are invisible.
+            var batchClaims = new ConstraintBatchClaims();
+            var getValidAndCompliantEvents = new List<(EventToAppend Event, Result<(ExpandoObject CompliantEvent, ConstraintValidationContext ConstraintValidationContext), AppendResult> Result)>();
+            foreach (var e in events)
             {
-                var result = await GetValidAndCompliantEvent(e.EventSourceType, e.EventSourceId, e.eventStreamType, e.eventStreamId, e.EventType, e.Content, correlationId, e.Subject);
-                return (Event: e, Result: result);
-            });
+                var result = await GetValidAndCompliantEvent(e.EventSourceType, e.EventSourceId, e.eventStreamType, e.eventStreamId, e.EventType, e.Content, correlationId, e.Subject, batchClaims);
+                getValidAndCompliantEvents.Add((e, result));
+            }
 
-            var getValidAndCompliantEvents = await Task.WhenAll(tasks);
             var failedEvents = getValidAndCompliantEvents.Where(eventAndResult => !eventAndResult.Result.IsSuccess).ToList();
 
             if (failedEvents.Count != 0)
@@ -595,7 +599,8 @@ public class EventSequence(
         EventType eventType,
         JsonObject content,
         CorrelationId correlationId,
-        Subject? subject = null)
+        Subject? subject = null,
+        ConstraintBatchClaims? batchClaims = default)
     {
         try
         {
@@ -606,7 +611,7 @@ public class EventSequence(
                 return schemaError;
             }
 
-            var checkConstraintViolation = await CheckConstraintViolation(eventSourceId, eventType, correlationId, compliantEventAsExpandoObject, eventSourceType, eventStreamType, eventStreamId);
+            var checkConstraintViolation = await CheckConstraintViolation(eventSourceId, eventType, correlationId, compliantEventAsExpandoObject, eventSourceType, eventStreamType, eventStreamId, batchClaims);
             if (checkConstraintViolation.TryGetError(out var error))
             {
                 return error;
@@ -659,9 +664,10 @@ public class EventSequence(
         ExpandoObject compliantEventAsExpandoObject,
         EventSourceType? eventSourceType = default,
         EventStreamType? eventStreamType = default,
-        EventStreamId? eventStreamId = default)
+        EventStreamId? eventStreamId = default,
+        ConstraintBatchClaims? batchClaims = default)
     {
-        var constraintContext = _constraints!.Establish(eventSourceId, eventType.Id, compliantEventAsExpandoObject, eventSourceType, eventStreamType, eventStreamId);
+        var constraintContext = _constraints!.Establish(eventSourceId, eventType.Id, compliantEventAsExpandoObject, eventSourceType, eventStreamType, eventStreamId, batchClaims);
         var constraintValidationResult = await constraintContext.Validate();
         if (constraintValidationResult.IsValid)
         {

--- a/Source/Kernel/Core/Events/Constraints/ConstraintBatchClaims.cs
+++ b/Source/Kernel/Core/Events/Constraints/ConstraintBatchClaims.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+/// <summary>
+/// Tracks unique constraint values claimed by events within a single batch append.
+/// </summary>
+/// <remarks>
+/// When appending many events as a single operation, every event is validated against the persisted
+/// constraint index before any of them are written. Without tracking the values claimed by earlier
+/// events in the same batch, two events in the batch could both claim the same unique value and both
+/// be appended. This accumulator makes earlier claims visible to later events within the batch so that
+/// intra-batch duplicates are rejected the same way cross-batch duplicates are.
+/// </remarks>
+public sealed class ConstraintBatchClaims
+{
+    readonly Dictionary<ClaimKey, EventSourceId> _claims = [];
+
+    /// <summary>
+    /// Attempt to claim a unique value for an event source within the batch.
+    /// </summary>
+    /// <param name="constraintName">The <see cref="ConstraintName"/> the value belongs to.</param>
+    /// <param name="scopeKey">The scope key the value is constrained within.</param>
+    /// <param name="value">The <see cref="UniqueConstraintValue"/> being claimed.</param>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> claiming the value.</param>
+    /// <returns>True if the claim is allowed, false if the value is already claimed by a different event source in the batch.</returns>
+    public bool TryClaim(ConstraintName constraintName, string scopeKey, UniqueConstraintValue value, EventSourceId eventSourceId)
+    {
+        var key = new ClaimKey(constraintName, scopeKey, value);
+        if (_claims.TryGetValue(key, out var claimant))
+        {
+            return claimant == eventSourceId;
+        }
+
+        _claims[key] = eventSourceId;
+        return true;
+    }
+
+    record ClaimKey(ConstraintName ConstraintName, string ScopeKey, UniqueConstraintValue Value);
+}

--- a/Source/Kernel/Core/Events/Constraints/ConstraintValidation.cs
+++ b/Source/Kernel/Core/Events/Constraints/ConstraintValidation.cs
@@ -19,6 +19,7 @@ public class ConstraintValidation(IEnumerable<IConstraintValidator> validators) 
         ExpandoObject content,
         EventSourceType? eventSourceType = default,
         EventStreamType? eventStreamType = default,
-        EventStreamId? eventStreamId = default) =>
-        new(validators, eventSourceId, eventTypeId, content, eventSourceType, eventStreamType, eventStreamId);
+        EventStreamId? eventStreamId = default,
+        ConstraintBatchClaims? batchClaims = default) =>
+        new(validators, eventSourceId, eventTypeId, content, eventSourceType, eventStreamType, eventStreamId, batchClaims);
 }

--- a/Source/Kernel/Core/Events/Constraints/ConstraintValidationContext.cs
+++ b/Source/Kernel/Core/Events/Constraints/ConstraintValidationContext.cs
@@ -24,6 +24,7 @@ public record ConstraintValidationContext
     /// <param name="eventSourceType">The <see cref="EventSourceType"/> of the event being validated.</param>
     /// <param name="eventStreamType">The <see cref="EventStreamType"/> of the event being validated.</param>
     /// <param name="eventStreamId">The <see cref="EventStreamId"/> of the event being validated.</param>
+    /// <param name="batchClaims">Optional <see cref="ConstraintBatchClaims"/> shared by all events in a batch append, used to detect intra-batch duplicates.</param>
     public ConstraintValidationContext(
         IEnumerable<IConstraintValidator> validators,
         EventSourceId eventSourceId,
@@ -31,7 +32,8 @@ public record ConstraintValidationContext
         ExpandoObject content,
         EventSourceType? eventSourceType = default,
         EventStreamType? eventStreamType = default,
-        EventStreamId? eventStreamId = default)
+        EventStreamId? eventStreamId = default,
+        ConstraintBatchClaims? batchClaims = default)
     {
         EventSourceId = eventSourceId;
         EventTypeId = eventTypeId;
@@ -39,6 +41,7 @@ public record ConstraintValidationContext
         EventSourceType = eventSourceType;
         EventStreamType = eventStreamType;
         EventStreamId = eventStreamId;
+        BatchClaims = batchClaims;
         _updaters = validators.OfType<IHaveUpdateConstraintIndex>().Select(v => v.GetUpdateFor(this)).ToArray();
         Validators = validators.Where(_ => _.CanValidate(this)).ToArray();
     }
@@ -77,6 +80,11 @@ public record ConstraintValidationContext
     /// Gets the <see cref="IConstraintValidator">validators</see> involved in the context.
     /// </summary>
     public IEnumerable<IConstraintValidator> Validators { get; }
+
+    /// <summary>
+    /// Gets the <see cref="ConstraintBatchClaims"/> shared by all events in a batch append, or <see langword="null"/> when validating a single event.
+    /// </summary>
+    public ConstraintBatchClaims? BatchClaims { get; }
 
     /// <summary>
     /// Perform validation on a <see cref="EventToValidateForConstraints"/>.

--- a/Source/Kernel/Core/Events/Constraints/IConstraintValidation.cs
+++ b/Source/Kernel/Core/Events/Constraints/IConstraintValidation.cs
@@ -20,6 +20,7 @@ public interface IConstraintValidation
     /// <param name="eventSourceType">The <see cref="EventSourceType"/> of the event.</param>
     /// <param name="eventStreamType">The <see cref="EventStreamType"/> of the event.</param>
     /// <param name="eventStreamId">The <see cref="EventStreamId"/> of the event.</param>
+    /// <param name="batchClaims">Optional <see cref="ConstraintBatchClaims"/> shared by all events in a batch append, used to detect intra-batch duplicates.</param>
     /// <returns>A <see cref="ConstraintValidationContext"/> that can be used for validation.</returns>
     ConstraintValidationContext Establish(
         EventSourceId eventSourceId,
@@ -27,5 +28,6 @@ public interface IConstraintValidation
         ExpandoObject content,
         EventSourceType? eventSourceType = default,
         EventStreamType? eventStreamType = default,
-        EventStreamId? eventStreamId = default);
+        EventStreamId? eventStreamId = default,
+        ConstraintBatchClaims? batchClaims = default);
 }

--- a/Source/Kernel/Core/Events/Constraints/UniqueConstraintValidator.cs
+++ b/Source/Kernel/Core/Events/Constraints/UniqueConstraintValidator.cs
@@ -38,6 +38,15 @@ public class UniqueConstraintValidator(
         var value = propertiesWithValues.GetValue();
         var scopeKey = definition.Scope.BuildScopeKey(context.EventSourceType, context.EventStreamType, context.EventStreamId);
         var (isAllowed, sequenceNumber) = await storage.IsAllowed(context.EventSourceId, definition, value, scopeKey);
+
+        // The persisted index does not yet reflect events earlier in the same batch, so also reconcile against
+        // the in-batch claims to catch two events in one batch claiming the same value for different sources.
+        if (isAllowed && context.BatchClaims is not null)
+        {
+            var claimValue = definition.IgnoreCasing ? value.ToLowerInvariant() : value;
+            isAllowed = context.BatchClaims.TryClaim(definition.Name, scopeKey, claimValue, context.EventSourceId);
+        }
+
         return isAllowed ?
             ConstraintValidationResult.Success :
             new()


### PR DESCRIPTION
## Fixed
- Unique constraints are now enforced across events appended in the same `AppendMany` batch — two events in one batch can no longer both claim the same unique value and both be appended.