### PR TITLE
Resolve passive read models via immediate projection

### DIFF
--- a/Integration/Client/for_ReadModels/when_getting_instance_by_key/and_projection_is_active.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instance_by_key/and_projection_is_active.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_by_key.and_projection_is_active.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_by_key;
+
+[Collection(ChronicleCollection.Name)]
+public class and_projection_is_active(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : given.a_projection_with_events(chronicleFixture)
+    {
+        public SomeReadModel Result;
+
+        async Task Because()
+        {
+            var handler = EventStore.Projections.GetHandlerFor<SomeProjection>();
+            await handler.WaitTillActive();
+
+            await EventStore.EventLog.Append(EventSourceId, FirstEvent);
+            var appendResult = await EventStore.EventLog.Append(EventSourceId, SecondEvent);
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            // A materialized (active) projection resolves by its specific key from the stored sink.
+            Result = await EventStore.ReadModels.GetInstanceById<SomeReadModel>(EventSourceId.Value);
+        }
+    }
+
+    [Fact] void should_return_the_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_number_from_first_event() => Context.Result.Number.ShouldEqual(Context.FirstEvent.Number);
+    [Fact] void should_have_value_from_second_event() => Context.Result.Value.ShouldEqual(Context.SecondEvent.Value);
+}

--- a/Integration/Client/for_ReadModels/when_getting_instance_for_passive_projection/and_parent_event_exists.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instance_for_passive_projection/and_parent_event_exists.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_for_passive_projection.and_parent_event_exists.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_for_passive_projection;
+
+[Collection(ChronicleCollection.Name)]
+public class and_parent_event_exists(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        public Guid ApplicationId;
+        public PassiveApplication Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(PassiveApplicationCreated),
+            typeof(PassiveEventModelCreated)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(PassiveApplication)];
+
+        async Task Because()
+        {
+            ApplicationId = Guid.Parse("a1b2c3d4-e5f6-7890-abcd-555555555555");
+
+            // A passive projection never subscribes an observer, so nothing is ever written to a
+            // materialized sink. Appending the parent event and immediately resolving the instance by
+            // key must produce the read model via on-demand immediate projection — not return null.
+            await EventStore.EventLog.Append(ApplicationId.ToString(), new PassiveApplicationCreated("Sample Application"));
+
+            Result = await EventStore.ReadModels.GetInstanceById<PassiveApplication>(ApplicationId.ToString());
+        }
+    }
+
+    [Fact] void should_return_the_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_set_the_application_name() => Context.Result.Name.ShouldEqual("Sample Application");
+
+    // The immediate projection replays only the parent event source, so the joined children
+    // collection is left unset (null) when no child events exist — the value the reactor reads
+    // back via a null-conditional access. The regression returned a null *model*, which is what
+    // this spec guards against.
+    [Fact] void should_not_have_event_models_yet() => Context.Result.EventModels.ShouldBeNull();
+}
+
+[EventType]
+public record PassiveApplicationCreated(string Name);
+
+[EventType]
+public record PassiveEventModelCreated(Guid ApplicationId, string Name);
+
+[Passive]
+[FromEvent<PassiveApplicationCreated>]
+public record PassiveApplication(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<PassiveEventModelCreated>(parentKey: nameof(PassiveEventModelCreated.ApplicationId))]
+    IEnumerable<PassiveEventModel> EventModels);
+
+[FromEvent<PassiveEventModelCreated>]
+public record PassiveEventModel(Guid Id, string Name);
+
+#pragma warning restore SA1402

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/with_passive_read_model.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/with_passive_read_model.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Sinks;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_registering;
+
+public class with_passive_read_model : given.all_dependencies_with_configured_sink
+{
+    [Passive]
+    class MyPassiveReadModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    Contracts.ReadModels.IReadModels _readModelsService;
+    RegisterManyRequest _capturedRequest;
+    IProjectionHandler _projectionHandler;
+
+    void Establish()
+    {
+        _projectionHandler = Substitute.For<IProjectionHandler>();
+        _projectionHandler.ReadModelType.Returns(typeof(MyPassiveReadModel));
+        _projectionHandler.Id.Returns(new ProjectionId(Guid.NewGuid().ToString()));
+
+        _projections.GetAllHandlers().Returns([_projectionHandler]);
+        _reducers.GetAllHandlers().Returns([]);
+
+        _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
+        _services.ReadModels.Returns(_readModelsService);
+        _readModelsService.When(_ => _.RegisterMany(Arg.Any<RegisterManyRequest>()))
+            .Do(_ => _capturedRequest = _.Arg<RegisterManyRequest>());
+    }
+
+    async Task Because() => await _readModels.Register();
+
+    [Fact] void should_register_with_none_sink_type() => _capturedRequest.ReadModels[0].Sink.TypeId.ShouldEqual(SinkTypeId.None.Value);
+}

