### PR TITLE
Fix SQL: Workbench shows no event stores and unique constraint value too long

### DIFF
--- a/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
+++ b/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
@@ -22,7 +22,6 @@ namespace Cratis.Chronicle.Storage.Sql.Cluster;
 public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkFactories, IJobTypes jobTypes, JsonSerializerOptions jsonSerializerOptions) : IClusterStorage, IDisposable
 {
     readonly BehaviorSubject<IEnumerable<EventStoreName>> _eventStoresSubject = new([]);
-    int _eventStoresInitialized;
 
     /// <inheritdoc/>
     public async Task<IEnumerable<EventStoreName>> GetEventStores()
@@ -35,10 +34,12 @@ public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkF
     /// <inheritdoc/>
     public ISubject<IEnumerable<EventStoreName>> ObserveEventStores()
     {
-        if (Interlocked.CompareExchange(ref _eventStoresInitialized, 1, 0) == 0)
-        {
-            _ = PushEventStoresToSubjectAsync();
-        }
+        // Always push the current state so any new SSE subscriber receives the data once
+        // the async DB fetch completes — the Subject intermediary in InvokeAndWrapWithTransformSubject
+        // is a plain Subject (no replay), so the BehaviorSubject's synchronous initial emission
+        // is swallowed before the subscriber attaches. Re-pushing after each subscribe call ensures
+        // the subscriber gets data via the async emission that follows.
+        _ = PushEventStoresToSubjectAsync();
         return _eventStoresSubject;
     }
 

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueConstraints/UniqueConstraintMigrator.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueConstraints/UniqueConstraintMigrator.cs
@@ -1,11 +1,15 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using Cratis.Arc.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.UniqueConstraints;
+
+#pragma warning disable CA2100 // Table and column names are internal constants, not user input.
 
 /// <summary>
 /// Represents an implementation of <see cref="IUniqueConstraintMigrator"/>.
@@ -16,13 +20,65 @@ public class UniqueConstraintMigrator(
     ITableMigrator<UniqueConstraintDbContext> tableMigrator,
     ILogger<UniqueConstraintMigrator> logger) : IUniqueConstraintMigrator
 {
-    /// <inheritdoc/>
-    public Task EnsureTableMigrated(string tableName, UniqueConstraintDbContext context) =>
-        tableMigrator.EnsureTableMigrated(tableName, context, CreateTable);
+    static readonly ConcurrentDictionary<string, bool> _columnMigrations = new();
 
     /// <inheritdoc/>
-    public void ClearMigrationCache(string connectionStringPrefix) =>
+    public async Task EnsureTableMigrated(string tableName, UniqueConstraintDbContext context)
+    {
+        await tableMigrator.EnsureTableMigrated(tableName, context, CreateTable);
+        await EnsureValueColumnIsUnbounded(tableName, context);
+    }
+
+    /// <inheritdoc/>
+    public void ClearMigrationCache(string connectionStringPrefix)
+    {
         tableMigrator.ClearMigrationCacheForConnectionString(connectionStringPrefix);
+        foreach (var key in _columnMigrations.Keys.Where(k => k.StartsWith(connectionStringPrefix, StringComparison.OrdinalIgnoreCase)))
+        {
+            _columnMigrations.TryRemove(key, out _);
+        }
+    }
+
+    static async Task<bool> ValueColumnNeedsWidening(UniqueConstraintDbContext context, string tableName)
+    {
+        var connection = context.Database.GetDbConnection();
+        await connection.OpenAsync();
+
+        try
+        {
+            await using var command = connection.CreateCommand();
+
+            if (context.Database.IsNpgsql())
+            {
+                command.CommandText =
+                    "SELECT character_maximum_length FROM information_schema.columns " +
+                    "WHERE table_schema = 'public' AND table_name = '" + tableName + "' AND column_name = 'Value'";
+            }
+            else if (context.Database.IsSqlServer())
+            {
+                command.CommandText =
+                    "SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS " +
+                    "WHERE TABLE_NAME = '" + tableName + "' AND COLUMN_NAME = 'Value'";
+            }
+            else
+            {
+                return false;
+            }
+
+            var result = await command.ExecuteScalarAsync();
+            if (result is null || result is DBNull)
+            {
+                return false;
+            }
+
+            var maxLength = Convert.ToInt32(result);
+            return maxLength > 0 && maxLength <= 200;
+        }
+        finally
+        {
+            await connection.CloseAsync();
+        }
+    }
 
     async Task CreateTable(UniqueConstraintDbContext context, string tableName)
     {
@@ -35,18 +91,53 @@ public class UniqueConstraintMigrator(
             columns: table => new
             {
                 EventSourceId = table.StringColumn(migrationBuilder, maxLength: 200, nullable: false),
-                Value = table.StringColumn(migrationBuilder, maxLength: 200),
+                Value = table.StringColumn(migrationBuilder),
                 SequenceNumber = table.NumberColumn<decimal>(migrationBuilder, nullable: false)
             },
-            constraints: table => table.PrimaryKey($"PK_{tableName}", x => x.EventSourceId));
+            constraints: table => table.PrimaryKey("PK_" + tableName, x => x.EventSourceId));
 
         migrationBuilder.CreateIndex(
-            name: $"IX_{tableName}_Value",
+            name: "IX_" + tableName + "_Value",
             table: tableName,
             column: "Value");
 
         await tableMigrator.ExecuteMigrationOperations(context, migrationBuilder);
     }
+
+    async Task EnsureValueColumnIsUnbounded(string tableName, UniqueConstraintDbContext context)
+    {
+        var connectionString = context.Database.GetConnectionString() ?? string.Empty;
+        var cacheKey = connectionString + ":" + tableName + ":value-unbounded";
+
+        if (_columnMigrations.ContainsKey(cacheKey))
+        {
+            return;
+        }
+
+        if (!await ValueColumnNeedsWidening(context, tableName))
+        {
+            _columnMigrations.TryAdd(cacheKey, true);
+            return;
+        }
+
+        logger.WideningValueColumn(tableName);
+
+        var migrationBuilder = new MigrationBuilder(context.Database.ProviderName);
+
+        if (context.Database.IsNpgsql())
+        {
+            migrationBuilder.Sql("ALTER TABLE \"" + tableName + "\" ALTER COLUMN \"Value\" TYPE TEXT");
+        }
+        else if (context.Database.IsSqlServer())
+        {
+            migrationBuilder.Sql("ALTER TABLE [" + tableName + "] ALTER COLUMN [Value] NVARCHAR(MAX)");
+        }
+
+        if (migrationBuilder.Operations.Count > 0)
+        {
+            await tableMigrator.ExecuteMigrationOperations(context, migrationBuilder);
+        }
+
+        _columnMigrations.TryAdd(cacheKey, true);
+    }
 }
-
-

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueConstraints/UniqueConstraintMigratorLogging.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueConstraints/UniqueConstraintMigratorLogging.cs
@@ -12,4 +12,7 @@ internal static partial class UniqueConstraintMigratorLogging
 {
     [LoggerMessage(LogLevel.Debug, "Creating unique constraint table {TableName}")]
     internal static partial void CreatingUniqueConstraintTable(this ILogger<UniqueConstraintMigrator> logger, string tableName);
+
+    [LoggerMessage(LogLevel.Information, "Widening Value column in unique constraint table {TableName} from VARCHAR(200) to unbounded text")]
+    internal static partial void WideningValueColumn(this ILogger<UniqueConstraintMigrator> logger, string tableName);
 }


### PR DESCRIPTION
## Fixed

- SQL backend: Workbench event-store list and namespace dropdown now populate correctly — SSE observable subscriptions were silently receiving no data because the BehaviorSubject's initial emission was swallowed by a non-replaying Subject intermediary before any subscriber was attached
- SQL backend: Appending events no longer fails with `value too long for type character varying(200)` when a unique constraint value (e.g. a long email address) exceeds 200 characters — the `Value` column is now created as unbounded text, and existing tables are automatically altered in-place on next startup