### PR TITLE
Fix passive child updates and Mongo child add conflicts

### DIFF
--- a/Integration/Client/for_ReadModels/when_getting_instance_for_passive_projection/and_child_element_is_updated.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instance_for_passive_projection/and_child_element_is_updated.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_for_passive_projection.and_child_element_is_updated.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_for_passive_projection;
+
+[Collection(ChronicleCollection.Name)]
+public class and_child_element_is_updated(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        public Guid ContractId;
+        public Guid CandidateId;
+        public PassiveContract Result;
+
+        public override IEnumerable<Type> EventTypes =>
+        [
+            typeof(PassiveContractCreated),
+            typeof(PassiveCandidateSubmitted),
+            typeof(PassiveCandidateSigned)
+        ];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(PassiveContract)];
+
+        async Task Because()
+        {
+            ContractId = Guid.Parse("8b95cb59-3a99-4bda-a11a-cd0000000001");
+            CandidateId = Guid.Parse("8b95cb59-3a99-4bda-a11a-cd0000000002");
+
+            await EventStore.EventLog.Append(ContractId.ToString(), new PassiveContractCreated("Master Services Agreement"));
+            await EventStore.EventLog.Append(ContractId.ToString(), new PassiveCandidateSubmitted(CandidateId, "Ada Lovelace"));
+            await EventStore.EventLog.Append(ContractId.ToString(), new PassiveCandidateSigned(CandidateId, "Signed in the portal"));
+
+            Result = await EventStore.ReadModels.GetInstanceById<PassiveContract>(ContractId.ToString());
+        }
+    }
+
+    [Fact] void should_return_the_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_have_one_candidate() => Context.Result.Candidates.Count.ShouldEqual(1);
+    [Fact] void should_keep_candidate_identifier() => Candidate.CandidateId.ShouldEqual(Context.CandidateId);
+    [Fact] void should_set_candidate_as_signed() => Candidate.IsSigned.ShouldBeTrue();
+    [Fact] void should_set_candidate_signing_notes() => Candidate.SigningNotes.ShouldEqual("Signed in the portal");
+
+    PassiveCandidate Candidate => Context.Result.Candidates.Single();
+}
+
+[EventType]
+public record PassiveContractCreated(string Name);
+
+[EventType]
+public record PassiveCandidateSubmitted(Guid CandidateId, string Name);
+
+[EventType]
+public record PassiveCandidateSigned(Guid CandidateId, string Notes);
+
+[Passive]
+[FromEvent<PassiveContractCreated>]
+public record PassiveContract(
+    Guid Id,
+    string Name,
+    [ChildrenFrom<PassiveCandidateSubmitted>(key: nameof(PassiveCandidateSubmitted.CandidateId), identifiedBy: nameof(PassiveCandidate.CandidateId))]
+    IReadOnlyList<PassiveCandidate> Candidates);
+
+[FromEvent<PassiveCandidateSubmitted>]
+[FromEvent<PassiveCandidateSigned>(key: nameof(PassiveCandidateSigned.CandidateId))]
+public record PassiveCandidate(
+    [Key] Guid CandidateId,
+    [SetValue<PassiveCandidateSigned>(true)] bool IsSigned,
+    [SetFrom<PassiveCandidateSigned>(nameof(PassiveCandidateSigned.Notes))] string SigningNotes);
+
+#pragma warning restore SA1402

