### PR TITLE
Fix self-referential projection with keyed class-level FromEvent attributes

### DIFF
--- a/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/and_keyed_from_event_is_appended_with_sub_features.cs
+++ b/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/and_keyed_from_event_is_appended_with_sub_features.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_projecting_self_referential_children_with_keyed_from_event.and_keyed_from_event_is_appended_with_sub_features.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_projecting_self_referential_children_with_keyed_from_event;
+
+[Collection(ChronicleCollection.Name)]
+public class and_keyed_from_event_is_appended_with_sub_features(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture)
+        : given.a_self_ref_keyed_module_with_features(chronicleFixture)
+    {
+        public KeyedSelfRefFeature Result;
+
+        async Task Because()
+        {
+            await AppendFeature();
+            await AppendSubFeature();
+            await AppendTemplateUpdate();
+            Result = await ChronicleFixture.EventStore.ReadModels.GetInstanceByKey<KeyedSelfRefFeature>(Feature1Id);
+        }
+    }
+
+    [Fact]
+    void should_have_feature_name() => Context.Result.Name.ShouldEqual("Feature 1");
+
+    [Fact]
+    void should_have_ui_template_set() => Context.Result.UITemplateId.ShouldEqual("template-1");
+
+    [Fact]
+    void should_have_one_sub_feature() => Context.Result.SubFeatures.ShouldNotBeNull().Count().ShouldEqual(1);
+
+    [Fact]
+    void should_have_sub_feature_name() => Context.Result.SubFeatures!.First().Name.ShouldEqual("Sub Feature 1");
+
+    [Fact]
+    void should_not_have_self_as_sub_feature() =>
+        Context.Result.SubFeatures!.Any(sf => sf.Name == Context.Result.Name).ShouldBeFalse();
+}

--- a/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/and_keyed_from_event_is_appended_without_sub_features.cs
+++ b/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/and_keyed_from_event_is_appended_without_sub_features.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_projecting_self_referential_children_with_keyed_from_event.and_keyed_from_event_is_appended_without_sub_features.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_projecting_self_referential_children_with_keyed_from_event;
+
+[Collection(ChronicleCollection.Name)]
+public class and_keyed_from_event_is_appended_without_sub_features(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture)
+        : given.a_self_ref_keyed_module_with_features(chronicleFixture)
+    {
+        public KeyedSelfRefFeature Result;
+
+        async Task Because()
+        {
+            await AppendFeature();
+            await AppendTemplateUpdate();
+            Result = await ChronicleFixture.EventStore.ReadModels.GetInstanceByKey<KeyedSelfRefFeature>(Feature1Id);
+        }
+    }
+
+    [Fact]
+    void should_have_feature_name() => Context.Result.Name.ShouldEqual("Feature 1");
+
+    [Fact]
+    void should_have_ui_template_set() => Context.Result.UITemplateId.ShouldEqual("template-1");
+
+    [Fact]
+    void should_have_no_sub_features() => Context.Result.SubFeatures.ShouldBeNull();
+}

