### PR TITLE
Upgrading to latest Arc for improved BSON handling of numeric types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.16.0" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.0" />
-    <PackageVersion Include="Cratis.Arc" Version="20.43.2" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="20.43.2" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.43.2" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.43.2" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.43.2" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.43.2" />
+    <PackageVersion Include="Cratis.Arc" Version="20.43.3" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="20.43.3" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.43.3" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="20.43.3" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="20.43.3" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="20.43.3" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />


### PR DESCRIPTION
## Fixed

- Upgrading to latest Cratis Arc for improvements to BSON serialization/ converters for numeric types.
