### PR TITLE
Split Workbench overview from Development page

### DIFF
--- a/Documentation/workbench/development.md
+++ b/Documentation/workbench/development.md
@@ -1,0 +1,25 @@
+# Development
+
+The Development and Development-slim Docker images include a built-in administrator account so you can start exploring immediately without any configuration.
+
+## Accessing the Workbench
+
+When Chronicle is running via the Development or Development-slim image, the Workbench is served on port **8080**. Open your browser and navigate to:
+
+```
+http://localhost:8080
+```
+
+No separate installation or configuration is required — the Workbench starts automatically with the Kernel.
+
+## Logging In
+
+Use the following credentials on the login screen:
+
+| Field    | Value           |
+|----------|-----------------|
+| Username | `Admin`         |
+| Password | `ChangeMeNow!`  |
+
+> [!NOTE]
+> These credentials are for local development only. Never expose the development image or these credentials in a staging or production environment.

--- a/Documentation/workbench/index.md
+++ b/Documentation/workbench/index.md
@@ -1,25 +1,7 @@
 # Workbench
 
-The Workbench is a web-based tool built into the Chronicle Kernel that lets you inspect and interact with your event store directly in a browser. It is available when running the **Development** or **Development-slim** Docker images and is intended for local development workflows.
+The Workbench is a web-based tool built into the Chronicle Kernel that lets you inspect and interact with your event store directly in a browser.
 
-## Accessing the Workbench
+## Topics
 
-When Chronicle is running via the Development or Development-slim image, the Workbench is served on port **8080**. Open your browser and navigate to:
-
-```
-http://localhost:8080
-```
-
-No separate installation or configuration is required — the Workbench starts automatically with the Kernel.
-
-## Logging In
-
-The development images ship with a built-in administrator account. Use the following credentials on the login screen:
-
-| Field    | Value           |
-|----------|-----------------|
-| Username | `Admin`         |
-| Password | `ChangeMeNow!`  |
-
-> [!NOTE]
-> These credentials are for local development only. Never expose the development image or these credentials in a staging or production environment.
+- **[Development](development.md)** — accessing the Workbench when running the Development or Development-slim images, including login credentials

--- a/Documentation/workbench/toc.yml
+++ b/Documentation/workbench/toc.yml
@@ -1,2 +1,4 @@
 - name: Overview
   href: index.md
+- name: Development
+  href: development.md


### PR DESCRIPTION
## Changed
- Workbench documentation reorganized: the development credentials and access instructions move to a dedicated **Development** page, leaving the overview as a clean landing for future topics.