### PR TITLE
Implement missing SQL storage methods that threw NotImplementedException

### DIFF
--- a/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
+++ b/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
@@ -19,8 +19,11 @@ namespace Cratis.Chronicle.Storage.Sql.Cluster;
 /// <param name="sinkFactories"><see cref="IInstancesOf{T}"/> for getting all <see cref="ISinkFactory"/> instances.</param>
 /// <param name="jobTypes">The <see cref="IJobTypes"/> that knows about job types.</param>
 /// <param name="jsonSerializerOptions">The configured <see cref="JsonSerializerOptions"/> including all concept converters.</param>
-public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkFactories, IJobTypes jobTypes, JsonSerializerOptions jsonSerializerOptions) : IClusterStorage
+public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkFactories, IJobTypes jobTypes, JsonSerializerOptions jsonSerializerOptions) : IClusterStorage, IDisposable
 {
+    readonly BehaviorSubject<IEnumerable<EventStoreName>> _eventStoresSubject = new([]);
+    int _eventStoresInitialized;
+
     /// <inheritdoc/>
     public async Task<IEnumerable<EventStoreName>> GetEventStores()
     {
@@ -30,7 +33,14 @@ public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkF
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores() => throw new NotImplementedException();
+    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores()
+    {
+        if (Interlocked.CompareExchange(ref _eventStoresInitialized, 1, 0) == 0)
+        {
+            _ = PushEventStoresToSubjectAsync();
+        }
+        return _eventStoresSubject;
+    }
 
     /// <inheritdoc/>
     public IEventStoreStorage CreateStorageForEventStore(EventStoreName eventStore, SinksFactory sinksFactory)
@@ -44,5 +54,15 @@ public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkF
         await using var scope = await database.Cluster();
         await scope.DbContext.EventStores.Upsert(new EventStore { Name = eventStore });
         await scope.DbContext.SaveChangesAsync();
+        await PushEventStoresToSubjectAsync();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _eventStoresSubject.Dispose();
+
+    async Task PushEventStoresToSubjectAsync()
+    {
+        var stores = await GetEventStores();
+        _eventStoresSubject.OnNext(stores);
     }
 }

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
@@ -136,7 +136,16 @@ public class EventTypesStorage(EventStoreName eventStore, IDatabase database) : 
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(Concepts.Events.EventType eventType) => throw new NotImplementedException();
+    public async Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(Concepts.Events.EventType eventType)
+    {
+        var storedEventType = await GetSpecificEventType(eventType.Id);
+        if (storedEventType is null)
+        {
+            return [];
+        }
+
+        return storedEventType.Schemas.Select(kvp => storedEventType.ToKernel(new EventTypeGeneration(kvp.Key)));
+    }
 
     /// <inheritdoc/>
     public async Task<EventTypeSchema> GetFor(EventTypeId type, EventTypeGeneration? generation = null)

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceStorage.cs
@@ -13,14 +13,17 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces;
 /// </summary>
 /// <param name="eventStore">The event store.</param>
 /// <param name="database">The <see cref="IDatabase"/> to use for storage operations.</param>
-public class NamespaceStorage(EventStoreName eventStore, IDatabase database) : INamespaceStorage
+public class NamespaceStorage(EventStoreName eventStore, IDatabase database) : INamespaceStorage, IDisposable
 {
+    readonly ReplaySubject<IEnumerable<NamespaceState>> _subject = new(1);
+
     /// <inheritdoc/>
     public async Task Create(EventStoreNamespaceName name, DateTimeOffset created)
     {
         await using var scope = await database.EventStore(eventStore);
         await scope.DbContext.Namespaces.AddAsync(new Namespace { Name = name.ToString(), Created = created });
         await scope.DbContext.SaveChangesAsync();
+        await NotifyChange();
     }
 
     /// <inheritdoc/>
@@ -29,6 +32,7 @@ public class NamespaceStorage(EventStoreName eventStore, IDatabase database) : I
         await using var scope = await database.EventStore(eventStore);
         scope.DbContext.Namespaces.Remove(new Namespace { Name = name.ToString() });
         await scope.DbContext.SaveChangesAsync();
+        await NotifyChange();
     }
 
     /// <inheritdoc/>
@@ -51,5 +55,18 @@ public class NamespaceStorage(EventStoreName eventStore, IDatabase database) : I
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<NamespaceState>> ObserveAll() => throw new NotImplementedException();
+    public ISubject<IEnumerable<NamespaceState>> ObserveAll() => _subject;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _subject.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    async Task NotifyChange()
+    {
+        var all = await GetAll();
+        _subject.OnNext(all);
+    }
 }

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Observers/ObserverStateStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Observers/ObserverStateStorage.cs
@@ -4,22 +4,23 @@
 using System.Reactive.Subjects;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Observation;
-using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.Observation;
 using Microsoft.EntityFrameworkCore;
 
 namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Observers;
 
 /// <summary>
-/// Represents an implementation of <see cref="IEventTypesStorage"/> for SQL.
+/// Represents an implementation of <see cref="IObserverStateStorage"/> for SQL.
 /// </summary>
 /// <param name="eventStore">The name of the event store.</param>
 /// <param name="namespace">The name of the namespace.</param>
 /// <param name="database">The <see cref="IDatabase"/> to use for storage operations.</param>
-public class ObserverStateStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, IDatabase database) : IObserverStateStorage
+public class ObserverStateStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, IDatabase database) : IObserverStateStorage, IDisposable
 {
+    readonly ReplaySubject<IEnumerable<Observation.ObserverState>> _subject = new(1);
+
     /// <inheritdoc/>
-    public ISubject<IEnumerable<Observation.ObserverState>> ObserveAll() => throw new NotImplementedException();
+    public ISubject<IEnumerable<Observation.ObserverState>> ObserveAll() => _subject;
 
     /// <inheritdoc/>
     public async Task<IEnumerable<Observation.ObserverState>> GetAll()
@@ -66,6 +67,7 @@ public class ObserverStateStorage(EventStoreName eventStore, EventStoreNamespace
         var entity = state.ToSql();
         await scope.DbContext.Observers.Upsert(entity);
         await scope.DbContext.SaveChangesAsync();
+        await NotifyChange();
     }
 
     /// <inheritdoc/>
@@ -94,5 +96,19 @@ public class ObserverStateStorage(EventStoreName eventStore, EventStoreNamespace
         scope.DbContext.Observers.Remove(existing);
         await scope.DbContext.Observers.AddAsync(renamed);
         await scope.DbContext.SaveChangesAsync();
+        await NotifyChange();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _subject.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    async Task NotifyChange()
+    {
+        var all = await GetAll();
+        _subject.OnNext(all);
     }
 }


### PR DESCRIPTION
## Fixed
- `ClusterStorage.ObserveEventStores`, `EventTypesStorage.GetAllGenerationsForEventType`, `NamespaceStorage.ObserveAll`, and `ObserverStateStorage.ObserveAll` in the SQL storage backend no longer throw `NotImplementedException` at runtime — each is now fully implemented following the same `ReplaySubject`/`NotifyChange` pattern used by the rest of the SQL storage layer.