### PR TITLE
Add projection replay ordering specs and halt-on-failure rationale

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/a_performing_job_step.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/given/a_performing_job_step.cs
@@ -31,6 +31,7 @@ public class a_performing_job_step : Specification
     protected IEventSequenceStorage _eventSequenceStorage;
     protected HandleEventsForObserverState _performState;
     protected EventSourceId? _eventSourceIdFilter;
+    protected EventSequenceNumber _startSequenceNumber = EventSequenceNumber.Unavailable;
     protected readonly List<HandledBatch> _handledBatches = [];
 
     protected static AppendedEvent CreateEvent(EventSequenceNumber sequenceNumber, EventSourceId eventSourceId) =>
@@ -68,7 +69,7 @@ public class a_performing_job_step : Specification
         _eventCursor.MoveNext().Returns(_ => Task.FromResult(moveNextCount++ == 0));
 
         _eventSequenceStorage.GetRange(
-            Arg.Any<EventSequenceNumber>(),
+            Arg.Do<EventSequenceNumber>(value => _startSequenceNumber = value),
             Arg.Any<EventSequenceNumber>(),
             Arg.Do<EventSourceId?>(value => _eventSourceIdFilter = value),
             Arg.Any<IEnumerable<EventType>>(),

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_a_partition_fails.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_a_partition_fails.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.when_performing;
+
+public class and_a_partition_fails : given.a_performing_job_step
+{
+    void Establish()
+    {
+        // module#1 succeeds, feature#2 fails, module#3 should never be dispatched. Ordered replay halts at
+        // the first failure so it does not layer state onto a partition that failed to materialize.
+        _eventCursor.Current.Returns([
+            CreateEvent(1UL, "module"),
+            CreateEvent(2UL, "feature"),
+            CreateEvent(3UL, "module")
+        ]);
+
+        _observerSubscriber.OnNext(Arg.Any<Key>(), Arg.Any<IEnumerable<AppendedEvent>>(), Arg.Any<ObserverSubscriberContext>())
+            .Returns(call =>
+            {
+                var partition = call.Arg<Key>();
+                var events = call.ArgAt<IEnumerable<AppendedEvent>>(1).ToArray();
+                _handledBatches.Add(new(partition, events.Select(_ => _.Context.SequenceNumber).ToArray()));
+                return partition == (Key)"feature"
+                    ? Task.FromResult(ObserverSubscriberResult.Failed(EventSequenceNumber.Unavailable, "boom"))
+                    : Task.FromResult(ObserverSubscriberResult.Ok(events[^1].Context.SequenceNumber));
+            });
+    }
+
+    async Task Because() => await _jobStep.InvokePerformStep(_performState);
+
+    [Fact] void should_handle_the_module_partition_first() => _handledBatches[0].Partition.ShouldEqual((Key)"module");
+    [Fact] void should_attempt_the_failing_feature_partition() => _handledBatches[1].Partition.ShouldEqual((Key)"feature");
+    [Fact] void should_not_dispatch_anything_after_the_failure() => _handledBatches.Count.ShouldEqual(2);
+    [Fact] void should_report_the_failing_partition() => _observer.Received(1).PartitionFailed((Key)"feature", Arg.Any<EventSequenceNumber>(), Arg.Any<IEnumerable<string>>(), Arg.Any<string>());
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_events_span_multiple_cursor_pages.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_events_span_multiple_cursor_pages.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.when_performing;
+
+public class and_events_span_multiple_cursor_pages : given.a_performing_job_step
+{
+    void Establish()
+    {
+        // The cursor delivers the range across two pages, with the module partition continuing on the
+        // second page. Global sequence order must hold across pages, not just within a single page.
+        _eventCursor.Current.Returns(
+            [
+                CreateEvent(1UL, "module"),
+                CreateEvent(2UL, "feature")
+            ],
+            [
+                CreateEvent(3UL, "module")
+            ]);
+        var moveNextCount = 0;
+        _eventCursor.MoveNext().Returns(_ => Task.FromResult(moveNextCount++ < 2));
+    }
+
+    async Task Because() => await _jobStep.InvokePerformStep(_performState);
+
+    [Fact] void should_handle_three_consecutive_partition_batches_across_pages() => _handledBatches.Count.ShouldEqual(3);
+    [Fact] void should_handle_module_event_one_first() => _handledBatches[0].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)1UL);
+    [Fact] void should_handle_feature_event_two_second() => _handledBatches[1].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)2UL);
+    [Fact] void should_handle_module_event_three_from_the_next_page_last() => _handledBatches[2].SequenceNumbers[0].ShouldEqual((EventSequenceNumber)3UL);
+}

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_resuming_after_partial_success.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/when_performing/and_resuming_after_partial_success.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver.when_performing;
+
+public class and_resuming_after_partial_success : given.a_performing_job_step
+{
+    void Establish()
+    {
+        // A prior run halted after successfully handling event 2. Resuming must continue from the next event
+        // in global order, never re-read from the start, so it preserves the parent-before-child ordering.
+        _performState.LastSuccessfullyHandledEventSequenceNumber = 2UL;
+    }
+
+    async Task Because() => await _jobStep.InvokePerformStep(_performState);
+
+    [Fact] void should_resume_reading_after_the_last_successfully_handled_event() => _startSequenceNumber.ShouldEqual((EventSequenceNumber)3UL);
+}

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
@@ -165,6 +165,13 @@ public class HandleEventsForObserver(
                     .ToArray();
                 eventsToHandle = FilterRedactedEventsForUnsubscribedTypes(eventsToHandle, nonRedactionEventTypeIds);
 
+                // Dispatch consecutive same-partition batches sequentially, in global sequence order, and return
+                // immediately on the first failure instead of continuing to later partitions. This is intentional:
+                // a projection that resolves keys, joins, or child collections across event sources depends on
+                // earlier partitions already being materialized in the sink, so processing past a failed partition
+                // would layer state onto a parent that never materialized and silently produce an inconsistent read
+                // model. Halting preserves the same global-order contract live observation relies on and surfaces
+                // the failure through PartitionFailed so it can be recovered before more state is built on top of it.
                 foreach (var partitionEvents in GetConsecutivePartitionBatches(eventsToHandle))
                 {
                     if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
# Summary

Test and documentation follow-up to the merged projection replay ordering fix (#3414) — no functional change. It locks the replay-ordering behavior in with specs and documents why projection replay halts at the first failed partition.

- Specs covering: a partition failure halts the remainder of the replay, resume continues from the last successfully handled event, and global ordering is preserved across cursor pages.
- An inline rationale comment in `HandleEventsForObserver` explaining the intentional halt-on-failure — a cross-source projection would otherwise build child/joined state on a parent that never materialized and silently produce an inconsistent read model.