### PR TITLE
Fix RemovedWith on children not removing collection items

### DIFF
--- a/Integration/Client/Projections/Scenarios/ModelBound/Events/MarkerPlacedInRegion.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/Events/MarkerPlacedInRegion.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record MarkerPlacedInRegion(Guid RegionId, Guid MarkerId, string Label);

--- a/Integration/Client/Projections/Scenarios/ModelBound/Events/MarkerRemovedFromRegion.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/Events/MarkerRemovedFromRegion.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record MarkerRemovedFromRegion(Guid RegionId, Guid MarkerId);

--- a/Integration/Client/Projections/Scenarios/ModelBound/Events/RegionDefined.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/Events/RegionDefined.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+
+[EventType]
+public record RegionDefined(string Name);

--- a/Integration/Client/Projections/Scenarios/ModelBound/ReadModels/RegionMarkerItem.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/ReadModels/RegionMarkerItem.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.ReadModels;
+
+[RemovedWith<MarkerRemovedFromRegion>(key: nameof(MarkerRemovedFromRegion.MarkerId))]
+public record RegionMarkerItem(
+    Guid Id,
+    string Label);

--- a/Integration/Client/Projections/Scenarios/ModelBound/ReadModels/RegionReadModel.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/ReadModels/RegionReadModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.ReadModels;
+
+[FromEvent<RegionDefined>]
+public record RegionReadModel(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<MarkerPlacedInRegion>(
+        key: nameof(MarkerPlacedInRegion.MarkerId),
+        parentKey: nameof(MarkerPlacedInRegion.RegionId))]
+    IEnumerable<RegionMarkerItem> Markers);

--- a/Integration/Client/Projections/Scenarios/ModelBound/when_removing_a_child_from_a_collection/and_one_marker_is_removed.cs
+++ b/Integration/Client/Projections/Scenarios/ModelBound/when_removing_a_child_from_a_collection/and_one_marker_is_removed.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.Events;
+using Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.ReadModels;
+using context = Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.when_removing_a_child_from_a_collection.and_one_marker_is_removed.context;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.ModelBound.when_removing_a_child_from_a_collection;
+
+[Collection(ChronicleCollection.Name)]
+public class and_one_marker_is_removed(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        public Guid RegionId;
+        public Guid FirstMarkerId;
+        public Guid SecondMarkerId;
+        public RegionReadModel Result;
+
+        public override IEnumerable<Type> EventTypes =>
+            [typeof(RegionDefined), typeof(MarkerPlacedInRegion), typeof(MarkerRemovedFromRegion)];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(RegionReadModel)];
+
+        async Task Because()
+        {
+            RegionId = Guid.NewGuid();
+            FirstMarkerId = Guid.NewGuid();
+            SecondMarkerId = Guid.NewGuid();
+
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<RegionReadModel>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillSubscribed();
+
+            await EventStore.EventLog.Append(RegionId, new RegionDefined("North"));
+            await EventStore.EventLog.Append(RegionId, new MarkerPlacedInRegion(RegionId, FirstMarkerId, "Camp"));
+            await EventStore.EventLog.Append(RegionId, new MarkerPlacedInRegion(RegionId, SecondMarkerId, "Outpost"));
+            var appendResult = await EventStore.EventLog.Append(RegionId, new MarkerRemovedFromRegion(RegionId, FirstMarkerId));
+
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            Result = await EventStore.ReadModels.GetInstanceById<RegionReadModel>(RegionId.ToString());
+        }
+    }
+
+    [Fact] void should_return_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_one_marker_left() => Context.Result.Markers.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_other_marker() => Context.Result.Markers.First().Id.ShouldEqual(Context.SecondMarkerId);
+    [Fact] void should_not_have_the_removed_marker() => Context.Result.Markers.Any(_ => _.Id == Context.FirstMarkerId).ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_children_having_class_level_removed_with.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_children_having_class_level_removed_with.cs
@@ -16,6 +16,6 @@ public class with_children_having_class_level_removed_with : given.a_model_bound
     [Fact] void should_have_child_with_correct_name() => _result.Children.ContainsKey(nameof(ParentWithRemovableChildren.Items)).ShouldBeTrue();
     [Fact] void should_have_removed_with_on_children() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Count.ShouldEqual(1);
     [Fact] void should_have_removed_with_for_correct_event_type() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ChildItemRemoved)).Id.ToString());
