### PR TITLE
Fix polymorphic derived-type event content round-trip

### DIFF
--- a/Source/Clients/DotNET.Specs/Events/for_EventSerializer/when_serializing_event_with_polymorphic_property.cs
+++ b/Source/Clients/DotNET.Specs/Events/for_EventSerializer/when_serializing_event_with_polymorphic_property.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Events.for_EventSerializer;
+
+public class when_serializing_event_with_polymorphic_property : Specification
+{
+    public interface IShape;
+
+    [DerivedType("circle")]
+    public record Circle(int Radius) : IShape;
+
+    public record EventWithShape(IShape Shape);
+
+    EventSerializer _serializer;
+    JsonObject _result;
+
+    void Establish()
+    {
+        var clientArtifacts = Substitute.For<IClientArtifactsProvider>();
+        clientArtifacts.AdditionalEventInformationProviders.Returns([]);
+        var activator = Substitute.For<IClientArtifactsActivator>();
+        var eventTypes = Substitute.For<IEventTypes>();
+
+        // Pass options WITHOUT the derived-type converter to prove the serializer adds it when missing.
+        _serializer = new EventSerializer(clientArtifacts, activator, eventTypes, new JsonSerializerOptions());
+    }
+
+    async Task Because() => _result = await _serializer.Serialize(new EventWithShape(new Circle(5)));
+
+    [Fact] void should_write_the_derived_type_discriminator() => _result.ToJsonString().Contains("_derivedTypeId").ShouldBeTrue();
+    [Fact] void should_identify_the_concrete_derived_type() => _result.ToJsonString().Contains("circle").ShouldBeTrue();
+    [Fact] void should_write_the_concrete_subtype_property() => _result.ToJsonString().Contains("\"radius\":5").ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_polymorphic_type.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_polymorphic_type.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+public class when_generating_schema_for_polymorphic_type : Specification
+{
+    public abstract class Shape
+    {
+        public int Sides { get; set; }
+    }
+
+    public class Circle : Shape
+    {
+        public double Radius { get; set; }
+    }
+
+    public record Drawing(Shape Shape);
+
+    JsonSchemaGenerator _generator;
+    JsonSchema _result;
+
+    void Establish()
+    {
+        var derivedTypes = Substitute.For<IDerivedTypes>();
+        derivedTypes.HasDerivatives(typeof(Shape)).Returns(true);
+
+        _generator = new(
+            new ComplianceMetadataResolver(
+                new KnownInstancesOf<ICanProvideComplianceMetadataForType>(),
+                new KnownInstancesOf<ICanProvideComplianceMetadataForProperty>()),
+            new DefaultNamingPolicy(),
+            derivedTypes);
+    }
+
+    void Because() => _result = _generator.Generate(typeof(Drawing));
+
+    [Fact] void should_emit_an_open_schema_for_the_polymorphic_property() =>
+        _result.ActualProperties.Values.First().ActualTypeSchema.GetFlattenedProperties().ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET/Events/EventSerializer.cs
+++ b/Source/Clients/DotNET/Events/EventSerializer.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Cratis.Serialization;
 
 namespace Cratis.Chronicle.Events;
 
@@ -22,11 +23,13 @@ public class EventSerializer : IEventSerializer
     /// <param name="artifactActivator"><see cref="IServiceProvider"/> for resolving instances.</param>
     /// <param name="eventTypes"><see cref="IEventTypes"/> for resolving event types.</param>
     /// <param name="serializerOptions">The common <see creF="JsonSerializerOptions"/>.</param>
+    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> for serializing polymorphic event content adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the global <see cref="DerivedTypes.Instance"/>.</param>
     public EventSerializer(
         IClientArtifactsProvider clientArtifacts,
         IClientArtifactsActivator artifactActivator,
         IEventTypes eventTypes,
-        JsonSerializerOptions serializerOptions)
+        JsonSerializerOptions serializerOptions,
+        IDerivedTypes? derivedTypes = null)
     {
         _serializerOptions = new JsonSerializerOptions(serializerOptions)
         {
@@ -36,6 +39,15 @@ public class EventSerializer : IEventSerializer
                 new EventRedactedConverters(eventTypes)
             }
         };
+
+        // Ensure polymorphic event content (properties typed as a base/abstract type with [DerivedType]
+        // subtypes) round-trips with its discriminator. The common options may not carry the derived-type
+        // converter depending on when they were configured, so add it here when missing — otherwise the
+        // discriminator and concrete subtype properties are dropped and the value serializes as its base type.
+        if (!_serializerOptions.Converters.Any(converter => converter is DerivedTypeJsonConverterFactory))
+        {
+            _serializerOptions.Converters.Add(new DerivedTypeJsonConverterFactory(derivedTypes ?? DerivedTypes.Instance));
+        }
 
         var providers = new List<ICanProvideAdditionalEventInformation>();
         foreach (var providerType in clientArtifacts.AdditionalEventInformationProviders)

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -25,6 +25,7 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     readonly JsonSerializerOptions _serializerOptions;
     readonly JsonSchemaExporterOptions _exporterOptions;
     readonly IComplianceMetadataResolver _metadataResolver;
+    readonly IDerivedTypes _derivedTypes;
     readonly TypeFormats _typeFormats;
 
     /// <summary>
@@ -32,9 +33,11 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     /// </summary>
     /// <param name="metadataResolver"><see cref="IComplianceMetadataResolver"/> for resolving metadata.</param>
     /// <param name="namingPolicy"><see cref="INamingPolicy"/> to use for converting names during serialization.</param>
-    public JsonSchemaGenerator(IComplianceMetadataResolver metadataResolver, INamingPolicy namingPolicy)
+    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> used to recognize polymorphic base types adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the global <see cref="DerivedTypes.Instance"/>.</param>
+    public JsonSchemaGenerator(IComplianceMetadataResolver metadataResolver, INamingPolicy namingPolicy, IDerivedTypes? derivedTypes = null)
     {
         _metadataResolver = metadataResolver;
+        _derivedTypes = derivedTypes ?? DerivedTypes.Instance;
         _typeFormats = new TypeFormats();
 
         var resolver = new DefaultJsonTypeInfoResolver();
@@ -177,6 +180,24 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
         }
 
         if (schema is not JsonObject schemaObj) return schema;
+
+        // Polymorphic base types (those that have registered derived types via [DerivedType]) are
+        // stored verbatim. System.Text.Json's schema exporter only describes the abstract base's
+        // own properties, which would make the schema-driven storage conversion strip the derived
+        // type discriminator (_derivedTypeId) together with every concrete subtype property. Emitting
+        // an open object schema (no fixed properties) makes the ExpandoObject converter preserve the
+        // full polymorphic payload so the discriminator and concrete properties round-trip intact.
+        if (!schemaObj.ContainsKey("$ref") && _derivedTypes.HasDerivatives(formatType))
+        {
+            schemaObj.Remove("properties");
+            schemaObj.Remove("required");
+            schemaObj.Remove("allOf");
+            schemaObj.Remove("anyOf");
+            schemaObj.Remove("oneOf");
+            schemaObj.Remove("additionalProperties");
+            schemaObj["type"] = "object";
+            return schemaObj;
+        }
 
         // Geospatial types serialize as GeoJSON via their own converters and are materialized as the
         // typed CLR value by the schema-aware ExpandoObject converters using the format metadata

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_converting_polymorphic_value_with_open_schema.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_converting_polymorphic_value_with_open_schema.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter;
+
+public class when_converting_polymorphic_value_with_open_schema : Specification
+{
+    ExpandoObjectConverter _converter;
+    JsonSchema _schema;
+    JsonObject _result;
+
+    void Establish()
+    {
+        _converter = new(new TypeFormats());
+
+        // An open object schema (no fixed properties) is what the schema generator emits for a
+        // polymorphic base type adorned with [DerivedType]. The converter must preserve the full
+        // payload — including the derived type discriminator and every concrete subtype property.
+        _schema = JsonSchema.FromJson(
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "element": { "type": "object" }
+                }
+            }
+            """);
+    }
+
+    void Because()
+    {
+        var input = new JsonObject
+        {
+            ["element"] = new JsonObject
+            {
+                ["_derivedTypeId"] = "externalComponent",
+                ["componentName"] = "PrimeReact.Button",
+                ["width"] = 120
+            }
+        };
+
+        var expando = _converter.ToExpandoObject(input, _schema);
+        _result = _converter.ToJsonObject(expando, _schema);
+    }
+
+    [Fact] void should_preserve_the_derived_type_discriminator() => _result["element"]!["_derivedTypeId"]!.GetValue<string>().ShouldEqual("externalComponent");
+    [Fact] void should_preserve_concrete_subtype_properties() => _result["element"]!["componentName"]!.GetValue<string>().ShouldEqual("PrimeReact.Button");
+    [Fact] void should_preserve_base_properties() => _result["element"]!["width"]!.GetValue<int>().ShouldEqual(120);
+}


### PR DESCRIPTION
## Fixed
- Event properties typed as a `[DerivedType]` base (abstract/interface with derived types) now round-trip with their discriminator and concrete subtype properties intact. Previously the type discriminator and all subtype-specific properties were stripped on append, causing read-side deserialization to fail with "Cannot create an instance of \<abstract type\>".

# Summary
Two complementary fixes restore polymorphic serialization for event content:
- The JSON schema generator now emits an open object schema for base types that have registered derivatives, so the schema-driven storage conversion preserves the full payload instead of stripping it to the base type's properties.
- The client event serializer now ensures the derived-type converter is present in its options, so the discriminator and concrete properties are actually written into the event content.