### PR TITLE
Encrypt PII nested inside arrays and lists

### DIFF
--- a/Source/Clients/DotNET/Compliance/GDPR/PIIAppliedToNonConceptAsType.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/PIIAppliedToNonConceptAsType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 /// </remarks>
 /// <param name="type">The <see cref="Type"/> that has the attribute applied incorrectly.</param>
 public class PIIAppliedToNonConceptAsType(Type type)
-    : Exception($"The [PII] attribute is applied to '{type.FullName}', which does not inherit from ConceptAs<T>. The [PII] attribute is only supported on ConceptAs<T> types.")
-{
-}
+    : Exception($"The [PII] attribute is applied to '{type.FullName}', which does not inherit from ConceptAs<T>. The [PII] attribute is only supported on ConceptAs<T> types.");

--- a/Source/Clients/DotNET/Compliance/GDPR/PIINotSupportedOnEventSourceId.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/PIINotSupportedOnEventSourceId.cs
@@ -14,6 +14,4 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 /// </remarks>
 /// <param name="type">The <see cref="Type"/> that has the attribute applied incorrectly.</param>
 public class PIINotSupportedOnEventSourceId(Type type)
-    : Exception($"The [PII] attribute cannot be applied to '{type.FullName}' because it inherits from EventSourceId or EventSourceId<T>. Event source identifiers cannot be encrypted as they are required for event correlation.")
-{
-}
+    : Exception($"The [PII] attribute cannot be applied to '{type.FullName}' because it inherits from EventSourceId or EventSourceId<T>. Event source identifiers cannot be encrypted as they are required for event correlation.");

--- a/Source/Clients/DotNET/Compliance/NoComplianceMetadataForProperty.cs
+++ b/Source/Clients/DotNET/Compliance/NoComplianceMetadataForProperty.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Compliance;
 /// Initializes a new instance of the <see cref="NoComplianceMetadataForProperty"/> class.
 /// </remarks>
 /// <param name="property"><see cref="PropertyInfo"/> that does not have compliance metadata.</param>
-public class NoComplianceMetadataForProperty(PropertyInfo property) : Exception($"Property '{property.Name}' on type '{property.DeclaringType?.FullName}' does not have any compliance metadata.")
-{
-}
+public class NoComplianceMetadataForProperty(PropertyInfo property) : Exception($"Property '{property.Name}' on type '{property.DeclaringType?.FullName}' does not have any compliance metadata.");

--- a/Source/Clients/DotNET/Compliance/NoComplianceMetadataForType.cs
+++ b/Source/Clients/DotNET/Compliance/NoComplianceMetadataForType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Compliance;
 /// Initializes a new instance of the <see cref="NoComplianceMetadataForProperty"/> class.
 /// </remarks>
 /// <param name="type"><see cref="Type"/> that does not have compliance metadata.</param>
-public class NoComplianceMetadataForType(Type type) : Exception($"Types '{type.FullName}'  does not have any compliance metadata.")
-{
-}
+public class NoComplianceMetadataForType(Type type) : Exception($"Types '{type.FullName}'  does not have any compliance metadata.");

--- a/Source/Clients/DotNET/EventSequences/UnknownEventType.cs
+++ b/Source/Clients/DotNET/EventSequences/UnknownEventType.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.EventSequences;
 /// Initializes a new instance of the <see cref="UnknownEventType"/> class.
 /// </remarks>
 /// <param name="type">Type missing the <see cref="EventTypeAttribute"/>.</param>
-public class UnknownEventType(Type type) : Exception($"Type '{type.FullName}' is unknown. Have you remembered to mark it with the `[EventType]` attribute?")
-{
-}
+public class UnknownEventType(Type type) : Exception($"Type '{type.FullName}' is unknown. Have you remembered to mark it with the `[EventType]` attribute?");

--- a/Source/Clients/DotNET/Events/Constraints/UnknownConstraintType.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UnknownConstraintType.cs
@@ -7,6 +7,4 @@ namespace Cratis.Chronicle.Events.Constraints;
 /// Exception that gets thrown when an unknown constraint type is encountered.
 /// </summary>
 /// <param name="definition">The unknown <see cref="IConstraintDefinition"/>.</param>
-public class UnknownConstraintType(IConstraintDefinition definition) : Exception($"Unknown constraint type '{definition.GetType().Name}'")
-{
-}
+public class UnknownConstraintType(IConstraintDefinition definition) : Exception($"Unknown constraint type '{definition.GetType().Name}'");

--- a/Source/Clients/DotNET/Events/MultipleEventStoresDefined.cs
+++ b/Source/Clients/DotNET/Events/MultipleEventStoresDefined.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Events;
 /// <param name="observerType">The type of the observer.</param>
 /// <param name="eventStores">The collection of event store names found.</param>
 public class MultipleEventStoresDefined(Type observerType, IEnumerable<string> eventStores)
-    : Exception($"Observer '{observerType.FullName}' handles event types from multiple event stores: {string.Join(", ", eventStores.Select(s => $"'{s}'"))}. An observer can only observe events from a single event store.")
-{
-}
+    : Exception($"Observer '{observerType.FullName}' handles event types from multiple event stores: {string.Join(", ", eventStores.Select(s => $"'{s}'"))}. An observer can only observe events from a single event store.");

--- a/Source/Clients/DotNET/Events/MultipleEventTypesWithSameIdFound.cs
+++ b/Source/Clients/DotNET/Events/MultipleEventTypesWithSameIdFound.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Events;
 /// Initializes a new instance of <see cref="MultipleEventTypesWithSameIdFound"/>.
 /// </remarks>
 /// <param name="types">The CLR types.</param>
-public class MultipleEventTypesWithSameIdFound(IEnumerable<Type> types) : Exception($"Multiple event types with the same id found: {string.Join(", ", types.Select(_ => _.FullName))}")
-{
-}
+public class MultipleEventTypesWithSameIdFound(IEnumerable<Type> types) : Exception($"Multiple event types with the same id found: {string.Join(", ", types.Select(_ => _.FullName))}");

--- a/Source/Clients/DotNET/Projections/ModelBound/InvalidPropertyForType.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/InvalidPropertyForType.cs
@@ -8,6 +8,4 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </summary>
 /// <param name="type">The type the property was expected to be on.</param>
 /// <param name="propertyName">The property name that was not found.</param>
-public class InvalidPropertyForType(Type type, string propertyName) : Exception($"Property '{propertyName}' does not exist on type '{type.FullName}'")
-{
-}
+public class InvalidPropertyForType(Type type, string propertyName) : Exception($"Property '{propertyName}' does not exist on type '{type.FullName}'");

--- a/Source/Clients/DotNET/Reactors/UnknownReactorId.cs
+++ b/Source/Clients/DotNET/Reactors/UnknownReactorId.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Reactors;
 /// Initializes a new instance of <see cref="UnknownReactorId"/>.
 /// </remarks>
 /// <param name="reactorId">The identifier of the unknown reducer.</param>
-public class UnknownReactorId(ReactorId reactorId) : Exception($"Reactor with identifier '{reactorId}' is not a known Reactor")
-{
-}
+public class UnknownReactorId(ReactorId reactorId) : Exception($"Reactor with identifier '{reactorId}' is not a known Reactor");

--- a/Source/Clients/DotNET/Reactors/UnknownReactorType.cs
+++ b/Source/Clients/DotNET/Reactors/UnknownReactorType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Reactors;
 /// Initializes a new instance of <see cref="UnknownReactorType"/>.
 /// </remarks>
 /// <param name="type">The Type that is not an Reactor.</param>