-    [Fact] void should_use_specified_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().Key.ShouldEqual(nameof(ChildItemRemoved.ItemId));
-    [Fact] void should_use_specified_parent_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().ParentKey.ShouldEqual(nameof(ChildItemRemoved.ParentId));
+    [Fact] void should_use_specified_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().Key.ShouldEqual(naming_policy.GetPropertyName(new Properties.PropertyPath(nameof(ChildItemRemoved.ItemId))));
+    [Fact] void should_use_specified_parent_key_on_removed_with() => _result.Children[nameof(ParentWithRemovableChildren.Items)].RemovedWith.Values.First().ParentKey.ShouldEqual(naming_policy.GetPropertyName(new Properties.PropertyPath(nameof(ChildItemRemoved.ParentId))));
 }

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_with_custom_key.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building/with_class_level_removed_with_with_custom_key.cs
@@ -14,5 +14,5 @@ public class with_class_level_removed_with_with_custom_key : given.a_model_bound
     [Fact] void should_return_definition() => _result.ShouldNotBeNull();
     [Fact] void should_have_one_removed_with_entry() => _result.RemovedWith.Count.ShouldEqual(1);
     [Fact] void should_have_removed_with_for_correct_event_type() => _result.RemovedWith.Keys.First().Id.ShouldEqual(event_types.GetEventTypeFor(typeof(ReadModelRemoved)).Id.ToString());
-    [Fact] void should_use_specified_key_expression() => _result.RemovedWith.Values.First().Key.ShouldEqual(nameof(ReadModelRemoved.Id));
+    [Fact] void should_use_specified_key_expression() => _result.RemovedWith.Values.First().Key.ShouldEqual(naming_policy.GetPropertyName(new Properties.PropertyPath(nameof(ReadModelRemoved.Id))));
 }

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -388,13 +388,13 @@ static class ChildrenDefinitionExtensions
                     // Process RemovedWith attributes on constructor parameters
                     foreach (var (removedAttr, removedEventType) in parameter.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
                     {
-                        childrenDef.RemovedWith.ProcessRemovedWithAttribute(getOrCreateEventType, removedAttr, removedEventType);
+                        childrenDef.RemovedWith.ProcessRemovedWithAttribute(getOrCreateEventType, namingPolicy, removedAttr, removedEventType);
                     }
 
                     // Process RemovedWithJoin attributes on constructor parameters
                     foreach (var (removedJoinAttr, removedJoinEventType) in parameter.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
                     {
-                        childrenDef.RemovedWithJoin.ProcessRemovedWithJoinAttribute(getOrCreateEventType, removedJoinAttr, removedJoinEventType);
+                        childrenDef.RemovedWithJoin.ProcessRemovedWithJoinAttribute(getOrCreateEventType, namingPolicy, removedJoinAttr, removedJoinEventType);
                     }
                 }
             }
@@ -403,7 +403,7 @@ static class ChildrenDefinitionExtensions
             // No need to explicitly map properties here
 
             // Process class-level RemovedWith attributes on the child type
-            ProcessChildTypeLevelRemovedWith(childType, getOrCreateEventType, childrenDef);
+            ProcessChildTypeLevelRemovedWith(childType, getOrCreateEventType, namingPolicy, childrenDef);
 
             // Collect class-level FromEvent attributes on the child type
             var childClassLevelFromEvents = childType.GetCustomAttributes()