--- a/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_applying_indexed_child_property_difference_to_state.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_applying_indexed_child_property_difference_to_state.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes.for_ChangeCollectionPathExtensions;
+
+public class when_applying_indexed_child_property_difference_to_state : Specification
+{
+    ExpandoObject _state;
+    ExpandoObject _result;
+    Guid _candidateId;
+
+    void Establish()
+    {
+        _candidateId = Guid.NewGuid();
+
+        dynamic candidate = new ExpandoObject();
+        candidate.candidateId = _candidateId;
+        candidate.name = "Ada";
+        candidate.isCustomerSigned = false;
+        candidate.isPartnerSigned = false;
+
+        dynamic state = new ExpandoObject();
+        state.candidates = new List<object> { candidate };
+        _state = state;
+    }
+
+    void Because()
+    {
+        var propertyPath = new PropertyPath("[candidates].isCustomerSigned");
+        var arrayIndexers = new ArrayIndexers(
+        [
+            new ArrayIndexer(
+                new PropertyPath("[candidates]"),
+                new PropertyPath("candidateId"),
+                _candidateId)
+        ]);
+
+        var propertiesChanged = new PropertiesChanged<ExpandoObject>(
+            _state,
+            [new PropertyDifference(propertyPath, false, true, arrayIndexers)]);
+
+        _result = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(_state, new HashSet<PropertyPath>());
+    }
+
+    [Fact] void should_keep_one_candidate() => Candidates.Length.ShouldEqual(1);
+    [Fact] void should_preserve_child_identifier() => Candidate["candidateId"].ShouldEqual(_candidateId);
+    [Fact] void should_preserve_existing_child_field() => Candidate["name"].ShouldEqual("Ada");
+    [Fact] void should_apply_changed_child_field() => Candidate["isCustomerSigned"].ShouldEqual(true);
+    [Fact] void should_preserve_unrelated_child_field() => Candidate["isPartnerSigned"].ShouldEqual(false);
+
+    ExpandoObject[] Candidates => ((IEnumerable<object>)((IDictionary<string, object?>)_result)["candidates"]!).Cast<ExpandoObject>().ToArray();
+    IDictionary<string, object?> Candidate => Candidates[0];
+}

--- a/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_checking_child_operation_conflict_for_descendant_property.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_checking_child_operation_conflict_for_descendant_property.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes.for_ChangeCollectionPathExtensions;
+
+public class when_checking_child_operation_conflict_for_descendant_property : Specification
+{
+    PropertyDifference _childIdentifierDifference;
+    PropertyDifference _childFieldDifference;
+    PropertyDifference _siblingDifference;
+    ISet<PropertyPath> _collectionPathsWithChildOperations;
+
+    bool _childIdentifierResult;
+    bool _childFieldResult;
+    bool _siblingResult;
+
+    void Establish()
+    {
+        _collectionPathsWithChildOperations = new HashSet<PropertyPath>
+        {
+            new("candidates")
+        };
+
+        _childIdentifierDifference = new PropertyDifference("[candidates].$eventSourceId", null, "candidate-1");
+        _childFieldDifference = new PropertyDifference("[candidates].isCustomerSigned", false, true);
+        _siblingDifference = new PropertyDifference("name", "Before", "After");
+    }
+
+    void Because()
+    {
+        _childIdentifierResult = _childIdentifierDifference.ConflictsWithChildOperation(_collectionPathsWithChildOperations);
+        _childFieldResult = _childFieldDifference.ConflictsWithChildOperation(_collectionPathsWithChildOperations);
+        _siblingResult = _siblingDifference.ConflictsWithChildOperation(_collectionPathsWithChildOperations);
+    }
+
+    [Fact] void should_treat_child_identifier_as_conflicting() => _childIdentifierResult.ShouldBeTrue();
+    [Fact] void should_treat_child_field_as_conflicting() => _childFieldResult.ShouldBeTrue();
+    [Fact] void should_not_treat_sibling_property_as_conflicting() => _siblingResult.ShouldBeFalse();
+}

--- a/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
+++ b/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+using Cratis.Chronicle.Dynamic;
 using Cratis.Chronicle.Properties;
 
 namespace Cratis.Chronicle.Changes;
@@ -47,8 +48,31 @@ public static class ChangeCollectionPathExtensions
     /// <param name="difference">The property difference.</param>
     /// <param name="collectionPathsWithChildOperations">Collection paths with child operations.</param>
     /// <returns>True if the property difference conflicts with a child operation; false otherwise.</returns>
-    public static bool ConflictsWithChildOperation(this PropertyDifference difference, ISet<PropertyPath> collectionPathsWithChildOperations) =>
-        collectionPathsWithChildOperations.Contains(difference.PropertyPath.NormalizeCollectionPath());
+    public static bool ConflictsWithChildOperation(this PropertyDifference difference, ISet<PropertyPath> collectionPathsWithChildOperations)
+    {
+        var normalizedPropertyPath = difference.PropertyPath.NormalizeCollectionPath();
+
+        return collectionPathsWithChildOperations.Any(normalizedPropertyPath.IsSameAsOrDescendantOf);
+    }
+
+    /// <summary>
+    /// Applies property differences to an existing state object while excluding properties that conflict with child operations.
+    /// </summary>
+    /// <param name="propertiesChanged">The property change to apply.</param>
+    /// <param name="state">The state to apply the changes to.</param>
+    /// <param name="collectionPathsWithChildOperations">Collection paths with child operations.</param>
+    /// <returns>A state object with non-conflicting property differences applied.</returns>
+    public static ExpandoObject ApplyToStateWithoutChildOperationConflicts(this PropertiesChanged<ExpandoObject> propertiesChanged, ExpandoObject state, ISet<PropertyPath> collectionPathsWithChildOperations)
+    {
+        var result = state.Clone();
+
+        foreach (var difference in propertiesChanged.Differences.Where(_ => !_.ConflictsWithChildOperation(collectionPathsWithChildOperations)))
+        {
+            difference.PropertyPath.SetValue(result, difference.Changed!, difference.ArrayIndexers);
+        }
+
+        return result;
+    }
 
     /// <summary>
     /// Creates a state object from differences that do not conflict with child operations.
