### PR TITLE
Cache a DEVELOPMENT-symbol build so integration shards skip recompiling

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -10,6 +10,9 @@ env:
   DOTNET_VERSION: "10.0.x"
   DOTNET_CACHE: "dotnet-cache-${{ github.sha }}"
   DOTNET_OBJ_CACHE: "dotnet-obj-cache-${{ github.sha }}"
+  # Separate cache for the DEVELOPMENT-symbol build the integration tests consume.
+  DOTNET_DEV_CACHE: "dotnet-dev-cache-${{ github.sha }}"
+  DOTNET_DEV_OBJ_CACHE: "dotnet-dev-obj-cache-${{ github.sha }}"
   CRATIS_CHRONICLE_LOCAL_IMAGE: "ghcr.io/cratis/chronicle:${{ github.sha }}"
 
 on:
@@ -95,6 +98,65 @@ jobs:
           echo "key=${{ env.DOTNET_CACHE }}" >> "$GITHUB_OUTPUT"
           echo "image=${{ env.CRATIS_CHRONICLE_LOCAL_IMAGE }}" >> "$GITHUB_OUTPUT"
 
+  # The integration tests run with the DEVELOPMENT compile symbol, which the
+  # Release build above does not define, so every integration shard would
+  # otherwise recompile ~15-20 projects from source before its first test.
+  # Build that variant once here -- in parallel with dotnet-build, so it does
+  # not extend the critical path -- and cache it under its own key for the
+  # shards to restore and run with --no-build. The non-DEVELOPMENT cache stays
+  # for the specs/mongodb/integration-api jobs, which must exercise production
+  # (non-DEVELOPMENT) behavior.
+  dotnet-build-development:
+    runs-on: ubuntu-latest
+    outputs:
+      dotnet-cache-key: ${{ steps.export-dev-cache-key.outputs.key }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .Net
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            ${{ env.DOTNET8_VERSION }}
+            ${{ env.DOTNET9_VERSION }}
+            ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore obj cache
+        uses: actions/cache@v4
+        with:
+          path: ./**/obj
+          key: ${{ env.DOTNET_DEV_OBJ_CACHE }}
+          restore-keys: |
+            dotnet-dev-obj-cache-
+
+      - uses: actions/cache@v4
+        id: dotnet-dev-output
+        with:
+          path: ./**/bin
+          key: ${{ env.DOTNET_DEV_CACHE }}
+
+      - name: Add GitHub Package Registry to NuGet
+        run: |
+          dotnet nuget update source github --username cratis --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text || \
+          dotnet nuget add source --name github --username cratis --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text https://nuget.pkg.github.com/cratis/index.json
+
+      - name: Build with DEVELOPMENT symbol
+        run: dotnet build --configuration Release -p:EnableDevelopmentSymbol=true -p:DisableProxyGenerator=true -p:DisableDockerBuild=true
+
+      - name: Export dev cache key
+        id: export-dev-cache-key
+        run: echo "key=${{ env.DOTNET_DEV_CACHE }}" >> "$GITHUB_OUTPUT"
+
   specs:
     runs-on: ubuntu-latest
     needs: [dotnet-build]
@@ -130,11 +192,13 @@ jobs:
           retention-days: 1
 
   integration:
-    needs: [dotnet-build]
+    needs: [dotnet-build, dotnet-build-development]
     uses: ./.github/workflows/integration.yml
     secrets: inherit
     with:
-      dotnet-cache-key: ${{ needs.dotnet-build.outputs.dotnet-cache-key }}
+      # Integration shards restore the DEVELOPMENT-symbol build and run --no-build;
+      # the Docker image still comes from dotnet-build.
+      dotnet-cache-key: ${{ needs.dotnet-build-development.outputs.dotnet-cache-key }}
       chronicle-image: ${{ needs.dotnet-build.outputs.chronicle-image }}
 
   integration-api:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -127,12 +127,17 @@ jobs:
         # transient pipeline/container flake does not redden the whole job. A systemic
         # failure (many tests failing, e.g. a fixture/container start error) fails fast
         # without retrying, and a deterministic failure stays red on every attempt.
+        #
+        # --no-build: the restored cache is the DEVELOPMENT-symbol build from
+        # dotnet-build-development, so the shard runs it directly instead of
+        # recompiling the kernel from source. The restore step above still
+        # regenerates project.assets.json and the package cache for the test host.
         run: |
           .github/scripts/run-tests-with-retry.sh \
             Integration/Client/Client.csproj \
             "${{ matrix.filter }}" \
             -p:DisableDockerBuild=true \
-            -p:EnableDevelopmentSymbol=true \
+            --no-build \
             --collect:"XPlat Code Coverage"
 
       - name: Upload coverage results
@@ -194,7 +199,7 @@ jobs:
           .github/scripts/run-tests-with-retry.sh \
             Integration/Kernel/Kernel.csproj \
             "FullyQualifiedName~${{ matrix.namespace }}" \
-            -p:EnableDevelopmentSymbol=true \
+            --no-build \
             --collect:"XPlat Code Coverage"
 
       - name: Upload coverage results


### PR DESCRIPTION
# Summary

Internal CI optimization — no user-facing change.

The integration tests run with the `DEVELOPMENT` compile symbol, which the cached Release build from `dotnet-build` does not define. Injecting the symbol (`-p:EnableDevelopmentSymbol=true`) invalidates that cache, so every one of the ~73 integration shards recompiled ~15–20 projects from source before its first test ran — roughly two minutes of duplicated compilation per shard.

This adds a `dotnet-build-development` job that builds the DEVELOPMENT variant **once**, in parallel with `dotnet-build` so the critical path is unchanged, and caches it under its own key. The integration shards restore that cache and run with `--no-build` (the existing restore step still regenerates `project.assets.json` and the package cache the test host and coverage collector need). The non-DEVELOPMENT cache is left untouched, so the `specs`, `mongodb`, and `integration-api` jobs continue to exercise production (non-`DEVELOPMENT`) behavior.

Validated locally: the full-solution Release build with the symbol is clean, and `dotnet test --no-build` resolves and lists the DEVELOPMENT-symbol integration assembly. The CI run on this PR exercises the `--no-build` path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)