### PR TITLE
Changing to development tag and not production tag

### DIFF
--- a/Source/Clients/Aspire/ChronicleDistributedApplicationBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleDistributedApplicationBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class ChronicleDistributedApplicationBuilderExtensions
         var resource = new ChronicleResource(name);
         var imageTag = configure is null
             ? ChronicleContainerImageTags.DevelopmentTag
-            : ChronicleContainerImageTags.Tag;
+            : ChronicleContainerImageTags.DevelopmentSlimTag;
 
         var resourceBuilder = builder
             .AddResource(resource)


### PR DESCRIPTION
## Fixed

- Fixing so that we don't fall back to production tag - but development slim when other databases are configured for Aspire setup.