@@ -521,16 +521,17 @@ static class ChildrenDefinitionExtensions
     static void ProcessChildTypeLevelRemovedWith(
         Type childType,
         Func<Type, EventType> getOrCreateEventType,
+        INamingPolicy namingPolicy,
         ChildrenDefinition childrenDef)
     {
         foreach (var (attr, eventType) in childType.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
         {
-            childrenDef.RemovedWith.ProcessRemovedWithAttribute(getOrCreateEventType, attr, eventType);
+            childrenDef.RemovedWith.ProcessRemovedWithAttribute(getOrCreateEventType, namingPolicy, attr, eventType);
         }
 
         foreach (var (attr, eventType) in childType.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
         {
-            childrenDef.RemovedWithJoin.ProcessRemovedWithJoinAttribute(getOrCreateEventType, attr, eventType);
+            childrenDef.RemovedWithJoin.ProcessRemovedWithJoinAttribute(getOrCreateEventType, namingPolicy, attr, eventType);
         }
     }
 

--- a/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
@@ -243,12 +243,12 @@ internal class ModelBoundProjectionBuilder(
     {
         foreach (var (attr, eventType) in modelType.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
         {
-            definition.RemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, attr, eventType);
+            definition.RemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
 
         foreach (var (attr, eventType) in modelType.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
         {
-            definition.RemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, attr, eventType);
+            definition.RemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
     }
 
@@ -364,12 +364,12 @@ internal class ModelBoundProjectionBuilder(
 
         foreach (var (attr, eventType) in parameter.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
         {
-            targetRemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, attr, eventType);
+            targetRemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
 
         foreach (var (attr, eventType) in parameter.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
         {
-            targetRemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, attr, eventType);
+            targetRemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
 
         // Only process ChildrenFromAttribute when at root level.
@@ -488,12 +488,12 @@ internal class ModelBoundProjectionBuilder(
 
         foreach (var (attr, eventType) in property.GetAttributesOfGenericType<RemovedWithAttribute<object>>())
         {
-            targetRemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, attr, eventType);
+            targetRemovedWith.ProcessRemovedWithAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
 
         foreach (var (attr, eventType) in property.GetAttributesOfGenericType<RemovedWithJoinAttribute<object>>())
         {
-            targetRemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, attr, eventType);
+            targetRemovedWithJoin.ProcessRemovedWithJoinAttribute(GetOrCreateEventType, _namingPolicy, attr, eventType);
         }
 
         // Only process ChildrenFromAttribute when at root level.

--- a/Source/Clients/DotNET/Projections/ModelBound/RemovedWithExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/RemovedWithExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Properties;
+using Cratis.Serialization;
 using EventType = Cratis.Chronicle.Contracts.Events.EventType;
 
 namespace Cratis.Chronicle.Projections.ModelBound;
@@ -16,11 +18,13 @@ static class RemovedWithExtensions
     /// </summary>
     /// <param name="targetRemovedWith">The target RemovedWith dictionary to add the definition to.</param>
     /// <param name="getOrCreateEventType">Function to get or create a cached EventType instance.</param>
+    /// <param name="namingPolicy">The <see cref="INamingPolicy"/> used to convert event property names to their serialized form.</param>
     /// <param name="attr">The RemovedWith attribute to process.</param>
     /// <param name="eventType">The event type that triggers removal.</param>
     internal static void ProcessRemovedWithAttribute(
         this IDictionary<EventType, RemovedWithDefinition> targetRemovedWith,
         Func<Type, EventType> getOrCreateEventType,
+        INamingPolicy namingPolicy,
         Attribute attr,
         Type eventType)
     {
@@ -33,8 +37,8 @@ static class RemovedWithExtensions
 
         targetRemovedWith[eventTypeId] = new RemovedWithDefinition
         {
-            Key = key,
-            ParentKey = parentKey
+            Key = ApplyNamingPolicy(namingPolicy, key),
+            ParentKey = ApplyNamingPolicy(namingPolicy, parentKey)
         };
     }
 
@@ -43,11 +47,13 @@ static class RemovedWithExtensions
     /// </summary>
     /// <param name="targetRemovedWithJoin">The target RemovedWithJoin dictionary to add the definition to.</param>
     /// <param name="getOrCreateEventType">Function to get or create a cached EventType instance.</param>
+    /// <param name="namingPolicy">The <see cref="INamingPolicy"/> used to convert event property names to their serialized form.</param>
     /// <param name="attr">The RemovedWithJoin attribute to process.</param>
     /// <param name="eventType">The event type that triggers removal.</param>
     internal static void ProcessRemovedWithJoinAttribute(
         this IDictionary<EventType, RemovedWithJoinDefinition> targetRemovedWithJoin,
         Func<Type, EventType> getOrCreateEventType,
+        INamingPolicy namingPolicy,
         Attribute attr,
         Type eventType)
     {
@@ -58,7 +64,17 @@ static class RemovedWithExtensions
 
         targetRemovedWithJoin[eventTypeId] = new RemovedWithJoinDefinition
         {
-            Key = key
+            Key = ApplyNamingPolicy(namingPolicy, key)
         };
     }
+
+    /// <summary>
+    /// Applies the naming policy to a key expression so it matches the serialized event property name, unless the
+    /// expression is a well-known projection expression (e.g. <c>$eventSourceId</c>) which must be left untouched.
+    /// </summary>
+    /// <param name="namingPolicy">The <see cref="INamingPolicy"/> to apply.</param>
+    /// <param name="expression">The key expression to convert.</param>
+    /// <returns>The converted key expression.</returns>
+    static string ApplyNamingPolicy(INamingPolicy namingPolicy, string expression) =>
+        expression.StartsWith('$') ? expression : namingPolicy.GetPropertyName(new PropertyPath(expression));
 }

--- a/Source/Clients/Testing.Specs/ReadModels/CollectionWithRemovableRoles.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/CollectionWithRemovableRoles.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Root read model projected from <see cref="CollectionCreated"/> with role children that can be removed
+/// via the child's class-level <see cref="RemovedWithAttribute{TEvent}"/>.
+/// </summary>
+/// <param name="Id">Collection identifier.</param>
+/// <param name="Roles">Role children keyed by <see cref="SystemRoleAdded.RoleId"/>.</param>
+[Passive]
+[FromEvent<CollectionCreated>]
+public sealed record CollectionWithRemovableRoles(
+    [Key] Guid Id,
+    [ChildrenFrom<SystemRoleAdded>(key: nameof(SystemRoleAdded.RoleId), parentKey: nameof(SystemRoleAdded.CollectionId), identifiedBy: nameof(RemovableCollectionRole.Id))]
+    IReadOnlyList<RemovableCollectionRole> Roles);

--- a/Source/Clients/Testing.Specs/ReadModels/RemovableCollectionRole.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/RemovableCollectionRole.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Child read model for a collection role that is removed via a class-level <see cref="RemovedWithAttribute{TEvent}"/>.
+/// </summary>
+/// <param name="Id">The role identifier used as the key.</param>
+/// <param name="Name">Role name.</param>
+[RemovedWith<RoleRemovedFromCollection>(key: nameof(RoleRemovedFromCollection.RoleId))]
+public sealed record RemovableCollectionRole(
+    [Key] Guid Id,
+    string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/RoleRemovedFromCollection.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/RoleRemovedFromCollection.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for removing a role from a collection.
+/// </summary>
+/// <param name="CollectionId">The collection identifier.</param>
+/// <param name="RoleId">The role identifier.</param>
+[EventType]
+public record RoleRemovedFromCollection(Guid CollectionId, Guid RoleId);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_removing_child_from_collection/and_role_was_added.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_removing_child_from_collection/and_role_was_added.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_removing_child_from_collection;
+
+public class and_role_was_added : Specification
+{
+    ReadModelScenario<CollectionWithRemovableRoles> _scenario;
+    EventSourceId _collectionId;
+    Guid _collectionGuid;
+    Guid _roleGuid;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<CollectionWithRemovableRoles>();
+        _collectionGuid = Guid.NewGuid();
+        _roleGuid = Guid.NewGuid();
+        _collectionId = new EventSourceId(_collectionGuid);
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_collectionId)
+            .Events(
+                new CollectionCreated(_collectionGuid),
+                new SystemRoleAdded(_collectionGuid, _roleGuid, "Administrator"),
+                new RoleRemovedFromCollection(_collectionGuid, _roleGuid));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_no_roles() => _scenario.Instance!.Roles.Count.ShouldEqual(0);
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -421,6 +421,10 @@ internal static class ProjectionReadModelProcessor
                     items.Add(childAdded.Child);
                     break;
 
+                case ChildRemoved childRemoved:
+                    ApplyChildRemoved(state, childRemoved);
+                    break;
+
                 case Joined joined:
                     state = ApplyActualChanges(key, joined.Changes, state);
                     break;
@@ -432,6 +436,45 @@ internal static class ProjectionReadModelProcessor
         }
 
         return state;
+    }
+
+    /// <summary>
+    /// Removes a child from its collection in the projection state, mirroring how the production sinks
+    /// apply a <see cref="ChildRemoved"/> change. Walks the children property path and removes from every
+    /// matching leaf collection the item whose identifier property equals the removed key.
+    /// </summary>
+    /// <param name="state">The projection state to mutate.</param>
+    /// <param name="childRemoved">The <see cref="ChildRemoved"/> change to apply.</param>
+    static void ApplyChildRemoved(ExpandoObject state, ChildRemoved childRemoved)
+    {
+        var segments = childRemoved.ChildrenProperty.Segments.Select(s => s.Value).ToArray();
+        RemoveFromCollection(state, segments, 0, childRemoved.IdentifiedByProperty.Path, childRemoved.Key);
+    }
+
+    static void RemoveFromCollection(IDictionary<string, object?> current, string[] segments, int index, string identifiedByProperty, object key)
+    {
+        if (index >= segments.Length || !current.TryGetValue(segments[index], out var value) || value is not System.Collections.IEnumerable enumerable)
+        {
+            return;
+        }
+
+        var items = enumerable.Cast<object>().ToList();
+
+        if (index == segments.Length - 1)
+        {
+            items.RemoveAll(item =>
+                item is ExpandoObject expando &&
+                ((IDictionary<string, object?>)expando).TryGetValue(identifiedByProperty, out var idValue) &&
+                Equals(NormalizeStateValue(idValue), NormalizeStateValue(key)));
+            current[segments[index]] = items;
+            return;
+        }
+
+        // Intermediate collection — recurse into each element to reach the leaf collection.
+        foreach (var item in items.OfType<ExpandoObject>())
+        {
+            RemoveFromCollection(item, segments, index + 1, identifiedByProperty, key);
+        }
     }
 
     static void ApplyPropertyDifferences(IEnumerable<PropertyDifference> differences, ExpandoObject state)

--- a/Source/Kernel/Storage.Specs/Sinks/InMemory/for_InMemorySink/when_applying_changes/and_change_removes_a_child.cs
+++ b/Source/Kernel/Storage.Specs/Sinks/InMemory/for_InMemorySink/when_applying_changes/and_change_removes_a_child.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.Sinks.InMemory.for_InMemorySink.when_applying_changes;
+
+public class and_change_removes_a_child : Specification
+{
+    const string RemovedRoleId = "role-1";
+    const string KeptRoleId = "role-2";
+
+    InMemorySink _sink;
+    IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    Key _key;
+    ExpandoObject? _result;
+
+    void Establish()
+    {
+        _key = new Key("user-1", ArrayIndexers.NoIndexers);
+        _sink = new InMemorySink(CreateReadModelDefinition(), new TypeFormats());
+
+        dynamic initialState = new ExpandoObject();
+        initialState.roles = new[] { CreateRole(RemovedRoleId), CreateRole(KeptRoleId) };
+
+        var childRemoved = new ChildRemoved(CreateRole(RemovedRoleId), new PropertyPath("roles"), new PropertyPath("id"), RemovedRoleId);
+
+        _changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        _changeset.InitialState.Returns((ExpandoObject)initialState);
+        _changeset.Changes.Returns([childRemoved]);
+    }
+
+    async Task Because()
+    {
+        await _sink.ApplyChanges(_key, _changeset, 42UL);
+        _result = await _sink.FindOrDefault(_key);
+    }
+
+    [Fact] void should_have_one_role_left() => GetRoles().Length.ShouldEqual(1);
+    [Fact] void should_keep_the_other_role() => GetValue<string>(GetRoles()[0], "id").ShouldEqual(KeptRoleId);
+
+    static T GetValue<T>(ExpandoObject target, string property)
+    {
+        var dictionary = (IDictionary<string, object?>)target;
+        return (T)dictionary[property]!;
+    }
+
+    ExpandoObject[] GetRoles()
+    {
+        var dictionary = (IDictionary<string, object?>)_result!;
+        return ((IEnumerable<object>)dictionary["roles"]).Cast<ExpandoObject>().ToArray();
+    }
+
+    static ExpandoObject CreateRole(string id)
+    {
+        dynamic item = new ExpandoObject();
+        item.id = id;
+        return item;
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-read-model",
+            "TestReadModel",
+            "TestReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, new JsonSchema() }
+            },
+            []);
+}

--- a/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
+++ b/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
@@ -239,6 +239,16 @@ public class InMemorySink(
                     collection.Add(childAdded.State);
                     break;
 
+                case ChildRemoved childRemoved:
+                    var childCollection = state.EnsureCollection<ExpandoObject, object>(childRemoved.ChildrenProperty, key.ArrayIndexers);
+                    var childToRemove = childCollection.FindByKey(childRemoved.IdentifiedByProperty, childRemoved.Key);
+                    if (childToRemove is not null)
+                    {
+                        childCollection.Remove(childToRemove);
+                    }
+
+                    break;
+
                 case NestedCleared nestedCleared:
                     var stateDict = (IDictionary<string, object?>)state;
                     stateDict[nestedCleared.NestedProperty.LastSegment.Value] = null;


### PR DESCRIPTION
## Fixed
- `[RemovedWith<T>]` on a child collection type now actually removes the item from the collection. Its key expression was stored verbatim (e.g. `RoleId`) while the projection's other keys are camelCased, so it never matched the serialized event content and no removal was produced. (#135)
- In-memory read models now apply child removals — the in-memory sink silently ignored `ChildRemoved` changes (the MongoDB and SQL sinks already handled them).