--- a/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/given/a_self_ref_keyed_module_with_features.cs
+++ b/Integration/Client/for_ReadModels/when_projecting_self_referential_children_with_keyed_from_event/given/a_self_ref_keyed_module_with_features.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_projecting_self_referential_children_with_keyed_from_event.given;
+
+public class a_self_ref_keyed_module_with_features(ChronicleFixture chronicleFixture) : Specification
+{
+    protected ChronicleFixture ChronicleFixture => chronicleFixture;
+
+    protected EventSourceId Feature1Id { get; private set; }
+
+    protected KeyedSelfRefSubFeatureAdded SubFeature1AddedEvent { get; private set; }
+    protected KeyedSelfRefFeatureUITemplateSet Feature1TemplateSetEvent { get; private set; }
+
+    void Establish()
+    {
+        Feature1Id = EventSourceId.From("feature-1");
+        SubFeature1AddedEvent = new KeyedSelfRefSubFeatureAdded(Feature1Id, "Sub Feature 1");
+        Feature1TemplateSetEvent = new KeyedSelfRefFeatureUITemplateSet(Feature1Id, "template-1");
+    }
+
+    protected async Task AppendFeature()
+    {
+        await ChronicleFixture.EventStore.EventLog.Append(Feature1Id, new KeyedSelfRefFeatureAdded("Feature 1"));
+    }
+
+    protected async Task AppendSubFeature()
+    {
+        await ChronicleFixture.EventStore.EventLog.Append(Feature1Id, SubFeature1AddedEvent);
+    }
+
+    protected async Task AppendTemplateUpdate()
+    {
+        await ChronicleFixture.EventStore.EventLog.Append(Feature1Id, Feature1TemplateSetEvent);
+    }
+}
+
+[EventType]
+public record KeyedSelfRefFeatureAdded(string Name);
+
+[EventType]
+public record KeyedSelfRefSubFeatureAdded(EventSourceId ParentFeatureId, string Name);
+
+[EventType]
+public record KeyedSelfRefFeatureUITemplateSet(EventSourceId FeatureId, string UITemplateId);
+
+[FromEvent<KeyedSelfRefFeatureAdded>]
+[FromEvent<KeyedSelfRefSubFeatureAdded>(parentKey: nameof(KeyedSelfRefSubFeatureAdded.ParentFeatureId))]
+[FromEvent<KeyedSelfRefFeatureUITemplateSet>(key: nameof(KeyedSelfRefFeatureUITemplateSet.FeatureId))]
+[ReadModel]
+public record KeyedSelfRefFeature(
+    string Name,
+    string? UITemplateId = null,
+    [ChildrenFrom<KeyedSelfRefSubFeatureAdded>(
+        identifiedBy: nameof(KeyedSelfRefFeature.Name),
+        parentKey: nameof(KeyedSelfRefSubFeatureAdded.ParentFeatureId))]
+    IEnumerable<KeyedSelfRefFeature>? SubFeatures = null);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_having/self_referencing_children_with_keyed_from_event.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_having/self_referencing_children_with_keyed_from_event.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_children_having;
+
+public class self_referencing_children_with_keyed_from_event : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([
+            typeof(SelfRefKeyedModuleCreated),
+            typeof(SelfRefKeyedFeatureAdded),
+            typeof(SelfRefKeyedSubFeatureAdded),
+            typeof(SelfRefKeyedFeatureUITemplateSet)
+        ]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(SelfRefKeyedModule));
+
+    [Fact]
+    void should_not_add_keyed_from_event_as_nested_sub_feature_creator()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(SelfRefKeyedFeatureUITemplateSet)).ToContract();
+        var featureChildrenDef = _result.Children[nameof(SelfRefKeyedModule.Features)];
+        var subFeaturesDef = featureChildrenDef.Children[nameof(SelfRefKeyedFeature.SubFeatures)];
+        subFeaturesDef.From.Keys.ShouldNotContain(et => et.IsEqual(eventType));
+    }
+
+    [Fact]
+    void should_still_add_structural_self_ref_event_to_nested_sub_features()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(SelfRefKeyedSubFeatureAdded)).ToContract();
+        var featureChildrenDef = _result.Children[nameof(SelfRefKeyedModule.Features)];
+        var subFeaturesDef = featureChildrenDef.Children[nameof(SelfRefKeyedFeature.SubFeatures)];
+        subFeaturesDef.From.Keys.ShouldContain(et => et.IsEqual(eventType));
+    }
+}
+
+[EventType]
+public record SelfRefKeyedModuleCreated(string Name);
+
+[EventType]
+public record SelfRefKeyedFeatureAdded(SelfRefKeyedModuleId ModuleId, SelfRefKeyedFeatureId FeatureId, string Name);
+
+[EventType]
+public record SelfRefKeyedSubFeatureAdded(SelfRefKeyedFeatureId ParentFeatureId, string Name);
+
+[EventType]
+public record SelfRefKeyedFeatureUITemplateSet(SelfRefKeyedFeatureId FeatureId, string UITemplateId);
+
+public record SelfRefKeyedModuleId(Guid Value);
+public record SelfRefKeyedFeatureId(Guid Value);
+
+[FromEvent<SelfRefKeyedFeatureAdded>]
+[FromEvent<SelfRefKeyedSubFeatureAdded>(parentKey: nameof(SelfRefKeyedSubFeatureAdded.ParentFeatureId))]
+[FromEvent<SelfRefKeyedFeatureUITemplateSet>(key: nameof(SelfRefKeyedFeatureUITemplateSet.FeatureId))]
+public record SelfRefKeyedFeature(
+    [Key] SelfRefKeyedFeatureId Id,
+    string Name,
+    string? UITemplateId,
+    [ChildrenFrom<SelfRefKeyedSubFeatureAdded>(
+        identifiedBy: nameof(SelfRefKeyedFeature.Id),
+        parentKey: nameof(SelfRefKeyedSubFeatureAdded.ParentFeatureId))]
+    IEnumerable<SelfRefKeyedFeature> SubFeatures);
+
+[FromEvent<SelfRefKeyedModuleCreated>]
+public record SelfRefKeyedModule(
+    [Key] SelfRefKeyedModuleId Id,
+    string Name,
+    [ChildrenFrom<SelfRefKeyedFeatureAdded>(
+        key: nameof(SelfRefKeyedFeatureAdded.FeatureId),
+        identifiedBy: nameof(SelfRefKeyedFeature.Id),
+        parentKey: nameof(SelfRefKeyedFeatureAdded.ModuleId))]
+    IEnumerable<SelfRefKeyedFeature> Features);
+
+#pragma warning restore SA1402

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -9,6 +9,8 @@ using Cratis.Chronicle.Properties;
 using Cratis.Serialization;
 using EventType = Cratis.Chronicle.Contracts.Events.EventType;
 
