### PR TITLE
Share model-bound projection snippets

### DIFF
--- a/Documentation/projections/_snippets/model-bound/configuration-child-updates.md
+++ b/Documentation/projections/_snippets/model-bound/configuration-child-updates.md
@@ -1,0 +1,15 @@
+```csharp
+public record Dashboard(
+    [Key] Guid Id,
+    string Name,
+
+    [ChildrenFrom<ConfigurationAdded>(
+        key: nameof(ConfigurationAdded.ConfigurationId),
+        parentKey: nameof(ConfigurationAdded.DashboardId))]
+    IEnumerable<Configuration> Configurations);
+
+[FromEvent<ConfigurationRenamed>(parentKey: nameof(ConfigurationRenamed.DashboardId))]
+public record Configuration(
+    [Key] Guid Id,
+    string Name);
+```

--- a/Documentation/projections/_snippets/model-bound/order-lines-class-removal.md
+++ b/Documentation/projections/_snippets/model-bound/order-lines-class-removal.md
@@ -1,0 +1,14 @@
+```csharp
+public record Order(
+    [Key] Guid Id,
+
+    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
+    IEnumerable<OrderLine> Lines);
+
+[RemovedWith<LineItemRemoved>(
+    key: nameof(LineItemRemoved.ItemId),
+    parentKey: nameof(LineItemRemoved.OrderId))]
+public record OrderLine(
+    [Key] Guid Id,
+    string Description);
+```

--- a/Documentation/projections/_snippets/model-bound/order-lines-property-removal.md
+++ b/Documentation/projections/_snippets/model-bound/order-lines-property-removal.md
@@ -1,0 +1,12 @@
+```csharp
+public record Order(
+    [Key] Guid Id,
+
+    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
+    [RemovedWith<LineItemRemoved>(key: nameof(LineItemRemoved.ItemId))]
+    IEnumerable<OrderLine> Lines);
+
+public record OrderLine(
+    [Key] Guid Id,
+    string Description);
+```

--- a/Documentation/projections/model-bound/children.md
+++ b/Documentation/projections/model-bound/children.md
@@ -136,23 +136,9 @@ When a `QuantityIncreased` event occurs later:
 
 Use a class-level `FromEvent` on the child type when later child events should auto-map into the existing child instance. If those events come from the child's own event source, specify `parentKey` so Chronicle can still resolve the parent document:
 
-```csharp
-public record Dashboard(
-    [Key] Guid Id,
+[!INCLUDE [configuration child updates](../_snippets/model-bound/configuration-child-updates.md)]
 
-    [ChildrenFrom<ConfigurationAdded>(
-        key: nameof(ConfigurationAdded.ConfigurationId),
-        identifiedBy: nameof(Configuration.Id),
-        parentKey: nameof(ConfigurationAdded.DashboardId))]
-    IEnumerable<Configuration> Configurations);
-
-[FromEvent<ConfigurationRenamed>(parentKey: nameof(ConfigurationRenamed.DashboardId))]
-public record Configuration(
-    [Key] Guid Id,
-    string Name);
-```
-
-`ChildrenFrom` handles how the child is first added to the collection. The child type's own `FromEvent` handles later updates, and `parentKey` is the equivalent of `.UsingParentKey(...)` in a fluent child projection.
+`ChildrenFrom` handles how the child is first added to the collection. The child type's own `FromEvent` handles later updates, and `parentKey` is the equivalent of `.UsingParentKey(...)` in a fluent child projection. You do not need `identifiedBy` here because `Configuration.Id` is marked with `[Key]`.
 
 ## Removing Children
 
@@ -160,39 +146,13 @@ Use `RemovedWith` to remove children from collections. You can apply it either o
 
 ### Property-Level Removal
 
-```csharp
-public record Order(
-    [Key]
-    Guid OrderId,
-
-    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
-    [RemovedWith<LineItemRemoved>(key: nameof(LineItemRemoved.ItemId))]
-    IEnumerable<OrderLine> Lines);
-
-public record OrderLine(
-    [Key] Guid Id,
-    string Description);
-```
+[!INCLUDE [order lines property removal](../_snippets/model-bound/order-lines-property-removal.md)]
 
 ### Class-Level Removal
 
 Apply `RemovedWith` directly on the child type for better separation of concerns:
 
-```csharp
-public record Order(
-    [Key]
-    Guid OrderId,
-
-    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
-    IEnumerable<OrderLine> Lines);
-
-[RemovedWith<LineItemRemoved>(
-    key: nameof(LineItemRemoved.ItemId),
-    parentKey: nameof(LineItemRemoved.OrderId))]
-public record OrderLine(
-    [Key] Guid Id,
-    string Description);
-```
+[!INCLUDE [order lines class removal](../_snippets/model-bound/order-lines-class-removal.md)]
 
 ### RemovedWithJoin
 

