### PR TITLE
Fix read-model collections of concepts persisting empty

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <!-- Pin the native SQLite library to a patched build (GHSA-2m69-gcr7-jv3q affects <= 2.1.11 pulled in transitively by EF Core Sqlite). -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />

--- a/Integration/Client/for_Reducers/ConceptCollectionItem.cs
+++ b/Integration/Client/for_Reducers/ConceptCollectionItem.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.for_Reducers;
+
+/// <summary>
+/// A bare string concept used as the element type of a read-model collection.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record ConceptCollectionItem(string Value) : ConceptAs<string>(Value);

--- a/Integration/Client/for_Reducers/ConceptCollectionItemAdded.cs
+++ b/Integration/Client/for_Reducers/ConceptCollectionItemAdded.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.for_Reducers;
+
+/// <summary>
+/// Emitted when an item is added to a concept collection.
+/// </summary>
+/// <param name="Item">The added <see cref="ConceptCollectionItem"/>.</param>
+[EventType]
+public record ConceptCollectionItemAdded(ConceptCollectionItem Item);

--- a/Integration/Client/for_Reducers/ConceptCollectionReadModel.cs
+++ b/Integration/Client/for_Reducers/ConceptCollectionReadModel.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.for_Reducers;
+
+/// <summary>
+/// Read model mirroring the shape that surfaced the bug — a scalar concept (which persists fine)
+/// alongside a collection of bare concepts (which previously persisted empty).
+/// </summary>
+/// <param name="Latest">The most recently added item — a scalar concept.</param>
+/// <param name="Items">The collection of <see cref="ConceptCollectionItem"/>.</param>
+public record ConceptCollectionReadModel(ConceptCollectionItem Latest, IReadOnlyList<ConceptCollectionItem> Items);

--- a/Integration/Client/for_Reducers/ConceptCollectionReducer.cs
+++ b/Integration/Client/for_Reducers/ConceptCollectionReducer.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Chronicle.Integration.for_Reducers;
+
+/// <summary>
+/// Reducer that folds <see cref="ConceptCollectionItemAdded"/> events into a growing
+/// <see cref="ConceptCollectionReadModel.Items"/> concept collection.
+/// </summary>
+[DependencyInjection.IgnoreConvention]
+public class ConceptCollectionReducer : IReducerFor<ConceptCollectionReadModel>
+{
+    /// <summary>
+    /// Gets the number of handled events.
+    /// </summary>
+    public int HandledEvents;
+
+    /// <summary>
+    /// Handles a <see cref="ConceptCollectionItemAdded"/> by appending the item to the collection.
+    /// </summary>
+    /// <param name="evt">The event.</param>
+    /// <param name="input">The current read model.</param>
+    /// <param name="ctx">The event context.</param>
+    /// <returns>The updated read model.</returns>
+    public Task<ConceptCollectionReadModel?> OnConceptCollectionItemAdded(ConceptCollectionItemAdded evt, ConceptCollectionReadModel? input, EventContext ctx)
+    {
+        Interlocked.Increment(ref HandledEvents);
+        var items = input?.Items?.ToList() ?? [];
+        items.Add(evt.Item);
+        return Task.FromResult<ConceptCollectionReadModel?>(new ConceptCollectionReadModel(evt.Item, items));
+    }
+
+    /// <summary>
+    /// Waits until the handled event count reaches the specified value.
+    /// </summary>
+    /// <param name="count">Target event count.</param>
+    /// <param name="timeout">Optional timeout.</param>
+    /// <returns>A <see cref="Task"/> that completes when the count is reached.</returns>
+    public async Task WaitTillHandledEventReaches(int count, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (HandledEvents < count)
+        {
+            await Task.Delay(50, cts.Token);
+        }
+    }
+}

