### PR TITLE
Speed up CI integration tests and fix SQLite concurrent-write stalls

### DIFF
--- a/.github/scripts/generate-integration-matrix.py
+++ b/.github/scripts/generate-integration-matrix.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Generate the GitHub Actions matrix for the client integration specs.
+
+Every client integration namespace -- a directory under ``Integration/Client``
+that contains ``[Fact]`` tests -- runs against every infrastructure
+configuration (runtime mode x storage backend). Large namespaces are split
+into several shards that run as separate, parallel jobs so the slowest single
+job no longer gates the whole workflow.
+
+Sharding only changes how the work is distributed: every shard of a namespace
+together covers exactly the same tests as the un-sharded namespace would, so
+coverage across all five infrastructure configurations is preserved.
+
+Balancing is by ``[Fact]`` count across test classes. Each spec file declares
+the facts on its first top-level class, so a shard targets a class with
+``FullyQualifiedName~<namespace>.<class>.`` (note the trailing dot). Class
+fully-qualified names are mutually exclusive as substrings, so each test is
+owned by exactly one shard -- never double-run, never dropped. (A class that is
+a dotted ancestor of another, e.g. a genuine nested type, is folded into the
+same shard so the substring filter still owns it exactly once.)
+"""
+
+import json
+import os
+import re
+from collections import defaultdict
+
+CLIENT_ROOT = "Integration/Client"
+NAMESPACE_PREFIX = "Cratis.Chronicle.Integration."
+
+# Number of parallel shards per namespace. Any namespace not listed here runs as
+# a single job. Tuned from observed CI wall-clock: Projections (617 facts) was
+# the critical path of the whole run, and the others have a slow out-of-process
+# SQLite configuration whose contention eases when fewer tests share one job.
+SHARD_COUNTS = {
+    "Projections": 4,
+    "for_EventSequence": 2,
+    "for_Reactors": 2,
+    "for_Reducers": 2,
+}
+
+# mode | database | needs-docker. Out-of-process exercises every storage backend
+# through the real Chronicle container; in-process covers MongoDB.
+INFRA_CONFIGS = [
+    ("inprocess", "mongodb", False),
+    ("outofprocess", "mongodb", True),
+    ("outofprocess", "sqlite", True),
+    ("outofprocess", "postgresql", True),
+    ("outofprocess", "mssql", True),
+]
+
+_NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z0-9_.]+)", re.MULTILINE)
+# A top-level type declaration starts at column 0 (no leading whitespace). The
+# nested setup/`context` types and helper records are indented, so the first
+# match is the spec class that declares the file's [Fact] methods.
+_TOP_LEVEL_TYPE_RE = re.compile(
+    r"^(?:public |internal |sealed |abstract |static |partial )*(?:class|record)\s+([A-Za-z_]\w*)",
+    re.MULTILINE,
+)
+
+
+def _read(path):
+    with open(path, encoding="utf-8", errors="ignore") as handle:
+        return handle.read()
+
+
+def _namespaces_with_facts():
+    """Top-level directories under CLIENT_ROOT that contain at least one [Fact]."""
+    namespaces = []
+    for entry in sorted(os.listdir(CLIENT_ROOT)):
+        directory = os.path.join(CLIENT_ROOT, entry)
+        if not os.path.isdir(directory) or entry in ("bin", "obj"):
+            continue
+        if _test_class_counts(directory):
+            namespaces.append(entry)
+    return namespaces
+
+
+def _test_class_counts(namespace_dir):
+    """Map each test class fully-qualified name to its number of [Fact] tests.
+
+    A spec file declares all of its facts on its first top-level class, so the
+    facts are attributed to ``<namespace>.<first-top-level-class>``.
+    """
+    counts = defaultdict(int)
+    for dirpath, dirnames, filenames in os.walk(namespace_dir):
+        dirnames[:] = [d for d in dirnames if d not in ("bin", "obj")]
+        for filename in filenames:
+            if not filename.endswith(".cs"):
+                continue
+            text = _read(os.path.join(dirpath, filename))
+            facts = text.count("[Fact]")
+            if not facts:
+                continue
+            namespace = _NAMESPACE_RE.search(text)
+            declaring_type = _TOP_LEVEL_TYPE_RE.search(text)
+            if namespace and declaring_type:
+                counts[f"{namespace.group(1)}.{declaring_type.group(1)}"] += facts
+    return counts
+
+
+def _group_by_ancestor(counts):
+    """Fold every namespace into its shortest dotted ancestor present in the set.
+
+    This makes each group own a disjoint subtree, so a ``~group.`` substring
+    filter never matches a test that belongs to another group.
+    """
+    namespaces = sorted(counts)  # shorter (ancestor) namespaces sort first
+    groups = defaultdict(int)
+    for namespace in namespaces:
+        owner = namespace
+        for candidate in namespaces:
+            if namespace.startswith(candidate + "."):
+                owner = candidate  # first match is the shortest ancestor
+                break
+        groups[owner] += counts[namespace]
+    return groups
+
+
+def _pack(groups, num_shards):
+    """Greedy largest-first bin-packing of groups into balanced shards."""
+    buckets = [[] for _ in range(num_shards)]
+    loads = [0] * num_shards
+    for namespace, count in sorted(groups.items(), key=lambda kv: (-kv[1], kv[0])):
+        target = loads.index(min(loads))
+        buckets[target].append(namespace)
+        loads[target] += count
+    return [bucket for bucket in buckets if bucket]
+
+
+def _shards_for(namespace):
+    """Return a list of (shard_label, test_filter) for a namespace."""
+    fully_qualified = NAMESPACE_PREFIX + namespace
+    shard_count = SHARD_COUNTS.get(namespace, 1)
+    if shard_count <= 1:
+        # Identical to the historical behavior: one job, one namespace filter.
+        return [("all", f"FullyQualifiedName~{fully_qualified}")]
+
+    groups = _group_by_ancestor(_test_class_counts(os.path.join(CLIENT_ROOT, namespace)))
+    buckets = _pack(groups, shard_count)
+    shards = []
+    for index, bucket in enumerate(buckets, start=1):
+        test_filter = "|".join(f"FullyQualifiedName~{ns}." for ns in sorted(bucket))
+        shards.append((f"{index}of{len(buckets)}", test_filter))
+    return shards
+
+
+def main():
+    include = []
+    for namespace in _namespaces_with_facts():
+        fully_qualified = NAMESPACE_PREFIX + namespace
+        for shard_label, test_filter in _shards_for(namespace):
+            for mode, database, needs_docker in INFRA_CONFIGS:
+                include.append(
+                    {
+                        "namespace": fully_qualified,
+                        "shard": shard_label,
+                        "filter": test_filter,
+                        "mode": mode,
+                        "database": database,
+                        "needs-docker": needs_docker,
+                    }
+                )
+    print(json.dumps({"include": include}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,37 +23,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Each client namespace runs against all five infrastructure configs;
+      # large namespaces are additionally split into parallel shards so the
+      # slowest single job no longer gates the whole run. The shard set covers
+      # exactly the same tests as the un-sharded namespace -- see the script.
       - name: Discover Client integration namespaces
         id: client
         run: |
-          namespaces=""
-          while IFS= read -r dir; do
-            if grep -R -q '\[Fact\]' "$dir" --include='*.cs'; then
-              namespaces+="$(basename "$dir")"$'\n'
-            fi
-          done < <(find Integration/Client -mindepth 1 -maxdepth 1 -type d ! -name 'bin' ! -name 'obj' | sort)
-
-          namespaces=$(echo "$namespaces" | sed '/^$/d' | sort -u)
-
-          # mode|database|needs-docker
-          declare -a configs=(
-            "inprocess|mongodb|false"
-            "outofprocess|mongodb|true"
-            "outofprocess|sqlite|true"
-            "outofprocess|postgresql|true"
-            "outofprocess|mssql|true"
-          )
-
-          matrix='{"include":['
-          for ns in $namespaces; do
-            [ -z "$ns" ] && continue
-            for config in "${configs[@]}"; do
-              IFS='|' read -r mode database needs_docker <<< "$config"
-              matrix+="{\"namespace\":\"Cratis.Chronicle.Integration.${ns}\",\"mode\":\"${mode}\",\"database\":\"${database}\",\"needs-docker\":${needs_docker}},"
-            done
-          done
-          matrix="${matrix%,}]}"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(python3 .github/scripts/generate-integration-matrix.py)" >> "$GITHUB_OUTPUT"
 
       - name: Discover Kernel integration namespaces
         id: kernel
@@ -81,13 +58,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The integration test projects target net10.0 only (Directory.Build.props),
+      # and these jobs only run already-built net10.0 assemblies, so installing the
+      # 8.0/9.0 SDKs on every matrix shard is pure setup overhead. Multi-targeting
+      # only happens during `dotnet pack` in the publish workflows.
       - name: Setup .Net
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.410
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore build output
         uses: actions/cache@v4
@@ -126,12 +104,16 @@ jobs:
               docker pull mcr.microsoft.com/mssql/server:2025-latest
             fi
 
-      - name: Run Client integration tests (${{ matrix.namespace }} | ${{ matrix.mode }} | ${{ matrix.database }})
+      - name: Run Client integration tests (${{ matrix.namespace }} ${{ matrix.shard }} | ${{ matrix.mode }} | ${{ matrix.database }})
         env:
           CRATIS_CHRONICLE_LOCAL_IMAGE: ${{ inputs.chronicle-image }}
           CHRONICLE_RUNTIME_MODE: ${{ matrix.mode }}
           CHRONICLE_STORAGE_PROVIDER: ${{ matrix.database }}
-          CHRONICLE_TEST_TIMEOUT_SECONDS: ${{ matrix.database == 'mongodb' && '120' || '600' }}
+          # A genuine eventual-consistency wait settles in seconds; a wait that
+          # runs for minutes is a flake, not slow progress. Cap the non-Mongo
+          # backends well below the old 600s so a stuck poll costs ~150s, not 10
+          # minutes, before the retry script re-runs only the failed test(s).
+          CHRONICLE_TEST_TIMEOUT_SECONDS: ${{ matrix.database == 'mongodb' && '120' || '150' }}
           # Ryuk is the Testcontainers reaper sidecar. It exists to clean
           # up containers when the host process dies unexpectedly. GitHub-
           # hosted runners are destroyed after the job, so Ryuk has nothing
@@ -148,7 +130,7 @@ jobs:
         run: |
           .github/scripts/run-tests-with-retry.sh \
             Integration/Client/Client.csproj \
-            "FullyQualifiedName~${{ matrix.namespace }}" \
+            "${{ matrix.filter }}" \
             -p:DisableDockerBuild=true \
             -p:EnableDevelopmentSymbol=true \
             --collect:"XPlat Code Coverage"
@@ -157,7 +139,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-results-client-${{ matrix.namespace }}-${{ matrix.mode }}-${{ matrix.database }}
+          name: coverage-results-client-${{ matrix.namespace }}-${{ matrix.shard }}-${{ matrix.mode }}-${{ matrix.database }}
           path: ./coverage-results/
           retention-days: 1
 
@@ -172,13 +154,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # The integration test projects target net10.0 only (Directory.Build.props),
+      # and these jobs only run already-built net10.0 assemblies, so installing the
+      # 8.0/9.0 SDKs on every matrix shard is pure setup overhead. Multi-targeting
+      # only happens during `dotnet pack` in the publish workflows.
       - name: Setup .Net
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.410
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore build output
         uses: actions/cache@v4

--- a/Source/Kernel/Storage.Sql/Database.cs
+++ b/Source/Kernel/Storage.Sql/Database.cs
@@ -476,6 +476,15 @@ public class Database(IServiceProvider serviceProvider, IOptions<ChronicleOption
         builder
             .UseApplicationServiceProvider(serviceProvider)
             .AddConceptAsSupport();
+
+        // SQLite serializes writers on a database-wide lock; the kernel writes from many grains at
+        // once, so without WAL + a busy timeout concurrent writes fail with SQLITE_BUSY and stall
+        // observer catch-up. The interceptor applies those pragmas on every SQLite connection.
+        if (connectionString.GetDatabaseType() == DatabaseType.Sqlite)
+        {
+            builder.AddInterceptors(SqlitePragmaConnectionInterceptor.Instance);
+        }
+
         return builder.Options;
     }
 

--- a/Source/Kernel/Storage.Sql/SqlitePragmaConnectionInterceptor.cs
+++ b/Source/Kernel/Storage.Sql/SqlitePragmaConnectionInterceptor.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Cratis.Chronicle.Storage.Sql;
+
+/// <summary>
+/// An EF Core connection interceptor that applies SQLite pragmas needed for concurrent access on
+/// every opened connection.
+/// </summary>
+/// <remarks>
+/// The Chronicle kernel writes to a single SQLite database from many Orleans grains concurrently
+/// (event-sequence appends plus read-model/observer-state sink writes). SQLite's default
+/// rollback-journal mode takes a database-wide exclusive lock for every write, so under that load
+/// writers collide and fail immediately with <c>SQLITE_BUSY</c>, stalling observer catch-up. WAL
+/// mode lets readers proceed during a write and lets writers append without locking out readers, and
+/// <c>busy_timeout</c> makes a contending writer wait for the lock instead of failing instantly.
+/// Durability is preserved: <c>synchronous</c> is intentionally left at its default so a committed
+/// transaction is still flushed.
+/// </remarks>
+public sealed class SqlitePragmaConnectionInterceptor : DbConnectionInterceptor
+{
+    /// <summary>
+    /// A shared, stateless instance of the interceptor.
+    /// </summary>
+    public static readonly SqlitePragmaConnectionInterceptor Instance = new();
+
+    /// <summary>
+    /// The pragmas applied on every open. WAL persists in the database header (set once, sticks);
+    /// <c>busy_timeout</c> is per-connection and is re-applied each time. 30s is comfortably above
+    /// any genuine catch-up window.
+    /// </summary>
+    const string Pragmas = "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=30000;";
+
+    /// <inheritdoc/>
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = Pragmas;
+        command.ExecuteNonQuery();
+    }
+
+    /// <inheritdoc/>
+    public override async Task ConnectionOpenedAsync(DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = Pragmas;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
# Summary

Primarily a CI/test-infrastructure performance change. The .NET integration test matrix is split into balanced parallel shards so the slowest namespace (Projections, previously a single ~40-minute job) no longer gates the whole run; the non-Mongo per-test timeout is lowered so a flaky eventual-consistency poll is absorbed by the existing per-test retry instead of burning ten minutes; and the integration jobs install only the net10.0 SDK they actually run. All five infrastructure configurations (in-process Mongo; out-of-process Mongo/SQLite/PostgreSQL/MSSQL) and full code coverage are preserved — every shard of a namespace together runs exactly the same tests as before, with none duplicated or dropped.

It also fixes the root cause behind the slow SQLite runs, which affects anyone running Chronicle on SQLite.

## Fixed

- SQLite-backed Chronicle no longer stalls under concurrent writes. Connections now use WAL journaling and a busy timeout, so simultaneous appends and projection/observer writes from multiple grains wait for the write lock instead of failing immediately with `SQLITE_BUSY` and stalling observer catch-up. Durability is preserved.