@@ -78,4 +102,8 @@ public static class ChangeCollectionPathExtensions
         var segments = propertyPath.Segments.Select(_ => _.Value);
         return new PropertyPath(string.Join('.', segments));
     }
+
+    static bool IsSameAsOrDescendantOf(this PropertyPath propertyPath, PropertyPath candidateParentPath) =>
+        propertyPath == candidateParentPath ||
+        (candidateParentPath.IsSet && propertyPath.Path.StartsWith($"{candidateParentPath.Path}.", StringComparison.Ordinal));
 }

--- a/Source/Kernel/Core/Projections/Projection.cs
+++ b/Source/Kernel/Core/Projections/Projection.cs
@@ -402,7 +402,7 @@ public class Projection(
             switch (change)
             {
                 case PropertiesChanged<ExpandoObject> propertiesChanged:
-                    state = state.MergeWith(propertiesChanged.ToStateWithoutChildOperationConflicts(collectionPathsWithChildOperations));
+                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations);
                     break;
 
                 case ChildAdded childAdded:

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ChangesetConverter/when_converting_to_update_definition/and_child_identifier_change_targets_the_same_collection_as_a_child_added.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ChangesetConverter/when_converting_to_update_definition/and_child_identifier_change_targets_the_same_collection_as_a_child_added.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ChangesetConverter.when_converting_to_update_definition;
+
+public class and_child_identifier_change_targets_the_same_collection_as_a_child_added : given.a_changeset_converter
+{
+    IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    Key _key;
+    EventSequenceNumber _eventSequenceNumber;
+    UpdateDefinitionAndArrayFilters _result;
+    BsonValue _expectedBsonValue;
+    PropertyPath _rolesProperty;
+    PropertyPath _roleIdProperty;
+
+    void Establish()
+    {
+        _key = new Key("some-key", ArrayIndexers.NoIndexers);
+        _eventSequenceNumber = 42UL;
+        _expectedBsonValue = BsonValue.Create(42UL);
+        _rolesProperty = new PropertyPath("Roles");
+        _roleIdProperty = new PropertyPath("[Roles].Id");
+
+        dynamic childState = new ExpandoObject();
+        childState.Id = "role-1";
+        childState.Name = "Administrator";
+
+        var childAdded = new ChildAdded(childState, _rolesProperty, new PropertyPath("Id"), "role-1", ArrayIndexers.NoIndexers);
+        var arrayIndexers = new ArrayIndexers(
+        [
+            new ArrayIndexer(_rolesProperty, new PropertyPath("Id"), "role-1")
+        ]);
+        var propertyDifference = new PropertyDifference(_roleIdProperty, null, "role-1", arrayIndexers);
+        var propertiesChanged = new PropertiesChanged<ExpandoObject>(new ExpandoObject(), [propertyDifference]);
+
+        _changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        _changeset.Changes.Returns([propertiesChanged, childAdded]);
+
+        _mongoDBConverter.ToMongoDBProperty(Arg.Any<PropertyPath>(), Arg.Any<ArrayIndexers>())
+            .Returns(new MongoDBProperty("Roles", []));
+        _mongoDBConverter.ToBsonValue(Arg.Any<object?>(), Arg.Any<PropertyPath>())
+            .Returns(new BsonArray());
+        _mongoDBConverter.ToBsonValue(_eventSequenceNumber)
+            .Returns(_expectedBsonValue);
+        _expandoObjectConverter.ToBsonDocument(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>())
+            .Returns(new BsonDocument());
+    }
+
+    async Task Because() => _result = await _converter.ToUpdateDefinition(_key, _changeset, _eventSequenceNumber);
+
+    [Fact] void should_indicate_has_changes() => _result.hasChanges.ShouldBeTrue();
+    [Fact] void should_have_update_definition() => _result.UpdateDefinition.ShouldNotBeNull();
+    [Fact] void should_not_convert_the_child_identifier_property_change_to_a_set() => _mongoDBConverter.DidNotReceive().ToBsonValue(Arg.Any<object?>(), Arg.Is<PropertyPath>(_ => _ == _roleIdProperty));
+    [Fact] void should_convert_the_child_added_to_a_push() => _expandoObjectConverter.Received(1).ToBsonDocument(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>());
+    [Fact] void should_convert_event_sequence_number_to_bson_value() => _mongoDBConverter.Received(1).ToBsonValue(_eventSequenceNumber);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_child_added_has_child_identifier_change_in_same_changeset.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_child_added_has_child_identifier_change_in_same_changeset.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Driver;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_child_added_has_child_identifier_change_in_same_changeset.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
+
+[Collection(MongoDBCollection.Name)]
+public class and_child_added_has_child_identifier_change_in_same_changeset(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : IAsyncLifetime
+    {
+        const string ContractId = "contract-1";
+        const string CandidateId = "candidate-1";
+
+        IMongoClient _client = default!;
+        IMongoDatabase _database = default!;
+        Sink _sink = default!;
+        Key _key = default!;
+        string _databaseName = default!;
+
+        public Exception? Error;
+        public ExpandoObject? Result;
+
+        public async Task InitializeAsync()
+        {
+            _databaseName = $"chronicle_sink_specs_{Guid.NewGuid():N}";
+            _client = new MongoClient(fixture.ConnectionString);
+            _database = _client.GetDatabase(_databaseName);
+            _key = new Key(ContractId, ArrayIndexers.NoIndexers);
+
+            var readModel = CreateReadModelDefinition();
+            var typeFormats = new TypeFormats();
+            var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
+            var collections = new SinkCollections(readModel, _database);
+            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+            var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
+            _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
+
+            try
+            {
+                await _sink.ApplyChanges(_key, CreateChangeset(), EventSequenceNumber.First);
+            }
+            catch (Exception error)
+            {
+                Error = error;
+            }
+
+            Result = await _sink.FindOrDefault(_key);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_databaseName is not null)
+            {
+                await _client.DropDatabaseAsync(_databaseName);
+            }
+        }
+
+        public ExpandoObject[] GetCandidates()
+        {
+            var result = (IDictionary<string, object?>)Result!;
+            return ((IEnumerable<object>)result["candidates"]!).Cast<ExpandoObject>().ToArray();
+        }
+
+        public IDictionary<string, object?> GetCandidate() => GetCandidates()[0];
+
+        static IChangeset<AppendedEvent, ExpandoObject> CreateChangeset()
+        {
+            dynamic child = new ExpandoObject();
+            child.candidateId = CandidateId;
+            child.name = "Ada Lovelace";
+
+            var candidatesProperty = new PropertyPath("candidates");
+            var childAdded = new ChildAdded(child, candidatesProperty, new PropertyPath("candidateId"), CandidateId, ArrayIndexers.NoIndexers);
+            var arrayIndexers = new ArrayIndexers(
+            [
+                new ArrayIndexer(candidatesProperty, new PropertyPath("candidateId"), CandidateId)
+            ]);
+            var identifierChanged = new PropertyDifference("[candidates].candidateId", null, CandidateId, arrayIndexers);
+            var propertiesChanged = new PropertiesChanged<ExpandoObject>(new ExpandoObject(), [identifierChanged]);
+
+            var changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+            changeset.Changes.Returns([childAdded, propertiesChanged]);
+            changeset.HasBeenRemoved().Returns(false);
+            changeset.HasJoined().Returns(false);
+
+            return changeset;
+        }
+
+        static ReadModelDefinition CreateReadModelDefinition() =>
+            new(
+                "test-contract-read-model",
+                "TestContractReadModel",
+                $"contracts_{Guid.NewGuid():N}",
+                ReadModelOwner.Client,
+                ReadModelSource.Code,
+                ReadModelObserverType.Projection,
+                ReadModelObserverIdentifier.Unspecified,
+                SinkDefinition.None,
+                new Dictionary<ReadModelGeneration, JsonSchema>
+                {
+                    { ReadModelGeneration.First, JsonSchema.FromType<Contract>() }
+                },
+                []);
+
+        record Candidate(string CandidateId, string Name);
+        record Contract(string Id, IEnumerable<Candidate> Candidates);
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_find_the_contract() => ctx.Result.ShouldNotBeNull();
+    [Fact] void should_have_one_candidate() => ctx.GetCandidates().Length.ShouldEqual(1);
+    [Fact] void should_keep_candidate_identifier_on_the_pushed_child() => ctx.GetCandidate()["candidateId"].ShouldEqual("candidate-1");
+    [Fact] void should_keep_candidate_name_on_the_pushed_child() => ctx.GetCandidate()["name"].ShouldEqual("Ada Lovelace");
+}

--- a/Source/Kernel/Storage.Specs/Sinks/InMemory/for_InMemorySink/when_applying_changes/and_indexed_child_property_changes.cs
+++ b/Source/Kernel/Storage.Specs/Sinks/InMemory/for_InMemorySink/when_applying_changes/and_indexed_child_property_changes.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.Sinks.InMemory.for_InMemorySink.when_applying_changes;
+
+public class and_indexed_child_property_changes : Specification
+{
+    Guid _candidateId;
+    InMemorySink _sink;
+    IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    Key _key;
+    ExpandoObject? _result;
+    IEnumerable<FailedPartition> _failedPartitions;
+
+    void Establish()
+    {
+        _candidateId = Guid.NewGuid();
+        _key = new Key("contract-1", ArrayIndexers.NoIndexers);
+        _sink = new InMemorySink(CreateReadModelDefinition(), new TypeFormats());
+
+        dynamic candidate = new ExpandoObject();
+        candidate.candidateId = _candidateId;
+        candidate.name = "Ada";
+        candidate.isCustomerSigned = false;
+        candidate.isPartnerSigned = false;
+
+        dynamic state = new ExpandoObject();
+        state.candidates = new List<object> { candidate };
+
+        var arrayIndexers = new ArrayIndexers(
+        [
+            new ArrayIndexer(
+                new PropertyPath("[candidates]"),
+                new PropertyPath("candidateId"),
+                _candidateId)
+        ]);
+
+        PropertyDifference[] differences =
+        [
+            new PropertyDifference(new PropertyPath("[candidates].isCustomerSigned"), false, true, arrayIndexers)
+        ];
+        var propertiesChanged = new PropertiesChanged<ExpandoObject>(state, differences);
+
+        _changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        _changeset.InitialState.Returns((ExpandoObject)state);
+        Change[] changes = [propertiesChanged];
+        _changeset.Changes.Returns(changes);
+    }
+
+    async Task Because()
+    {
+        _failedPartitions = await _sink.ApplyChanges(_key, _changeset, 42UL);
+        _result = await _sink.FindOrDefault(_key);
+    }
+
+    [Fact] void should_not_fail() => _failedPartitions.ShouldBeEmpty();
+    [Fact] void should_keep_one_candidate() => Candidates.Length.ShouldEqual(1);
+    [Fact] void should_preserve_child_identifier() => Candidate["candidateId"].ShouldEqual(_candidateId);
+    [Fact] void should_preserve_existing_child_field() => Candidate["name"].ShouldEqual("Ada");
+    [Fact] void should_apply_changed_child_field() => Candidate["isCustomerSigned"].ShouldEqual(true);
+    [Fact] void should_preserve_unrelated_child_field() => Candidate["isPartnerSigned"].ShouldEqual(false);
+
+    ExpandoObject[] Candidates => ((IEnumerable<object>)((IDictionary<string, object?>)_result!)["candidates"]!).Cast<ExpandoObject>().ToArray();
+    IDictionary<string, object?> Candidate => Candidates[0];
+
+    static ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-read-model",
+            "TestReadModel",
+            "TestReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, new JsonSchema() }
+            },
+            []);
+}

--- a/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
+++ b/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
@@ -231,7 +231,7 @@ public class InMemorySink(
             switch (change)
             {
                 case PropertiesChanged<ExpandoObject> propertiesChanged:
-                    state = state.MergeWith(propertiesChanged.ToStateWithoutChildOperationConflicts(collectionPathsWithChildOperations));
+                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations);
                     break;
 
                 case ChildAdded childAdded:


### PR DESCRIPTION
## Fixed

- Fixed passive read model projections dropping child element updates.
- Fixed MongoDB sink conflicts when a child add and child identifier update appear in the same changeset.