### PR TITLE
Fix duplicate --results-directory breaking integration test jobs

### DIFF
--- a/.github/scripts/run-tests-with-retry.sh
+++ b/.github/scripts/run-tests-with-retry.sh
@@ -31,7 +31,11 @@ EXTRA_ARGS=("$@")
 
 MAX_ATTEMPTS="${TEST_MAX_ATTEMPTS:-3}"
 MAX_RETRY_TESTS="${TEST_MAX_RETRY_TESTS:-20}"
-RESULTS_DIR="$(mktemp -d)"
+# This script owns --results-directory (TRX files are read back to find failed tests on retry).
+# Callers that also want coverage collected into a known location set TEST_RESULTS_DIR so both the
+# TRX files and the coverage results land there — passing a second --results-directory as an extra
+# arg would make `dotnet test` fail with "expects a single argument but 2 were provided".
+RESULTS_DIR="${TEST_RESULTS_DIR:-$(mktemp -d)}"
 
 # Extracts the fully-qualified names of failed tests from a TRX result file.
 extract_failed() {

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -138,6 +138,9 @@ jobs:
           # to do and its anonymous Docker Hub manifest call at session
           # init is a frequent source of flakiness. Disable it on CI.
           TESTCONTAINERS_RYUK_DISABLED: true
+          # The retry script owns --results-directory; point it at ./coverage-results so the
+          # collected coverage and TRX files land where the upload step reads them.
+          TEST_RESULTS_DIR: ./coverage-results
         # On failure, only the failed tests are re-run (up to TEST_MAX_ATTEMPTS), so a
         # transient pipeline/container flake does not redden the whole job. A systemic
         # failure (many tests failing, e.g. a fixture/container start error) fails fast
@@ -148,8 +151,7 @@ jobs:
             "FullyQualifiedName~${{ matrix.namespace }}" \
             -p:DisableDockerBuild=true \
             -p:EnableDevelopmentSymbol=true \
-            --collect:"XPlat Code Coverage" \
-            --results-directory ./coverage-results
+            --collect:"XPlat Code Coverage"
 
       - name: Upload coverage results
         if: always()
@@ -200,6 +202,9 @@ jobs:
         env:
           # See client-integration-specs for the rationale.
           TESTCONTAINERS_RYUK_DISABLED: true
+          # The retry script owns --results-directory; point it at ./coverage-results so the
+          # collected coverage and TRX files land where the upload step reads them.
+          TEST_RESULTS_DIR: ./coverage-results
         # See client-integration-specs for the retry rationale. The kernel project
         # does not have Client's Docker build target.
         run: |
@@ -207,8 +212,7 @@ jobs:
             Integration/Kernel/Kernel.csproj \
             "FullyQualifiedName~${{ matrix.namespace }}" \
             -p:EnableDevelopmentSymbol=true \
-            --collect:"XPlat Code Coverage" \
-            --results-directory ./coverage-results
+            --collect:"XPlat Code Coverage"
 
       - name: Upload coverage results
         if: always()


### PR DESCRIPTION
## Fixed

- Every integration test job failed with `Option '--results-directory' expects a single argument but 2 were provided`. The coverage-collection change passed `--results-directory` to the retry test runner, which already supplies its own (it reads the TRX back to retry only failed tests), so `dotnet test` received the option twice. The runner now owns the directory and collects coverage there; the duplicate argument is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)