### PR TITLE
Fix projection replay ordering across partitions

### DIFF
--- a/.ai/skills/ship-changes/SKILL.md
+++ b/.ai/skills/ship-changes/SKILL.md
@@ -123,9 +123,13 @@ Use `mcp_github_github_create_pull_request` with:
 
 ### PR description format
 
-Follow `.github/pull_request_template.md`. Include only non-empty sections.
+Follow `.github/pull_request_template.md` exactly, and write the body as
+release notes. Include only non-empty sections.
 
 ```markdown
+# Summary
+<optional short overview>
+
 ## Added
 - <release-note bullet> (#<actual-issue-number>)
 
@@ -138,9 +142,11 @@ Follow `.github/pull_request_template.md`. Include only non-empty sections.
 
 Rules:
 - Bullets are short, release-note ready, written for a user reading the changelog.
+- Use `# Summary` when the release-note bullets need context. The summary should
+  explain what was fixed from the consumer's point of view and why the fix matters
+  when that context is useful, instead of listing implementation details.
 - End every bullet with `(#<N>)` using the **real** GitHub issue number. Search issues first. If there is no issue, omit the reference entirely — never write `(#issue)` or reuse an example number.
 - Remove any empty sections — no blank headings.
-- Include a `# Summary` paragraph only when the bullets alone don't tell the full story.
 - Never include any Copilot prompt transcript or "Original prompt" block.
 
 ### Searching for a related issue

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/TestableHandleEventsForObserver.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/TestableHandleEventsForObserver.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Monads;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver;
+
+/// <summary>
+/// A testable subclass of <see cref="HandleEventsForObserver"/> that exposes the protected
+/// <see cref="HandleEventsForObserver.PerformStep"/> and provides a way to inject test doubles.
+/// </summary>
+/// <param name="state">The persistent state for the job step.</param>
+/// <param name="throttle">The throttle for limiting parallel execution.</param>
+/// <param name="storage">The storage for the cluster.</param>
+/// <param name="eventCompliance">The <see cref="IEventCompliance"/> for decrypting PII event content.</param>
+/// <param name="logger">The logger.</param>
+public class TestableHandleEventsForObserver(
+    [PersistentState(nameof(JobStepState), WellKnownGrainStorageProviders.JobSteps)]
+    IPersistentState<HandleEventsForObserverState> state,
+    IJobStepThrottle throttle,
+    IStorage storage,
+    IEventCompliance eventCompliance,
+    ILogger<HandleEventsForObserver> logger)
+    : HandleEventsForObserver(state, throttle, storage, eventCompliance, logger), IGrainType
+{
+    static readonly FieldInfo _observerField = typeof(HandleEventsForObserver).GetField("_observer", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    static readonly FieldInfo _subscriptionField = typeof(HandleEventsForObserver).GetField("_subscription", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    readonly IHandleEventsForObserver _selfReference = Substitute.For<IHandleEventsForObserver>();
+
+    /// <inheritdoc/>
+    public Type GrainType => typeof(IHandleEventsForObserver);
+
+    /// <inheritdoc/>
+    protected override IHandleEventsForObserver GetSelfGrainReference() => _selfReference;
+
+    /// <summary>
+    /// Sets up internal fields for testing, bypassing the full grain preparation flow.
+    /// </summary>
+    /// <param name="observer">The <see cref="IObserver"/> grain mock.</param>
+    /// <param name="subscription">The observer subscription.</param>
+    public void SetupForTesting(IObserver observer, ObserverSubscription subscription)
+    {
+        _observerField.SetValue(this, observer);
+        _subscriptionField.SetValue(this, subscription);
+    }
+
+    /// <summary>
+    /// Exposes the protected <see cref="HandleEventsForObserver.PerformStep"/> for testing.
+    /// </summary>
+    /// <param name="currentState">The current state of the job step.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The result of the step.</returns>
+    public Task<Catch<JobStepResult>> InvokePerformStep(HandleEventsForObserverState currentState, CancellationToken cancellationToken = default) =>
+        PerformStep(currentState, cancellationToken);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/HandledBatch.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/HandledBatch.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.given;
+
+public record HandledBatch(Key Partition, IReadOnlyList<EventSequenceNumber> SequenceNumbers);

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/ISomeObserverType.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/ISomeObserverType.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.given;
+
+public interface ISomeObserverType : IObserverSubscriber;
+

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/a_performing_job_step.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/a_performing_job_step.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.EventTypes;
+using Cratis.Chronicle.Storage.Jobs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.given;
+
+public class a_performing_job_step : Specification
+{
+    protected TestableHandleEventsForObserver _jobStep;
+    protected IPersistentState<HandleEventsForObserverState> _stateStorage;
+    protected TestKitSilo _silo = new();
+    protected Storage.IStorage _storage;
+    protected IObserver _observer;
+    protected ISomeObserverType _observerSubscriber;
+    protected IEventCursor _eventCursor;
+    protected IEventSequenceStorage _eventSequenceStorage;
+    protected HandleEventsForObserverState _performState;
+    protected EventSourceId? _eventSourceIdFilter;
+    protected readonly List<HandledBatch> _handledBatches = [];
+
+    protected static AppendedEvent CreateEvent(EventSequenceNumber sequenceNumber, EventSourceId eventSourceId) =>
+        AppendedEvent.EmptyWithEventSequenceNumber(sequenceNumber) with
+        {
+            Context = EventContext.Empty with
+            {
+                SequenceNumber = sequenceNumber,
+                EventSourceId = eventSourceId
+            }
+        };
+
+    async Task Establish()
+    {
+        var eventStoreStorage = Substitute.For<Storage.IEventStoreStorage>();
+        var namespaceStorage = Substitute.For<Storage.IEventStoreNamespaceStorage>();
+        _eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+        var eventTypesStorage = Substitute.For<IEventTypesStorage>();
+
+        _storage = Substitute.For<Storage.IStorage>();
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(eventStoreStorage);
+        eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(namespaceStorage);
+        namespaceStorage.GetEventSequence(Arg.Any<EventSequenceId>()).Returns(_eventSequenceStorage);
+        eventStoreStorage.EventTypes.Returns(eventTypesStorage);
+        eventTypesStorage.GetFor(Arg.Any<IEnumerable<EventType>>())
+            .Returns(Task.FromResult<IEnumerable<EventTypeSchema>>([]));
+
+        _eventCursor = Substitute.For<IEventCursor>();
+        _eventCursor.Current.Returns([
+            CreateEvent(1UL, "module"),
+            CreateEvent(2UL, "feature"),
+            CreateEvent(3UL, "module")
+        ]);
+        var moveNextCount = 0;
+        _eventCursor.MoveNext().Returns(_ => Task.FromResult(moveNextCount++ == 0));
+
+        _eventSequenceStorage.GetRange(
+            Arg.Any<EventSequenceNumber>(),
+            Arg.Any<EventSequenceNumber>(),
+            Arg.Do<EventSourceId?>(value => _eventSourceIdFilter = value),
+            Arg.Any<IEnumerable<EventType>>(),
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(_eventCursor));
+
+        var observerKey = new ObserverKey("observer-id", "event-store", "event-store-namespace", EventSequenceId.Log);
+        var subscription = new ObserverSubscription(
+            "observer-id",
+            observerKey,
+            [],
+            typeof(ISomeObserverType),
+            SiloAddress.Zero);
+        _observer = Substitute.For<IObserver>();
+        _observer.GetSubscription().Returns(subscription);
+        _observerSubscriber = Substitute.For<ISomeObserverType>();
+        _observerSubscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(call =>
+            {
+                var partition = call.Arg<Key>();
+                var events = call.ArgAt<IEnumerable<AppendedEvent>>(1).ToArray();
+                _handledBatches.Add(new(partition, events.Select(_ => _.Context.SequenceNumber).ToArray()));
+                return Task.FromResult(ObserverSubscriberResult.Ok(events[^1].Context.SequenceNumber));
+            });
+
+        _silo.AddProbe(_ => _observer);
+        _silo.AddProbe(_ => _observerSubscriber);
+        _silo.AddService(_storage);
+        _silo.AddService(Substitute.For<IJobStepThrottle>());
+
+        var eventCompliance = Substitute.For<IEventCompliance>();
+        eventCompliance
+            .Release(Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<IDictionary<EventType, EventTypeSchema>>())
+            .Returns(callInfo => Task.FromResult(callInfo.Arg<IEnumerable<AppendedEvent>>().ToArray()));
+        _silo.AddService(eventCompliance);
+
+        var logger = _silo.AddService(NullLogger<HandleEventsForObserver>.Instance);
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        _silo.AddService(loggerFactory);
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+
+        _stateStorage = _silo.AddPersistentStateStorage<HandleEventsForObserverState>(
+            nameof(JobStepState),
+            WellKnownGrainStorageProviders.JobSteps);
+
+        _performState = new HandleEventsForObserverState
+        {
+            ObserverKey = observerKey,
+            StartEventSequenceNumber = EventSequenceNumber.First,
+            EndEventSequenceNumber = EventSequenceNumber.Max,
+            EventObservationState = EventObservationState.Replay,
+            LastSuccessfullyHandledEventSequenceNumber = EventSequenceNumber.Unavailable
+        };
+
+        _jobStep = await _silo.CreateGrainAsync<TestableHandleEventsForObserver>(
+            JobStepId.New(),
+            new JobStepKey(JobId.New(), "event-store", "event-store-namespace"));
+        _jobStep.SetupForTesting(_observer, subscription);
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_child_partition_depends_on_parent_partition.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_child_partition_depends_on_parent_partition.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.when_performing;
+
+public class and_child_partition_depends_on_parent_partition : given.a_performing_job_step
+{
+    bool _parentWasMaterialized;
+    bool _childWasResolved;
+
+    void Establish()
+    {
+        _eventCursor.Current.Returns([
+            CreateEvent(1UL, "parent"),
+            CreateEvent(2UL, "child")
+        ]);
+
+        _observerSubscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(call =>
+            {
+                var partition = call.Arg<Key>();
+                var events = call.ArgAt<IEnumerable<AppendedEvent>>(1).ToArray();
+                _handledBatches.Add(new(partition, events.Select(_ => _.Context.SequenceNumber).ToArray()));
+                if (partition == (Key)"parent")
+                {
+                    _parentWasMaterialized = true;
+                    return Task.FromResult(ObserverSubscriberResult.Ok(events[^1].Context.SequenceNumber));
+                }
+
+                if (!_parentWasMaterialized)
+                {
+                    return Task.FromResult(ObserverSubscriberResult.Failed(EventSequenceNumber.Unavailable, "Parent was not materialized"));
+                }
+
+                _childWasResolved = true;
+                return Task.FromResult(ObserverSubscriberResult.Ok(events[^1].Context.SequenceNumber));
+            });
+    }
+
+    async Task Because() => await _jobStep.InvokePerformStep(_performState);
+
+    [Fact] void should_materialize_parent() => _parentWasMaterialized.ShouldBeTrue();
+    [Fact] void should_resolve_child_after_parent() => _childWasResolved.ShouldBeTrue();
+    [Fact] void should_not_report_partition_failed() => _observer.DidNotReceive().PartitionFailed(Arg.Any<Key>(), Arg.Any<EventSequenceNumber>(), Arg.Any<IEnumerable<string>>(), Arg.Any<string>());
+    [Fact] void should_handle_parent_before_child() => _handledBatches[0].Partition.ShouldEqual((Key)"parent");
+    [Fact] void should_handle_child_after_parent() => _handledBatches[1].Partition.ShouldEqual((Key)"child");
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_events_are_interleaved_across_partitions.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_events_are_interleaved_across_partitions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.when_performing;
+
+public class and_events_are_interleaved_across_partitions : given.a_performing_job_step
+{
+    async Task Because() => await _jobStep.InvokePerformStep(_performState);
+
+    [Fact] void should_read_without_event_source_id_filter() => _eventSourceIdFilter.ShouldBeNull();
+    [Fact] void should_handle_three_consecutive_partition_batches() => _handledBatches.Count.ShouldEqual(3);
+    [Fact] void should_handle_first_module_partition_first() => _handledBatches[0].Partition.ShouldEqual((Key)"module");
+    [Fact] void should_handle_first_module_event_first() => _handledBatches[0].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)1UL);
+    [Fact] void should_handle_feature_partition_second() => _handledBatches[1].Partition.ShouldEqual((Key)"feature");
+    [Fact] void should_handle_feature_event_second() => _handledBatches[1].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)2UL);
+    [Fact] void should_handle_second_module_partition_last() => _handledBatches[2].Partition.ShouldEqual((Key)"module");
+    [Fact] void should_handle_second_module_event_last() => _handledBatches[2].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)3UL);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/TestableReplayObserver.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/TestableReplayObserver.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_ReplayObserver;
+
+/// <summary>
+/// A testable subclass of <see cref="ReplayObserver"/> that exposes step preparation.
+/// </summary>
+/// <param name="replayStateServiceClient">The <see cref="IObserverServiceClient"/> for replay notifications.</param>
+/// <param name="storage">The <see cref="IStorage"/> for accessing key indexes.</param>
+/// <param name="jsonSerializerOptions">The serializer options used for JSON serialization.</param>
+/// <param name="logger">The logger.</param>
+public class TestableReplayObserver(
+    IObserverServiceClient replayStateServiceClient,
+    IStorage storage,
+    JsonSerializerOptions jsonSerializerOptions,
+    ILogger<ReplayObserver> logger)
+    : ReplayObserver(replayStateServiceClient, storage, jsonSerializerOptions, logger), IGrainType
+{
+    /// <inheritdoc/>
+    public Type GrainType => typeof(IReplayObserver);
+
+    /// <summary>
+    /// Invokes <see cref="ReplayObserver.PrepareSteps"/> for testing.
+    /// </summary>
+    /// <param name="request">The request to prepare steps for.</param>
+    /// <returns>The prepared steps.</returns>
+    public Task<IImmutableList<JobStepDetails>> PrepareStepsForTesting(ReplayObserverRequest request) =>
+        PrepareSteps(request);
+}
+

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/given/a_replay_observer_job.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/given/a_replay_observer_job.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Chronicle.Storage.Keys;
+using Cratis.Monads;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Core;
+using Orleans.TestKit;
+using Orleans.Utilities;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
+using IEventStoreNamespaceStorage = Cratis.Chronicle.Storage.IEventStoreNamespaceStorage;
+using IEventStoreStorage = Cratis.Chronicle.Storage.IEventStoreStorage;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_ReplayObserver.given;
+
+public class a_replay_observer_job : Specification
+{
+    protected TestKitSilo _silo = new();
+    protected TestableReplayObserver _job;
+    protected IObserverServiceClient _replayServiceClient;
+    protected IChronicleStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IJobStorage _jobStorage;
+    protected IJobStepStorage _jobStepStorage;
+    protected IJobTypes _jobTypes;
+    protected IObserverKeyIndexes _keyIndexes;
+    protected IObserverKeyIndex _keyIndex;
+    protected JobId _jobId;
+    protected JobKey _jobKey;
+    protected ReplayObserverRequest _request;
+    protected IStorage<JobStateWithLastHandledEvent> _stateStorage;
+
+    protected static IObserverKeys CreateKeys(params Key[] keys) => new ObserverKeysForTesting(keys);
+
+    async Task Establish()
+    {
+        _jobId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        _jobKey = new("event-store", "namespace");
+
+        var observerKey = new ObserverKey("observer-id", "event-store", "namespace", EventSequenceId.Log);
+        _request = new(
+            observerKey,
+            ObserverType.Projection,
+            []);
+
+        _replayServiceClient = Substitute.For<IObserverServiceClient>();
+        _storage = Substitute.For<IChronicleStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _jobStorage = Substitute.For<IJobStorage>();
+        _jobStepStorage = Substitute.For<IJobStepStorage>();
+        _jobTypes = Substitute.For<IJobTypes>();
+        _keyIndexes = Substitute.For<IObserverKeyIndexes>();
+        _keyIndex = Substitute.For<IObserverKeyIndex>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_namespaceStorage);
+        _namespaceStorage.Jobs.Returns(_jobStorage);
+        _namespaceStorage.JobSteps.Returns(_jobStepStorage);
+        _namespaceStorage.ObserverKeyIndexes.Returns(_keyIndexes);
+
+        _keyIndexes.GetFor(Arg.Any<ObserverKey>()).Returns(Task.FromResult(_keyIndex));
+        _keyIndex.GetKeys(Arg.Any<EventSequenceNumber>()).Returns(CreateKeys());
+
+        _jobStepStorage.GetForJob(Arg.Any<JobId>(), Arg.Any<JobStepStatus[]>())
+            .Returns(Task.FromResult(Catch<IImmutableList<JobStepState>>.Success(ImmutableList<JobStepState>.Empty)));
+
+        _jobTypes.GetFor(Arg.Any<Type>())
+            .Returns(Result<JobType, IJobTypes.GetForError>.Success(new JobType("ReplayObserver")));
+
+        _silo.AddService(new JsonSerializerOptions());
+        _silo.AddService(_replayServiceClient);
+        _silo.AddService(_storage);
+        _silo.AddService(_jobTypes);
+        _silo.AddService(NullLogger<IJob>.Instance);
+        _silo.AddService(NullLogger<ObserverManager<IJobObserver>>.Instance);
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        _silo.AddService(loggerFactory);
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(NullLogger.Instance);
+
+        _stateStorage = _silo.StorageManager.GetStorage<JobStateWithLastHandledEvent>(
+            typeof(TestableReplayObserver).FullName!);
+
+        _job = await _silo.CreateGrainAsync<TestableReplayObserver>(_jobId, _jobKey);
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/when_preparing_steps/and_observer_is_a_projection.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/when_preparing_steps/and_observer_is_a_projection.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_ReplayObserver.when_preparing_steps;
+
+public class and_observer_is_a_projection : given.a_replay_observer_job
+{
+    IImmutableList<JobStepDetails> _steps;
+
+    async Task Because() => _steps = await _job.PrepareStepsForTesting(_request);
+
+    [Fact] void should_create_one_step() => _steps.Count.ShouldEqual(1);
+    [Fact] void should_use_ordered_observer_step() => _steps[0].Type.ShouldEqual(typeof(IHandleEventsForObserver));
+    [Fact] void should_not_enumerate_partitions() => _keyIndexes.DidNotReceive().GetFor(Arg.Any<ObserverKey>());
+    [Fact] void should_request_replay_observation_state() => ((HandleEventsForObserverArguments)_steps[0].Request).EventObservationState.ShouldEqual(EventObservationState.Replay);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/when_preparing_steps/and_observer_is_not_a_projection.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_ReplayObserver/when_preparing_steps/and_observer_is_not_a_projection.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Jobs;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_ReplayObserver.when_preparing_steps;
+
+public class and_observer_is_not_a_projection : given.a_replay_observer_job
+{
+    static readonly Key _key1 = (Key)"partition-1";
+    static readonly Key _key2 = (Key)"partition-2";
+    IImmutableList<JobStepDetails> _steps;
+
+    void Establish()
+    {
+        _request = _request with { ObserverType = ObserverType.Reactor };
+        _keyIndex.GetKeys(Arg.Any<EventSequenceNumber>()).Returns(CreateKeys(_key1, _key2));
+    }
+
+    async Task Because() => _steps = await _job.PrepareStepsForTesting(_request);
+
+    [Fact] void should_create_one_step_per_partition() => _steps.Count.ShouldEqual(2);
+    [Fact] void should_use_partition_steps() => _steps.All(_ => _.Type == typeof(IHandleEventsForPartition)).ShouldBeTrue();
+    [Fact] void should_include_first_partition() => ((HandleEventsForPartitionArguments)_steps[0].Request).Partition.ShouldEqual(_key1);
+    [Fact] void should_include_second_partition() => ((HandleEventsForPartitionArguments)_steps[1].Request).Partition.ShouldEqual(_key2);
+}
+

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
@@ -1,0 +1,428 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Monads;
+using Microsoft.Extensions.Logging;
+using OneOf.Types;
+
+namespace Cratis.Chronicle.Observation.Jobs;
+
+/// <summary>
+/// Represents a step in a replay job that handles events in global event-sequence order.
+/// </summary>
+/// <param name="state"><see cref="IPersistentState{TState}"/> for managing state of the job step.</param>
+/// <param name="throttle">The <see cref="IJobStepThrottle"/> for limiting parallel execution.</param>
+/// <param name="storage"><see cref="IStorage"/> for accessing storage for the cluster.</param>
+/// <param name="eventCompliance"><see cref="IEventCompliance"/> for decrypting PII event content before dispatching to subscribers.</param>
+/// <param name="logger">The logger.</param>
+public class HandleEventsForObserver(
+    [PersistentState(nameof(JobStepState), WellKnownGrainStorageProviders.JobSteps)]
+    IPersistentState<HandleEventsForObserverState> state,
+    IJobStepThrottle throttle,
+    IStorage storage,
+    IEventCompliance eventCompliance,
+    ILogger<HandleEventsForObserver> logger) : JobStep<HandleEventsForObserverArguments, HandleEventsForPartitionResult, HandleEventsForObserverState>(state, throttle, logger), IHandleEventsForObserver
+{
+    const string SubscriberDisconnected = "Subscriber is disconnected";
+
+    IEventSequenceStorage? _eventSequenceStorage;
+    IObserver _observer = null!;
+    ObserverSubscription _subscription = ObserverSubscription.Unsubscribed;
+    Dictionary<EventType, EventTypeSchema> _eventTypeSchemas = [];
+
+    IHandleEventsForObserver _selfGrainReference = null!;
+
+    /// <inheritdoc/>
+    public override async Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        _selfGrainReference = GetSelfGrainReference();
+
+        if (State.IsPrepared)
+        {
+            _observer = GrainFactory.GetGrain<IObserver>(State.ObserverKey);
+            _subscription = await _observer.GetSubscription();
+        }
+        await base.OnActivateAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task ReportNewSuccessfullyHandledEvent(EventSequenceNumber lastHandledEventSequenceNumber)
+    {
+        using var scope = logger.BeginJobStepScope(State);
+        State.LastSuccessfullyHandledEventSequenceNumber = lastHandledEventSequenceNumber;
+        var writeStateResult = await WriteStateAsync();
+        if (writeStateResult.TryGetException(out var error))
+        {
+            logger.FailedToPersistSuccessfullyHandledEvent(error, lastHandledEventSequenceNumber);
+            writeStateResult.RethrowError();
+        }
+    }
+
+    /// <summary>
+    /// Gets the self grain reference for this grain instance.
+    /// </summary>
+    /// <returns>The <see cref="IHandleEventsForObserver"/> grain reference.</returns>
+    protected virtual IHandleEventsForObserver GetSelfGrainReference() => this.AsReference<IHandleEventsForObserver>();
+
+    /// <inheritdoc/>
+    protected override ValueTask InitializeState(HandleEventsForObserverArguments request)
+    {
+        State.ObserverKey = request.ObserverKey;
+        State.EventObservationState = request.EventObservationState;
+        State.EventTypes = request.EventTypes.ToArray();
+        State.StartEventSequenceNumber = request.StartEventSequenceNumber;
+        State.EndEventSequenceNumber = request.EndEventSequenceNumber;
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    protected override ValueTask<HandleEventsForPartitionResult?> CreateCancelledResultFromCurrentState(HandleEventsForObserverState currentState) =>
+        ValueTask.FromResult<HandleEventsForPartitionResult?>(new(currentState.LastSuccessfullyHandledEventSequenceNumber));
+
+    /// <inheritdoc/>
+    protected override async Task<Monads.Result<PrepareJobStepError>> PrepareStep(HandleEventsForObserverArguments request)
+    {
+        try
+        {
+            logger.Preparing(request.StartEventSequenceNumber, request.EndEventSequenceNumber);
+            _observer = GrainFactory.GetGrain<IObserver>(request.ObserverKey);
+            _subscription = await _observer.GetSubscription();
+
+            if (_subscription.IsSubscribed)
+            {
+                logger.SuccessfullyPrepared();
+                return Result.Success<PrepareJobStepError>();
+            }
+
+            logger.PreparingStoppedUnsubscribed();
+            return Result.Failed(PrepareJobStepError.CannotPrepare);
+        }
+        catch (Exception e)
+        {
+            logger.FailedPreparing(e, nameof(HandleEventsForObserver));
+            return Result.Failed(PrepareJobStepError.UnexpectedErrorPreparing);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<Catch<JobStepResult>> PerformStep(HandleEventsForObserverState currentState, CancellationToken cancellationToken)
+    {
+        var lastSuccessfullyHandledEventSequenceNumber = EventSequenceNumber.Unavailable;
+        _subscription = await _observer.GetSubscription();
+        try
+        {
+            lastSuccessfullyHandledEventSequenceNumber = currentState.LastSuccessfullyHandledEventSequenceNumber;
+            if (!_subscription.IsSubscribed)
+            {
+                logger.PerformingStoppedUnsubscribed();
+                return JobStepResult.Failed(SubscriberDisconnected, "This should have been ensured in the Prepare operation");
+            }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                logger.CancelledBeforeHandlingAnyEvents();
+                return JobStepResult.Failed(PerformJobStepError.CancelledWithNoResult());
+            }
+            var eventSequenceStorage = GetEventSequenceStorage(
+                currentState.ObserverKey.EventStore,
+                currentState.ObserverKey.Namespace,
+                currentState.ObserverKey.EventSequenceId);
+            var requestedEventTypes = currentState.EventTypes.ToArray();
+            var eventTypesToRead = requestedEventTypes.Length != 0
+                ? requestedEventTypes
+                : _subscription.EventTypes.ToArray();
+            var nonRedactionEventTypeIds = eventTypesToRead
+                .Where(et => et.Id != GlobalEventTypes.Redaction)
+                .Select(et => et.Id)
+                .ToHashSet();
+            _eventTypeSchemas = (await storage.GetEventStore(currentState.ObserverKey.EventStore).EventTypes.GetFor(eventTypesToRead))
+                .ToDictionary(_ => _.Type);
+
+            using var events = await eventSequenceStorage.GetRange(
+                currentState.LastSuccessfullyHandledEventSequenceNumber == EventSequenceNumber.Unavailable
+                    ? currentState.StartEventSequenceNumber
+                    : currentState.LastSuccessfullyHandledEventSequenceNumber.Next(),
+                currentState.EndEventSequenceNumber,
+                eventTypes: eventTypesToRead,
+                cancellationToken: cancellationToken);
+
+            var subscriberContext = new ObserverSubscriberContext(_subscription.Arguments);
+            var lastEventSequenceNumberAttempted = EventSequenceNumber.Unavailable;
+            while (await events.MoveNext())
+            {
+                var eventsToHandle = SetObservationStateIfSpecified(currentState.EventObservationState, events)
+                    .OrderBy(_ => _.Context.SequenceNumber)
+                    .ToArray();
+                eventsToHandle = FilterRedactedEventsForUnsubscribedTypes(eventsToHandle, nonRedactionEventTypeIds);
+
+                foreach (var partitionEvents in GetConsecutivePartitionBatches(eventsToHandle))
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        LogCancelled(lastSuccessfullyHandledEventSequenceNumber);
+                        return JobStepResult.Failed(PerformJobStepError.CancelledWithPartialResult(CreateResult(lastSuccessfullyHandledEventSequenceNumber)));
+                    }
+
+                    var partition = partitionEvents[0].Context.EventSourceId;
+                    var handleEventsResult = await TryHandleEvents(partition, partitionEvents, subscriberContext);
+                    if (handleEventsResult.TryGetException(out var handleEventsException))
+                    {
+                        var exceptionMessages = handleEventsException.GetAllMessages().ToArray();
+                        var exceptionStackTrace = handleEventsException.StackTrace ?? string.Empty;
+                        lastEventSequenceNumberAttempted = partitionEvents[0].Context.SequenceNumber;
+                        await _observer.PartitionFailed(partition, lastEventSequenceNumberAttempted, exceptionMessages, exceptionStackTrace);
+                        return JobStepResult.Failed(PerformJobStepError.FailedWithPartialResult(CreateResult(lastSuccessfullyHandledEventSequenceNumber), exceptionMessages, exceptionStackTrace));
+                    }
+                    if (handleEventsResult.TryGetResult(out var handledEventsResult))
+                    {
+                        var (eventObserverResult, handledEvents) = handledEventsResult;
+                        var (result, newLastSuccessfullyHandledEventSequenceNumber) = await HandleSubscriberResult(
+                            currentState,
+                            partition,
+                            eventObserverResult,
+                            handledEvents,
+                            lastSuccessfullyHandledEventSequenceNumber);
+                        lastSuccessfullyHandledEventSequenceNumber = newLastSuccessfullyHandledEventSequenceNumber;
+                        if (result is not null)
+                        {
+                            return result;
+                        }
+                    }
+                }
+            }
+
+            if (lastSuccessfullyHandledEventSequenceNumber == EventSequenceNumber.Unavailable)
+            {
+                logger.HandledNoEvents();
+            }
+            else
+            {
+                logger.HandledAllEvents(lastSuccessfullyHandledEventSequenceNumber);
+            }
+
+            return JobStepResult.Succeeded(CreateResult(lastSuccessfullyHandledEventSequenceNumber));
+        }
+        catch (TaskCanceledException)
+        {
+            LogCancelled(lastSuccessfullyHandledEventSequenceNumber);
+            return JobStepResult.Failed(PerformJobStepError.CancelledWithPartialResult(CreateResult(lastSuccessfullyHandledEventSequenceNumber)));
+        }
+        catch (Exception e)
+        {
+            logger.FailedPerforming(e, nameof(HandleEventsForObserver));
+            if (!lastSuccessfullyHandledEventSequenceNumber.IsActualValue)
+            {
+                return e;
+            }
+
+            logger.FailedWithPartialSuccess(e, lastSuccessfullyHandledEventSequenceNumber);
+            return JobStepResult.Failed(PerformJobStepError.FailedWithPartialResult(CreateResult(lastSuccessfullyHandledEventSequenceNumber), e));
+        }
+    }
+
+    static AppendedEvent[] SetObservationStateIfSpecified(EventObservationState eventObservationState, IEventCursor events)
+    {
+        if (eventObservationState != EventObservationState.None)
+        {
+            return events.Current.Select(@event =>
+                @event with
+                {
+                    Context = @event.Context with
+                    {
+                        ObservationState = eventObservationState
+                    }
+                }).ToArray();
+        }
+
+        return events.Current.ToArray();
+    }
+
+    static AppendedEvent[] FilterRedactedEventsForUnsubscribedTypes(AppendedEvent[] events, HashSet<EventTypeId> nonRedactionEventTypeIds)
+    {
+        if (nonRedactionEventTypeIds.Count == 0)
+        {
+            return events;
+        }
+
+        var filtered = new AppendedEvent[events.Length];
+        var count = 0;
+        foreach (var @event in events)
+        {
+            if (@event.Context.EventType.Id != GlobalEventTypes.Redaction)
+            {
+                filtered[count++] = @event;
+                continue;
+            }
+
+            if (@event.Content is not IDictionary<string, object?> contentDict || !contentDict.TryGetValue("originalEventType", out var originalEventTypeObj))
+            {
+                continue;
+            }
+
+            var originalEventTypeId = originalEventTypeObj?.ToString();
+            if (originalEventTypeId is not null && nonRedactionEventTypeIds.Contains(new EventTypeId(originalEventTypeId)))
+            {
+                filtered[count++] = @event;
+            }
+        }
+
+        return count == filtered.Length ? filtered : filtered[..count];
+    }
+
+    static IEnumerable<AppendedEvent[]> GetConsecutivePartitionBatches(AppendedEvent[] events)
+    {
+        var index = 0;
+        while (index < events.Length)
+        {
+            var partition = events[index].Context.EventSourceId;
+            var start = index;
+            while (index < events.Length && events[index].Context.EventSourceId == partition)
+            {
+                index++;
+            }
+
+            yield return events[start..index];
+        }
+    }
+
+    static HandleEventsForPartitionResult CreateResult(EventSequenceNumber lastSuccessfullyHandled) => new(lastSuccessfullyHandled);
+
+    async Task<(JobStepResult? Result, EventSequenceNumber LastSuccessfullyHandledEventSequenceNumber)> HandleSubscriberResult(
+        HandleEventsForObserverState currentState,
+        Key partition,
+        ObserverSubscriberResult eventObserverResult,
+        AppendedEvent[] handledEvents,
+        EventSequenceNumber lastSuccessfullyHandledEventSequenceNumber)
+    {
+        var handledCount = EventCount.Zero;
+        if (eventObserverResult.LastSuccessfulObservation.IsActualValue)
+        {
+            handledCount = handledEvents.Count(_ => _.Context.SequenceNumber <= eventObserverResult.LastSuccessfulObservation);
+        }
+
+        switch (eventObserverResult.State)
+        {
+            case ObserverSubscriberState.Ok:
+                await _selfGrainReference.ReportNewSuccessfullyHandledEvent(eventObserverResult.LastSuccessfulObservation);
+                var okHandledEvents = handledEvents.Where(e => e.Context.SequenceNumber <= eventObserverResult.LastSuccessfulObservation).ToArray();
+                await _observer.ReportHandledEvents(partition, okHandledEvents);
+                return (null, eventObserverResult.LastSuccessfulObservation);
+            case ObserverSubscriberState.Failed:
+                return await HandleFailedSubscriberResult(
+                    currentState,
+                    partition,
+                    eventObserverResult,
+                    handledEvents,
+                    handledCount,
+                    lastSuccessfullyHandledEventSequenceNumber);
+            case ObserverSubscriberState.Disconnected:
+                var lastEventSequenceNumberAttempted = handledEvents[0].Context.SequenceNumber;
+                logger.EventHandlerDisconnected(partition, lastSuccessfullyHandledEventSequenceNumber);
+                await _observer.PartitionFailed(partition, lastEventSequenceNumberAttempted, [SubscriberDisconnected], string.Empty);
+                return (
+                    JobStepResult.Failed(PerformJobStepError.FailedWithPartialResult(
+                        CreateResult(lastSuccessfullyHandledEventSequenceNumber),
+                        [SubscriberDisconnected],
+                        string.Empty)),
+                    lastSuccessfullyHandledEventSequenceNumber);
+            default:
+                return (null, lastSuccessfullyHandledEventSequenceNumber);
+        }
+    }
+
+    async Task<(JobStepResult Result, EventSequenceNumber LastSuccessfullyHandledEventSequenceNumber)> HandleFailedSubscriberResult(
+        HandleEventsForObserverState currentState,
+        Key partition,
+        ObserverSubscriberResult eventObserverResult,
+        AppendedEvent[] handledEvents,
+        EventCount handledCount,
+        EventSequenceNumber lastSuccessfullyHandledEventSequenceNumber)
+    {
+        var lastEventSequenceNumberAttempted = EventSequenceNumber.Unavailable;
+        if (eventObserverResult.HandledAnyEvents)
+        {
+            var failedEvent = handledEvents.FirstOrDefault(e => e.Context.SequenceNumber > eventObserverResult.LastSuccessfulObservation);
+            lastEventSequenceNumberAttempted = failedEvent is not null
+                ? failedEvent.Context.SequenceNumber
+                : eventObserverResult.LastSuccessfulObservation.Next();
+
+            await _selfGrainReference.ReportNewSuccessfullyHandledEvent(eventObserverResult.LastSuccessfulObservation);
+            lastSuccessfullyHandledEventSequenceNumber = eventObserverResult.LastSuccessfulObservation;
+            var failedHandledEvents = handledEvents.Where(e => e.Context.SequenceNumber <= eventObserverResult.LastSuccessfulObservation).ToArray();
+            await _observer.ReportHandledEvents(partition, failedHandledEvents);
+        }
+        else
+        {
+            lastEventSequenceNumberAttempted = handledEvents[0].Context.SequenceNumber;
+        }
+
+        logger.FailedHandlingEvents(partition, handledCount, lastEventSequenceNumberAttempted, lastSuccessfullyHandledEventSequenceNumber);
+        var failedAt = lastEventSequenceNumberAttempted.IsActualValue ? lastEventSequenceNumberAttempted : currentState.StartEventSequenceNumber;
+        await _observer.PartitionFailed(partition, failedAt, eventObserverResult.ExceptionMessages, eventObserverResult.ExceptionStackTrace);
+        return (
+            JobStepResult.Failed(PerformJobStepError.FailedWithPartialResult(
+                CreateResult(lastSuccessfullyHandledEventSequenceNumber),
+                eventObserverResult.ExceptionMessages,
+                eventObserverResult.ExceptionStackTrace)),
+            lastSuccessfullyHandledEventSequenceNumber);
+    }
+
+    async Task<Catch<(ObserverSubscriberResult Result, AppendedEvent[] HandledEvents), None>> TryHandleEvents(
+        Key partition,
+        AppendedEvent[] events,
+        ObserverSubscriberContext subscriberContext)
+    {
+        try
+        {
+            var decryptedEvents = await DecryptEvents(events);
+            var subscriber = GrainFactory.GetGrain(_subscription.SubscriberType, GetObserverSubscriberKey(partition)) as IObserverSubscriber;
+            var result = await subscriber!.OnNext(partition, decryptedEvents, subscriberContext);
+            return (result, decryptedEvents);
+        }
+        catch (Exception ex)
+        {
+            logger.ErrorHandling(ex, partition);
+            return ex;
+        }
+    }
+
+    void LogCancelled(EventSequenceNumber lastHandledSequenceNumber)
+    {
+        if (!lastHandledSequenceNumber.IsActualValue)
+        {
+            logger.CancelledBeforeHandlingAnyEvents();
+        }
+        else
+        {
+            logger.CancelledAfterHandlingEvents(lastHandledSequenceNumber);
+        }
+    }
+
+    ObserverSubscriberKey GetObserverSubscriberKey(Key partition)
+    {
+        return new(
+            State.ObserverKey.ObserverId,
+            State.ObserverKey.EventStore,
+            State.ObserverKey.Namespace,
+            State.ObserverKey.EventSequenceId,
+            partition,
+            _subscription.SiloAddress.ToParsableString());
+    }
+
+    IEventSequenceStorage GetEventSequenceStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, EventSequenceId eventSequenceId) =>
+        _eventSequenceStorage ??= storage.GetEventStore(eventStore).GetNamespace(@namespace).GetEventSequence(eventSequenceId);
+
+    Task<AppendedEvent[]> DecryptEvents(IEnumerable<AppendedEvent> events) =>
+        eventCompliance.Release(events, _eventTypeSchemas);
+}
+

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverArguments.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverArguments.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+
+namespace Cratis.Chronicle.Observation.Jobs;
+
+/// <summary>
+/// Represents the arguments passed along to a job step that handles events for an observer in event-sequence order.
+/// </summary>
+/// <param name="ObserverKey">The <see cref="ObserverKey"/> with extended details about the observer.</param>
+/// <param name="ObserverType">The <see cref="ObserverType"/>.</param>
+/// <param name="StartEventSequenceNumber">The event sequence number the job step should start from.</param>
+/// <param name="EndEventSequenceNumber">The event sequence number the job step should go to.</param>
+/// <param name="EventObservationState">The event observation state to set for the events.</param>
+/// <param name="EventTypes">The event types that are to replay.</param>
+public record HandleEventsForObserverArguments(
+    ObserverKey ObserverKey,
+    ObserverType ObserverType,
+    EventSequenceNumber StartEventSequenceNumber,
+    EventSequenceNumber EndEventSequenceNumber,
+    EventObservationState EventObservationState,
+    IEnumerable<EventType> EventTypes) : IObserverJobRequest;
+

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverLogging.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverLogging.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Observation.Jobs;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class HandleEventsForObserverLogging
+{
+    [LoggerMessage(LogLevel.Debug, "Preparing HandleEventsForObserver job step handling events from sequence number {FromSequenceNumber} to sequence number {ToSequenceNumber}")]
+    internal static partial void Preparing(this ILogger<HandleEventsForObserver> logger, EventSequenceNumber fromSequenceNumber, EventSequenceNumber toSequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "Preparing of HandleEventsForObserver job step stopped due to the observer subscriber being disconnected")]
+    internal static partial void PreparingStoppedUnsubscribed(this ILogger<HandleEventsForObserver> logger);
+
+    [LoggerMessage(LogLevel.Debug, "HandleEventsForObserver job step successfully prepared")]
+    internal static partial void SuccessfullyPrepared(this ILogger<HandleEventsForObserver> logger);
+
+    [LoggerMessage(LogLevel.Warning, "Performing HandleEventsForObserver job step stopped due to the observer subscriber being disconnected")]
+    internal static partial void PerformingStoppedUnsubscribed(this ILogger<HandleEventsForObserver> logger);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step successfully handled {EventCount} events for partition {Partition}, but failed handling event at event sequence number {FailedEventSequenceNumber}. Last successfully handled event sequence number is {LastHandledEventSequenceNumber}")]
+    internal static partial void FailedHandlingEvents(this ILogger<HandleEventsForObserver> logger, Key partition, EventCount eventCount, EventSequenceNumber failedEventSequenceNumber, EventSequenceNumber lastHandledEventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step failed handling events for partition {Partition} due to disconnection. Last successfully handled event sequence number is {LastHandledEventSequenceNumber}")]
+    internal static partial void EventHandlerDisconnected(this ILogger<HandleEventsForObserver> logger, Key partition, EventSequenceNumber lastHandledEventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Debug, "HandleEventsForObserver job step completed successfully all events. Last successfully handled event sequence number is {LastHandledEventSequenceNumber}")]
+    internal static partial void HandledAllEvents(this ILogger<HandleEventsForObserver> logger, EventSequenceNumber lastHandledEventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step completed handling no events")]
+    internal static partial void HandledNoEvents(this ILogger<HandleEventsForObserver> logger);
+
+    [LoggerMessage(LogLevel.Warning, "An error occurred for HandleEventsForObserver job step for partition {Partition}")]
+    internal static partial void ErrorHandling(this ILogger<HandleEventsForObserver> logger, Exception error, Key partition);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step was cancelled before handling any events")]
+    internal static partial void CancelledBeforeHandlingAnyEvents(this ILogger<HandleEventsForObserver> logger);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step was cancelled and the last handled event sequence number is {LastHandledEventSequenceNumber}")]
+    internal static partial void CancelledAfterHandlingEvents(this ILogger<HandleEventsForObserver> logger, EventSequenceNumber lastHandledEventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step failed to persist state about successfully handling event with sequence number {LastHandledEventSequenceNumber}")]
+    internal static partial void FailedToPersistSuccessfullyHandledEvent(this ILogger<HandleEventsForObserver> logger, Exception error, EventSequenceNumber lastHandledEventSequenceNumber);
+
+    [LoggerMessage(LogLevel.Warning, "HandleEventsForObserver job step failed, but it had successfully handled some events. Last successfully handled event was: {LastHandledEventSequenceNumber}")]
+    internal static partial void FailedWithPartialSuccess(this ILogger<HandleEventsForObserver> logger, Exception error, EventSequenceNumber lastHandledEventSequenceNumber);
+}
+

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverState.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserverState.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Storage.Jobs;
+
+namespace Cratis.Chronicle.Observation.Jobs;
+
+/// <summary>
+/// Represents the state for a <see cref="IHandleEventsForObserver"/> job step.
+/// </summary>
+public class HandleEventsForObserverState : JobStepState
+{
+    /// <summary>
+    /// The <see cref="ObserverKey"/> for the observer.
+    /// </summary>
+    public ObserverKey ObserverKey { get; set; } = ObserverKey.NotSet;
+
+    /// <summary>
+    /// Gets or sets the last successfully handled event sequence number.
+    /// </summary>
+    public EventSequenceNumber LastSuccessfullyHandledEventSequenceNumber { get; set; } = EventSequenceNumber.Unavailable;
+
+    /// <summary>
+    /// Gets or sets the <see cref="EventSequenceNumber"/> to start processing from.
+    /// </summary>
+    public EventSequenceNumber StartEventSequenceNumber { get; set; } = EventSequenceNumber.Unavailable;
+
+    /// <summary>
+    /// Gets or sets the <see cref="EventSequenceNumber"/> to stop processing at.
+    /// </summary>
+    public EventSequenceNumber EndEventSequenceNumber { get; set; } = EventSequenceNumber.Unavailable;
+
+    /// <summary>
+    /// Gets or sets the <see cref="EventObservationState"/>.
+    /// </summary>
+    public EventObservationState EventObservationState { get; set; } = EventObservationState.None;
+
+    /// <summary>
+    /// Gets or sets the collection of <see cref="EventType"/> to process.
+    /// </summary>
+    public IEnumerable<EventType> EventTypes { get; set; } = [];
+}
+

--- a/Source/Kernel/Core/Observation/Jobs/IHandleEventsForObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/IHandleEventsForObserver.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Jobs;
+
+namespace Cratis.Chronicle.Observation.Jobs;
+
+/// <summary>
+/// Defines a step in the replay job that handles events for an observer in event-sequence order.
+/// </summary>
+public interface IHandleEventsForObserver : IJobStep<HandleEventsForObserverArguments, HandleEventsForPartitionResult, HandleEventsForObserverState>
+{
+    /// <summary>
+    /// Persists state about a new successfully handled <see cref="EventSequenceNumber"/>.
+    /// </summary>
+    /// <param name="lastHandledEventSequenceNumber">The last handled event sequence number.</param>
+    /// <returns>The task representing the operation.</returns>
+    Task ReportNewSuccessfullyHandledEvent(EventSequenceNumber lastHandledEventSequenceNumber);
+}
+

--- a/Source/Kernel/Core/Observation/Jobs/ReplayObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/ReplayObserver.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Text.Json;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Storage;
 using Microsoft.Extensions.Logging;
@@ -30,6 +31,21 @@ public class ReplayObserver(
     /// <inheritdoc/>
     protected override async Task<IImmutableList<JobStepDetails>> PrepareSteps(ReplayObserverRequest request)
     {
+        if (request.ObserverType == ObserverType.Projection)
+        {
+            return
+            [
+                CreateStep<IHandleEventsForObserver>(
+                    new HandleEventsForObserverArguments(
+                        request.ObserverKey,
+                        request.ObserverType,
+                        EventSequenceNumber.First,
+                        EventSequenceNumber.Max,
+                        EventObservationState.Replay,
+                        request.EventTypes))
+            ];
+        }
+
         var observerKeyIndexes = storage.GetEventStore(JobKey.EventStore).GetNamespace(JobKey.Namespace).ObserverKeyIndexes;
         var index = await observerKeyIndexes.GetFor(request.ObserverKey);
 


### PR DESCRIPTION
# Summary
Projection replay could rebuild deep read models differently than live observation because replay processed each event-source id independently. Consumers could see the root document replayed while joined or child collections, such as feature/slice/event hierarchies, were missing or varied between replay runs. This changes projection replay to dispatch events in global append order across partitions, matching the ordering guarantees live observation relies on.

This PR also updates the local shipping guidance so future PR descriptions use the pull request template as release notes and reserve the overview for consumer-facing context when the bullets need it.

## Fixed

- Fixed projection replay for deep joined or child-stream read models so nested children are rebuilt consistently instead of depending on partition scheduling. (#3345)