--- a/Source/Clients/DotNET/ReadModels/ReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModels.cs
@@ -94,7 +94,7 @@ public class ReadModels(
                 Sink = new()
                 {
                     ConfigurationId = Guid.Empty,
-                    TypeId = _defaultSinkTypeId
+                    TypeId = GetSinkTypeIdFor(readModel.ReadModelType)
                 },
                 Schema = schemaGenerator.Generate(readModel.ReadModelType).ToJson(),
                 Indexes = GetIndexesForType(readModel.ReadModelType, string.Empty),
@@ -150,7 +150,7 @@ public class ReadModels(
                 Sink = new()
                 {
                     ConfigurationId = Guid.Empty,
-                    TypeId = _defaultSinkTypeId
+                    TypeId = GetSinkTypeIdFor(typeof(TReadModel))
                 },
                 Schema = schemaGenerator.Generate(typeof(TReadModel)).ToJson(),
                 Indexes = GetIndexesForType(typeof(TReadModel), string.Empty),
@@ -460,6 +460,19 @@ public class ReadModels(
 
         return released;
     }
+
+    /// <summary>
+    /// Resolves the <see cref="SinkTypeId"/> for a read model type.
+    /// </summary>
+    /// <param name="readModelType">The read model type to resolve the sink for.</param>
+    /// <returns>The <see cref="SinkTypeId"/> to register the read model with.</returns>
+    /// <remarks>
+    /// Passive read models never have an observer writing to a materialized sink, so they register
+    /// with <see cref="SinkTypeId.None"/>. This lets the kernel fall through to immediate
+    /// projection when resolving the instance by key instead of reading an empty sink and returning null.
+    /// </remarks>
+    SinkTypeId GetSinkTypeIdFor(Type readModelType) =>
+        readModelType.IsPassive() ? SinkTypeId.None : _defaultSinkTypeId;
 
     List<IndexDefinition> GetIndexesForType(Type type, string prefix)
     {

--- a/Source/Clients/DotNET/Sinks/SinkTypeId.cs
+++ b/Source/Clients/DotNET/Sinks/SinkTypeId.cs
@@ -10,7 +10,12 @@ namespace Cratis.Chronicle.Sinks;
 public record SinkTypeId(string Value) : ConceptAs<string>(Value)
 {
     /// <summary>
-    /// Implicitly convert from <see cref="string"/> representation of a <see cref="Guid"/> to <see cref="SinkTypeId"/>.
+    /// Gets the none representation of <see cref="SinkTypeId"/>.
+    /// </summary>
+    public static readonly SinkTypeId None = "None";
+
+    /// <summary>
+    /// Implicitly convert from <see cref="string"/> to <see cref="SinkTypeId"/>.
     /// </summary>
     /// <param name="value">String value to convert from.</param>
     public static implicit operator SinkTypeId(string value) => new(value);

--- a/Source/Clients/DotNET/Sinks/WellKnownSinkTypes.cs
+++ b/Source/Clients/DotNET/Sinks/WellKnownSinkTypes.cs
@@ -14,11 +14,6 @@ public static class WellKnownSinkTypes
     public static readonly SinkTypeId InMemory = "InMemory";
 
     /// <summary>
-    /// Gets the identifier of the NotSet projection sink (no sink).
-    /// </summary>
-    public static readonly SinkTypeId NotSet = "NotSet";
-
-    /// <summary>
     /// Gets the identifier of the MongoDB projection sink.
     /// </summary>
     public static readonly SinkTypeId MongoDB = "MongoDB";

--- a/Source/Kernel/Concepts/Sinks/WellKnownSinkTypes.cs
+++ b/Source/Kernel/Concepts/Sinks/WellKnownSinkTypes.cs
@@ -14,11 +14,6 @@ public static class WellKnownSinkTypes
     public static readonly SinkTypeId InMemory = "InMemory";
 
     /// <summary>
-    /// Gets the identifier of the NotSet projection sink (no sink).
-    /// </summary>
-    public static readonly SinkTypeId NotSet = "NotSet";
-
-    /// <summary>
     /// Gets the identifier of the MongoDB projection sink.
     /// </summary>
     public static readonly SinkTypeId MongoDB = "MongoDB";

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_an_immediate_projection_with_pii.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_an_immediate_projection_with_pii.cs
@@ -37,7 +37,7 @@ public class and_read_model_is_an_immediate_projection_with_pii : given.all_depe
         _readModel.GetDefinition().Returns(_readModelDefinition);
 
         // Passive sink → the lookup falls through to the immediate projection.
-        _sink.TypeId.Returns(WellKnownSinkTypes.NotSet);
+        _sink.TypeId.Returns(SinkTypeId.None);
 
         var immediateProjection = Substitute.For<IImmediateProjection>();
         immediateProjection.GetModelInstance().Returns(new ProjectionResult(

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -214,7 +214,7 @@ internal sealed class ReadModels(
                 var sink = await namespaceStorage.Sinks.GetFor(definition);
 
                 // For passive projections the sink never has data; fall through to immediate projection.
-                if (sink.TypeId != WellKnownSinkTypes.NotSet)
+                if (sink.TypeId != SinkTypeId.None)
                 {
                     var key = new Key(request.ReadModelKey, ArrayIndexers.NoIndexers);
                     var storedState = await sink.FindOrDefault(key);

--- a/Source/Kernel/Storage/Sinks/NullProjectionSinkFactory.cs
+++ b/Source/Kernel/Storage/Sinks/NullProjectionSinkFactory.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.Storage.Sinks;
 public class NullProjectionSinkFactory : ISinkFactory
 {
     /// <inheritdoc/>
-    public SinkTypeId TypeId => WellKnownSinkTypes.NotSet;
+    public SinkTypeId TypeId => SinkTypeId.None;
 
     /// <inheritdoc/>
     public ISink CreateFor(EventStoreName eventStore, EventStoreNamespaceName @namespace, ReadModelDefinition readModel) => NullSink.Instance;

--- a/Source/Kernel/Storage/Sinks/NullSink.cs
+++ b/Source/Kernel/Storage/Sinks/NullSink.cs
@@ -25,7 +25,7 @@ public class NullSink : ISink
     public static readonly NullSink Instance = new();
 
     /// <inheritdoc/>
-    public SinkTypeId TypeId => WellKnownSinkTypes.NotSet;
+    public SinkTypeId TypeId => SinkTypeId.None;
 
     /// <inheritdoc/>
     public Task<IEnumerable<FailedPartition>> ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset, EventSequenceNumber eventSequenceNumber) =>


### PR DESCRIPTION
## Fixed
- Resolving a passive read model by id now returns the projected instance via immediate projection instead of `null`. Passive read models were registered with the default sink (which they never write to), so look-ups read an empty sink and returned `null`, crashing reactors that consumed the result.