-public class UnknownReactorType(Type type) : Exception($"Type '{type}' is not a known Reactor")
-{
-}
+public class UnknownReactorType(Type type) : Exception($"Type '{type}' is not a known Reactor");

--- a/Source/Clients/DotNET/Reducers/UnknownReducerType.cs
+++ b/Source/Clients/DotNET/Reducers/UnknownReducerType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Reducers;
 /// Initializes a new instance of <see cref="UnknownReducerType"/>.
 /// </remarks>
 /// <param name="type">The Type that is not an reducer.</param>
-public class UnknownReducerType(Type type) : Exception($"Type '{type}' is not a known reducer")
-{
-}
+public class UnknownReducerType(Type type) : Exception($"Type '{type}' is not a known reducer");

--- a/Source/Infrastructure/Properties/ChildrenPropertyIsNotEnumerable.cs
+++ b/Source/Infrastructure/Properties/ChildrenPropertyIsNotEnumerable.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Properties;
 /// Initializes a new instance of the <see cref="ChildrenPropertyIsNotEnumerable"/> class.
 /// </remarks>
 /// <param name="property"><see cref="PropertyPath"/> that is wrong type.</param>
-public class ChildrenPropertyIsNotEnumerable(PropertyPath property) : Exception($"Property at '{property.Path}' is not of enumerable type.")
-{
-}
+public class ChildrenPropertyIsNotEnumerable(PropertyPath property) : Exception($"Property at '{property.Path}' is not of enumerable type.");

--- a/Source/Infrastructure/Properties/ChildrenPropertyIsNotEnumerableForType.cs
+++ b/Source/Infrastructure/Properties/ChildrenPropertyIsNotEnumerableForType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Chronicle.Properties;
 /// </remarks>
 /// <param name="type">Type that is the root of the <see cref="PropertyPath"/>.</param>
 /// <param name="property"><see cref="PropertyPath"/> that is wrong type.</param>
-public class ChildrenPropertyIsNotEnumerableForType(Type type, PropertyPath property) : Exception($"Property at '{property.Path}' on '{type.FullName}' is not of enumerable type.")
-{
-}
+public class ChildrenPropertyIsNotEnumerableForType(Type type, PropertyPath property) : Exception($"Property at '{property.Path}' on '{type.FullName}' is not of enumerable type.");

--- a/Source/Infrastructure/Properties/MissingArrayIndexerForPropertyPath.cs
+++ b/Source/Infrastructure/Properties/MissingArrayIndexerForPropertyPath.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Properties;
 /// Initializes a new instance of the <see cref="MissingArrayIndexerForPropertyPath"/> class.
 /// </remarks>
 /// <param name="propertyPath"><see cref="PropertyPath"/> it is missing for.</param>
-public class MissingArrayIndexerForPropertyPath(PropertyPath propertyPath) : Exception($"Missing array indexer for '{propertyPath}'")
-{
-}
+public class MissingArrayIndexerForPropertyPath(PropertyPath propertyPath) : Exception($"Missing array indexer for '{propertyPath}'");

--- a/Source/Infrastructure/Properties/UnableToResolvePropertyPathOnType.cs
+++ b/Source/Infrastructure/Properties/UnableToResolvePropertyPathOnType.cs
@@ -11,6 +11,4 @@ namespace Cratis.Chronicle.Properties;
 /// </remarks>
 /// <param name="type">Type that does not hold the property path.</param>
 /// <param name="path">The <see cref="PropertyPath"/> that is not possible to resolve.</param>
-public class UnableToResolvePropertyPathOnType(Type type, PropertyPath path) : Exception($"Unable to resolve property path '${path}' on type '${type.FullName}'")
-{
-}
+public class UnableToResolvePropertyPathOnType(Type type, PropertyPath path) : Exception($"Unable to resolve property path '${path}' on type '${type.FullName}'");

