### PR TITLE
Update NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,14 +12,14 @@
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting" Version="13.4.3" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.15.0" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.15.0" />
-    <PackageVersion Include="Cratis.Arc" Version="20.40.0" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.40.0" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.40.0" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.40.0" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.40.0" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.40.0" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.15.1" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.15.1" />
+    <PackageVersion Include="Cratis.Arc" Version="20.40.1" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.40.1" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.40.1" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.40.1" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.40.1" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.40.1" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.52" />
-    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
+    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.5" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
@@ -126,7 +126,7 @@
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
-    <PackageVersion Include="SharpCompress" Version="0.49.1" />
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET9.props" Condition=" '$(TargetFramework)' == 'net9.0' " />


### PR DESCRIPTION
## Changed
- Bump Cratis packages to latest patch versions (7.15.1 and 20.40.1)
- Update protobuf-net.Grpc to 1.2.5
- Update SharpCompress to 1.0.0