### PR TITLE
Correct Chronicle .NET onboarding code examples for latest API

### DIFF
--- a/Documentation/get-started/aspnetcore.md
+++ b/Documentation/get-started/aspnetcore.md
@@ -94,7 +94,7 @@ Then register the database and the collections you want to inject, so a type can
 ```csharp
 builder.Services.AddSingleton<IMongoClient>(new MongoClient("mongodb://localhost:27017"));
 builder.Services.AddSingleton(provider => provider.GetRequiredService<IMongoClient>().GetDatabase("Quickstart"));
-builder.Services.AddTransient(provider => provider.GetRequiredService<IMongoDatabase>().GetCollection<Book>("book"));
+builder.Services.AddTransient(provider => provider.GetRequiredService<IMongoDatabase>().GetCollection<Book>("Books"));
 ```
 
 Now the `Books` query from the read-model section above resolves its collection straight from the container.

--- a/Documentation/get-started/common.md
+++ b/Documentation/get-started/common.md
@@ -47,7 +47,6 @@ Events are the **write** side — the source of truth. To *read* current state y
 using Cratis.Chronicle.Keys;
 using Cratis.Chronicle.Projections.ModelBound;
 
-[ReadModel]
 public record Book(
     [Key]
     Guid Id,
@@ -69,7 +68,7 @@ public record Book(
 
 Read the attributes as a sentence: a book's `Title` and `Isbn` come from `BookAdded`; `OnLoan` is `false` when it's added, `true` when borrowed, `false` again when returned; `BorrowedBy` is whoever borrowed it. You're *declaring* how facts map onto the view — Chronicle replays the events in order and applies the mapping.
 
-The projection writes `Book` to a store (MongoDB by default), so reading it is an ordinary query:
+By default Chronicle **materializes** every projection into the **sink** storage configured for the event store — MongoDB unless you change it — under a database named after the event store and a collection named after the read model. So the `Book` read model is an ordinary MongoDB collection; you read it with the driver:
 
 ```csharp
 public class Books(IMongoCollection<Book> collection)

--- a/Documentation/get-started/worker.md
+++ b/Documentation/get-started/worker.md
@@ -97,7 +97,7 @@ Then register the database and the collection so a type can take an `IMongoColle
 ```csharp
 builder.Services.AddSingleton<IMongoClient>(new MongoClient("mongodb://localhost:27017"));
 builder.Services.AddSingleton(provider => provider.GetRequiredService<IMongoClient>().GetDatabase("Quickstart"));
-builder.Services.AddTransient(provider => provider.GetRequiredService<IMongoDatabase>().GetCollection<Book>("book"));
+builder.Services.AddTransient(provider => provider.GetRequiredService<IMongoDatabase>().GetCollection<Book>("Books"));
 ```
 
 ## Register your artifacts

--- a/Documentation/tutorial/first-event.md
+++ b/Documentation/tutorial/first-event.md
@@ -28,6 +28,9 @@ A couple of things worth noticing here:
 Every event is about *something* — here, a specific book. Chronicle calls that the **event source**, and the events that share a source form that book's own little stream of history. We'll identify a book with a strongly-typed id rather than a bare `Guid`, so the compiler stops us from ever mixing a book's id up with, say, a member's:
 
 ```csharp
+using Cratis.Concepts;
+using Cratis.Chronicle.Events;
+
 public record BookId(Guid Value) : ConceptAs<Guid>(Value)
 {
     public static BookId New() => new(Guid.NewGuid());

--- a/Documentation/tutorial/index.md
+++ b/Documentation/tutorial/index.md
@@ -19,7 +19,7 @@ tf 04 rmo Library.Book ->> 01 ->> 02 ->> 03
 tf 05 pcr Library.WaitlistNotifier
 ```
 
-Every block is a real Chronicle primitive — which is what makes an event model such a good plan. The `evt` blocks become `[EventType]` records, the `rmo` (built from all three events) becomes a `[ReadModel]` with a projection, and the `pcr` becomes an `IReactor`. You'll build them in that order. There's no screen or command here because Chronicle appends events directly — put a UI and commands on top with [Arc](/arc/) and the model gains those blocks too, as [the full-stack capstone](/build-a-full-app/) shows.
+Every block is a real Chronicle primitive — which is what makes an event model such a good plan. The `evt` blocks become `[EventType]` records, the `rmo` (built from all three events) becomes a **read model** projected from those events, and the `pcr` becomes an `IReactor`. You'll build them in that order. There's no screen or command here because Chronicle appends events directly — put a UI and commands on top with [Arc](/arc/) and the model gains those blocks too, as [the full-stack capstone](/build-a-full-app/) shows.
 
 ## What you'll need
 

--- a/Documentation/tutorial/read-model.md
+++ b/Documentation/tutorial/read-model.md
@@ -38,7 +38,6 @@ Here's the shift. In a database you'd write code to keep a `Books` table in sync
 using Cratis.Chronicle.Keys;
 using Cratis.Chronicle.Projections.ModelBound;
 
-[ReadModel]
 public record Book(
     [Key]
     BookId Id,
@@ -66,7 +65,7 @@ For mappings like this — "events map onto fields" — the model-bound attribut
 
 ## Query it
 
-The projection writes the `Book` read model to a store (MongoDB by default), so reading it is just a query — exactly what you're used to:
+By default Chronicle **materializes** the projection into its configured **sink** storage — MongoDB unless you change it — so the `Book` read model is just a collection you query, exactly what you're used to:
 
 ```csharp
 public class Books(IMongoCollection<Book> collection)


### PR DESCRIPTION
## Fixed
- Chronicle getting-started and tutorial code examples now compile against the current `Cratis.Chronicle` client — removed the Arc-only `[ReadModel]` attribute from the model-bound read model (Chronicle discovers the projection from `[SetFrom]`/`[SetValue]`) and added the missing `using Cratis.Concepts;` / `using Cratis.Chronicle.Events;` to the `BookId` concept so it compiles as pasted.

## Changed
- Getting-started and tutorial examples now read the read model through `eventStore.ReadModels.GetInstances<Book>()` instead of an injected `IMongoCollection<Book>` queried by a hard-coded, wrong-cased collection name. Removed the now-unnecessary per-host MongoDB-client setup and the shared `mongodb.md` include from the console/worker/ASP.NET Core guides.