### PR TITLE
Fix Kotlin Maven Central artifact ID and publish task

### DIFF
--- a/.github/workflows/publish-kotlin-client.yml
+++ b/.github/workflows/publish-kotlin-client.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Publish to Maven Central
         working-directory: ./Source/Clients/Kotlin
-        run: gradle publishAllPublicationsToMavenCentral --no-configuration-cache -Pversion=${{ inputs.version }}
+        run: gradle publishAndReleaseToMavenCentral --no-configuration-cache -Pversion=${{ inputs.version }}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/Source/Clients/Kotlin/build.gradle.kts
+++ b/Source/Clients/Kotlin/build.gradle.kts
@@ -61,7 +61,7 @@ mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
-    coordinates("io.cratis", "chronicle-client-kotlin", version.toString())
+    coordinates("io.cratis", "chronicle-contracts", version.toString())
 
     pom {
         name.set("Chronicle Kotlin Client")


### PR DESCRIPTION
## Fixed
- Corrected Kotlin client Maven artifact ID from `chronicle-client-kotlin` to `chronicle-contracts`
- Switched publish Gradle task to `publishAndReleaseToMavenCentral` to auto-release on Maven Central without a manual staging step