### PR TITLE
Fix concept collection round-trip in ReadModelScenario harness

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/ConceptListItem.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptListItem.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A bare string concept used as the element type of a read-model collection.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record ConceptListItem(string Value) : ConceptAs<string>(Value);

--- a/Source/Clients/Testing.Specs/ReadModels/ConceptListReadModel.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptListReadModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a top-level collection of bare concepts, used to verify the in-memory sink
+/// round-trips collection-of-concept elements as their unwrapped underlying value.
+/// </summary>
+/// <param name="Id">Identifier.</param>
+/// <param name="Items">The collection of <see cref="ConceptListItem"/>.</param>
+[Passive]
+[FromEvent<ConceptListSet>]
+public record ConceptListReadModel(Guid Id, IReadOnlyList<ConceptListItem> Items);

--- a/Source/Clients/Testing.Specs/ReadModels/ConceptListSet.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptListSet.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event carrying a collection of bare concepts.
+/// </summary>
+/// <param name="Items">The collection of <see cref="ConceptListItem"/>.</param>
+[EventType]
+public record ConceptListSet(IReadOnlyList<ConceptListItem> Items);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_concept_collection.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_concept_collection.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+public class when_projecting_a_concept_collection : Specification
+{
+    ReadModelScenario<ConceptListReadModel> _scenario;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ConceptListReadModel>();
+        _id = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_id)
+            .Events(new ConceptListSet([new ConceptListItem("a"), new ConceptListItem("b")]));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_items() => _scenario.Instance!.Items.Count.ShouldEqual(2);
+    [Fact] void should_round_trip_first_item() => _scenario.Instance!.Items[0].Value.ShouldEqual("a");
+    [Fact] void should_round_trip_second_item() => _scenario.Instance!.Items[1].Value.ShouldEqual("b");
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -211,7 +211,12 @@ internal static class ProjectionReadModelProcessor
 
         InjectIdentifierFromKey<TReadModel>(state, rootKey);
 
-        var json = JsonSerializer.Serialize(state);
+        // Serialize with the same options used to deserialize so concept values — both scalar and the
+        // elements of a concept collection (e.g. IReadOnlyList<MyConcept>) — are written in their
+        // unwrapped primitive form. Without these options a concept CLR object serializes as an object
+        // ({ "value": ... }), which the concept-aware deserializer then rejects when it expects the
+        // underlying primitive.
+        var json = JsonSerializer.Serialize(state, Globals.JsonSerializerOptions);
         return JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
     }
 


### PR DESCRIPTION
## Fixed
- `ReadModelScenario<T>` now correctly round-trips read-model properties typed as a collection of bare concepts (e.g. `IReadOnlyList<MyConcept>` where `MyConcept : ConceptAs<T>`). Previously such a property threw a `JsonException` ("Cannot get the value of a token type 'StartObject' as a string") when the projected instance was materialized, because the projection harness serialized the state without the concept-aware serializer options while deserializing with them. Scalar concept properties round-trip the same way.