### PR TITLE
Fix reducer child collection updates in MongoDB

### DIFF
--- a/Source/Infrastructure.Specs/Changes/for_ObjectsComparer/when_comparing_object_with_complex_collection_that_has_changed_element.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ObjectsComparer/when_comparing_object_with_complex_collection_that_has_changed_element.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Changes.for_ObjectComparer;
+
+public class when_comparing_object_with_complex_collection_that_has_changed_element : given.an_object_comparer
+{
+    record Member(Guid Id, string Status);
+    record Team(IEnumerable<Member> Members);
+
+    Team _left;
+    Team _right;
+
+    bool _result;
+    IEnumerable<PropertyDifference> _differences;
+
+    void Establish()
+    {
+        var id = Guid.NewGuid();
+        _left = new([new(id, "pending")]);
+        _right = new([new(id, "approved")]);
+    }
+
+    void Because() => _result = comparer.Compare(_left, _right, out _differences);
+
+    [Fact] void should_not_be_equal() => _result.ShouldBeFalse();
+    [Fact] void should_have_one_property_difference() => _differences.Count().ShouldEqual(1);
+    [Fact] void should_have_member_status_property_as_difference() => _differences.First().PropertyPath.Path.ShouldEqual($"{nameof(Team.Members)}.{nameof(Member.Status)}");
+    [Fact] void should_hold_original_member_status_as_difference() => _differences.First().Original.ShouldEqual("pending");
+    [Fact] void should_hold_changed_member_status_as_difference() => _differences.First().Changed.ShouldEqual("approved");
+}

--- a/Source/Infrastructure.Specs/Changes/for_ObjectsComparer/when_comparing_object_with_unequal_collections_on_second_element.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ObjectsComparer/when_comparing_object_with_unequal_collections_on_second_element.cs
@@ -23,5 +23,7 @@ public class when_comparing_object_with_unequal_collections_on_second_element : 
 
     [Fact] void should_not_be_equal() => _result.ShouldBeFalse();
     [Fact] void should_have_one_property_difference() => _differences.Count().ShouldEqual(1);
-    [Fact] void should_have_concept_property_as_difference() => _differences.First().PropertyPath.Path.ShouldEqual(nameof(TheType.Collection));
+    [Fact] void should_have_collection_property_as_difference() => _differences.First().PropertyPath.Path.ShouldEqual(nameof(TheType.Collection));
+    [Fact] void should_hold_original_element_as_difference() => _differences.First().Original.ShouldEqual(2);
+    [Fact] void should_hold_changed_element_as_difference() => _differences.First().Changed.ShouldEqual(5);
 }

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_reducer_changes_a_field_on_an_existing_child.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_reducer_changes_a_field_on_an_existing_child.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Sinks;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_reducer_changes_a_field_on_an_existing_child : given.all_dependencies
+{
+    IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    PropertyDifference[] _differences;
+
+    void Establish()
+    {
+        var initial = CreateTeam("Team One", "pending");
+        ((IDictionary<string, object?>)initial)[WellKnownProperties.Subject] = EventSourceIdValue;
+
+        var changed = CreateTeam("Team Two", "approved");
+
+        _objectComparer = new ObjectComparer();
+
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(initial));
+        _sink.ApplyChanges(
+                Arg.Any<Concepts.Keys.Key>(),
+                Arg.Any<IChangeset<AppendedEvent, ExpandoObject>>(),
+                Arg.Any<EventSequenceNumber>())
+            .Returns(callInfo =>
+            {
+                _changeset = callInfo.ArgAt<IChangeset<AppendedEvent, ExpandoObject>>(1);
+                return Task.FromResult(Enumerable.Empty<FailedPartition>());
+            });
+
+        _pipeline = new ReducerPipeline(
+            _readModelDefinition,
+            _sink,
+            _objectComparer,
+            new ReadModelsCompliance(_complianceManager, _expandoObjectConverter),
+            EventStore,
+            EventStoreNamespace);
+
+        Reducer = CreateReducer(changed);
+    }
+
+    ReducerDelegate Reducer { get; set; }
+
+    async Task Because()
+    {
+        await _pipeline.Handle(CreateContext(EventSourceIdValue), Reducer);
+
+        var propertiesChanged = _changeset.Changes.OfType<PropertiesChanged<ExpandoObject>>().Single();
+        _differences = propertiesChanged.Differences.ToArray();
+    }
+
+    [Fact] void should_apply_changes_to_the_sink() => _sink.Received(1).ApplyChanges(Arg.Any<Concepts.Keys.Key>(), Arg.Any<IChangeset<AppendedEvent, ExpandoObject>>(), Arg.Any<EventSequenceNumber>());
+    [Fact] void should_preserve_the_top_level_difference() => _differences.Any(_ => _.PropertyPath.Path == "name" && _.Original!.Equals("Team One") && _.Changed!.Equals("Team Two")).ShouldBeTrue();
+    [Fact] void should_collapse_the_child_field_difference_to_the_collection() => _differences.Any(_ => _.PropertyPath.Path == "[members]").ShouldBeTrue();
+    [Fact] void should_not_emit_the_indexerless_child_field_difference() => _differences.Any(_ => _.PropertyPath.Path == "[members].status").ShouldBeFalse();
+    [Fact] void should_hold_the_original_collection() => GetMemberStatus(_differences.Single(_ => _.PropertyPath.Path == "[members]").Original!).ShouldEqual("pending");
+    [Fact] void should_hold_the_changed_collection() => GetMemberStatus(_differences.Single(_ => _.PropertyPath.Path == "[members]").Changed!).ShouldEqual("approved");
+
+    static ExpandoObject CreateTeam(string name, string memberStatus)
+    {
+        dynamic member = new ExpandoObject();
+        member.memberId = "member-1";
+        member.status = memberStatus;
+
+        dynamic team = new ExpandoObject();
+        team.id = EventSourceIdValue;
+        team.name = name;
+        team.members = new object[] { member };
+
+        return team;
+    }
+
+    static string GetMemberStatus(object collection)
+    {
+        var member = ((IEnumerable<object>)collection).Cast<IDictionary<string, object?>>().Single();
+        return (string)member["status"]!;
+    }
+}

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Sinks;
@@ -90,7 +92,11 @@ public class ReducerPipeline(
 
             if (!objectComparer.Compare(initial, encryptedState, out var differences))
             {
-                changeset.Add(new PropertiesChanged<ExpandoObject>(null!, differences));
+                // The comparer has no child identity for reducer-owned collections. A nested,
+                // unindexed array path cannot be applied safely by sinks, so replace that collection.
+                changeset.Add(new PropertiesChanged<ExpandoObject>(
+                    null!,
+                    CollapseUnindexedCollectionDifferences(initial, encryptedState, differences)));
             }
         }
 
