### PR TITLE
Add development credentials note to quickstart guides

### DIFF
--- a/Documentation/get-started/common.md
+++ b/Documentation/get-started/common.md
@@ -35,7 +35,10 @@ That first argument is the [event source id](../concepts/event-source.md) — th
 > [!TIP]
 > We use a raw `Guid` here to keep the quickstart short. In real code you'd wrap it in a strongly-typed `BookId` so the compiler can't confuse a book's id with a member's — the [tutorial](/chronicle/tutorial/) shows exactly that.
 
-Run your app, then open the <a href="http://localhost:8080" target="_blank" rel="noopener">workbench</a>. Log in with the development credentials (username `Admin`, password `ChangeMeNow!`), pick your event store, and select **Sequences** — your `BookAdded` is sitting there at sequence number `0`, permanent and in order.
+Run your app, then open the <a href="http://localhost:8080" target="_blank" rel="noopener">workbench</a>, pick your event store, and select **Sequences** — your `BookAdded` is sitting there at sequence number `0`, permanent and in order.
+
+> [!NOTE]
+> If you are using the Development or Development-slim image, log in with username **Admin** and password **ChangeMeNow!**. See [Workbench — Development](../workbench/development.md) for details.
 
 ![Chronicle Workbench showing events](workbench.png)
 


### PR DESCRIPTION
## Changed
- Console, Worker Service, and ASP.NET Core quickstart guides now show a dedicated note block below the Workbench paragraph with the development login credentials (`Admin` / `ChangeMeNow!`) and a link to the Workbench — Development page.