### PR TITLE
Fix child-collection PII persisted in plaintext and failing to release

### DIFF
--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_a_child_collection_with_pii.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
+
+public class and_read_model_has_a_child_collection_with_pii : Specification
+{
+    const string PlaintextName = "Jane Doe";
+
+    EncryptChangeset _step;
+    IProjection _projection;
+    ProjectionEventContext _context;
+    ExpandoObject _child;
+
+    async Task Establish()
+    {
+        var schema = await JsonSchema.FromJsonAsync(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "contacts": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "contactId": { "type": "string" },
+                      "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                      "status": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        var typeFormats = new TypeFormats();
+        var complianceManager = new JsonComplianceManager(
+            new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+        var compliance = new ReadModelsCompliance(complianceManager, new ExpandoObjectConverter(typeFormats));
+        var objectComparer = new ObjectComparer();
+        _step = new EncryptChangeset(compliance, objectComparer, "test-store", "test-namespace");
+
+        _projection = Substitute.For<IProjection>();
+        _projection.TargetReadModelSchema.Returns(schema);
+
+        var @event = new AppendedEvent(
+            EventContext.From(
+                "test-store",
+                "test-namespace",
+                EventType.Unknown,
+                EventSourceType.Default,
+                "owner-1",
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                CorrelationId.NotSet),
+            new ExpandoObject());
+
+        _child = new ExpandoObject();
+        var childValues = (IDictionary<string, object?>)_child;
+        childValues["contactId"] = "contact-1";
+        childValues["name"] = PlaintextName;
+        childValues["status"] = "active";
+
+        var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, @event, new ExpandoObject());
+        changeset.AddChild("contacts", _child);
+        _context = new ProjectionEventContext(new Key("owner-1", ArrayIndexers.NoIndexers), @event, changeset, ProjectionOperationType.None, false);
+    }
+
+    async Task Because() => await _step.Perform(_projection, _context);
+
+    [Fact] void should_encrypt_the_child_pii_member() => ChildValue("name").ShouldNotEqual(PlaintextName);
+
+    [Fact] void should_store_the_child_pii_member_as_base64_ciphertext() => IsBase64(ChildValue("name")).ShouldBeTrue();
+
+    [Fact] void should_leave_non_pii_child_members_untouched() => ChildValue("status").ShouldEqual("active");
+
+    string ChildValue(string property) => (string)((IDictionary<string, object?>)_child)[property]!;
+
+    static bool IsBase64(string value)
+    {
+        Span<byte> buffer = new byte[value.Length];
+        return Convert.TryFromBase64String(value, buffer, out _);
+    }
+}

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
 
 namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
@@ -64,9 +67,62 @@ public class EncryptChangeset(
 
         if (propertyDifferences.Count != 0)
         {
-            context.Changeset.Add(new PropertiesChanged<System.Dynamic.ExpandoObject>(encrypted, propertyDifferences));
+            context.Changeset.Add(new PropertiesChanged<ExpandoObject>(encrypted, propertyDifferences));
         }
 
+        // Child-collection changes (ChildAdded, and children carried through Joined/ResolvedJoin) hold the
+        // materialized child built from the decrypted event and bypass the root-snapshot encryption above.
+        // The read path descends into arrays and decrypts per element, so these child payloads must be
+        // encrypted symmetrically on write — otherwise child-element PII is persisted in the clear and then
+        // fails to release on read.
+        await EncryptComplianceForChildren(schema, identifier, context.Changeset.Changes);
+
         return context;
+    }
+
+    async Task EncryptComplianceForChildren(JsonSchema schema, string identifier, IEnumerable<Change> changes)
+    {
+        foreach (var change in changes)
+        {
+            switch (change)
+            {
+                case ChildAdded { Child: ExpandoObject child } childAdded:
+                    await EncryptComplianceForChild(schema, childAdded.ChildrenProperty, identifier, child);
+                    break;
+
+                case Joined joined:
+                    await EncryptComplianceForChildren(schema, identifier, joined.Changes);
+                    break;
+
+                case ResolvedJoin resolvedJoin:
+                    await EncryptComplianceForChildren(schema, identifier, resolvedJoin.Changes);
+                    break;
+            }
+        }
+    }
+
+    async Task EncryptComplianceForChild(JsonSchema schema, PropertyPath childrenProperty, string identifier, ExpandoObject child)
+    {
+        var childSchema = schema.GetSchemaForPropertyPath(childrenProperty);
+        if (childSchema?.HasComplianceMetadata() != true)
+        {
+            return;
+        }
+
+        var encryptedChild = await readModelsCompliance.Apply(eventStore, eventStoreNamespace, childSchema, identifier, child);
+
+        // Apply writes the document compliance subject (__subject) into the result; a child element lives
+        // under the root document's subject and must not carry its own, so strip it before merging back.
+        var encryptedValues = (IDictionary<string, object?>)encryptedChild;
+        encryptedValues.Remove(WellKnownProperties.Subject);
+
+        // The MongoDB sink reads the child object directly when building the $push, so overwrite the child
+        // in place with its encrypted values rather than replacing the change in the changeset.
+        var childValues = (IDictionary<string, object?>)child;
+        childValues.Clear();
+        foreach (var (key, value) in encryptedValues)
+        {
+            childValues[key] = value;
+        }
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
@@ -141,28 +141,22 @@ public class when_a_projection_persists_a_child_collection_with_pii(when_a_proje
             StoredChildNameIsBase64 = IsBase64(StoredChildName);
 
             // Release the stored child element through the compliance manager using the child element schema,
-            // mirroring the per-array-element decryption the read path performs. With the child written in the
-            // clear (the regression) this throws trying to base64-decode plaintext, leaving the released name empty.
-            try
-            {
-                var childSchema = schema.GetSchemaForPropertyPath("contacts");
-                var releasedChild = await complianceManager.Release(
-                    EventStore,
-                    EventStoreNamespace,
-                    childSchema,
-                    Identifier,
-                    new JsonObject
-                    {
-                        ["contactId"] = storedChild["contactId"].AsString,
-                        ["name"] = storedChild["name"].AsString,
-                        ["status"] = storedChild["status"].AsString
-                    });
-                ReleasedChildName = releasedChild["name"]!.GetValue<string>();
-            }
-            catch
-            {
-                ReleasedChildName = string.Empty;
-            }
+            // mirroring the per-array-element decryption the read path performs. With the child encrypted at
+            // rest this round-trips to the original plaintext; were it persisted in the clear, this release
+            // would throw trying to base64-decode plaintext and fail the spec.
+            var childSchema = schema.GetSchemaForPropertyPath("contacts");
+            var releasedChild = await complianceManager.Release(
+                EventStore,
+                EventStoreNamespace,
+                childSchema,
+                Identifier,
+                new JsonObject
+                {
+                    ["contactId"] = storedChild["contactId"].AsString,
+                    ["name"] = storedChild["name"].AsString,
+                    ["status"] = storedChild["status"].AsString
+                });
+            ReleasedChildName = releasedChild["name"]!.GetValue<string>();
         }
 
         public async Task DisposeAsync()

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Compliance;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Regression for child-collection PII being written to the sink in the clear. A projection that adds a
+/// child carrying a <c>[PII]</c> member goes through the real projection encryption step (EncryptChangeset)
+/// and a real MongoDB sink; the stored child element must be ciphertext at rest and release back to the
+/// original plaintext, mirroring how the read path decrypts per array element.
+/// </summary>
+/// <param name="ctx">The shared fixture holding the projected and re-read values.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_persists_a_child_collection_with_pii(when_a_projection_persists_a_child_collection_with_pii.context ctx)
+    : IClassFixture<when_a_projection_persists_a_child_collection_with_pii.context>
+{
+    public class context(MongoDBFixture fixture) : IAsyncLifetime
+    {
+        public const string PlaintextName = "Jane Doe";
+        const string EventStore = "test-store";
+        const string EventStoreNamespace = "test-namespace";
+        const string Identifier = "contact-owner-1";
+
+        IMongoClient _client = default!;
+        string _databaseName = default!;
+
+        public string StoredChildName { get; private set; } = string.Empty;
+
+        public bool StoredChildNameIsBase64 { get; private set; }
+
+        public string ReleasedChildName { get; private set; } = string.Empty;
+
+        public async Task InitializeAsync()
+        {
+            var schema = await JsonSchema.FromJsonAsync(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "contacts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "contactId": { "type": "string" },
+                          "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                          "status": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var typeFormats = new TypeFormats();
+            var sinkConverter = new ExpandoObjectConverter(typeFormats);
+            var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
+            var complianceManager = new JsonComplianceManager(
+                new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
+                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+            var compliance = new ReadModelsCompliance(complianceManager, complianceConverter);
+            var objectComparer = new ObjectComparer();
+
+            _databaseName = $"chronicle_child_pii_{Guid.NewGuid():N}";
+            _client = new MongoClient(fixture.ConnectionString);
+            var database = _client.GetDatabase(_databaseName);
+
+            var readModel = new ReadModelDefinition(
+                "child-pii-read-model",
+                $"contacts_{Guid.NewGuid():N}",
+                "ChildPiiReadModel",
+                ReadModelOwner.Client,
+                ReadModelSource.Code,
+                ReadModelObserverType.Projection,
+                ReadModelObserverIdentifier.Unspecified,
+                SinkDefinition.None,
+                new Dictionary<ReadModelGeneration, JsonSchema> { { ReadModelGeneration.First, schema } },
+                []);
+
+            var collections = new SinkCollections(readModel, database);
+            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+            var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, sinkConverter);
+            var sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, sinkConverter);
+
+            var projection = Substitute.For<IProjection>();
+            projection.TargetReadModelSchema.Returns(schema);
+            var step = new EncryptChangeset(compliance, objectComparer, EventStore, EventStoreNamespace);
+
+            var key = new Key(Identifier, ArrayIndexers.NoIndexers);
+            var @event = new AppendedEvent(
+                EventContext.From(
+                    EventStore,
+                    EventStoreNamespace,
+                    EventType.Unknown,
+                    EventSourceType.Default,
+                    Identifier,
+                    EventStreamType.All,
+                    EventStreamId.Default,
+                    EventSequenceNumber.First,
+                    CorrelationId.NotSet),
+                new ExpandoObject());
+
+            var contact = new ExpandoObject();
+            var contactValues = (IDictionary<string, object?>)contact;
+            contactValues["contactId"] = "contact-1";
+            contactValues["name"] = PlaintextName;
+            contactValues["status"] = "active";
+
+            var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, @event, new ExpandoObject());
+            changeset.AddChild("contacts", contact);
+
+            var projectionContext = new ProjectionEventContext(key, @event, changeset, ProjectionOperationType.None, false);
+
+            await step.Perform(projection, projectionContext);
+            await sink.ApplyChanges(key, changeset, EventSequenceNumber.First);
+
+            var storedDocument = await collections.GetCollection()
+                .Find(Builders<BsonDocument>.Filter.Empty)
+                .FirstAsync();
+            var storedChild = storedDocument["contacts"].AsBsonArray[0].AsBsonDocument;
+            StoredChildName = storedChild["name"].AsString;
+            StoredChildNameIsBase64 = IsBase64(StoredChildName);
+
+            // Release the stored child element through the compliance manager using the child element schema,
+            // mirroring the per-array-element decryption the read path performs. With the child written in the
+            // clear (the regression) this throws trying to base64-decode plaintext, leaving the released name empty.
+            try
+            {
+                var childSchema = schema.GetSchemaForPropertyPath("contacts");
+                var releasedChild = await complianceManager.Release(
+                    EventStore,
+                    EventStoreNamespace,
+                    childSchema,
+                    Identifier,
+                    new JsonObject
+                    {
+                        ["contactId"] = storedChild["contactId"].AsString,
+                        ["name"] = storedChild["name"].AsString,
+                        ["status"] = storedChild["status"].AsString
+                    });
+                ReleasedChildName = releasedChild["name"]!.GetValue<string>();
+            }
+            catch
+            {
+                ReleasedChildName = string.Empty;
+            }
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_databaseName is not null)
+            {
+                await _client.DropDatabaseAsync(_databaseName);
+            }
+        }
+
+        static bool IsBase64(string value)
+        {
+            Span<byte> buffer = new byte[value.Length];
+            return Convert.TryFromBase64String(value, buffer, out _);
+        }
+    }
+
+    [Fact] void should_store_child_pii_as_ciphertext_not_plaintext() => ctx.StoredChildName.ShouldNotEqual(context.PlaintextName);
+
+    [Fact] void should_store_child_pii_as_base64_ciphertext() => ctx.StoredChildNameIsBase64.ShouldBeTrue();
+
+    [Fact] void should_release_child_pii_back_to_the_original_plaintext() => ctx.ReleasedChildName.ShouldEqual(context.PlaintextName);
+}


### PR DESCRIPTION
## Fixed

- Reading or releasing a read model whose `[ChildrenFrom]` / list child elements carry `[PII]` no longer fails with `Failed to release compliance metadata for property '...'` (`FormatException`).

## Security

- `[PII]` values inside read-model child collections and lists are now encrypted at rest, matching the encryption already applied to scalar PII properties — previously they were persisted in plaintext.