--- a/Integration/Client/for_Reducers/when_handling_concept_collection/and_reducer_persists_the_concept_collection.cs
+++ b/Integration/Client/for_Reducers/when_handling_concept_collection/and_reducer_persists_the_concept_collection.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Reducers;
+using context = Cratis.Chronicle.Integration.for_Reducers.when_handling_concept_collection.and_reducer_persists_the_concept_collection.context;
+
+namespace Cratis.Chronicle.Integration.for_Reducers.when_handling_concept_collection;
+
+[Collection(ChronicleCollection.Name)]
+public class and_reducer_persists_the_concept_collection(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification(chronicleFixture)
+    {
+        const string EventSourceId = "surface-1";
+
+        public ConceptCollectionReducer Reducer { get; private set; } = default!;
+        public ConceptCollectionReadModel Persisted { get; private set; } = default!;
+
+        public override IEnumerable<Type> EventTypes => [typeof(ConceptCollectionItemAdded)];
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            Reducer = new ConceptCollectionReducer();
+            services.AddSingleton(Reducer);
+        }
+
+        async Task Because()
+        {
+            await EventStore.ReadModels.Register<ConceptCollectionReadModel>();
+            var reducer = await EventStore.Reducers.Register<ConceptCollectionReducer, ConceptCollectionReadModel>();
+            await reducer.WaitTillSubscribed();
+
+            await EventStore.EventLog.Append(EventSourceId, new ConceptCollectionItemAdded(new ConceptCollectionItem("React")));
+            await EventStore.EventLog.Append(EventSourceId, new ConceptCollectionItemAdded(new ConceptCollectionItem("TypeScript")));
+            await Reducer.WaitTillHandledEventReaches(2);
+
+            // Read the materialized instance back from the sink (storage-agnostic) so the assertion
+            // reflects what was actually persisted and deserialized — not the in-memory reducer state.
+            Persisted = await WaitForPersistedInstance(TimeSpan.FromSeconds(10));
+        }
+
+        async Task<ConceptCollectionReadModel> WaitForPersistedInstance(TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            while (!cts.IsCancellationRequested)
+            {
+                var instances = await EventStore.ReadModels.Materialized.GetInstances<ConceptCollectionReadModel>();
+                var instance = instances.FirstOrDefault(_ => _.Latest is not null);
+                if (instance is { Items.Count: >= 2 })
+                {
+                    return instance;
+                }
+
+                await Task.Delay(100, CancellationToken.None);
+            }
+
+            return null!;
+        }
+    }
+
+    [Fact] void should_persist_the_instance() => Context.Persisted.ShouldNotBeNull();
+    [Fact] void should_persist_the_scalar_concept() => Context.Persisted.Latest.Value.ShouldEqual("TypeScript");
+    [Fact] void should_persist_the_whole_concept_collection() => Context.Persisted.Items.Count.ShouldEqual(2);
+    [Fact] void should_persist_the_first_concept_value() => Context.Persisted.Items.Select(_ => _.Value).ShouldContain("React");
+    [Fact] void should_persist_the_second_concept_value() => Context.Persisted.Items.Select(_ => _.Value).ShouldContain("TypeScript");
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_ConceptCollectionPersistence/given/a_schema_driven_round_trip.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_ConceptCollectionPersistence/given/a_schema_driven_round_trip.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Json;
+using Cratis.Json;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Schemas.for_ConceptCollectionPersistence.given;
+
+public class a_schema_driven_round_trip : Specification
+{
+    protected JsonSchemaGenerator _generator;
+    protected ExpandoObjectConverter _converter;
+    protected JsonSerializerOptions _clientOptions;
+
+    void Establish()
+    {
+        _generator = new(new ComplianceMetadataResolver(
+                new KnownInstancesOf<ICanProvideComplianceMetadataForType>(),
+                new KnownInstancesOf<ICanProvideComplianceMetadataForProperty>()),
+            new DefaultNamingPolicy());
+
+        _converter = new(new TypeFormats());
+
+        // Mirrors the serializer the Chronicle client uses to ship reduced/projected read-model state
+        // to the Kernel — concept values flatten to their underlying primitive via these converters.
+        _clientOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new EnumerableConceptAsJsonConverterFactory(),
+                new ConceptAsJsonConverterFactory()
+            }
+        };
+    }
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_ConceptCollectionPersistence/when_round_tripping_a_read_model_with_a_concept_collection.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_ConceptCollectionPersistence/when_round_tripping_a_read_model_with_a_concept_collection.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Dynamic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Schemas.for_ConceptCollectionPersistence;
+
+public class when_round_tripping_a_read_model_with_a_concept_collection : given.a_schema_driven_round_trip
+{
+    record Requirement(string Value) : ConceptAs<string>(Value);
+    record CandidateItem(string Name, int Score);
+    record Surface(
+        Guid Id,
+        IReadOnlyList<Requirement> Requirements,
+        IEnumerable<CandidateItem> Candidates);
+
+    IDictionary<string, object?> _result;
+
+    void Because()
+    {
+        var instance = new Surface(
+            Guid.NewGuid(),
+            [new Requirement("React"), new Requirement("TypeScript")],
+            [new CandidateItem("Alice", 10)]);
+
+        var schema = _generator.Generate(typeof(Surface));
+        var json = JsonSerializer.Serialize(instance, _clientOptions);
+        _result = _converter.ToExpandoObject(JsonNode.Parse(json)!.AsObject(), schema);
+    }
+
+    [Fact] void should_keep_the_concept_collection_property() => _result.ContainsKey("Requirements").ShouldBeTrue();
+    [Fact] void should_preserve_all_concept_collection_elements() => ((IEnumerable)_result["Requirements"]!).Cast<object>().Select(_ => _.ToString()).ShouldContainOnly(["React", "TypeScript"]);
+    [Fact] void should_keep_the_record_collection_property() => _result.ContainsKey("Candidates").ShouldBeTrue();
+    [Fact] void should_preserve_all_record_collection_elements() => ((IEnumerable)_result["Candidates"]!).Cast<ExpandoObject>().Count().ShouldEqual(1);
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_concept_collection_property.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_concept_collection_property.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+public class when_generating_schema_for_type_with_concept_collection_property : given.a_json_schema_generator
+{
+    record StringConcept(string Value) : ConceptAs<string>(Value);
+    record GuidConcept(Guid Value) : ConceptAs<Guid>(Value);
+    record TypeWithConceptCollections(
+        IReadOnlyList<StringConcept> StringConcepts,
+        IEnumerable<GuidConcept> GuidConcepts,
+        StringConcept ScalarConcept);
+
+    JsonSchema _result;
+
+    void Because() => _result = _generator.Generate(typeof(TypeWithConceptCollections));
+
+    [Fact] void should_make_string_concept_list_an_array() => _result.ActualProperties["StringConcepts"].Type.ShouldEqual(JsonObjectType.Array);
+    [Fact] void should_give_string_concept_list_string_items() => _result.ActualProperties["StringConcepts"].Item!.Type.ShouldEqual(JsonObjectType.String);
+    [Fact] void should_make_guid_concept_list_an_array() => _result.ActualProperties["GuidConcepts"].Type.ShouldEqual(JsonObjectType.Array);
+    [Fact] void should_give_guid_concept_list_string_items() => _result.ActualProperties["GuidConcepts"].Item!.Type.ShouldEqual(JsonObjectType.String);
+    [Fact] void should_give_guid_concept_list_items_the_underlying_primitive_format() => _result.ActualProperties["GuidConcepts"].Item!.Format.ShouldEqual("guid");
+    [Fact] void should_keep_scalar_concept_as_underlying_primitive() => _result.ActualProperties["ScalarConcept"].Type.ShouldEqual(JsonObjectType.String);
+}

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -10,6 +10,7 @@ using Cratis.Chronicle.Compliance;
 using Cratis.Chronicle.Events;
 using Cratis.Geospatial;
 using Cratis.Json;
+using Cratis.Reflection;
 using Cratis.Serialization;
 
 namespace Cratis.Chronicle.Schemas;
@@ -177,6 +178,28 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
             }
 
             return conceptSchema;
