### PR TITLE
Add Workbench documentation

### DIFF
--- a/Documentation/get-started/choose-hosting-model.mdx
+++ b/Documentation/get-started/choose-hosting-model.mdx
@@ -273,9 +273,10 @@ topology.
 ### See it in the workbench
 
 Whichever image you ran, it includes the **Chronicle workbench** — a web UI for poking at your event
-store. Open [http://localhost:8080](http://localhost:8080), pick an event store, and look at
-**Sequences** to watch events land in order. It's the quickest way to confirm the kernel is up and your
-app is actually appending.
+store. Open [http://localhost:8080](http://localhost:8080) and log in with the development credentials
+(username `Admin`, password `ChangeMeNow!`). Pick an event store and look at **Sequences** to watch
+events land in order. It's the quickest way to confirm the kernel is up and your app is actually
+appending.
 
 ## Let Aspire wire it up
 

--- a/Documentation/get-started/common.md
+++ b/Documentation/get-started/common.md
@@ -35,7 +35,7 @@ That first argument is the [event source id](../concepts/event-source.md) — th
 > [!TIP]
 > We use a raw `Guid` here to keep the quickstart short. In real code you'd wrap it in a strongly-typed `BookId` so the compiler can't confuse a book's id with a member's — the [tutorial](/chronicle/tutorial/) shows exactly that.
 
-Run your app, then open the <a href="http://localhost:8080" target="_blank" rel="noopener">workbench</a>, pick your event store, and select **Sequences** — your `BookAdded` is sitting there at sequence number `0`, permanent and in order.
+Run your app, then open the <a href="http://localhost:8080" target="_blank" rel="noopener">workbench</a>. Log in with the development credentials (username `Admin`, password `ChangeMeNow!`), pick your event store, and select **Sequences** — your `BookAdded` is sitting there at sequence number `0`, permanent and in order.
 
 ![Chronicle Workbench showing events](workbench.png)
 

--- a/Documentation/get-started/index.mdx
+++ b/Documentation/get-started/index.mdx
@@ -129,7 +129,7 @@ Append a fact → a projection builds state from it → a reactor acts on it. **
 
 ## See it in the workbench
 
-The Docker image includes the **Chronicle workbench** — a web UI for poking at your event store. Open [http://localhost:8080](http://localhost:8080), choose the `ChronicleConsole` event store, and look at **Sequences**: there's your `TestEvent`, sitting at sequence number `0`, permanent and in order. Append more and watch the log grow. This is the source of truth your projection and reactor were both reading from.
+The Docker image includes the **Chronicle workbench** — a web UI for poking at your event store. Open [http://localhost:8080](http://localhost:8080) and log in with the development credentials (username `Admin`, password `ChangeMeNow!`). Choose the `ChronicleConsole` event store and look at **Sequences**: there's your `TestEvent`, sitting at sequence number `0`, permanent and in order. Append more and watch the log grow. This is the source of truth your projection and reactor were both reading from.
 
 ## Where to go next
 

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -56,6 +56,8 @@
   href: testing/toc.yml
 - name: Troubleshooting
   href: troubleshooting/toc.yml
+- name: Workbench
+  href: workbench/toc.yml
 - name: Hosting
   href: hosting/toc.yml
 - name: Contributing

--- a/Documentation/workbench/index.md
+++ b/Documentation/workbench/index.md
@@ -1,0 +1,25 @@
+# Workbench
+
+The Workbench is a web-based tool built into the Chronicle Kernel that lets you inspect and interact with your event store directly in a browser. It is available when running the **Development** or **Development-slim** Docker images and is intended for local development workflows.
+
+## Accessing the Workbench
+
+When Chronicle is running via the Development or Development-slim image, the Workbench is served on port **8080**. Open your browser and navigate to:
+
+```
+http://localhost:8080
+```
+
+No separate installation or configuration is required — the Workbench starts automatically with the Kernel.
+
+## Logging In
+
+The development images ship with a built-in administrator account. Use the following credentials on the login screen:
+
+| Field    | Value           |
+|----------|-----------------|
+| Username | `Admin`         |
+| Password | `ChangeMeNow!`  |
+
+> [!NOTE]
+> These credentials are for local development only. Never expose the development image or these credentials in a staging or production environment.

--- a/Documentation/workbench/toc.yml
+++ b/Documentation/workbench/toc.yml
@@ -1,0 +1,2 @@
+- name: Overview
+  href: index.md


### PR DESCRIPTION
## Added
- New **Workbench** documentation section covering how to access the built-in web UI at `http://localhost:8080` when using the Development or Development-slim images, including the development login credentials.

## Changed
- Getting-started guides that reference the Workbench now include the development login credentials (`Admin` / `ChangeMeNow!`) so developers can log in without searching elsewhere.