--- a/Documentation/projections/model-bound/convention-based.md
+++ b/Documentation/projections/model-bound/convention-based.md
@@ -126,24 +126,9 @@ public record Order(
 
 When a child type has its own class-level `FromEvent` attribute, later child events can come from the child event source while still updating the correct parent document. Use `parentKey` to point Chronicle at the property on the event that identifies the parent:
 
-```csharp
-public record Dashboard(
-    [Key] Guid Id,
-    string Name,
+[!INCLUDE [configuration child updates](../_snippets/model-bound/configuration-child-updates.md)]
 
-    [ChildrenFrom<ConfigurationAdded>(
-        key: nameof(ConfigurationAdded.ConfigurationId),
-        identifiedBy: nameof(Configuration.Id),
-        parentKey: nameof(ConfigurationAdded.DashboardId))]
-    IEnumerable<Configuration> Configurations);
-
-[FromEvent<ConfigurationRenamed>(parentKey: nameof(ConfigurationRenamed.DashboardId))]
-public record Configuration(
-    [Key] Guid Id,
-    string Name);
-```
-
-This is the model-bound equivalent of using `.UsingParentKey(e => e.DashboardId)` in a fluent child projection. It is primarily useful on child types that are populated through `ChildrenFrom` and later updated by events from their own event source streams.
+This is the model-bound equivalent of using `.UsingParentKey(e => e.DashboardId)` in a fluent child projection. It is primarily useful on child types that are populated through `ChildrenFrom` and later updated by events from their own event source streams. The child key is discovered from `Configuration.Id`.
 
 ### Key Validation
 

--- a/Documentation/projections/model-bound/index.md
+++ b/Documentation/projections/model-bound/index.md
@@ -1,22 +1,26 @@
 # Model-Bound Projections
 
-Model-bound projections allow you to define projections using C# attributes directly on your read model types, eliminating the need to implement `IProjectionFor<T>` and rather put in metadata directly into your read model.
+Model-bound projections let the read model describe how it is built. Instead of creating a separate `IProjectionFor<T>` class, you put the projection metadata directly on the read model type and Chronicle builds the projection definition from those attributes.
 
 ## Overview
 
-Instead of creating a separate projection class, you decorate your read model properties with attributes that describe how they should be populated from events. The projection system automatically discovers these attributes and builds the projection definition.
+Start with convention-based mapping and add explicit attributes only where the event and read model use different names. That keeps the common case small while still making the exceptions visible.
 
 ## Basic Example
 
 ```csharp
+using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Keys;
 using Cratis.Chronicle.Projections.ModelBound;
 
+[EventType]
+public record AccountOpened(string Name, decimal InitialBalance);
+
+[FromEvent<AccountOpened>]
 public record AccountInfo(
     [Key]
     Guid Id,
 
-    [SetFrom<AccountOpened>(nameof(AccountOpened.Name))]
     string Name,
 
     [SetFrom<AccountOpened>(nameof(AccountOpened.InitialBalance))]
@@ -25,8 +29,10 @@ public record AccountInfo(
 
 In this example:
 
-- `[Key]` marks the property as the key for the read model (using `KeyAttribute` from `Cratis.Chronicle.Keys`)
-- `[SetFrom<TEvent>]` maps properties from specific events
+- `[FromEvent<AccountOpened>]` creates or updates an `AccountInfo` instance when an `AccountOpened` event is processed
+- `[Key]` marks the read model identifier
+- `Name` maps by convention because both the event and the read model use the same property name
+- `Balance` uses `[SetFrom<TEvent>]` because the event property is called `InitialBalance`
 
 ## Discovery
 

--- a/Documentation/projections/model-bound/removal.md
+++ b/Documentation/projections/model-bound/removal.md
@@ -87,39 +87,13 @@ Children can be removed in two ways:
 
 Apply `RemovedWith` on the collection property alongside `ChildrenFrom`:
 
-```csharp
-public record Order(
-    [Key]
-    Guid OrderId,
-
-    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
-    [RemovedWith<LineItemRemoved>(key: nameof(LineItemRemoved.ItemId))]
-    IEnumerable<OrderLine> Lines);
-
-public record OrderLine(
-    [Key] Guid Id,
-    string Description);
-```
+[!INCLUDE [order lines property removal](../_snippets/model-bound/order-lines-property-removal.md)]
 
 ### Class-Level Removal on Child Types
 
 Apply `RemovedWith` directly on the child type. This is particularly useful when the same child model is used in multiple parents or when you want to keep removal logic with the child definition:
 
-```csharp
-public record Order(
-    [Key]
-    Guid OrderId,
-
-    [ChildrenFrom<LineItemAdded>(key: nameof(LineItemAdded.ItemId))]
-    IEnumerable<OrderLine> Lines);
-
-[RemovedWith<LineItemRemoved>(
-    key: nameof(LineItemRemoved.ItemId),
-    parentKey: nameof(LineItemRemoved.OrderId))]
-public record OrderLine(
-    [Key] Guid Id,
-    string Description);
-```
+[!INCLUDE [order lines class removal](../_snippets/model-bound/order-lines-class-removal.md)]
 
 Both approaches produce the same result. The class-level approach keeps the removal definition with the child type, while the property-level approach keeps it with the parent.
 


### PR DESCRIPTION
## Summary
- Adds shared model-bound projection snippets for repeated child update and child removal examples.
- Replaces duplicate code blocks in the children, removal, and convention-based projection pages with includes.
- Simplifies the model-bound projection overview example to show FromEvent as the default and SetFrom only where names differ.

## Validation
- Verified model-bound projection attributes against current Chronicle source.
- npm run sync chronicle from the Documentation web project.
- npm run check from the Documentation web project: 0 errors, 0 broken local links.

## Merge note
- Merge Cratis/Documentation#32 before or with this PR so _snippets stays authoring-only in the generated site.