@@ -104,5 +110,113 @@ public class ReducerPipeline(
                 throw new InvalidOperationException($"Bulk operation failed for partition {firstFailure.EventSourceId} at sequence number {firstFailure.EventSequenceNumber}");
             }
         }
+    }
+
+    static List<PropertyDifference> CollapseUnindexedCollectionDifferences(
+        ExpandoObject? initial,
+        ExpandoObject changed,
+        IEnumerable<PropertyDifference> differences)
+    {
+        var result = new List<PropertyDifference>();
+        if (differences is null)
+        {
+            return result;
+        }
+
+        var collapsed = new HashSet<(PropertyPath PropertyPath, ArrayIndexers ArrayIndexers)>();
+
+        foreach (var difference in differences)
+        {
+            if (!TryGetUnindexedCollectionPath(difference, out var collectionPath))
+            {
+                result.Add(difference);
+                continue;
+            }
+
+            var collapsedKey = (collectionPath, difference.ArrayIndexers);
+            if (!collapsed.Add(collapsedKey))
+            {
+                continue;
+            }
+
+            result.Add(new PropertyDifference(
+                collectionPath,
+                GetValueAtPath(initial, collectionPath, difference.ArrayIndexers),
+                GetValueAtPath(changed, collectionPath, difference.ArrayIndexers),
+                difference.ArrayIndexers));
+        }
+
+        return result;
+    }
+
+    static bool TryGetUnindexedCollectionPath(PropertyDifference difference, out PropertyPath collectionPath)
+    {
+        collectionPath = PropertyPath.NotSet;
+
+        var currentPath = PropertyPath.Root;
+        var segments = difference.PropertyPath.Segments.ToArray();
+
+        for (var segmentIndex = 0; segmentIndex < segments.Length - 1; segmentIndex++)
+        {
+            var segment = segments[segmentIndex];
+            currentPath += segment;
+
+            if (segment is ArrayProperty && !difference.ArrayIndexers.HasFor(currentPath))
+            {
+                collectionPath = currentPath;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static object? GetValueAtPath(ExpandoObject? instance, PropertyPath propertyPath, ArrayIndexers arrayIndexers)
+    {
+        object? current = instance;
+        var currentPath = PropertyPath.Root;
+
+        foreach (var segment in propertyPath.Segments)
+        {
+            if (current is not ExpandoObject expandoObject)
+            {
+                return null;
+            }
+
+            if (!(expandoObject as IDictionary<string, object?>).TryGetValue(segment.Value, out current))
+            {
+                return null;
+            }
+
+            currentPath += segment;
+
+            if (segment is ArrayProperty && arrayIndexers.HasFor(currentPath))
+            {
+                current = GetElementForIndexer(current, arrayIndexers.GetFor(currentPath));
+            }
+        }
+
+        return current;
+    }
+
+    static object? GetElementForIndexer(object? collection, ArrayIndexer indexer)
+    {
+        if (collection is not IEnumerable enumerable)
+        {
+            return null;
+        }
+
+        var elements = enumerable.Cast<object>().ToArray();
+        if (!indexer.IdentifierProperty.IsSet && indexer.Identifier is int index)
+        {
+            return elements.Length > index ? elements[index] : null;
+        }
+
+        return elements
+            .OfType<ExpandoObject>()
+            .Cast<IDictionary<string, object?>>()
+            .SingleOrDefault(_ =>
+                _.TryGetValue(indexer.IdentifierProperty.Path, out var identifier) &&
+                Equals(identifier, indexer.Identifier));
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoDBCollection.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoDBCollection.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+/// <summary>
+/// Collection fixture that shares a single <see cref="MongoDBFixture"/> across MongoDB sink integration specs.
+/// </summary>
+[CollectionDefinition(Name)]
+public class MongoDBCollection : ICollectionFixture<MongoDBFixture>
+{
+    /// <summary>
+    /// Gets the name of the collection.
+    /// </summary>
+    public const string Name = "MongoDB";
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoDBFixture.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoDBFixture.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+/// <summary>
+/// Provides a shared MongoDB container for sink integration specs.
+/// </summary>
+public sealed class MongoDBFixture : IAsyncLifetime
+{
+    const int MongoDBPort = 27017;
+
+    IContainer? _container;
+
+    /// <summary>
+    /// Gets the MongoDB connection string.
+    /// </summary>
+    public string ConnectionString => $"mongodb://localhost:{_container!.GetMappedPublicPort(MongoDBPort)}/?directConnection=true";
+
+    /// <inheritdoc/>
+    public async Task InitializeAsync()
+    {
+        _container = new ContainerBuilder("mongo")
+            .WithPortBinding(MongoDBPort, assignRandomHostPort: true)
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilInternalTcpPortIsAvailable(MongoDBPort)
+                .UntilCommandIsCompleted("/bin/sh", "-c", "mongosh --quiet --eval 'db.adminCommand(\"ping\").ok' | grep -q 1"))
+            .Build();
+
+        await _container.StartAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_reducer_changes_a_field_on_an_existing_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_reducer_changes_a_field_on_an_existing_child.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Observation.Reducers;
+using Cratis.Chronicle.Observation.Reducers.Clients;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_reducer_changes_a_field_on_an_existing_child.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
+
+[Collection(MongoDBCollection.Name)]
+public class and_reducer_changes_a_field_on_an_existing_child(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : IAsyncLifetime
+    {
+        const string TeamId = "team-1";
+        const string MemberId = "member-1";
+
+        readonly ObjectComparer _objectComparer = new();
+
+        IMongoClient _client = default!;
+        IMongoDatabase _database = default!;
+        IMongoCollection<BsonDocument> _collection = default!;
+        MongoDBConverter _mongoDBConverter = default!;
+        ExpandoObjectConverter _expandoObjectConverter = default!;
+        Sink _sink = default!;
+        ReducerPipeline _pipeline = default!;
+        JsonSchema _schema = default!;
+        Key _key = default!;
+        string _databaseName = default!;
+
+        public Exception? Error;
+        public ExpandoObject? Result;
+        public PropertyDifference[] RawDifferences = [];
+
+        public async Task InitializeAsync()
+        {
+            _databaseName = $"chronicle_sink_specs_{Guid.NewGuid():N}";
+            _client = new MongoClient(fixture.ConnectionString);
+            _database = _client.GetDatabase(_databaseName);
+            _schema = JsonSchema.FromType<Team>();
+            _key = new Key(TeamId, ArrayIndexers.NoIndexers);
+
+            var readModel = CreateReadModelDefinition();
+            var typeFormats = new TypeFormats();
+            _expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
+            var collections = new SinkCollections(readModel, _database);
+            _mongoDBConverter = new MongoDBConverter(_expandoObjectConverter, typeFormats, readModel);
+            var changesetConverter = new ChangesetConverter(readModel, _mongoDBConverter, collections, _expandoObjectConverter);
+            _sink = new Sink(readModel, _mongoDBConverter, collections, changesetConverter, _expandoObjectConverter);
+            _pipeline = new ReducerPipeline(readModel, _sink, _objectComparer, new PassthroughReadModelsCompliance(), "test-store", "test-namespace");
+            _collection = collections.GetCollection();
+
+            var initial = CreateTeam("pending");
+            await InsertInitialDocument(initial);
+
+            var changed = CreateTeam("approved");
+            _objectComparer.Compare(initial, changed, out var rawDifferences);
+            RawDifferences = rawDifferences.ToArray();
+
+            try
+            {
+                await _pipeline.Handle(
+                    new ReducerContext([CreateEvent()], _key),
+                    (_, _) => Task.FromResult(new ReducerSubscriberResult(
+                        ObserverSubscriberResult.Ok(EventSequenceNumber.First),
+                        changed)));
+            }
+            catch (Exception error)
+            {
+                Error = error;
+            }
+
+            Result = await _sink.FindOrDefault(_key);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_databaseName is not null)
+            {
+                await _client.DropDatabaseAsync(_databaseName);
+            }
+        }
+
+        public ExpandoObject[] GetMembers()
+        {
+            var result = (IDictionary<string, object?>)Result!;
+            return ((IEnumerable<object>)result["members"]!).Cast<ExpandoObject>().ToArray();
+        }
+
+        public string GetMemberStatus()
+        {
+            var member = (IDictionary<string, object?>)GetMembers()[0];
+            return (string)member["status"]!;
+        }
+
+        async Task InsertInitialDocument(ExpandoObject initial)
+        {
+            var document = _expandoObjectConverter.ToBsonDocument(initial, _schema);
+            document["_id"] = _mongoDBConverter.ToBsonValue(_key);
+            await _collection.InsertOneAsync(document);
+        }
+
+        static ExpandoObject CreateTeam(string memberStatus)
+        {
+            dynamic member = new ExpandoObject();
+            member.memberId = MemberId;
+            member.status = memberStatus;
+
+            dynamic team = new ExpandoObject();
+            team.id = TeamId;
+            team.members = new object[] { member };
+
+            return team;
+        }
+
+        ReadModelDefinition CreateReadModelDefinition() =>
+            new(
+                "test-team-read-model",
+                "TestTeamReadModel",
+                $"teams_{Guid.NewGuid():N}",
+                ReadModelOwner.Client,
+                ReadModelSource.Code,
+                ReadModelObserverType.Reducer,
+                ReadModelObserverIdentifier.Unspecified,
+                SinkDefinition.None,
+                new Dictionary<ReadModelGeneration, JsonSchema>
+                {
+                    { ReadModelGeneration.First, _schema }
+                },
+                []);
+
+        static AppendedEvent CreateEvent()
+        {
+            var context = EventContext.From(
+                "test-store",
+                "test-namespace",
+                EventType.Unknown,
+                EventSourceType.Default,
+                TeamId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                CorrelationId.NotSet);
+
+            return new AppendedEvent(context, new ExpandoObject());
+        }
+
+        record Member(string MemberId, string Status);
+        record Team(string Id, IEnumerable<Member> Members);
+
+        sealed class PassthroughReadModelsCompliance : IReadModelsCompliance
+        {
+            public Task<ExpandoObject> Apply(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, string identifier, ExpandoObject instance) =>
+                Task.FromResult(instance);
+
+            public Task<JsonObject> ReleaseJson(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, JsonObject instance) =>
+                Task.FromResult(instance);
+
+            public Task<ExpandoObject> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, ExpandoObject instance) =>
+                Task.FromResult(instance);
+
+            public Task<IEnumerable<ExpandoObject>> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, IEnumerable<ExpandoObject> instances) =>
+                Task.FromResult(instances);
+        }
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_keep_object_comparer_fine_grained() => ctx.RawDifferences[0].PropertyPath.Path.ShouldEqual("[members].status");
+    [Fact] void should_find_the_team() => ctx.Result.ShouldNotBeNull();
+    [Fact] void should_keep_one_member() => ctx.GetMembers().Length.ShouldEqual(1);
+    [Fact] void should_update_the_member_status() => ctx.GetMemberStatus().ShouldEqual("approved");
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Storage.MongoDB.Specs.csproj
+++ b/Source/Kernel/Storage.MongoDB.Specs/Storage.MongoDB.Specs.csproj
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Cratis.Arc" />
+        <PackageReference Include="Cratis.Arc" />
+        <PackageReference Include="Testcontainers" />
         <ProjectReference Include="../Storage.MongoDB/Storage.MongoDB.csproj" />
         <ProjectReference Include="../Storage/Storage.csproj" />
         <ProjectReference Include="../Concepts/Concepts.csproj" />


### PR DESCRIPTION
## Fixed
- Fixed MongoDB read-model sink updates for reducer-owned child collections when an existing child element field changes.