### PR TITLE
Migrate Kotlin client to modern Maven Central publishing

### DIFF
--- a/.github/workflows/publish-kotlin-client.yml
+++ b/.github/workflows/publish-kotlin-client.yml
@@ -77,9 +77,9 @@ jobs:
 
       - name: Publish to Maven Central
         working-directory: ./Source/Clients/Kotlin
-        run: gradle publishToMavenCentral --no-configuration-cache -Pversion=${{ inputs.version }}
+        run: gradle publishAllPublicationsToMavenCentral --no-configuration-cache -Pversion=${{ inputs.version }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/Source/Clients/Kotlin/build.gradle.kts
+++ b/Source/Clients/Kotlin/build.gradle.kts
@@ -61,11 +61,11 @@ mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
-    coordinates("io.cratis", "chronicle-contracts", version.toString())
+    coordinates("io.cratis", "chronicle-client-kotlin", version.toString())
 
     pom {
-        name.set("Chronicle Contracts")
-        description.set("Generated gRPC Kotlin client for the Cratis Chronicle event sourcing platform")
+        name.set("Chronicle Kotlin Client")
+        description.set("Event sourcing Kotlin client for Chronicle")
         url.set("https://github.com/cratis/chronicle")
         licenses {
             license {


### PR DESCRIPTION
## Changed
- Kotlin client artifact ID corrected to `chronicle-client-kotlin` and POM metadata updated to match its purpose
- Kotlin publish pipeline updated to use `publishAllPublicationsToMavenCentral` task and correct `signingInMemoryKeyPassword` environment variable required by the vanniktech plugin for the new Central Portal API