### PR TITLE
Update dependencies and harden projection value conversion

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,25 +14,25 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.0" />
-    <PackageVersion Include="Cratis.Arc" Version="20.42.0" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.42.0" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.42.0" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.42.0" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.42.0" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.42.0" />
+    <PackageVersion Include="Cratis.Arc" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.43.2" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.7.0" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
@@ -48,12 +48,12 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <!-- Orleans -->
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.2.0" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.0" />
+    <PackageVersion Include="Microsoft.Orleans.Client" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Serialization" Version="10.2.0" />
-    <PackageVersion Include="Microsoft.Orleans.Serialization.Abstractions" Version="10.1.0" />
+    <PackageVersion Include="Microsoft.Orleans.Serialization.Abstractions" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Serialization.SystemTextJson" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Streaming" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Orleans.Reminders" Version="10.2.0" />
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="protobuf-net.Reflection" Version="3.2.52" />
-    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
+    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.5" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
@@ -126,7 +126,7 @@
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
-    <PackageVersion Include="SharpCompress" Version="0.49.1" />
+    <PackageVersion Include="SharpCompress" Version="1.0.0" />
   </ItemGroup>
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET8.props" Condition=" '$(TargetFramework)' == 'net8.0' " />
   <Import Project="$(MSBuildThisFileDirectory)/Directory.Packages.NET9.props" Condition=" '$(TargetFramework)' == 'net9.0' " />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <!-- Aspire -->
-    <PackageVersion Include="Aspire.Hosting" Version="13.4.4" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.5" />
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.0" />

--- a/Source/Kernel/Core.Specs/Recommendations/SpecsTypeManifestProvider.cs
+++ b/Source/Kernel/Core.Specs/Recommendations/SpecsTypeManifestProvider.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Recommendations;
+using Orleans.Serialization.Configuration;
+
+[assembly: TypeManifestProvider(typeof(SpecsTypeManifestProvider))]
+
+namespace Cratis.Chronicle.Recommendations;
+
+/// <summary>
+/// Represents a <see cref="TypeManifestProviderBase"/> that allows the recommendation request types used in
+/// specs through Orleans' type manifest.
+/// </summary>
+/// <remarks>
+/// The production silo allows recommendation request types by registering the Cratis JSON serializer (see
+/// SerializationConfigurationExtensions). The OrleansTestKit silo used by specs does not configure that
+/// serializer, so Orleans' strict type manifest (enforced as of Orleans 10.2) rejects these types when
+/// constructing the generic <c>IRecommendation&lt;TRequest&gt;</c> grain type. Allowing them here restores
+/// the behavior for specs without relaxing production security.
+/// </remarks>
+public class SpecsTypeManifestProvider : TypeManifestProviderBase
+{
+    /// <inheritdoc/>
+    protected override void ConfigureInner(TypeManifestOptions options) =>
+        options.AllowAllTypes = true;
+}

--- a/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -73,7 +73,13 @@ public partial class EventValueProviderExpressionResolvers(ITypeFormats typeForm
 
             foreach (var property in properties)
             {
-                expandoObject[property.Name] = Convert(property, expandoObject[property.Name]);
+                // A value does not necessarily carry every property declared by the schema. Only convert
+                // properties that are actually present on the value; absent ones are simply not part of
+                // this concrete shape and must not be accessed by indexer (which would throw).
+                if (expandoObject.TryGetValue(property.Name, out var propertyValue))
+                {
+                    expandoObject[property.Name] = Convert(property, propertyValue);
+                }
             }
             return expandoObject;
         }

--- a/Source/Kernel/Storage.Sql/EventStores/ReadModels/ReadModelDefinition.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/ReadModels/ReadModelDefinition.cs
@@ -51,7 +51,7 @@ public class ReadModelDefinition
     /// <summary>
     /// Gets or sets the type of the sink the read model is stored to.
     /// </summary>
-    public string SinkType { get; set; } = Cratis.Chronicle.Concepts.Sinks.SinkTypeId.None;
+    public string SinkType { get; set; } = Concepts.Sinks.SinkTypeId.None;
 
     /// <summary>
     /// Gets or sets the configuration identifier for the sink of the read model.


### PR DESCRIPTION
## Changed
- Updated dependencies: Cratis.Arc 20.43.2, Orleans 10.2.0, Entity Framework Core 10.0.9, protobuf-net.Grpc 1.2.5, and SharpCompress 1.0.0.

## Fixed
- Projection value conversion no longer fails when an event value omits a property declared by its schema.