--- a/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
@@ -92,18 +92,23 @@ public static class ComplianceJsonSchemaExtensions
 
     static bool HasComplianceMetadata(JsonSchema schema, HashSet<JsonSchema> visited)
     {
-        // Guard against self-referencing / recursive schemas (e.g. a tree node with a
-        // child collection of its own type) which would otherwise recurse forever.
-        if (!visited.Add(schema))
+        // Resolve $ref / allOf to the underlying schema and key the visited set on THAT. A
+        // recursive read model (e.g. a child collection of the model's own type) expresses every
+        // reference as a pointer to one shared definition, so resolving to the actual schema gives
+        // a stable identity that recognises the cycle and terminates. Keying on the wrapper object
+        // does not work: NJsonSchema's Properties/Item accessors hand back a fresh wrapper on each
+        // access, so the same logical schema is never seen twice and the traversal recurses forever.
+        var actual = schema.ActualSchema;
+        if (!visited.Add(actual))
         {
             return false;
         }
 
-        var hasMetadata = schema.ExtensionData?.ContainsKey(ComplianceKey) ?? false;
+        var hasMetadata = actual.ExtensionData?.ContainsKey(ComplianceKey) ?? false;
 
-        if (!hasMetadata && schema.Properties.Count > 0)
+        if (!hasMetadata && actual.Properties.Count > 0)
         {
-            foreach (var property in schema.GetFlattenedProperties())
+            foreach (var property in actual.GetFlattenedProperties())
             {
                 hasMetadata = HasComplianceMetadata(property, visited);
                 if (hasMetadata) break;
@@ -114,9 +119,9 @@ public static class ComplianceJsonSchemaExtensions
         // where Email is a [PII] concept, or a list of objects carrying [PII] members. Without
         // descending into the item schema, list-valued PII is missed entirely and stored in the
         // clear.
-        if (!hasMetadata && schema.Item is not null)
+        if (!hasMetadata && actual.Item is not null)
         {
-            hasMetadata = HasComplianceMetadata(schema.Item.ActualSchema, visited);
+            hasMetadata = HasComplianceMetadata(actual.Item, visited);
         }
 
         return hasMetadata;

--- a/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
@@ -79,21 +79,8 @@ public static class ComplianceJsonSchemaExtensions
     /// </summary>
     /// <param name="schema"><see cref="JsonSchema"/> to check.</param>
     /// <returns>True if it has, false if not.</returns>
-    public static bool HasComplianceMetadata(this JsonSchema schema)
-    {
-        var hasMetadata = schema.ExtensionData?.ContainsKey(ComplianceKey) ?? false;
-
-        if (!hasMetadata && schema.Properties.Count > 0)
-        {
-            foreach (var property in schema.GetFlattenedProperties())
-            {
-                hasMetadata = property.HasComplianceMetadata();
-                if (hasMetadata) break;
-            }
-        }
-
-        return hasMetadata;
-    }
+    public static bool HasComplianceMetadata(this JsonSchema schema) =>
+        HasComplianceMetadata(schema, []);
 
     /// <summary>
     /// Check if the property has compliance metadata.
@@ -102,6 +89,38 @@ public static class ComplianceJsonSchemaExtensions
     /// <returns>True if it has, false if not.</returns>
     public static bool HasComplianceMetadata(this JsonSchemaProperty property) =>
         HasComplianceMetadata((JsonSchema)property);
+
+    static bool HasComplianceMetadata(JsonSchema schema, HashSet<JsonSchema> visited)
+    {
+        // Guard against self-referencing / recursive schemas (e.g. a tree node with a
+        // child collection of its own type) which would otherwise recurse forever.
+        if (!visited.Add(schema))
+        {
+            return false;
+        }
+
+        var hasMetadata = schema.ExtensionData?.ContainsKey(ComplianceKey) ?? false;
+
+        if (!hasMetadata && schema.Properties.Count > 0)
+        {
+            foreach (var property in schema.GetFlattenedProperties())
+            {
+                hasMetadata = HasComplianceMetadata(property, visited);
+                if (hasMetadata) break;
+            }
+        }
+
+        // Compliance metadata can live on an array's element type — e.g. IReadOnlyList<Email>
+        // where Email is a [PII] concept, or a list of objects carrying [PII] members. Without
+        // descending into the item schema, list-valued PII is missed entirely and stored in the
+        // clear.
+        if (!hasMetadata && schema.Item is not null)
+        {
+            hasMetadata = HasComplianceMetadata(schema.Item.ActualSchema, visited);
+        }
+
+        return hasMetadata;
+    }
 
     static void ConvertComplianceIfNeeded(JsonSchema schema)
     {

--- a/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/ComplianceJsonSchemaExtensions.cs
@@ -15,6 +15,8 @@ public static class ComplianceJsonSchemaExtensions
     /// </summary>
     public const string ComplianceKey = "compliance";
 
+    const int MaxComplianceTraversalDepth = 64;
+
     /// <summary>
     /// Ensure the compliance metadata is correct with correct types.
     /// </summary>
@@ -80,7 +82,7 @@ public static class ComplianceJsonSchemaExtensions
     /// <param name="schema"><see cref="JsonSchema"/> to check.</param>
     /// <returns>True if it has, false if not.</returns>
     public static bool HasComplianceMetadata(this JsonSchema schema) =>
-        HasComplianceMetadata(schema, []);
+        HasComplianceMetadata(schema, [], 0);
 
     /// <summary>
     /// Check if the property has compliance metadata.
@@ -90,16 +92,19 @@ public static class ComplianceJsonSchemaExtensions
     public static bool HasComplianceMetadata(this JsonSchemaProperty property) =>
         HasComplianceMetadata((JsonSchema)property);
 
-    static bool HasComplianceMetadata(JsonSchema schema, HashSet<JsonSchema> visited)
+    static bool HasComplianceMetadata(JsonSchema schema, HashSet<JsonSchema> visited, int depth)
     {
-        // Resolve $ref / allOf to the underlying schema and key the visited set on THAT. A
-        // recursive read model (e.g. a child collection of the model's own type) expresses every
-        // reference as a pointer to one shared definition, so resolving to the actual schema gives
-        // a stable identity that recognises the cycle and terminates. Keying on the wrapper object
-        // does not work: NJsonSchema's Properties/Item accessors hand back a fresh wrapper on each
-        // access, so the same logical schema is never seen twice and the traversal recurses forever.
+        // Walking a schema graph to look for compliance metadata has to contend with recursive
+        // read models (e.g. a child collection of the model's own type). Two termination guards:
+        //   1. A visited set keyed on the resolved ActualSchema, which recognises a cycle whenever
+        //      references resolve back to one shared definition object.
+        //   2. A depth bound, because NJsonSchema does not guarantee a stable identity for schemas
+        //      reached through $ref/Item — its accessors can hand back a fresh wrapper on each
+        //      access, so (1) alone is not enough for every shape. The bound guarantees termination
+        //      regardless of identity, and does not cause false negatives: compliance metadata is
+        //      shallow, so anything real is found long before this depth.
         var actual = schema.ActualSchema;
-        if (!visited.Add(actual))
+        if (depth > MaxComplianceTraversalDepth || !visited.Add(actual))
         {
             return false;
         }
@@ -110,7 +115,7 @@ public static class ComplianceJsonSchemaExtensions
         {
             foreach (var property in actual.GetFlattenedProperties())
             {
-                hasMetadata = HasComplianceMetadata(property, visited);
+                hasMetadata = HasComplianceMetadata(property, visited, depth + 1);
                 if (hasMetadata) break;
             }
         }
@@ -121,7 +126,7 @@ public static class ComplianceJsonSchemaExtensions
         // clear.
         if (!hasMetadata && actual.Item is not null)
         {
-            hasMetadata = HasComplianceMetadata(actual.Item, visited);
+            hasMetadata = HasComplianceMetadata(actual.Item, visited, depth + 1);
         }
 
         return hasMetadata;

--- a/Source/Kernel/Concepts/Jobs/UnknownClrTypeForJobStepType.cs
+++ b/Source/Kernel/Concepts/Jobs/UnknownClrTypeForJobStepType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Concepts.Jobs;
 /// Initializes a new instance of the <see cref="UnknownClrTypeForJobStepType"/> class.
 /// </remarks>
 /// <param name="type"><see cref="JobType"/> that has an invalid type identifier.</param>
-public class UnknownClrTypeForJobStepType(JobStepType type) : Exception($"Unknown job step type '{type}'")
-{
-}
+public class UnknownClrTypeForJobStepType(JobStepType type) : Exception($"Unknown job step type '{type}'");

--- a/Source/Kernel/Concepts/Jobs/UnknownClrTypeForJobType.cs
+++ b/Source/Kernel/Concepts/Jobs/UnknownClrTypeForJobType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Concepts.Jobs;
 /// Initializes a new instance of the <see cref="UnknownClrTypeForJobType"/> class.
 /// </remarks>
 /// <param name="type"><see cref="JobType"/> that has an invalid type identifier.</param>
-public class UnknownClrTypeForJobType(JobType type) : Exception($"Unknown job type '{type}'")
-{
-}
+public class UnknownClrTypeForJobType(JobType type) : Exception($"Unknown job type '{type}'");

--- a/Source/Kernel/Concepts/Recommendations/UnknownClrTypeForRecommendationType.cs
+++ b/Source/Kernel/Concepts/Recommendations/UnknownClrTypeForRecommendationType.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Concepts.Recommendations;
 /// Initializes a new instance of the <see cref="UnknownClrTypeForRecommendationType"/> class.
 /// </remarks>
 /// <param name="type"><see cref="RecommendationType"/> that has an invalid type identifier.</param>
-public class UnknownClrTypeForRecommendationType(RecommendationType type) : Exception($"Unknown operation type '{type}'")
-{
-}
+public class UnknownClrTypeForRecommendationType(RecommendationType type) : Exception($"Unknown operation type '{type}'");

--- a/Source/Kernel/Contracts/Primitives/NoValueSetForOneOf.cs
+++ b/Source/Kernel/Contracts/Primitives/NoValueSetForOneOf.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Contracts.Primitives;
 /// Initializes a new instance of the <see cref="NoValueSetForOneOf"/> class.
 /// </remarks>
 /// <param name="types">Types for the one of.</param>
-public class NoValueSetForOneOf(params Type[] types) : Exception($"No value set for OneOf<{string.Join(", ", types.Select(_ => _.Name))}>")
-{
-}
+public class NoValueSetForOneOf(params Type[] types) : Exception($"No value set for OneOf<{string.Join(", ", types.Select(_ => _.Name))}>");

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_compliant_scalars.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_compliant_scalars.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
+
+public class a_value_handler_and_a_type_with_a_list_of_compliant_scalars : Specification
+{
+    protected JsonSchema _schema;
+    protected IJsonCompliancePropertyValueHandler _valueHandler;
+    protected JsonComplianceManager _manager;
+
+    protected readonly ComplianceMetadataType _metadataType = "test-metadata-type";
+
+    async Task Establish()
+    {
+        // Compliance metadata lives on the array's element type — the IReadOnlyList<Email> shape.
+        // Built from JSON so it matches how a persisted schema is loaded at runtime.
+        _schema = await JsonSchema.FromJsonAsync(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "emails": {
+                  "type": "array",
+                  "items": { "type": "string", "compliance": [ { "metadataType": "test-metadata-type", "details": "" } ] }
+                }
+              }
+            }
+            """);
+
+        _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
+        _valueHandler.Type.Returns(_metadataType);
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+    }
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
+
+public class a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member : Specification
+{
+    protected JsonSchema _schema;
+    protected IJsonCompliancePropertyValueHandler _valueHandler;
+    protected JsonComplianceManager _manager;
+
+    protected readonly ComplianceMetadataType _metadataType = "test-metadata-type";
+
+    async Task Establish()
+    {
+        // Compliance metadata lives on a member of the objects held in the list.
+        _schema = await JsonSchema.FromJsonAsync(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "contacts": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "email": { "type": "string", "compliance": [ { "metadataType": "test-metadata-type", "details": "" } ] }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
+        _valueHandler.Type.Returns(_metadataType);
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+    }
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_a_list_of_compliant_scalars.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_a_list_of_compliant_scalars.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+public class when_applying_to_a_list_of_compliant_scalars : given.a_value_handler_and_a_type_with_a_list_of_compliant_scalars
+{
+    const string Identifier = "9ae5067b-2920-4c97-a263-efe35bec2b43";
+    const string EncryptedValue = "encrypted";
+
+    JsonObject _input;
+    JsonObject _result;
+
+    void Establish()
+    {
+        _input = new JsonObject
+        {
+            ["emails"] = new JsonArray("one@cratis.io", "two@cratis.io")
+        };
+
+        _valueHandler.Apply(string.Empty, string.Empty, Identifier, Arg.Any<JsonNode>()).Returns(_ => Task.FromResult<JsonNode>(JsonValue.Create(EncryptedValue)));
+    }
+
+    async Task Because() => _result = await _manager.Apply(string.Empty, string.Empty, _schema, Identifier, _input);
+
+    [Fact] void should_encrypt_every_element() => _result["emails"]!.AsArray().Select(_ => _!.GetValue<string>()).ToArray().ShouldEqual([EncryptedValue, EncryptedValue]);
+    [Fact] void should_invoke_the_handler_for_each_element() => _valueHandler.Received(2).Apply(string.Empty, string.Empty, Identifier, Arg.Any<JsonNode>());
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_a_list_of_objects_with_a_compliant_member.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_a_list_of_objects_with_a_compliant_member.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+public class when_applying_to_a_list_of_objects_with_a_compliant_member : given.a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member
+{
+    const string Identifier = "9ae5067b-2920-4c97-a263-efe35bec2b43";
+    const string EncryptedValue = "encrypted";
+
+    JsonObject _input;
+    JsonObject _result;
+
+    void Establish()
+    {
+        _input = new JsonObject
+        {
+            ["contacts"] = new JsonArray(
+                new JsonObject { ["email"] = "a@cratis.io" },
+                new JsonObject { ["email"] = "b@cratis.io" })
+        };
+
+        _valueHandler.Apply(string.Empty, string.Empty, Identifier, Arg.Any<JsonNode>()).Returns(_ => Task.FromResult<JsonNode>(JsonValue.Create(EncryptedValue)));
+    }
+
+    async Task Because() => _result = await _manager.Apply(string.Empty, string.Empty, _schema, Identifier, _input);
+
+    [Fact] void should_encrypt_the_compliant_member_of_each_element() => _result["contacts"]!.AsArray().Select(_ => _!["email"]!.GetValue<string>()).ToArray().ShouldEqual([EncryptedValue, EncryptedValue]);
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_an_empty_list_of_compliant_scalars.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_applying_to_an_empty_list_of_compliant_scalars.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+public class when_applying_to_an_empty_list_of_compliant_scalars : given.a_value_handler_and_a_type_with_a_list_of_compliant_scalars
+{
+    const string Identifier = "9ae5067b-2920-4c97-a263-efe35bec2b43";
+
+    JsonObject _input;
+    JsonObject _result;
+
+    void Establish() => _input = new JsonObject { ["emails"] = new JsonArray() };
+
+    async Task Because() => _result = await _manager.Apply(string.Empty, string.Empty, _schema, Identifier, _input);
+
+    [Fact] void should_keep_the_array_empty() => _result["emails"]!.AsArray().Count.ShouldEqual(0);
+    [Fact] void should_not_invoke_the_handler() => _valueHandler.DidNotReceiveWithAnyArgs().Apply(default!, default!, default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_checking_recursive_schema.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_checking_recursive_schema.cs
@@ -9,9 +9,30 @@ public class when_checking_recursive_schema : Specification
 {
     record TreeNode(string Id, IReadOnlyList<TreeNode> Children);
 
-    bool _result;
+    bool _fromTypeResult;
+    bool _selfReferencingArrayResult;
 
-    void Because() => _result = JsonSchema.FromType<TreeNode>().HasComplianceMetadata();
+    async Task Because()
+    {
+        // A read model whose child collection is of its own type. The array-item traversal added
+        // for list-valued PII must terminate rather than recurse forever — and recognising the
+        // cycle relies on resolving each reference to its shared definition, because the schema
+        // accessors otherwise hand back fresh wrapper objects on every access (which is exactly
+        // what crashed projection read models with deep/recursive hierarchies).
+        _fromTypeResult = JsonSchema.FromType<TreeNode>().HasComplianceMetadata();
 
-    [Fact] void should_not_hang_or_overflow() => _result.ShouldBeFalse();
+        var selfReferencingArray = await JsonSchema.FromJsonAsync(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "children": { "type": "array", "items": { "$ref": "#" } }
+              }
+            }
+            """);
+        _selfReferencingArrayResult = selfReferencingArray.HasComplianceMetadata();
+    }
+
+    [Fact] void should_terminate_for_a_recursive_type() => _fromTypeResult.ShouldBeFalse();
+    [Fact] void should_terminate_for_a_self_referencing_array() => _selfReferencingArrayResult.ShouldBeFalse();
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_checking_recursive_schema.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_checking_recursive_schema.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+public class when_checking_recursive_schema : Specification
+{
+    record TreeNode(string Id, IReadOnlyList<TreeNode> Children);
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromType<TreeNode>().HasComplianceMetadata();
+
+    [Fact] void should_not_hang_or_overflow() => _result.ShouldBeFalse();
+}

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -129,18 +129,22 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                     break;
 
                 default:
-                    foreach (var metadata in itemComplianceMetadata.DistinctBy(_ => _.metadataType))
-                    {
-                        if (_propertyValueHandlers.TryGetValue(metadata.metadataType, out var handler))
+                    foreach (var metadata in itemComplianceMetadata
+                        .DistinctBy(_ => _.metadataType)
+                        .Select(_ =>
                         {
-                            try
-                            {
-                                array[i] = await action(handler, identifier, element);
-                            }
-                            catch (Exception ex)
-                            {
-                                throw new InvalidOperationException($"Failed to {actionName} compliance metadata for property '{elementPath}'.", ex);
-                            }
+                            var found = _propertyValueHandlers.TryGetValue(_.metadataType, out var handler);
+                            return (metadataType: _.metadataType, handler, found);
+                        })
+                        .Where(_ => _.found))
+                    {
+                        try
+                        {
+                            array[i] = await action(metadata.handler!, identifier, element);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new InvalidOperationException($"Failed to {actionName} compliance metadata for property '{elementPath}'.", ex);
                         }
                     }
 

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -62,6 +62,7 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
             {
                 var propertyPath = string.IsNullOrEmpty(path) ? property : $"{path}.{property}";
                 var propertySchema = schema.GetFlattenedProperties().Single(_ => _.Name == property);
+                var handlerApplied = false;
                 foreach (var metadata in propertySchema.GetComplianceMetadata().Concat(complianceMetadataForContainer).DistinctBy(_ => _.metadataType))
                 {
                     if (_propertyValueHandlers.TryGetValue(metadata.metadataType, out var handler))
@@ -69,6 +70,7 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                         try
                         {
                             json[property] = await action(handler, identifier, value);
+                            handlerApplied = true;
                         }
                         catch (Exception ex)
                         {
@@ -81,6 +83,68 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                 {
                     await HandleActionFor(propertySchema.ActualTypeSchema, identifier, jsonObjectValue, actionName, action, propertyPath);
                 }
+                else if (!handlerApplied && value is JsonArray jsonArrayValue)
+                {
+                    // The property itself was not encrypted as a whole, so descend into the array
+                    // and handle compliance metadata that lives on the element type — [PII] scalar
+                    // concepts (e.g. IReadOnlyList<Email>) or [PII] members inside element objects.
+                    await HandleActionForArray(propertySchema.ActualTypeSchema, identifier, jsonArrayValue, actionName, action, propertyPath);
+                }
+            }
+        }
+    }
+
+    async Task HandleActionForArray(
+        JsonSchema arraySchema,
+        string identifier,
+        JsonArray array,
+        string actionName,
+        Func<IJsonCompliancePropertyValueHandler, string, JsonNode, Task<JsonNode>> action,
+        string path)
+    {
+        var itemSchema = arraySchema.Item?.ActualSchema;
+        if (itemSchema is null)
+        {
+            return;
+        }
+
+        var itemComplianceMetadata = itemSchema.GetComplianceMetadata().ToArray();
+        for (var i = 0; i < array.Count; i++)
+        {
+            var element = array[i];
+            if (element is null)
+            {
+                continue;
+            }
+
+            var elementPath = $"{path}[{i}]";
+            switch (element)
+            {
+                case JsonObject elementObject:
+                    await HandleActionFor(itemSchema, identifier, elementObject, actionName, action, elementPath);
+                    break;
+
+                case JsonArray elementArray:
+                    await HandleActionForArray(itemSchema, identifier, elementArray, actionName, action, elementPath);
+                    break;
+
+                default:
+                    foreach (var metadata in itemComplianceMetadata.DistinctBy(_ => _.metadataType))
+                    {
+                        if (_propertyValueHandlers.TryGetValue(metadata.metadataType, out var handler))
+                        {
+                            try
+                            {
+                                array[i] = await action(handler, identifier, element);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new InvalidOperationException($"Failed to {actionName} compliance metadata for property '{elementPath}'.", ex);
+                            }
+                        }
+                    }
+
+                    break;
             }
         }
     }

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -129,22 +129,18 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                     break;
 
                 default:
-                    foreach (var metadata in itemComplianceMetadata
-                        .DistinctBy(_ => _.metadataType)
-                        .Select(_ =>
-                        {
-                            var found = _propertyValueHandlers.TryGetValue(_.metadataType, out var handler);
-                            return (metadataType: _.metadataType, handler, found);
-                        })
-                        .Where(_ => _.found))
+                    foreach (var metadata in itemComplianceMetadata.DistinctBy(_ => _.metadataType))
                     {
-                        try
+                        if (_propertyValueHandlers.TryGetValue(metadata.metadataType, out var handler))
                         {
-                            array[i] = await action(metadata.handler!, identifier, element);
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new InvalidOperationException($"Failed to {actionName} compliance metadata for property '{elementPath}'.", ex);
+                            try
+                            {
+                                array[i] = await action(handler, identifier, element);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new InvalidOperationException($"Failed to {actionName} compliance metadata for property '{elementPath}'.", ex);
+                            }
                         }
                     }
 

--- a/Source/Kernel/Core/Helpers/InvalidGrainName.cs
+++ b/Source/Kernel/Core/Helpers/InvalidGrainName.cs
@@ -10,6 +10,4 @@ namespace Orleans;
 /// Initializes a new instance of the <see cref="InvalidGrainName"/> class.
 /// </remarks>
 /// <param name="grainType">Violating grain type.</param>
-public class InvalidGrainName(Type grainType) : Exception($"Grain type '{grainType.Name}' is invalid. No interface for the grain was matched. It should follow the convention of `IFoo` -> `Foo`.")
-{
-}
+public class InvalidGrainName(Type grainType) : Exception($"Grain type '{grainType.Name}' is invalid. No interface for the grain was matched. It should follow the convention of `IFoo` -> `Foo`.");

--- a/Source/Kernel/Core/Observation/Reactors/Clients/MissingStateForReactorSubscriber.cs
+++ b/Source/Kernel/Core/Observation/Reactors/Clients/MissingStateForReactorSubscriber.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Observation.Reactors.Clients;
 /// Initializes a new instance of the <see cref="MissingStateForReactorSubscriber"/> class.
 /// </remarks>
 /// <param name="observerId"><see cref="ObserverId"/> that has missing state.</param>
-public class MissingStateForReactorSubscriber(ObserverId observerId) : Exception($"Missing state for Reactor observer subscriber with id {observerId}")
-{
-}
+public class MissingStateForReactorSubscriber(ObserverId observerId) : Exception($"Missing state for Reactor observer subscriber with id {observerId}");

--- a/Source/Kernel/Core/Observation/Reducers/Clients/InvalidReturnContentFromReducer.cs
+++ b/Source/Kernel/Core/Observation/Reducers/Clients/InvalidReturnContentFromReducer.cs
@@ -14,6 +14,4 @@ namespace Cratis.Chronicle.Observation.Reducers.Clients;
 /// <param name="httpStatusCode">The <see cref="HttpStatusCode"/> for the response.</param>
 /// <param name="reason">The reason for failing.</param>
 /// <param name="content">The invalid content.</param>
-public class InvalidReturnContentFromReducer(HttpStatusCode httpStatusCode, string reason, string content) : Exception($"Invalid content returned from reducer, status code '{httpStatusCode}', with reason phrase '{reason}' and content: '{content}'")
-{
-}
+public class InvalidReturnContentFromReducer(HttpStatusCode httpStatusCode, string reason, string content) : Exception($"Invalid content returned from reducer, status code '{httpStatusCode}', with reason phrase '{reason}' and content: '{content}'");

--- a/Source/Kernel/Core/Observation/Reducers/Clients/MissingStateForReducerSubscriber.cs
+++ b/Source/Kernel/Core/Observation/Reducers/Clients/MissingStateForReducerSubscriber.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Observation.Reducers.Clients;
 /// Initializes a new instance of the <see cref="MissingStateForReducerSubscriber"/> class.
 /// </remarks>
 /// <param name="observerId"><see cref="ObserverId"/> that has missing state.</param>
-public class MissingStateForReducerSubscriber(ObserverId observerId) : Exception($"Missing state for reducer observer subscriber with id {observerId}")
-{
-}
+public class MissingStateForReducerSubscriber(ObserverId observerId) : Exception($"Missing state for reducer observer subscriber with id {observerId}");

--- a/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/UnsupportedEventValueExpression.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/UnsupportedEventValueExpression.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Projections.Engine.Expressions.EventValues;
 /// </remarks>
 /// <param name="property">The property that has unsupported expression.</param>
 /// <param name="expression">The unsupported expression.</param>
-public class UnsupportedEventValueExpression(JsonSchemaProperty property, string expression) : Exception($"Unknown event value expression '{expression}' for property '{property.Name}'")
-{
-}
+public class UnsupportedEventValueExpression(JsonSchemaProperty property, string expression) : Exception($"Unknown event value expression '{expression}' for property '{property.Name}'");

--- a/Source/Kernel/Core/Projections/Engine/Expressions/Keys/InvalidCompositeKeyPropertyMappingExpression.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/Keys/InvalidCompositeKeyPropertyMappingExpression.cs
@@ -15,6 +15,4 @@ namespace Cratis.Chronicle.Projections.Engine.Expressions.Keys;
 /// <param name="projectionId">Identifier of the projection.</param>
 /// <param name="identifiedByProperty">The property used as identifier for the key.</param>
 /// <param name="expression">Key/value expression.</param>
-public class InvalidCompositeKeyPropertyMappingExpression(ProjectionId projectionId, PropertyPath identifiedByProperty, string expression) : Exception($"Expression '{expression}' in projection '{projectionId}' for property '{identifiedByProperty}' is invalid. Expecting a key/value of property=expression")
-{
-}
+public class InvalidCompositeKeyPropertyMappingExpression(ProjectionId projectionId, PropertyPath identifiedByProperty, string expression) : Exception($"Expression '{expression}' in projection '{projectionId}' for property '{identifiedByProperty}' is invalid. Expecting a key/value of property=expression");

--- a/Source/Kernel/Core/Projections/Engine/Expressions/Keys/MissingCompositeExpressions.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/Keys/MissingCompositeExpressions.cs
@@ -16,6 +16,4 @@ namespace Cratis.Chronicle.Projections.Engine.Expressions.Keys;
 /// <param name="identifiedByProperty">The property used as identifier for the key.</param>
 /// <param name="expression">Key/value expression.</param>
 public class MissingCompositeExpressions(ProjectionId projectionId, PropertyPath identifiedByProperty, string expression)
-    : Exception($"There are no property expressions in '{expression}' in projection '{projectionId}' for property '{identifiedByProperty}' is invalid. Expecting a collection key/value of property=expression separated by ,")
-{
-}
+    : Exception($"There are no property expressions in '{expression}' in projection '{projectionId}' for property '{identifiedByProperty}' is invalid. Expecting a collection key/value of property=expression separated by ,");

--- a/Source/Kernel/Core/Projections/Engine/Expressions/Keys/UnsupportedKeyExpression.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/Keys/UnsupportedKeyExpression.cs
@@ -10,6 +10,4 @@ namespace Cratis.Chronicle.Projections.Engine.Expressions.Keys;
 /// Initializes a new instance of the <see cref="UnsupportedReadModelPropertyExpression"/> class.
 /// </remarks>
 /// <param name="expression">The unsupported expression.</param>
-public class UnsupportedKeyExpression(string expression) : Exception($"Unknown key expression '{expression}'")
-{
-}
+public class UnsupportedKeyExpression(string expression) : Exception($"Unknown key expression '{expression}'");

--- a/Source/Kernel/Core/Projections/Engine/MissingKeyResolverForEventType.cs
+++ b/Source/Kernel/Core/Projections/Engine/MissingKeyResolverForEventType.cs
@@ -13,6 +13,4 @@ namespace Cratis.Chronicle.Projections.Engine;
 /// Initializes a new instance of the <see cref="MissingKeyResolverForEventType"/>.
 /// </remarks>
 /// <param name="eventType">The <see cref="EventType"/>.</param>
-public class MissingKeyResolverForEventType(EventType eventType) : Exception($"Missing key resolver for '{eventType}'")
-{
-}
+public class MissingKeyResolverForEventType(EventType eventType) : Exception($"Missing key resolver for '{eventType}'");

--- a/Source/Kernel/Core/Projections/Engine/MissingProjection.cs
+++ b/Source/Kernel/Core/Projections/Engine/MissingProjection.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Projections.Engine;
 /// Initializes a new instance of the <see cref="MissingProjection"/> class.
 /// </remarks>
 /// <param name="id">The <see cref="ProjectionId"/> for the missing projection.</param>
-public class MissingProjection(ProjectionId id) : Exception($"Missing projection with id {id.Value}")
-{
-}
+public class MissingProjection(ProjectionId id) : Exception($"Missing projection with id {id.Value}");

--- a/Source/Kernel/Core/Projections/Engine/UnableToResolveInstanceForProjection.cs
+++ b/Source/Kernel/Core/Projections/Engine/UnableToResolveInstanceForProjection.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Projections.Engine;
 /// Initializes a new instance of the <see cref="UnableToResolveInstanceForProjection"/> class.
 /// </remarks>
 /// <param name="projectionPath">Path within the projection.</param>
-public class UnableToResolveInstanceForProjection(ProjectionPath projectionPath) : Exception($"Projection with path '{projectionPath.Value}' can't resolve the instance to project to.")
-{
-}
+public class UnableToResolveInstanceForProjection(ProjectionPath projectionPath) : Exception($"Projection with path '{projectionPath.Value}' can't resolve the instance to project to.");

--- a/Source/Kernel/Core/StateMachines/TransitioningDuringOnLeaveIsNotSupported.cs
+++ b/Source/Kernel/Core/StateMachines/TransitioningDuringOnLeaveIsNotSupported.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.StateMachines;
 /// <param name="stateType">Type of state that is trying to transition.</param>
 /// <param name="targetStateType">Type of state that it is attempting a transition to.</param>
 /// <param name="stateMachineType">Type of state machine.</param>
-public class TransitioningDuringOnLeaveIsNotSupported(Type stateType, Type targetStateType, Type stateMachineType) : Exception($"State '{stateType.AssemblyQualifiedName}' in state machine '{stateMachineType.AssemblyQualifiedName}' is trying to transition to '{targetStateType.FullName}' during OnLeave, which is not supported")
-{
-}
+public class TransitioningDuringOnLeaveIsNotSupported(Type stateType, Type targetStateType, Type stateMachineType) : Exception($"State '{stateType.AssemblyQualifiedName}' in state machine '{stateMachineType.AssemblyQualifiedName}' is trying to transition to '{targetStateType.FullName}' during OnLeave, which is not supported");

--- a/Source/Kernel/Core/StateMachines/UnknownCurrentState.cs
+++ b/Source/Kernel/Core/StateMachines/UnknownCurrentState.cs
@@ -11,6 +11,4 @@ namespace Cratis.Chronicle.StateMachines;
 /// </remarks>
 /// <param name="currentState">Current state that is unknown.</param>
 /// <param name="stateMachineType">The state machine that the current state is unknown for.</param>
-public class UnknownCurrentState(string currentState, Type stateMachineType) : Exception($"Current state '{currentState}' is unknown for the state machine '{stateMachineType.FullName}'")
-{
-}
+public class UnknownCurrentState(string currentState, Type stateMachineType) : Exception($"Current state '{currentState}' is unknown for the state machine '{stateMachineType.FullName}'");

--- a/Source/Kernel/Core/StateMachines/UnknownStateTypeInStateMachine.cs
+++ b/Source/Kernel/Core/StateMachines/UnknownStateTypeInStateMachine.cs
@@ -11,6 +11,4 @@ namespace Cratis.Chronicle.StateMachines;
 /// </remarks>
 /// <param name="type">State type that is unknown.</param>
 /// <param name="stateMachineType">The state machine that the type is unknown for.</param>
-public class UnknownStateTypeInStateMachine(Type type, Type stateMachineType) : Exception($"Type '{type.FullName}' is unknown in the state machine '{stateMachineType.FullName}'")
-{
-}
+public class UnknownStateTypeInStateMachine(Type type, Type stateMachineType) : Exception($"Type '{type.FullName}' is unknown in the state machine '{stateMachineType.FullName}'");

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Observation.Reducers;
+using Cratis.Chronicle.Observation.Reducers.Clients;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Sinks.InMemory;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity.given;
+
+/// <summary>
+/// Base for cross-sink parity scenarios. The same sequence of projected read-model states is
+/// driven through both the in-memory sink and a real MongoDB sink, and the resulting documents
+/// are compared so that any divergence in how the two sinks apply a changeset fails the spec.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
+public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
+{
+    readonly ObjectComparer _objectComparer = new();
+
+    IMongoClient _client = default!;
+    string _databaseName = default!;
+    InMemorySink _inMemorySink = default!;
+    Sink _mongoSink = default!;
+    ReducerPipeline _inMemoryPipeline = default!;
+    ReducerPipeline _mongoPipeline = default!;
+    JsonSchema _schema = default!;
+    Key _key = default!;
+
+    /// <summary>Gets the read-model type whose schema drives the sinks.</summary>
+    protected abstract Type ReadModelType { get; }
+
+    /// <summary>Gets the key value the read model is stored under.</summary>
+    protected virtual object KeyValue => "root-1";
+
+    /// <summary>Gets the ordered projected states applied (each factory produces a fresh instance per sink).</summary>
+    protected abstract IReadOnlyList<Func<ExpandoObject>> States { get; }
+
+    public ExpandoObject? InMemoryResult { get; private set; }
+
+    public ExpandoObject? MongoResult { get; private set; }
+
+    public IReadOnlyList<PropertyDifference> ParityDifferences { get; private set; } = [];
+
+    /// <summary>Gets a human-readable description of any divergence, or empty when the sinks match.</summary>
+    public string ParityReport { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        _databaseName = $"chronicle_sink_parity_{Guid.NewGuid():N}";
+        _client = new MongoClient(fixture.ConnectionString);
+        var database = _client.GetDatabase(_databaseName);
+        _schema = JsonSchema.FromType(ReadModelType);
+        _key = new Key(KeyValue, ArrayIndexers.NoIndexers);
+
+        var typeFormats = new TypeFormats();
+        var readModel = CreateReadModelDefinition();
+        var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
+
+        _inMemorySink = new InMemorySink(readModel, typeFormats);
+
+        var collections = new SinkCollections(readModel, database);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+        var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
+        _mongoSink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
+
+        var compliance = new PassthroughReadModelsCompliance();
+        _inMemoryPipeline = new ReducerPipeline(readModel, _inMemorySink, _objectComparer, compliance, "test-store", "test-namespace");
+        _mongoPipeline = new ReducerPipeline(readModel, _mongoSink, _objectComparer, compliance, "test-store", "test-namespace");
+
+        foreach (var state in States)
+        {
+            await ApplyThroughBoth(state);
+        }
+
+        InMemoryResult = await _inMemorySink.FindOrDefault(_key);
+        MongoResult = await _mongoSink.FindOrDefault(_key);
+
+        if (InMemoryResult is not null && MongoResult is not null)
+        {
+            // Compare the read-model data only. Sink-internal metadata (the '__'-prefixed
+            // last-handled-sequence-number and friends) is not part of the projected read model
+            // and is legitimately tracked differently by each sink.
+            _objectComparer.Compare(WithoutMetadata(InMemoryResult), WithoutMetadata(MongoResult), out var differences);
+            ParityDifferences = differences.ToArray();
+            ParityReport = string.Join(
+                " || ",
+                ParityDifferences.Select(_ => $"{_.PropertyPath.Path}: in-memory='{_.Original}' mongo='{_.Changed}'"));
+        }
+    }
+
+    static ExpandoObject WithoutMetadata(ExpandoObject instance)
+    {
+        var clone = new ExpandoObject();
+        var target = (IDictionary<string, object?>)clone;
+        foreach (var (key, value) in (IDictionary<string, object?>)instance)
+        {
+            if (!key.StartsWith("__", StringComparison.Ordinal))
+            {
+                target[key] = value;
+            }
+        }
+
+        return clone;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _inMemorySink?.Dispose();
+        if (_databaseName is not null)
+        {
+            await _client.DropDatabaseAsync(_databaseName);
+        }
+    }
+
+    protected static ExpandoObject Expando(params (string Key, object? Value)[] properties)
+    {
+        var instance = new ExpandoObject();
+        var dictionary = (IDictionary<string, object?>)instance;
+        foreach (var (key, value) in properties)
+        {
+            dictionary[key] = value;
+        }
+
+        return instance;
+    }
+
+    async Task ApplyThroughBoth(Func<ExpandoObject> stateFactory)
+    {
+        await _inMemoryPipeline.Handle(
+            new ReducerContext([CreateEvent()], _key),
+            (_, _) => Task.FromResult(new ReducerSubscriberResult(ObserverSubscriberResult.Ok(EventSequenceNumber.First), stateFactory())));
+
+        await _mongoPipeline.Handle(
+            new ReducerContext([CreateEvent()], _key),
+            (_, _) => Task.FromResult(new ReducerSubscriberResult(ObserverSubscriberResult.Ok(EventSequenceNumber.First), stateFactory())));
+    }
+
+    ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-parity-read-model",
+            "TestParityReadModel",
+            $"parity_{Guid.NewGuid():N}",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Reducer,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, _schema }
+            },
+            []);
+
+    AppendedEvent CreateEvent()
+    {
+        var context = EventContext.From(
+            "test-store",
+            "test-namespace",
+            EventType.Unknown,
+            EventSourceType.Default,
+            _key.Value.ToString()!,
+            EventStreamType.All,
+            EventStreamId.Default,
+            EventSequenceNumber.First,
+            CorrelationId.NotSet);
+
+        return new AppendedEvent(context, new ExpandoObject());
+    }
+
+    sealed class PassthroughReadModelsCompliance : IReadModelsCompliance
+    {
+        public Task<ExpandoObject> Apply(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, string identifier, ExpandoObject instance) =>
+            Task.FromResult(instance);
+
+        public Task<JsonObject> ReleaseJson(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, JsonObject instance) =>
+            Task.FromResult(instance);
+
+        public Task<ExpandoObject> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, ExpandoObject instance) =>
+            Task.FromResult(instance);
+
+        public Task<IEnumerable<ExpandoObject>> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, JsonSchema schema, IEnumerable<ExpandoObject> instances) =>
+            Task.FromResult(instances);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_adds_a_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_adds_a_child.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_adds_a_child(when_a_reducer_adds_a_child.context ctx) : IClassFixture<when_a_reducer_adds_a_child.context>
+{
+    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+    {
+        protected override Type ReadModelType => typeof(Team);
+
+        protected override IReadOnlyList<Func<ExpandoObject>> States =>
+        [
+            () => CreateTeam("member-1"),
+            () => CreateTeam("member-1", "member-2")
+        ];
+
+        static ExpandoObject CreateTeam(params string[] memberIds) =>
+            Expando(
+                ("id", "root-1"),
+                ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
+
+        record Member(string MemberId, string Status);
+        record Team(string Id, IEnumerable<Member> Members);
+    }
+
+    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_removes_a_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_removes_a_child.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_removes_a_child(when_a_reducer_removes_a_child.context ctx) : IClassFixture<when_a_reducer_removes_a_child.context>
+{
+    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+    {
+        protected override Type ReadModelType => typeof(Team);
+
+        protected override IReadOnlyList<Func<ExpandoObject>> States =>
+        [
+            () => CreateTeam("member-1", "member-2", "member-3"),
+            () => CreateTeam("member-1", "member-3")
+        ];
+
+        static ExpandoObject CreateTeam(params string[] memberIds) =>
+            Expando(
+                ("id", "root-1"),
+                ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
+
+        record Member(string MemberId, string Status);
+        record Team(string Id, IEnumerable<Member> Members);
+    }
+
+    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_child_field.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_child_field.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_updates_a_child_field(when_a_reducer_updates_a_child_field.context ctx) : IClassFixture<when_a_reducer_updates_a_child_field.context>
+{
+    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+    {
+        protected override Type ReadModelType => typeof(Team);
+
+        protected override IReadOnlyList<Func<ExpandoObject>> States =>
+        [
+            () => CreateTeam("pending"),
+            () => CreateTeam("approved")
+        ];
+
+        static ExpandoObject CreateTeam(string status) =>
+            Expando(
+                ("id", "root-1"),
+                ("members", new object[] { Expando(("memberId", "member-1"), ("status", status)) }));
+
+        record Member(string MemberId, string Status);
+        record Team(string Id, IEnumerable<Member> Members);
+    }
+
+    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+    [Fact] void should_have_a_result_from_both_sinks() => (ctx.InMemoryResult is not null && ctx.MongoResult is not null).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_nested_object.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_nested_object.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_updates_a_nested_object(when_a_reducer_updates_a_nested_object.context ctx) : IClassFixture<when_a_reducer_updates_a_nested_object.context>
+{
+    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+    {
+        protected override Type ReadModelType => typeof(Profile);
+
+        protected override IReadOnlyList<Func<ExpandoObject>> States =>
+        [
+            () => CreateProfile("Oslo", "Norway"),
+            () => CreateProfile("Bergen", "Norway")
+        ];
+
+        static ExpandoObject CreateProfile(string city, string country) =>
+            Expando(
+                ("id", "root-1"),
+                ("home", Expando(("city", city), ("country", country))));
+
+        record Address(string City, string Country);
+        record Profile(string Id, Address Home);
+    }
+
+    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_one_among_several_children.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_one_among_several_children.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_updates_one_among_several_children(when_a_reducer_updates_one_among_several_children.context ctx) : IClassFixture<when_a_reducer_updates_one_among_several_children.context>
+{
+    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+    {
+        protected override Type ReadModelType => typeof(Team);
+
+        protected override IReadOnlyList<Func<ExpandoObject>> States =>
+        [
+            () => CreateTeam(("member-1", "active"), ("member-2", "active"), ("member-3", "active")),
+            () => CreateTeam(("member-1", "active"), ("member-2", "promoted"), ("member-3", "active"))
+        ];
+
+        static ExpandoObject CreateTeam(params (string Id, string Status)[] members) =>
+            Expando(
+                ("id", "root-1"),
+                ("members", members.Select(m => (object)Expando(("memberId", m.Id), ("status", m.Status))).ToArray()));
+
+        record Member(string MemberId, string Status);
+        record Team(string Id, IEnumerable<Member> Members);
+    }
+
+    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+}

--- a/Source/Kernel/Storage/Compliance/MissingEncryptionKey.cs
+++ b/Source/Kernel/Storage/Compliance/MissingEncryptionKey.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Storage.Compliance;
 /// Initializes a new instance of the <see cref="MissingEncryptionKey"/> class.
 /// </remarks>
 /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> that is missing.</param>
-public class MissingEncryptionKey(EncryptionKeyIdentifier identifier) : Exception($"Missing encryption key for identifier '{identifier}'")
-{
-}
+public class MissingEncryptionKey(EncryptionKeyIdentifier identifier) : Exception($"Missing encryption key for identifier '{identifier}'");

--- a/Source/Kernel/Storage/EventSequences/MissingEvent.cs
+++ b/Source/Kernel/Storage/EventSequences/MissingEvent.cs
@@ -18,6 +18,4 @@ namespace Cratis.Chronicle.Storage.EventSequences;
 public class MissingEvent(
     EventSequenceId eventSequenceId,
     EventTypeId eventTypeId,
-    EventSourceId eventSourceId) : Exception($"Missing event {eventTypeId} for {eventSourceId} in {eventSequenceId}")
-{
-}
+    EventSourceId eventSourceId) : Exception($"Missing event {eventTypeId} for {eventSourceId} in {eventSequenceId}");

--- a/Source/Kernel/Storage/Sinks/UnknownSink.cs
+++ b/Source/Kernel/Storage/Sinks/UnknownSink.cs
@@ -12,6 +12,4 @@ namespace Cratis.Chronicle.Storage.Sinks;
 /// Initializes a new instance of the <see cref="UnknownSink"/> class.
 /// </remarks>
 /// <param name="typeId">The unknown <see cref="SinkTypeId"/>.</param>
-public class UnknownSink(SinkTypeId typeId) : Exception($"Projection sink type of '{typeId}' is unknown.")
-{
-}
+public class UnknownSink(SinkTypeId typeId) : Exception($"Projection sink type of '{typeId}' is unknown.");

--- a/Source/Tools/GrpcCodeGenerator/NamespaceMismatchException.cs
+++ b/Source/Tools/GrpcCodeGenerator/NamespaceMismatchException.cs
@@ -15,7 +15,4 @@ public class NamespaceMismatchException(
     string expectedNamespace,
     string actualNamespace,
     string typeName)
-    : Exception($"Service '{serviceName}' has namespace mismatch. Expected '{expectedNamespace}' but type '{typeName}' is in '{actualNamespace}'.")
-{
-}
-
+    : Exception($"Service '{serviceName}' has namespace mismatch. Expected '{expectedNamespace}' but type '{typeName}' is in '{actualNamespace}'.");


### PR DESCRIPTION
# Summary

Encrypt `[PII]` values that live inside arrays and lists — previously they were skipped during compliance application and stored in the clear. This PR also includes two internal changes with no user-facing impact: it removes unnecessary empty `{ }` type bodies flagged by Meziantou.Analyzer 3.0.108 (MA0206) so Release builds pass, and it adds a cross-sink parity test suite that guards the in-memory and MongoDB sinks against behavioral divergence.

## Security

- `[PII]` values inside arrays and lists are now encrypted at rest per element — scalar concept lists (for example `IReadOnlyList<Email>`) and `[PII]` members of objects held in a list. Previously the compliance manager only descended into nested objects, so list-valued PII was never visited and was persisted in the clear.