+        }
+
+        // Handle enumerables whose element type is a concept (e.g. IReadOnlyList<Requirement>).
+        // System.Text.Json's schema exporter cannot introspect the EnumerableConceptAsJsonConverter,
+        // so it emits a permissive boolean schema (`true`) for the property. A non-object schema is
+        // not a JsonObject, so it is excluded from the read model's flattened properties — which
+        // silently drops the property from the persisted document (it never reaches the storage sink).
+        // Emit a proper array schema whose items are the concept's underlying primitive schema, the
+        // same primitive mapping a scalar concept gets, so the value round-trips through the sink.
+        if (type != typeof(string) && type.IsEnumerable() && !type.IsDictionary())
+        {
+            var elementType = type.GetEnumerableElementType();
+            if (elementType?.IsConcept() == true)
+            {
+                var underlyingItemType = elementType.GetConceptValueType();
+                var itemSchema = context.TypeInfo.Options.GetJsonSchemaAsNode(underlyingItemType, _exporterOptions);
+                return new JsonObject
+                {
+                    ["type"] = "array",
+                    ["items"] = itemSchema
+                };
+            }
         }
 
         if (schema is not JsonObject schemaObj) return schema;

--- a/Source/Kernel/Storage.Sql/Storage.Sql.csproj
+++ b/Source/Kernel/Storage.Sql/Storage.Sql.csproj
@@ -23,6 +23,8 @@
       <PackageReference Include="Cratis.Arc.EntityFrameworkCore" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+      <!-- Override the vulnerable native SQLite library (GHSA-2m69-gcr7-jv3q) pulled in transitively by EF Core Sqlite. -->
+      <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
       <PackageReference Include="Microsoft.Data.SqlClient" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />


### PR DESCRIPTION
## Fixed

- Read-model properties typed as a collection of concepts (e.g. `IReadOnlyList<MyConcept>` where `MyConcept : ConceptAs<string>`) are no longer silently persisted as an empty/missing array. Such a property now stores the unwrapped underlying values, the same way a scalar concept already did. A scalar concept and a collection of records in the same read model were always persisted correctly; only collections of bare concepts were affected.

## Security

- Pin the native SQLite library (`SQLitePCLRaw.lib.e_sqlite3`) to the patched `3.50.3` build, addressing a known high-severity vulnerability (GHSA-2m69-gcr7-jv3q) bundled in the `2.1.11` version pulled in transitively by EF Core Sqlite.
