### PR TITLE
Fix invalid YAML indentation breaking the build & integration pipeline

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -317,6 +317,7 @@ jobs:
             git commit -m "Update coverage statistics [skip ci]"
             git pull --rebase origin ${{ github.ref_name }}
             git push
+          fi
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,17 +147,17 @@ jobs:
             Integration/Client/Client.csproj \
             "FullyQualifiedName~${{ matrix.namespace }}" \
             -p:DisableDockerBuild=true \
-           -p:EnableDevelopmentSymbol=true \
-           --collect:"XPlat Code Coverage" \
-           --results-directory ./coverage-results
+            -p:EnableDevelopmentSymbol=true \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./coverage-results
 
       - name: Upload coverage results
-       if: always()
-       uses: actions/upload-artifact@v4
-       with:
-         name: coverage-results-client-${{ matrix.namespace }}-${{ matrix.mode }}-${{ matrix.database }}
-         path: ./coverage-results/
-         retention-days: 1
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-results-client-${{ matrix.namespace }}-${{ matrix.mode }}-${{ matrix.database }}
+          path: ./coverage-results/
+          retention-days: 1
 
   kernel-integration-specs:
     needs: [discover]
@@ -206,14 +206,14 @@ jobs:
           .github/scripts/run-tests-with-retry.sh \
             Integration/Kernel/Kernel.csproj \
             "FullyQualifiedName~${{ matrix.namespace }}" \
-           -p:EnableDevelopmentSymbol=true \
-           --collect:"XPlat Code Coverage" \
-           --results-directory ./coverage-results
+            -p:EnableDevelopmentSymbol=true \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./coverage-results
 
       - name: Upload coverage results
-       if: always()
-       uses: actions/upload-artifact@v4
-       with:
-         name: coverage-results-kernel-${{ matrix.namespace }}
-         path: ./coverage-results/
-         retention-days: 1
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-results-kernel-${{ matrix.namespace }}
+          path: ./coverage-results/
+          retention-days: 1


### PR DESCRIPTION
## Fixed

- The `.NET Build & Integration` pipeline failed validation immediately (0s) on every pull request, so no PR could build or run integration specs. The integration workflow's coverage-collection steps were indented with 7 spaces instead of 8, making the workflow file invalid YAML; every workflow that calls it as a reusable workflow failed to validate. Corrected the indentation and added a missing `fi` in the coverage-statistics step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)