### PR TITLE
Fix SQL read model query crash when existing table is missing schema columns

### DIFF
--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/given/a_read_model_migrator.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/given/a_read_model_migrator.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+#pragma warning disable CA2100 // Table names come from internal constants, not user input.
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels.for_ReadModelMigrator.given;
+
+/// <summary>
+/// Establishes a real named shared-cache in-memory SQLite database together with a real
+/// <see cref="TableMigrator{TContext}"/> and <see cref="ReadModelMigrator"/>.
+/// A named shared-cache database is used instead of the default <c>:memory:</c> connection
+/// so that the <see cref="TableMigrator{TContext}"/> can open and close its own transient
+/// connections (as it does in production) while the master connection keeps the database alive.
+/// </summary>
+public class a_read_model_migrator : Specification
+{
+    string _connectionString;
+    SqliteConnection _masterConnection;
+    protected ReadModelMigrator _migrator;
+
+    void Establish()
+    {
+        // Each Guid-named database is unique to this spec instance, so the TableMigrator's
+        // static cache entries are naturally isolated between test runs.
+        var dbName = $"rmm_{Guid.NewGuid():N}";
+        _connectionString = $"DataSource={dbName};Mode=Memory;Cache=Shared";
+
+        _masterConnection = new SqliteConnection(_connectionString);
+        _masterConnection.Open();
+
+        var tableMigrator = new TableMigrator<ReadModelDbContext>(
+            Substitute.For<ILogger<TableMigrator<ReadModelDbContext>>>());
+
+        _migrator = new ReadModelMigrator(
+            tableMigrator,
+            Substitute.For<ILogger<ReadModelMigrator>>());
+    }
+
+    void Destroy()
+    {
+        _masterConnection.Close();
+        _masterConnection.Dispose();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ReadModelDbContext"/> that targets the spec's named in-memory database.
+    /// </summary>
+    /// <param name="tableName">Name of the read model table.</param>
+    /// <param name="columns">Column definitions derived from the read model schema.</param>
+    /// <returns>A configured <see cref="ReadModelDbContext"/>.</returns>
+    protected ReadModelDbContext CreateContext(string tableName, IReadOnlyList<ProjectedColumn> columns)
+    {
+        var options = new DbContextOptionsBuilder<ReadModelDbContext>()
+            .UseSqlite(_connectionString)
+            .AddConceptAsSupport()
+            .Options;
+
+        return new ReadModelDbContext(options, tableName, columns, _migrator);
+    }
+
+    /// <summary>
+    /// Returns the column names that physically exist in the given table by querying
+    /// SQLite's <c>PRAGMA table_info</c> via the master connection.
+    /// Column name is at ordinal 1 (0 = cid, 1 = name, 2 = type, …).
+    /// </summary>
+    /// <param name="tableName">Name of the table to inspect.</param>
+    /// <returns>A set of column names, compared case-insensitively.</returns>
+    protected async Task<IReadOnlySet<string>> GetActualColumnNamesAsync(string tableName)
+    {
+        await using var command = _masterConnection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info(\"{tableName}\")";
+
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            columns.Add(reader.GetString(1));
+        }
+
+        return columns;
+    }
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_does_not_exist.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_does_not_exist.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels.for_ReadModelMigrator.when_ensuring_table_is_migrated;
+
+public class and_table_does_not_exist : given.a_read_model_migrator
+{
+    const string TableName = "books_inventory";
+
+    IReadOnlyList<ProjectedColumn> _columns;
+    IReadOnlySet<string> _actualColumns;
+
+    void Establish()
+    {
+        _columns =
+        [
+            new ProjectedColumn("Id",    typeof(string), IsKey: true,  IsJson: false, IsArray: false, IsNullable: false),
+            new ProjectedColumn("Title", typeof(string), IsKey: false, IsJson: false, IsArray: false, IsNullable: true),
+            new ProjectedColumn(WellKnownProperties.LastHandledEventSequenceNumber, typeof(long?), IsKey: false, IsJson: false, IsArray: false, IsNullable: true)
+        ];
+    }
+
+    async Task Because()
+    {
+        await using var context = CreateContext(TableName, _columns);
+        await _migrator.EnsureTableMigrated(TableName, context);
+        _actualColumns = await GetActualColumnNamesAsync(TableName);
+    }
+
+    [Fact] void should_create_the_id_column() => _actualColumns.Contains("Id").ShouldBeTrue();
+    [Fact] void should_create_the_title_column() => _actualColumns.Contains("Title").ShouldBeTrue();
+    [Fact] void should_create_the_bookkeeping_column() => _actualColumns.Contains(WellKnownProperties.LastHandledEventSequenceNumber).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_exists_with_all_expected_columns.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_exists_with_all_expected_columns.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels.for_ReadModelMigrator.when_ensuring_table_is_migrated;
+
+public class and_table_exists_with_all_expected_columns : given.a_read_model_migrator
+{
+    const string TableName = "books_already_current";
+
+    IReadOnlyList<ProjectedColumn> _columns;
+    IReadOnlySet<string> _actualColumns;
+
+    async Task Establish()
+    {
+        _columns =
+        [
+            new ProjectedColumn("Id",    typeof(string), IsKey: true,  IsJson: false, IsArray: false, IsNullable: false),
+            new ProjectedColumn("Title", typeof(string), IsKey: false, IsJson: false, IsArray: false, IsNullable: true),
+            new ProjectedColumn(WellKnownProperties.LastHandledEventSequenceNumber, typeof(long?), IsKey: false, IsJson: false, IsArray: false, IsNullable: true)
+        ];
+
+        await using var context = CreateContext(TableName, _columns);
+        await _migrator.EnsureTableMigrated(TableName, context);
+    }
+
+    async Task Because()
+    {
+        // Second call with the same schema — must be a no-op and must not throw.
+        await using var context = CreateContext(TableName, _columns);
+        await _migrator.EnsureTableMigrated(TableName, context);
+        _actualColumns = await GetActualColumnNamesAsync(TableName);
+    }
+
+    [Fact] void should_retain_the_id_column() => _actualColumns.Contains("Id").ShouldBeTrue();
+    [Fact] void should_retain_the_title_column() => _actualColumns.Contains("Title").ShouldBeTrue();
+    [Fact] void should_retain_the_bookkeeping_column() => _actualColumns.Contains(WellKnownProperties.LastHandledEventSequenceNumber).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_exists_with_missing_columns.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/ReadModels/for_ReadModelMigrator/when_ensuring_table_is_migrated/and_table_exists_with_missing_columns.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels.for_ReadModelMigrator.when_ensuring_table_is_migrated;
+
+/// <summary>
+/// Reproduces the "column b.Title does not exist" bug where two read models share the same
+/// container name across namespaces. The Lending read model creates the "Books" table with an
+/// "Available" column; when the Inventory read model later calls EnsureTableMigrated expecting a
+/// "Title" column the migrator must detect the gap and ALTER TABLE ADD COLUMN rather than crashing.
+/// </summary>
+public class and_table_exists_with_missing_columns : given.a_read_model_migrator
+{
+    const string TableName = "books_shared_container";
+
+    IReadOnlyList<ProjectedColumn> _inventoryColumns;
+    IReadOnlySet<string> _actualColumns;
+
+    async Task Establish()
+    {
+        // Lending read model creates the "Books" table first — only Id and Available columns.
+        IReadOnlyList<ProjectedColumn> lendingColumns =
+        [
+            new ProjectedColumn("Id",        typeof(string), IsKey: true,  IsJson: false, IsArray: false, IsNullable: false),
+            new ProjectedColumn("Available", typeof(int?),   IsKey: false, IsJson: false, IsArray: false, IsNullable: true),
+            new ProjectedColumn(WellKnownProperties.LastHandledEventSequenceNumber, typeof(long?), IsKey: false, IsJson: false, IsArray: false, IsNullable: true)
+        ];
+
+        await using var lendingContext = CreateContext(TableName, lendingColumns);
+        await _migrator.EnsureTableMigrated(TableName, lendingContext);
+
+        // Inventory read model expects Id and Title — Title is absent from the existing table.
+        _inventoryColumns =
+        [
+            new ProjectedColumn("Id",    typeof(string), IsKey: true,  IsJson: false, IsArray: false, IsNullable: false),
+            new ProjectedColumn("Title", typeof(string), IsKey: false, IsJson: false, IsArray: false, IsNullable: true),
+            new ProjectedColumn(WellKnownProperties.LastHandledEventSequenceNumber, typeof(long?), IsKey: false, IsJson: false, IsArray: false, IsNullable: true)
+        ];
+    }
+
+    async Task Because()
+    {
+        await using var inventoryContext = CreateContext(TableName, _inventoryColumns);
+        await _migrator.EnsureTableMigrated(TableName, inventoryContext);
+        _actualColumns = await GetActualColumnNamesAsync(TableName);
+    }
+
+    [Fact] void should_add_the_missing_title_column() => _actualColumns.Contains("Title").ShouldBeTrue();
+    [Fact] void should_preserve_the_id_column() => _actualColumns.Contains("Id").ShouldBeTrue();
+    [Fact] void should_preserve_the_pre_existing_available_column() => _actualColumns.Contains("Available").ShouldBeTrue();
+    [Fact] void should_preserve_the_bookkeeping_column() => _actualColumns.Contains(WellKnownProperties.LastHandledEventSequenceNumber).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigrator.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigrator.cs
@@ -1,13 +1,16 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using Cratis.Arc.EntityFrameworkCore;
 using Cratis.Arc.EntityFrameworkCore.Json;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.Extensions.Logging;
 
 #pragma warning disable SA1204 // Static helpers placed after the public methods that drive them.
+#pragma warning disable CA2100 // Table and column names are internal constants, not user input.
 
 namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
 
@@ -23,13 +26,106 @@ public class ReadModelMigrator(
     ITableMigrator<ReadModelDbContext> tableMigrator,
     ILogger<ReadModelMigrator> logger) : IReadModelMigrator
 {
-    /// <inheritdoc/>
-    public Task EnsureTableMigrated(string tableName, ReadModelDbContext context) =>
-        tableMigrator.EnsureTableMigrated(tableName, context, CreateTable);
+    static readonly ConcurrentDictionary<string, bool> _columnMigrations = new();
 
     /// <inheritdoc/>
-    public void ClearMigrationCache(string connectionStringPrefix) =>
+    public async Task EnsureTableMigrated(string tableName, ReadModelDbContext context)
+    {
+        await tableMigrator.EnsureTableMigrated(tableName, context, CreateTable);
+        await EnsureMissingColumnsAdded(tableName, context);
+    }
+
+    /// <inheritdoc/>
+    public void ClearMigrationCache(string connectionStringPrefix)
+    {
         tableMigrator.ClearMigrationCacheForConnectionString(connectionStringPrefix);
+        foreach (var key in _columnMigrations.Keys.Where(k => k.StartsWith(connectionStringPrefix, StringComparison.OrdinalIgnoreCase)))
+        {
+            _columnMigrations.TryRemove(key, out _);
+        }
+    }
+
+    async Task EnsureMissingColumnsAdded(string tableName, ReadModelDbContext context)
+    {
+        // Build a cache key that covers this connection string, table, and exact column set.
+        // When the schema changes the key changes and we re-check the database.
+        var connectionString = context.Database.GetConnectionString() ?? string.Empty;
+        var columnsKey = string.Join('|', context.Columns.Select(c => c.Name));
+        var cacheKey = $"{connectionString}:{tableName}:{columnsKey}";
+
+        if (_columnMigrations.ContainsKey(cacheKey))
+        {
+            return;
+        }
+
+        var existingColumns = await GetExistingColumnNames(context, tableName);
+        var missingColumns = context.Columns
+            .Where(col => !existingColumns.Contains(col.Name))
+            .ToList();
+
+        if (missingColumns.Count > 0)
+        {
+            logger.AddingMissingColumns(missingColumns.Count, tableName, string.Join(',', missingColumns.Select(c => c.Name)));
+
+            var migrationBuilder = new MigrationBuilder(context.Database.ProviderName);
+            var databaseType = migrationBuilder.GetDatabaseType();
+
+            foreach (var column in missingColumns)
+            {
+                // New columns added to an existing table must be nullable so existing rows
+                // receive NULL rather than a default value. Primary-key columns cannot be
+                // missing from an existing table, so this case only applies to non-key columns.
+                var op = BuildAddColumnOperation(column, databaseType, tableName);
+                op.IsNullable = true;
+                migrationBuilder.Operations.Add(op);
+            }
+
+            await tableMigrator.ExecuteMigrationOperations(context, migrationBuilder);
+        }
+
+        _columnMigrations.TryAdd(cacheKey, true);
+    }
+
+    static async Task<HashSet<string>> GetExistingColumnNames(ReadModelDbContext context, string tableName)
+    {
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+        try
+        {
+            await using var command = connection.CreateCommand();
+            int nameOrdinal;
+
+            if (context.Database.IsNpgsql())
+            {
+                command.CommandText = $"SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '{tableName}'";
+                nameOrdinal = 0;
+            }
+            else if (context.Database.IsSqlServer())
+            {
+                command.CommandText = $"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{tableName}'";
+                nameOrdinal = 0;
+            }
+            else
+            {
+                // SQLite PRAGMA table_info returns: cid, name, type, notnull, dflt_value, pk
+                command.CommandText = $"PRAGMA table_info(\"{tableName}\")";
+                nameOrdinal = 1;
+            }
+
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            await using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                columns.Add(reader.GetString(nameOrdinal));
+            }
+
+            return columns;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
 
     async Task CreateTable(ReadModelDbContext context, string tableName)
     {

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigratorLogging.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ReadModelMigratorLogging.cs
@@ -12,4 +12,7 @@ internal static partial class ReadModelMigratorLogging
 {
     [LoggerMessage(LogLevel.Debug, "Creating read model table {TableName}")]
     internal static partial void CreatingReadModelTable(this ILogger<ReadModelMigrator> logger, string tableName);
+
+    [LoggerMessage(LogLevel.Debug, "Adding {ColumnCount} missing column(s) to read model table {TableName}: {Columns}")]
+    internal static partial void AddingMissingColumns(this ILogger<ReadModelMigrator> logger, int columnCount, string tableName, string columns);
 }


### PR DESCRIPTION
## Fixed
- SQL read model instances query failing with \`42703: column does not exist\` when two read models share the same container name across namespaces and the existing table was created by a different read model with a different column set.

## Summary
\`ReadModelMigrator.EnsureTableMigrated\` previously only created the table when it did not exist; it never verified that existing table columns matched the expected schema. After the fix, every \`EnsureTableMigrated\` call also runs \`EnsureMissingColumnsAdded\`, which queries the real column names from the database and issues \`ALTER TABLE ADD COLUMN\` for any columns present in the schema but absent in the table. Results are cached by connection-string + table + column-set so the extra DB roundtrip is paid at most once per unique schema per process.