+#pragma warning disable SA1313
+
 namespace Cratis.Chronicle.Projections.ModelBound;
 
 /// <summary>
@@ -357,10 +359,11 @@ static class ChildrenDefinitionExtensions
 
                     if (includeSelfReferencingEvents && shouldAutoMap && !hasExplicitMapping)
                     {
-                        foreach (var fromEventType in childType
+                        foreach (var (fromEventAttr, fromEventType) in childType
                             .GetAttributesOfGenericType<FromEventAttribute<object>>()
-                            .Select(_ => _.EventType)
-                            .Where(fromEventType => fromEventType.GetProperty(parameter.Name!, BindingFlags.Public | BindingFlags.Instance) is not null))
+                            .Where(pair =>
+                                ShouldPropagateChildClassLevelFromEventForSelfReference(pair.Attribute, childType, eventType, parentModelType, namingPolicy) &&
+                                pair.EventType.GetProperty(parameter.Name!, BindingFlags.Public | BindingFlags.Instance) is not null))
                         {
                             childrenDef.From.AddSetMapping(getOrCreateEventType, namingPolicy, fromEventType, paramPropertyName, parameter.Name!);
                         }
@@ -396,7 +399,9 @@ static class ChildrenDefinitionExtensions
             var childClassLevelFromEvents = childType.GetCustomAttributes()
                 .Where(attr => attr.GetType().IsGenericType &&
                               attr.GetType().GetGenericTypeDefinition() == typeof(FromEventAttribute<>) &&
-                              (includeSelfReferencingEvents || ShouldPropagateChildClassLevelFromEvent(attr, childType)))
+                              (includeSelfReferencingEvents
+                                  ? ShouldPropagateChildClassLevelFromEventForSelfReference(attr, childType, eventType, parentModelType, namingPolicy)
+                                  : ShouldPropagateChildClassLevelFromEvent(attr, childType)))
                 .ToList();
 
             // Process properties for attributes (this handles SetFromContext and other attributes on properties)
@@ -530,6 +535,40 @@ static class ChildrenDefinitionExtensions
 
         var eventType = fromEventAttribute.GetType().GetGenericArguments()[0];
         return !HasChildrenFromForEventType(childType, eventType);
+    }
+
+    static bool ShouldPropagateChildClassLevelFromEventForSelfReference(
+        Attribute fromEventAttribute,
+        Type _1,
+        Type childCreatingEventType,
+        Type? _2,
+        INamingPolicy _3)
+    {
+        var childLevelEventType = fromEventAttribute.GetType().GetGenericArguments()[0];
+
+        // Always propagate if it's the child-creating event itself
+        if (childLevelEventType == childCreatingEventType)
+        {
+            return true;
+        }
+
+        // For other events: check if they are keyed update events
+        var keyProperty = fromEventAttribute.GetType().GetProperty(nameof(FromEventAttribute<object>.Key));
+        var parentKeyProperty = fromEventAttribute.GetType().GetProperty(nameof(FromEventAttribute<object>.ParentKey));
+
+        var key = keyProperty?.GetValue(fromEventAttribute) as string;
+        var parentKey = parentKeyProperty?.GetValue(fromEventAttribute) as string;
+
+        // If it doesn't have an explicit key, it's not a keyed event, so propagate it
+        if (string.IsNullOrEmpty(key))
+        {
+            return true;
+        }
+
+        // It has an explicit key. Only propagate if it also has an EXPLICIT parent key.
+        // Keyed update events without explicit parent keys should not be propagated in self-referential cases,
+        // as they would be upserted as self-children when resolved via EventSourceId fallback.
+        return !string.IsNullOrEmpty(parentKey);
     }
 
     static bool ShouldPropagateChildMemberEvent(Type eventType, Type? childType, bool includeSelfReferencingEvents)


### PR DESCRIPTION
## Fixed
- Prevent keyed update events without explicit parent keys from being propagated to nested self-referential children definitions, which was causing stack overflow on tree traversal