### PR TITLE
Add Aspire builder support for HashiCorp Vault and Azure Key Vault; route OpenIddict storage to SQL or MongoDB

### DIFF
--- a/Integration/Client/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/given/a_compiled_pdl_nested_projection.cs
+++ b/Integration/Client/Projections/Scenarios/when_projecting_with_nested_in_nested_from_pdl/given/a_compiled_pdl_nested_projection.cs
@@ -38,7 +38,7 @@ namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_projecting_wit
 /// behaves identically to the declarative path that Phase 1 covers.
 /// </para>
 /// </remarks>
-public abstract class a_compiled_pdl_nested_projection : Cratis.Specifications.Specification
+public abstract class a_compiled_pdl_nested_projection : Specifications.Specification
 {
     public const string Declaration = """
         projection PdlSlice => PdlDeepNestedSlice
@@ -95,8 +95,8 @@ public abstract class a_compiled_pdl_nested_projection : Cratis.Specifications.S
             errors => throw new InvalidOperationException(
                 $"PDL compilation failed: {string.Join(", ", errors.Errors.Select(e => e.Message))}"));
 
-        _outerNested = _projection.Nested![(Cratis.Chronicle.Properties.PropertyPath)"command"];
-        _innerNested = _outerNested.Nested![(Cratis.Chronicle.Properties.PropertyPath)"validation"];
+        _outerNested = _projection.Nested![(Properties.PropertyPath)"command"];
+        _innerNested = _outerNested.Nested![(Properties.PropertyPath)"validation"];
     }
 
     static ReadModelDefinition CreateReadModelDefinition<T>()

--- a/Integration/Client/for_EventAppendCollection/given/a_reactor_that_executes_a_command_scope.cs
+++ b/Integration/Client/for_EventAppendCollection/given/a_reactor_that_executes_a_command_scope.cs
@@ -23,9 +23,9 @@ public class a_reactor_that_executes_a_command_scope(ChronicleFixture fixture) :
 
     static void RegisterArcActivitySource(IServiceCollection services, string typeName)
     {
-        var type = typeof(Cratis.Arc.Commands.ICommandPipeline).Assembly.GetType(typeName)!;
-        var activitySourceType = typeof(Cratis.Traces.ActivitySource<>).MakeGenericType(type);
-        var activitySourceInterfaceType = typeof(Cratis.Traces.IActivitySource<>).MakeGenericType(type);
+        var type = typeof(Arc.Commands.ICommandPipeline).Assembly.GetType(typeName)!;
+        var activitySourceType = typeof(Traces.ActivitySource<>).MakeGenericType(type);
+        var activitySourceInterfaceType = typeof(Traces.IActivitySource<>).MakeGenericType(type);
         services.AddSingleton(activitySourceType, _ => Activator.CreateInstance(
             activitySourceType,
             new System.Diagnostics.ActivitySource(activitySourceType.FullName ?? activitySourceType.Name))!);

--- a/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
@@ -11,6 +11,9 @@ namespace Cratis.Chronicle.Aspire;
 /// </summary>
 public static class ChronicleAspireBuilderExtensions
 {
+    const string HashiCorpVaultStorageType = "vault";
+    const string AzureKeyVaultStorageType = "azure-key-vault";
+
     /// <summary>
     /// Configures the Chronicle resource to use an external MongoDB connection string.
     /// </summary>
@@ -103,6 +106,67 @@ public static class ChronicleAspireBuilderExtensions
         {
             context.EnvironmentVariables[ChronicleContainerImageTags.StorageTypeEnvironmentVariable] = "Sqlite";
             context.EnvironmentVariables[ChronicleContainerImageTags.StorageConnectionDetailsEnvironmentVariable] = connectionString;
+        });
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Chronicle resource to use HashiCorp Vault for compliance encryption key storage.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sets the <c>Cratis__Chronicle__Compliance__Encryption__Storage__Type</c> container environment variable to <c>vault</c>,
+    /// <c>Cratis__Chronicle__Compliance__Encryption__Storage__ConnectionDetails</c> to the resolved Vault endpoint URL,
+    /// and <c>VAULT_TOKEN</c> to the provided token.
+    /// </para>
+    /// <para>
+    /// These map to <c>Cratis:Chronicle:Compliance:Encryption:Storage:Type</c>,
+    /// <c>Cratis:Chronicle:Compliance:Encryption:Storage:ConnectionDetails</c>, and the
+    /// <c>VAULT_TOKEN</c> environment variable in the Chronicle server configuration respectively.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IChronicleAspireBuilder"/> to configure.</param>
+    /// <param name="vaultEndpoint">The <see cref="EndpointReference"/> pointing to the HashiCorp Vault HTTP endpoint.</param>
+    /// <param name="vaultToken">The Vault authentication token. For development, this is typically the dev root token.</param>
+    /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    public static IChronicleAspireBuilder WithHashiCorpVault(
+        this IChronicleAspireBuilder builder,
+        EndpointReference vaultEndpoint,
+        string vaultToken)
+    {
+        builder.ResourceBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[ChronicleContainerImageTags.ComplianceEncryptionStorageTypeEnvironmentVariable] = HashiCorpVaultStorageType;
+            context.EnvironmentVariables[ChronicleContainerImageTags.ComplianceEncryptionStorageConnectionDetailsEnvironmentVariable] = vaultEndpoint;
+            context.EnvironmentVariables[ChronicleContainerImageTags.VaultTokenEnvironmentVariable] = vaultToken;
+        });
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Chronicle resource to use Azure Key Vault for compliance encryption key storage.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sets the <c>Cratis__Chronicle__Compliance__Encryption__Storage__Type</c> container environment variable to <c>azure-key-vault</c>
+    /// and <c>Cratis__Chronicle__Compliance__Encryption__Storage__ConnectionDetails</c> to the Azure Key Vault URI.
+    /// </para>
+    /// <para>
+    /// Authentication is performed via <c>DefaultAzureCredential</c> on the Chronicle server side.
+    /// Ensure the Chronicle container's managed identity or workload identity has the necessary Key Vault permissions.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IChronicleAspireBuilder"/> to configure.</param>
+    /// <param name="keyVaultUri">The Azure Key Vault URI (e.g. <c>https://my-vault.vault.azure.net/</c>).</param>
+    /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    public static IChronicleAspireBuilder WithAzureKeyVault(
+        this IChronicleAspireBuilder builder,
+        string keyVaultUri)
+    {
+        builder.ResourceBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[ChronicleContainerImageTags.ComplianceEncryptionStorageTypeEnvironmentVariable] = AzureKeyVaultStorageType;
+            context.EnvironmentVariables[ChronicleContainerImageTags.ComplianceEncryptionStorageConnectionDetailsEnvironmentVariable] = keyVaultUri;
         });
         return builder;
     }

--- a/Source/Clients/Aspire/ChronicleContainerImageTags.cs
+++ b/Source/Clients/Aspire/ChronicleContainerImageTags.cs
@@ -54,4 +54,22 @@ public static class ChronicleContainerImageTags
     /// Maps to <c>Cratis:Chronicle:Storage:ConnectionDetails</c> in the Chronicle server configuration.
     /// </summary>
     public const string StorageConnectionDetailsEnvironmentVariable = "Cratis__Chronicle__Storage__ConnectionDetails";
+
+    /// <summary>
+    /// Environment variable key for the Chronicle compliance encryption storage type.
+    /// Maps to <c>Cratis:Chronicle:Compliance:Encryption:Storage:Type</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string ComplianceEncryptionStorageTypeEnvironmentVariable = "Cratis__Chronicle__Compliance__Encryption__Storage__Type";
+
+    /// <summary>
+    /// Environment variable key for the Chronicle compliance encryption storage connection details.
+    /// Maps to <c>Cratis:Chronicle:Compliance:Encryption:Storage:ConnectionDetails</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string ComplianceEncryptionStorageConnectionDetailsEnvironmentVariable = "Cratis__Chronicle__Compliance__Encryption__Storage__ConnectionDetails";
+
+    /// <summary>
+    /// Environment variable key for the HashiCorp Vault token used for Chronicle compliance encryption key storage.
+    /// Chronicle reads this variable directly; the value must be a valid Vault token.
+    /// </summary>
+    public const string VaultTokenEnvironmentVariable = "VAULT_TOKEN";
 }

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -68,7 +68,7 @@ public class EventStore : IEventStore
     /// <param name="schemaGenerator"><see cref="IJsonSchemaGenerator"/> for generating JSON schemas.</param>
     /// <param name="namingPolicy"><see cref="INamingPolicy"/> to use for converting names during serialization.</param>
     /// <param name="serviceProvider"><see cref="IServiceProvider"/> for getting instances of services.</param>
-    /// <param name="reactorSideEffectHandlers"><see cref="Reactors.SideEffects.IReactorSideEffectHandlers"/> for handling reactor side-effect return values.</param>
+    /// <param name="reactorSideEffectHandlers"><see cref="IReactorSideEffectHandlers"/> for handling reactor side-effect return values.</param>
     /// <param name="artifactActivator"><see cref="IClientArtifactsActivator"/> for creating artifact instances.</param>
     /// <param name="autoDiscoverAndRegister">Whether to automatically discover and register artifacts.</param>
     /// <param name="jsonSerializerOptions"><see cref="JsonSerializerOptions"/> for serialization.</param>
@@ -88,7 +88,7 @@ public class EventStore : IEventStore
         IJsonSchemaGenerator schemaGenerator,
         INamingPolicy namingPolicy,
         IServiceProvider serviceProvider,
-        Reactors.SideEffects.IReactorSideEffectHandlers reactorSideEffectHandlers,
+        IReactorSideEffectHandlers reactorSideEffectHandlers,
         IClientArtifactsActivator artifactActivator,
         bool autoDiscoverAndRegister,
         JsonSerializerOptions jsonSerializerOptions,
@@ -192,14 +192,14 @@ public class EventStore : IEventStore
         FailedPartitions = new FailedPartitions(this);
 
         var readModelsWatcherManager = new ReadModelWatcherManager(new ReadModelWatcherFactory(this, jsonSerializerOptions));
-        var materializedReadModels = new ReadModels.MaterializedReadModels(
+        var materializedReadModels = new MaterializedReadModels(
             this,
             projections,
             Reducers,
             schemaGenerator,
             _servicesAccessor,
             jsonSerializerOptions,
-            loggerFactory.CreateLogger<ReadModels.MaterializedReadModels>());
+            loggerFactory.CreateLogger<MaterializedReadModels>());
 
         ReadModels = new ReadModels.ReadModels(
             this,

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -137,14 +137,14 @@ public class EventStoreForTesting : IEventStore
 
         var readModelWatcherManager = new ReadModelWatcherManager(new ReadModelWatcherFactory(this, _jsonSerializerOptions));
 
-        var materializedReadModels = new Chronicle.ReadModels.MaterializedReadModels(
+        var materializedReadModels = new MaterializedReadModels(
             this,
             _projections,
             _reducers,
             JsonSchemaGenerator,
             (Connection as IChronicleServicesAccessor)!,
             _jsonSerializerOptions,
-            NullLogger<Chronicle.ReadModels.MaterializedReadModels>.Instance);
+            NullLogger<MaterializedReadModels>.Instance);
 
         var realReadModels = new Chronicle.ReadModels.ReadModels(
             this,

--- a/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
+++ b/Source/Clients/XUnit.Integration/ChronicleOrleansInProcessWebApplicationFactory.cs
@@ -219,10 +219,10 @@ public class ChronicleOrleansInProcessWebApplicationFactory<TStartup>(
                     }
                     services.AddKeyedSingleton<IActivitySource<EventSequences.EventSequence>>(ClientActivity.SourceName, (sp, key) =>
                         new ActivitySource<EventSequences.EventSequence>(sp.GetRequiredKeyedService<System.Diagnostics.ActivitySource>(key)));
-                    services.AddKeyedSingleton<IActivitySource<Cratis.Chronicle.Reactors.Reactors>>(ClientActivity.SourceName, (sp, key) =>
-                        new ActivitySource<Cratis.Chronicle.Reactors.Reactors>(sp.GetRequiredKeyedService<System.Diagnostics.ActivitySource>(key)));
-                    services.AddKeyedSingleton<IActivitySource<Cratis.Chronicle.Reducers.Reducers>>(ClientActivity.SourceName, (sp, key) =>
-                        new ActivitySource<Cratis.Chronicle.Reducers.Reducers>(sp.GetRequiredKeyedService<System.Diagnostics.ActivitySource>(key)));
+                    services.AddKeyedSingleton<IActivitySource<Reactors.Reactors>>(ClientActivity.SourceName, (sp, key) =>
+                        new ActivitySource<Reactors.Reactors>(sp.GetRequiredKeyedService<System.Diagnostics.ActivitySource>(key)));
+                    services.AddKeyedSingleton<IActivitySource<Reducers.Reducers>>(ClientActivity.SourceName, (sp, key) =>
+                        new ActivitySource<Reducers.Reducers>(sp.GetRequiredKeyedService<System.Diagnostics.ActivitySource>(key)));
 
                     services.AddSingleton<IChronicleClient>(sp =>
                     {

--- a/Source/Kernel/Core/Observation/Observer.Handling.cs
+++ b/Source/Kernel/Core/Observation/Observer.Handling.cs
@@ -218,15 +218,15 @@ public partial class Observer
     }
 
     /// <summary>
-    /// Returns a new <see cref="Storage.Observation.ObserverState"/> with handled event counts incremented
+    /// Returns a new <see cref="ObserverState"/> with handled event counts incremented
     /// for the given partition and the provided successfully handled events.
     /// </summary>
-    /// <param name="state">The current <see cref="Storage.Observation.ObserverState"/> to update.</param>
+    /// <param name="state">The current <see cref="ObserverState"/> to update.</param>
     /// <param name="partition">The <see cref="Key"/> identifying the partition whose counts to increment.</param>
     /// <param name="handledEvents">The events that were successfully handled.</param>
-    /// <returns>A new <see cref="Storage.Observation.ObserverState"/> with <see cref="Storage.Observation.ObserverState.HandledEventCount"/>, <see cref="Storage.Observation.ObserverState.HandledEventCountPerEventType"/>, and <see cref="Storage.Observation.ObserverState.HandledEventCountPerPartition"/> incremented accordingly.</returns>
-    static Storage.Observation.ObserverState WithIncrementedHandledEventCounts(
-        Storage.Observation.ObserverState state,
+    /// <returns>A new <see cref="ObserverState"/> with <see cref="ObserverState.HandledEventCount"/>, <see cref="ObserverState.HandledEventCountPerEventType"/>, and <see cref="ObserverState.HandledEventCountPerPartition"/> incremented accordingly.</returns>
+    static ObserverState WithIncrementedHandledEventCounts(
+        ObserverState state,
         Key partition,
         IEnumerable<AppendedEvent> handledEvents)
     {
@@ -259,15 +259,15 @@ public partial class Observer
     }
 
     /// <summary>
-    /// Returns a new <see cref="Storage.Observation.ObserverState"/> with the given partition's contribution
-    /// subtracted from all handled event counts, and the partition removed from <see cref="Storage.Observation.ObserverState.HandledEventCountPerPartition"/>.
+    /// Returns a new <see cref="ObserverState"/> with the given partition's contribution
+    /// subtracted from all handled event counts, and the partition removed from <see cref="ObserverState.HandledEventCountPerPartition"/>.
     /// Used when a partition replay begins.
     /// </summary>
-    /// <param name="state">The current <see cref="Storage.Observation.ObserverState"/> to update.</param>
+    /// <param name="state">The current <see cref="ObserverState"/> to update.</param>
     /// <param name="partition">The <see cref="Key"/> identifying the partition whose counts to subtract.</param>
-    /// <returns>A new <see cref="Storage.Observation.ObserverState"/> with the partition's counts removed and aggregates adjusted.</returns>
-    static Storage.Observation.ObserverState WithSubtractedPartitionHandledEventCounts(
-        Storage.Observation.ObserverState state,
+    /// <returns>A new <see cref="ObserverState"/> with the partition's counts removed and aggregates adjusted.</returns>
+    static ObserverState WithSubtractedPartitionHandledEventCounts(
+        ObserverState state,
         Key partition)
     {
         if (!state.HandledEventCountPerPartition.TryGetValue(partition, out var partitionCounts))

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -661,7 +661,7 @@ internal sealed class ReadModels(
         string namespaceName,
         string eventSequenceId,
         EventSourceId? eventSourceId = default,
-        IEnumerable<Concepts.Events.EventType>? eventTypes = default,
+        IEnumerable<EventType>? eventTypes = default,
         ulong? eventCount = default)
     {
         var eventSequenceStorage = storage
@@ -788,7 +788,7 @@ internal sealed class ReadModels(
         IReadModelsCompliance complianceHelper,
         JsonSerializerOptions jsonSerializerOptions) : IProjectionChangesetObserver
     {
-        public async Task OnChangeset(Concepts.EventStoreNamespaceName namespaceName, Concepts.ReadModels.ReadModelKey readModelKey, JsonObject readModel)
+        public async Task OnChangeset(Concepts.EventStoreNamespaceName namespaceName, ReadModelKey readModelKey, JsonObject readModel)
         {
             var decrypted = await complianceHelper.ReleaseJson(
                 eventStore,
@@ -806,5 +806,5 @@ internal sealed class ReadModels(
         }
     }
 
-    record ConnectedReducerContext(ReducerId ReducerId, ConnectionId ConnectionId, IEnumerable<Concepts.Events.EventType> EventTypes);
+    record ConnectedReducerContext(ReducerId ReducerId, ConnectionId ConnectionId, IEnumerable<EventType> EventTypes);
 }

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -144,7 +144,7 @@ public static class ChronicleServerSiloBuilderExtensions
                     grainFactory,
                     sp.GetRequiredService<Cratis.Chronicle.Projections.Engine.Pipelines.IProjectionPipelineManager>(),
                     sp.GetRequiredService<IInstancesOf<ICanPerformKernelStateReset>>(),
-                    sp.GetRequiredService<Cratis.Chronicle.Setup.KernelBootstrapResetHandler>()));
+                    sp.GetRequiredService<KernelBootstrapResetHandler>()));
         });
 
         return builder;

--- a/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
@@ -2,8 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security.Cryptography.X509Certificates;
-using Cratis.Chronicle.Storage.MongoDB.Security;
+using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Security;
+using Cratis.Chronicle.Storage.Sql.Cluster.Security;
+using MongoDbApplicationStorage = Cratis.Chronicle.Storage.MongoDB.Security.ApplicationStorage;
+using MongoDbAuthorizationStorage = Cratis.Chronicle.Storage.MongoDB.Security.AuthorizationStorage;
+using MongoDbScopeStorage = Cratis.Chronicle.Storage.MongoDB.Security.ScopeStorage;
+using MongoDbTokenStorage = Cratis.Chronicle.Storage.MongoDB.Security.TokenStorage;
 
 namespace Cratis.Chronicle.Server.Authentication.OpenIddict;
 
@@ -27,11 +32,25 @@ public static class OpenIddictServiceCollectionExtensions
             return services;
         }
 
-        // Add Security storage implementations for OpenIddict
-        services.AddSingleton<IApplicationStorage, ApplicationStorage>();
-        services.AddSingleton<IAuthorizationStorage, AuthorizationStorage>();
-        services.AddSingleton<IScopeStorage, ScopeStorage>();
-        services.AddSingleton<ITokenStorage, TokenStorage>();
+        // Add Security storage implementations for OpenIddict — use SQL or MongoDB depending on storage type
+        var isSqlStorage = string.Equals(chronicleOptions.Storage.Type, StorageType.Sqlite, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(chronicleOptions.Storage.Type, StorageType.MsSql, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(chronicleOptions.Storage.Type, StorageType.PostgreSql, StringComparison.OrdinalIgnoreCase);
+
+        if (isSqlStorage)
+        {
+            services.AddSingleton(sp => sp.GetRequiredService<ISystemStorage>().Applications);
+            services.AddSingleton<IAuthorizationStorage, SqlAuthorizationStorage>();
+            services.AddSingleton<IScopeStorage, SqlScopeStorage>();
+            services.AddSingleton<ITokenStorage, SqlTokenStorage>();
+        }
+        else
+        {
+            services.AddSingleton<IApplicationStorage, MongoDbApplicationStorage>();
+            services.AddSingleton<IAuthorizationStorage, MongoDbAuthorizationStorage>();
+            services.AddSingleton<IScopeStorage, MongoDbScopeStorage>();
+            services.AddSingleton<ITokenStorage, MongoDbTokenStorage>();
+        }
 
         // Note: Data Protection is configured in AddChronicleAuthentication
         // and will be reused here for OpenIddict

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceJsonStringColumns.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceJsonStringColumns.cs
@@ -16,7 +16,7 @@ internal static class NamespaceJsonStringColumns
     /// <summary>
     /// The (entity type, property name) pairs to bind to the provider-native JSON column type.
     /// </summary>
-    public static readonly (System.Type EntityType, string PropertyName)[] All =
+    public static readonly (Type EntityType, string PropertyName)[] All =
     [
         (typeof(Jobs.Job), "StateJson"),
         (typeof(JobSteps.JobStep), "StateJson"),

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/DynamicReadModelEntity.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/DynamicReadModelEntity.cs
@@ -6,7 +6,7 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
 /// <summary>
 /// Dictionary-backed entity used for read-model rows whose shape is only known at runtime
 /// (one entity registration per read model, with columns derived from the read model's
-/// <see cref="Cratis.Chronicle.Schemas.JsonSchema"/>). Each entry corresponds to one column;
+/// <see cref="Schemas.JsonSchema"/>). Each entry corresponds to one column;
 /// EF treats it as a shared-type entity with indexer-properties, so per-column dirty tracking
 /// gives us field-level UPDATEs without needing a generated CLR type per read model.
 /// </summary>

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ProjectedColumn.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ProjectedColumn.cs
@@ -4,7 +4,7 @@
 namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
 
 /// <summary>
-/// Describes a single column on a read-model table derived from the read model's <see cref="Cratis.Chronicle.Schemas.JsonSchema"/>.
+/// Describes a single column on a read-model table derived from the read model's <see cref="Schemas.JsonSchema"/>.
 /// Leaf properties (primitives, dates, guids, concepts of those) map to a typed column. Collections and
 /// complex objects map to a single JSON-typed column (jsonb on PostgreSQL, nvarchar(max) on SQL Server, text on SQLite).
 /// </summary>

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigrator.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigrator.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
 
 /// <summary>
 /// Represents an implementation of <see cref="IReadModelMigrator"/> that creates the read-model table
-/// with the column shape derived from the read model's <see cref="Cratis.Chronicle.Schemas.JsonSchema"/>.
+/// with the column shape derived from the read model's <see cref="Schemas.JsonSchema"/>.
 /// Each leaf property in the schema becomes a typed column; arrays and nested objects become a JSON
 /// column (jsonb on PostgreSQL, nvarchar(max) on SQL Server, text on SQLite).
 /// </summary>

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Seeding/EventSeedingConverters.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Seeding/EventSeedingConverters.cs
@@ -40,13 +40,13 @@ public static class EventSeedingConverters
     {
         var byEventTypeRaw = JsonSerializer.Deserialize<IDictionary<string, IEnumerable<SeededEventEntry>>>(entity.ByEventTypeJson, jsonSerializerOptions)
             ?? new Dictionary<string, IEnumerable<SeededEventEntry>>();
-        var byEventType = byEventTypeRaw.ToDictionary<KeyValuePair<string, IEnumerable<SeededEventEntry>>, EventTypeId, IEnumerable<SeededEventEntry>>(
+        var byEventType = byEventTypeRaw.ToDictionary(
             k => (EventTypeId)k.Key,
             v => v.Value);
 
         var byEventSourceRaw = JsonSerializer.Deserialize<IDictionary<string, IEnumerable<SeededEventEntry>>>(entity.ByEventSourceJson, jsonSerializerOptions)
             ?? new Dictionary<string, IEnumerable<SeededEventEntry>>();
-        var byEventSource = byEventSourceRaw.ToDictionary<KeyValuePair<string, IEnumerable<SeededEventEntry>>, EventSourceId, IEnumerable<SeededEventEntry>>(
+        var byEventSource = byEventSourceRaw.ToDictionary(
             k => (EventSourceId)k.Key,
             v => v.Value);
 

--- a/Source/Kernel/Storage.Sql/IDatabase.cs
+++ b/Source/Kernel/Storage.Sql/IDatabase.cs
@@ -62,7 +62,7 @@ public interface IDatabase
     /// <param name="eventStore">The name of the event store.</param>
     /// <param name="namespace">The name of the namespace.</param>
     /// <param name="containerName">The container name of the read model (table name).</param>
-    /// <param name="columns">The columns derived from the read model's <see cref="Cratis.Chronicle.Schemas.JsonSchema"/>.</param>
+    /// <param name="columns">The columns derived from the read model's <see cref="Schemas.JsonSchema"/>.</param>
     /// <returns>A <see cref="DbContextScope{ReadModelDbContext}"/> for the specified read model table.</returns>
     Task<DbContextScope<ReadModelDbContext>> ReadModelTable(EventStoreName eventStore, EventStoreNamespaceName @namespace, string containerName, IReadOnlyList<ProjectedColumn> columns);
 

--- a/Source/Kernel/Storage.Sql/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.Sql/Sinks/Sink.cs
@@ -32,7 +32,7 @@ namespace Cratis.Chronicle.Storage.Sql.Sinks;
 
 /// <summary>
 /// SQL implementation of <see cref="ISink"/> backed by a per-read-model table whose column shape is
-/// derived from the read model's <see cref="Cratis.Chronicle.Schemas.JsonSchema"/>: each leaf
+/// derived from the read model's <see cref="JsonSchema"/>: each leaf
 /// property becomes a real typed column, collections and nested objects become a single JSON column
 /// (<c>jsonb</c> on PostgreSQL, <c>nvarchar(max)</c> on SQL Server, <c>TEXT</c> on SQLite). Changes
 /// from the projection engine are translated into per-column updates on a tracked

--- a/Source/Kernel/Storage.Vault/VaultChronicleBuilderExtensions.cs
+++ b/Source/Kernel/Storage.Vault/VaultChronicleBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class VaultChronicleBuilderExtensions
     /// Configures Chronicle to use HashiCorp Vault for encryption key storage, based on the <see cref="ChronicleOptions"/>.
     /// </summary>
     /// <remarks>
-    /// When <see cref="Configuration.Encryption.Storage"/> is configured and its type is <c>vault</c>,
+    /// When <see cref="Encryption.Storage"/> is configured and its type is <c>vault</c>,
     /// this method adds a <see cref="Storage.Vault.VaultEncryptionKeyStorage"/> wrapped in a <see cref="CacheEncryptionKeyStorage"/>
     /// as <see cref="IEncryptionKeyStorage"/>. Because it is registered last, it overrides the default storage registration.
     /// If compliance encryption storage is not configured, or the type is not <c>vault</c>, no changes are made.


### PR DESCRIPTION
## Added
- `WithHashiCorpVault` and `WithAzureKeyVault` extension methods on `IChronicleAspireBuilder` to configure compliance encryption key storage from Aspire host code without manually setting environment variables (#3205, #685)
- Compliance encryption storage environment variable constants in `ChronicleContainerImageTags`

## Fixed
- OpenIddict storage registrations now route to SQL-backed implementations when the configured storage type is SQLite, MS SQL, or PostgreSQL, preventing authentication failures with SQL backends