### PR TITLE
Fix read-model child-collection PII compliance across projection and reducer legs

### DIFF
--- a/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_checking_whole_collection_replacement_conflict.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_checking_whole_collection_replacement_conflict.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes.for_ChangeCollectionPathExtensions;
+
+public class when_checking_whole_collection_replacement_conflict : Specification
+{
+    PropertyDifference _wholeCollection;
+    PropertyDifference _childField;
+    PropertyDifference _sibling;
+    ISet<PropertyPath> _wholeCollectionReplacementPaths;
+
+    bool _wholeCollectionResult;
+    bool _childFieldResult;
+    bool _siblingResult;
+
+    void Establish()
+    {
+        _wholeCollectionReplacementPaths = new HashSet<PropertyPath> { new("contacts") };
+
+        _wholeCollection = new PropertyDifference("[contacts]", null, "replacement");
+        _childField = new PropertyDifference("[contacts].label", "old", "new");
+        _sibling = new PropertyDifference("status", "pending", "approved");
+    }
+
+    void Because()
+    {
+        _wholeCollectionResult = _wholeCollection.ConflictsWithWholeCollectionReplacement(_wholeCollectionReplacementPaths);
+        _childFieldResult = _childField.ConflictsWithWholeCollectionReplacement(_wholeCollectionReplacementPaths);
+        _siblingResult = _sibling.ConflictsWithWholeCollectionReplacement(_wholeCollectionReplacementPaths);
+    }
+
+    [Fact] void should_not_treat_the_whole_collection_replacement_itself_as_conflicting() => _wholeCollectionResult.ShouldBeFalse();
+
+    [Fact] void should_treat_a_child_field_under_the_collection_as_conflicting() => _childFieldResult.ShouldBeTrue();
+
+    [Fact] void should_not_treat_a_sibling_property_as_conflicting() => _siblingResult.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_getting_whole_collection_replacement_paths.cs
+++ b/Source/Infrastructure.Specs/Changes/for_ChangeCollectionPathExtensions/when_getting_whole_collection_replacement_paths.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes.for_ChangeCollectionPathExtensions;
+
+public class when_getting_whole_collection_replacement_paths : Specification
+{
+    ISet<PropertyPath> _result;
+
+    void Because()
+    {
+        var changes = new Change[]
+        {
+            new PropertiesChanged<ExpandoObject>(
+                new ExpandoObject(),
+                [
+                    new PropertyDifference("[contacts]", null, Array.Empty<object>()),
+                    new PropertyDifference("status", "pending", "approved")
+                ])
+        };
+
+        _result = changes.GetWholeCollectionReplacementPaths();
+    }
+
+    [Fact] void should_include_the_whole_collection_path() => _result.Contains(new PropertyPath("contacts")).ShouldBeTrue();
+
+    [Fact] void should_not_include_a_scalar_property_path() => _result.Contains(new PropertyPath("status")).ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/given/a_collapse_specification.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/given/a_collapse_specification.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+/// <summary>
+/// Base for <see cref="UnindexedCollectionDifferences"/> collapse scenarios, providing helpers for
+/// building the <see cref="ExpandoObject"/> states the differences are computed against.
+/// </summary>
+public class a_collapse_specification : Specification
+{
+    protected static ExpandoObject Expando(params (string Key, object? Value)[] properties)
+    {
+        var instance = new ExpandoObject();
+        var dictionary = (IDictionary<string, object?>)instance;
+        foreach (var (key, value) in properties)
+        {
+            dictionary[key] = value;
+        }
+
+        return instance;
+    }
+
+    protected static object[] Collection(params object[] items) => items;
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_collection_member_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_collection_member_changed.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_a_collection_member_changed : a_collapse_specification
+{
+    object[] _original;
+    object[] _changed;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish()
+    {
+        _original = Collection(Expando(("contactId", "c1"), ("name", "Jane")));
+        _changed = Collection(Expando(("contactId", "c1"), ("name", "cipher")));
+    }
+
+    void Because() =>
+        _result = new[] { new PropertyDifference("[contacts].name", "Jane", "cipher") }
+            .Collapse(Expando(("contacts", _original)), Expando(("contacts", _changed)));
+
+    [Fact] void should_produce_a_single_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_replace_the_whole_changed_collection() => ReferenceEquals(_result[0].Changed, _changed).ShouldBeTrue();
+
+    [Fact] void should_carry_the_whole_original_collection() => ReferenceEquals(_result[0].Original, _original).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_collection_member_is_indexed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_collection_member_is_indexed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_a_collection_member_is_indexed : a_collapse_specification
+{
+    PropertyDifference _difference;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() =>
+        _difference = new PropertyDifference(
+            new PropertyPath("[contacts].name"),
+            "Jane",
+            "Jane Smith",
+            new ArrayIndexers([new ArrayIndexer(new PropertyPath("[contacts]"), new PropertyPath("contactId"), "c1")]));
+
+    void Because()
+    {
+        var state = Expando(("contacts", Collection(Expando(("contactId", "c1"), ("name", "Jane")))));
+        _result = new[] { _difference }.Collapse(state, state);
+    }
+
+    [Fact] void should_produce_a_single_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_leave_the_indexed_difference_untouched() => ReferenceEquals(_result[0], _difference).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_deeply_nested_collection_member_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_a_deeply_nested_collection_member_changed.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_a_deeply_nested_collection_member_changed : a_collapse_specification
+{
+    object[] _changedOrders;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() =>
+        _changedOrders = Collection(Expando(("lines", Collection(Expando(("price", "cipher"))))));
+
+    void Because()
+    {
+        var changed = Expando(("orders", _changedOrders));
+        _result = new[] { new PropertyDifference("[orders].[lines].price", "10", "cipher") }.Collapse(changed, changed);
+    }
+
+    [Fact] void should_produce_a_single_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_collapse_at_the_outermost_unindexed_collection() => ReferenceEquals(_result[0].Changed, _changedOrders).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_an_unrelated_top_level_property_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_an_unrelated_top_level_property_changed.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_an_unrelated_top_level_property_changed : a_collapse_specification
+{
+    object[] _changed;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() => _changed = Collection(Expando(("contactId", "c1"), ("name", "cipher")));
+
+    void Because() =>
+        _result = new[]
+        {
+            new PropertyDifference("[contacts].name", "Jane", "cipher"),
+            new PropertyDifference("status", "pending", "approved")
+        }.Collapse(Expando(("contacts", Collection(Expando(("contactId", "c1"))))), Expando(("contacts", _changed)));
+
+    [Fact] void should_keep_both_the_collapsed_collection_and_the_top_level_difference() => _result.Count.ShouldEqual(2);
+
+    [Fact] void should_leave_the_top_level_difference_untouched() =>
+        _result.Single(_ => _.PropertyPath.Path == "status").Changed.ShouldEqual("approved");
+
+    [Fact] void should_collapse_the_collection_difference() =>
+        _result.Count(_ => ReferenceEquals(_.Changed, _changed)).ShouldEqual(1);
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_no_property_targets_a_collection.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_no_property_targets_a_collection.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_no_property_targets_a_collection : a_collapse_specification
+{
+    PropertyDifference _status;
+    PropertyDifference _name;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish()
+    {
+        _status = new PropertyDifference("status", "pending", "approved");
+        _name = new PropertyDifference("name", "Jane", "Jane Smith");
+    }
+
+    void Because()
+    {
+        var state = Expando(("status", "approved"), ("name", "Jane Smith"));
+        _result = new[] { _status, _name }.Collapse(state, state);
+    }
+
+    [Fact] void should_return_every_difference() => _result.Count.ShouldEqual(2);
+
+    [Fact] void should_leave_the_differences_untouched() =>
+        (ReferenceEquals(_result[0], _status) && ReferenceEquals(_result[1], _name)).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_several_members_of_a_collection_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_several_members_of_a_collection_changed.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_several_members_of_a_collection_changed : a_collapse_specification
+{
+    object[] _changed;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() => _changed = Collection(Expando(("contactId", "c1"), ("name", "cipher-name"), ("email", "cipher-email")));
+
+    void Because() =>
+        _result = new[]
+        {
+            new PropertyDifference("[contacts].name", "Jane", "cipher-name"),
+            new PropertyDifference("[contacts].email", "jane@example.com", "cipher-email")
+        }.Collapse(Expando(("contacts", Collection(Expando(("contactId", "c1"))))), Expando(("contacts", _changed)));
+
+    [Fact] void should_collapse_to_a_single_collection_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_replace_the_whole_changed_collection() => ReferenceEquals(_result[0].Changed, _changed).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_differences_are_null.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_differences_are_null.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_the_differences_are_null : a_collapse_specification
+{
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Because()
+    {
+        var state = Expando(("contacts", Collection(Expando(("name", "Jane")))));
+        _result = ((IEnumerable<PropertyDifference>)null!).Collapse(state, state);
+    }
+
+    [Fact] void should_produce_no_differences() => _result.ShouldBeEmpty();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_original_state_is_null.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_original_state_is_null.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_the_original_state_is_null : a_collapse_specification
+{
+    object[] _changed;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() => _changed = Collection(Expando(("contactId", "c1"), ("name", "cipher")));
+
+    void Because() =>
+        _result = new[] { new PropertyDifference("[contacts].name", null, "cipher") }
+            .Collapse(null, Expando(("contacts", _changed)));
+
+    [Fact] void should_produce_a_single_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_replace_the_whole_changed_collection() => ReferenceEquals(_result[0].Changed, _changed).ShouldBeTrue();
+
+    [Fact] void should_carry_a_null_original_value() => _result[0].Original.ShouldBeNull();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_whole_collection_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_the_whole_collection_changed.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_the_whole_collection_changed : a_collapse_specification
+{
+    PropertyDifference _difference;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish() =>
+        _difference = new PropertyDifference(
+            "[contacts]",
+            Collection(Expando(("name", "Jane"))),
+            Collection(Expando(("name", "cipher"))));
+
+    void Because()
+    {
+        var state = Expando(("contacts", Collection(Expando(("name", "cipher")))));
+        _result = new[] { _difference }.Collapse(state, state);
+    }
+
+    [Fact] void should_produce_a_single_difference() => _result.Count.ShouldEqual(1);
+
+    [Fact] void should_leave_the_whole_collection_difference_untouched() => ReferenceEquals(_result[0], _difference).ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_there_are_no_differences.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_there_are_no_differences.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_there_are_no_differences : a_collapse_specification
+{
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Because()
+    {
+        var state = Expando(("contacts", Collection(Expando(("name", "Jane")))));
+        _result = Array.Empty<PropertyDifference>().Collapse(state, state);
+    }
+
+    [Fact] void should_produce_no_differences() => _result.ShouldBeEmpty();
+}

--- a/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_two_collections_changed.cs
+++ b/Source/Infrastructure.Specs/Changes/for_UnindexedCollectionDifferences/when_collapsing_differences/and_two_collections_changed.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.given;
+
+namespace Cratis.Chronicle.Changes.for_UnindexedCollectionDifferences.when_collapsing_differences;
+
+public class and_two_collections_changed : a_collapse_specification
+{
+    object[] _changedContacts;
+    object[] _changedAddresses;
+    IReadOnlyList<PropertyDifference> _result;
+
+    void Establish()
+    {
+        _changedContacts = Collection(Expando(("name", "cipher")));
+        _changedAddresses = Collection(Expando(("city", "cipher")));
+    }
+
+    void Because()
+    {
+        var changed = Expando(("contacts", _changedContacts), ("addresses", _changedAddresses));
+        _result = new[]
+        {
+            new PropertyDifference("[contacts].name", "Jane", "cipher"),
+            new PropertyDifference("[addresses].city", "Oslo", "cipher")
+        }.Collapse(changed, changed);
+    }
+
+    [Fact] void should_collapse_each_collection_independently() => _result.Count.ShouldEqual(2);
+
+    [Fact] void should_replace_the_whole_contacts_collection() => _result.Count(_ => ReferenceEquals(_.Changed, _changedContacts)).ShouldEqual(1);
+
+    [Fact] void should_replace_the_whole_addresses_collection() => _result.Count(_ => ReferenceEquals(_.Changed, _changedAddresses)).ShouldEqual(1);
+}

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_serializing_a_blob_encrypted_list.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_serializing_a_blob_encrypted_list.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter;
+
+public class when_serializing_a_blob_encrypted_list : Specification
+{
+    const string Blob = "Mv6b9CejjH6U05D7Nzig0gsc1VFd2QvfoOf7axEys4SMGWCb46YYMslJarlr40g==";
+
+    ExpandoObjectConverter _converter;
+    JsonSchema _schema;
+    ExpandoObject _input;
+    JsonObject _json;
+    ExpandoObject _roundTripped;
+
+    void Establish()
+    {
+        _converter = new(new TypeFormats());
+
+        // A coarse [PII] on a whole list is blob-encrypted to a single ciphertext string even though the
+        // schema type stays array. The converter must keep it a scalar string in both directions; treating
+        // the string as an enumerable of characters shreds the ciphertext and breaks the release round trip.
+        _schema = JsonSchema.FromJson(
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "scores": {
+                        "type": "array",
+                        "items": { "type": "object", "properties": { "value": { "type": "integer" } } }
+                    }
+                }
+            }
+            """);
+
+        _input = new ExpandoObject();
+        ((IDictionary<string, object?>)_input)["scores"] = Blob;
+    }
+
+    void Because()
+    {
+        _json = _converter.ToJsonObject(_input, _schema);
+        _roundTripped = _converter.ToExpandoObject(_json, _schema);
+    }
+
+    [Fact] void should_serialize_the_blob_as_a_scalar_string() => _json["scores"]!.GetValue<string>().ShouldEqual(Blob);
+
+    [Fact] void should_not_shred_the_blob_into_an_array() => (_json["scores"] is JsonArray).ShouldBeFalse();
+
+    [Fact] void should_round_trip_the_blob_back_to_the_string() => ((IDictionary<string, object?>)_roundTripped)["scores"].ShouldEqual(Blob);
+}

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_serializing_a_normal_list.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_serializing_a_normal_list.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter;
+
+public class when_serializing_a_normal_list : Specification
+{
+    ExpandoObjectConverter _converter;
+    JsonSchema _schema;
+    ExpandoObject _input;
+    JsonObject _json;
+
+    void Establish()
+    {
+        _converter = new(new TypeFormats());
+        _schema = JsonSchema.FromJson(
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "scores": {
+                        "type": "array",
+                        "items": { "type": "object", "properties": { "value": { "type": "integer" } } }
+                    }
+                }
+            }
+            """);
+
+        // A real list value (not a blob-encrypted string) must still serialize as a JSON array — the
+        // scalar-string guard for coarse [PII] lists must not over-trigger and flatten genuine arrays.
+        var element = new ExpandoObject();
+        ((IDictionary<string, object?>)element)["value"] = 5;
+        _input = new ExpandoObject();
+        ((IDictionary<string, object?>)_input)["scores"] = new object[] { element };
+    }
+
+    void Because() => _json = _converter.ToJsonObject(_input, _schema);
+
+    [Fact] void should_serialize_the_list_as_an_array() => (_json["scores"] is JsonArray).ShouldBeTrue();
+
+    [Fact] void should_preserve_the_element() => _json["scores"]![0]!["value"]!.GetValue<int>().ShouldEqual(5);
+}

--- a/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
+++ b/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
@@ -56,17 +56,65 @@ public static class ChangeCollectionPathExtensions
     }
 
     /// <summary>
+    /// Gets the normalized paths of collections that are replaced as a whole by a single property difference.
+    /// </summary>
+    /// <param name="changes">The changes to inspect.</param>
+    /// <returns>A set of normalized collection paths replaced wholesale.</returns>
+    /// <remarks>
+    /// A difference whose property path ends in an array segment (e.g. the collapsed compliance difference
+    /// for <c>contacts</c>) replaces the entire collection in one <c>$set</c>. Any element-level difference
+    /// under that same collection must then be dropped — a sink cannot apply both a whole-collection
+    /// replacement and a positional update to the same path in one operation.
+    /// </remarks>
+    public static ISet<PropertyPath> GetWholeCollectionReplacementPaths(this IEnumerable<Change> changes)
+    {
+        var paths = new HashSet<PropertyPath>();
+
+        foreach (var propertiesChanged in changes.OfType<PropertiesChanged<ExpandoObject>>())
+        {
+            foreach (var difference in propertiesChanged.Differences)
+            {
+                if (difference.PropertyPath.LastSegment is ArrayProperty)
+                {
+                    paths.Add(difference.PropertyPath.NormalizeCollectionPath());
+                }
+            }
+        }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Check whether a property difference targets an element inside a collection that is replaced as a whole.
+    /// </summary>
+    /// <param name="difference">The property difference.</param>
+    /// <param name="wholeCollectionReplacementPaths">Collection paths replaced wholesale.</param>
+    /// <returns>True if the property difference is a strict descendant of a wholesale replacement; false otherwise.</returns>
+    public static bool ConflictsWithWholeCollectionReplacement(this PropertyDifference difference, ISet<PropertyPath> wholeCollectionReplacementPaths)
+    {
+        var normalizedPropertyPath = difference.PropertyPath.NormalizeCollectionPath();
+
+        return wholeCollectionReplacementPaths.Any(replacement =>
+            normalizedPropertyPath != replacement &&
+            replacement.IsSet &&
+            normalizedPropertyPath.Path.StartsWith($"{replacement.Path}.", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// Applies property differences to an existing state object while excluding properties that conflict with child operations.
     /// </summary>
     /// <param name="propertiesChanged">The property change to apply.</param>
     /// <param name="state">The state to apply the changes to.</param>
     /// <param name="collectionPathsWithChildOperations">Collection paths with child operations.</param>
+    /// <param name="wholeCollectionReplacementPaths">Optional collection paths replaced wholesale; element-level differences under them are dropped.</param>
     /// <returns>A state object with non-conflicting property differences applied.</returns>
-    public static ExpandoObject ApplyToStateWithoutChildOperationConflicts(this PropertiesChanged<ExpandoObject> propertiesChanged, ExpandoObject state, ISet<PropertyPath> collectionPathsWithChildOperations)
+    public static ExpandoObject ApplyToStateWithoutChildOperationConflicts(this PropertiesChanged<ExpandoObject> propertiesChanged, ExpandoObject state, ISet<PropertyPath> collectionPathsWithChildOperations, ISet<PropertyPath>? wholeCollectionReplacementPaths = null)
     {
         var result = state.Clone();
 
-        foreach (var difference in propertiesChanged.Differences.Where(_ => !_.ConflictsWithChildOperation(collectionPathsWithChildOperations)))
+        foreach (var difference in propertiesChanged.Differences.Where(_ =>
+            !_.ConflictsWithChildOperation(collectionPathsWithChildOperations) &&
+            (wholeCollectionReplacementPaths is null || !_.ConflictsWithWholeCollectionReplacement(wholeCollectionReplacementPaths))))
         {
             difference.PropertyPath.SetValue(result, difference.Changed!, difference.ArrayIndexers);
         }

--- a/Source/Infrastructure/Changes/UnindexedCollectionDifferences.cs
+++ b/Source/Infrastructure/Changes/UnindexedCollectionDifferences.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Dynamic;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Changes;
+
+/// <summary>
+/// Extension methods for collapsing property differences that target an element inside an unindexed
+/// collection into a single whole-collection replacement.
+/// </summary>
+/// <remarks>
+/// When PII is re-encrypted across a whole read-model snapshot, the object comparer reports a difference
+/// for each nested child member (e.g. <c>contacts.contactEmail</c>) but has no child identity to attach,
+/// so the difference carries no array indexers. A sink cannot apply such a nested, unindexed array path —
+/// MongoDB rejects the dotted <c>$set</c> with WriteError Code 28. Both the reducer and the projection
+/// encryption step rely on this collapse to replace the entire collection in one safe <c>$set</c> instead.
+/// </remarks>
+public static class UnindexedCollectionDifferences
+{
+    /// <summary>
+    /// Collapses every difference that targets an element inside an unindexed collection into a single
+    /// difference that replaces the whole collection, leaving all other differences untouched.
+    /// </summary>
+    /// <param name="differences">The differences to collapse.</param>
+    /// <param name="original">The original state the differences were computed from.</param>
+    /// <param name="changed">The changed state the differences were computed against.</param>
+    /// <returns>The collapsed differences.</returns>
+    public static IReadOnlyList<PropertyDifference> Collapse(
+        this IEnumerable<PropertyDifference> differences,
+        ExpandoObject? original,
+        ExpandoObject changed)
+    {
+        var result = new List<PropertyDifference>();
+        if (differences is null)
+        {
+            return result;
+        }
+
+        var collapsed = new HashSet<(PropertyPath PropertyPath, ArrayIndexers ArrayIndexers)>();
+
+        foreach (var difference in differences)
+        {
+            if (!TryGetUnindexedCollectionPath(difference, out var collectionPath))
+            {
+                result.Add(difference);
+                continue;
+            }
+
+            var collapsedKey = (collectionPath, difference.ArrayIndexers);
+            if (!collapsed.Add(collapsedKey))
+            {
+                continue;
+            }
+
+            result.Add(new PropertyDifference(
+                collectionPath,
+                GetValueAtPath(original, collectionPath, difference.ArrayIndexers),
+                GetValueAtPath(changed, collectionPath, difference.ArrayIndexers),
+                difference.ArrayIndexers));
+        }
+
+        return result;
+    }
+
+    static bool TryGetUnindexedCollectionPath(PropertyDifference difference, out PropertyPath collectionPath)
+    {
+        collectionPath = PropertyPath.NotSet;
+
+        var currentPath = PropertyPath.Root;
+        var segments = difference.PropertyPath.Segments.ToArray();
+
+        for (var segmentIndex = 0; segmentIndex < segments.Length - 1; segmentIndex++)
+        {
+            var segment = segments[segmentIndex];
+            currentPath += segment;
+
+            if (segment is ArrayProperty && !difference.ArrayIndexers.HasFor(currentPath))
+            {
+                collectionPath = currentPath;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static object? GetValueAtPath(ExpandoObject? instance, PropertyPath propertyPath, ArrayIndexers arrayIndexers)
+    {
+        object? current = instance;
+        var currentPath = PropertyPath.Root;
+
+        foreach (var segment in propertyPath.Segments)
+        {
+            if (current is not ExpandoObject expandoObject)
+            {
+                return null;
+            }
+
+            if (!(expandoObject as IDictionary<string, object?>).TryGetValue(segment.Value, out current))
+            {
+                return null;
+            }
+
+            currentPath += segment;
+
+            if (segment is ArrayProperty && arrayIndexers.HasFor(currentPath))
+            {
+                current = GetElementForIndexer(current, arrayIndexers.GetFor(currentPath));
+            }
+        }
+
+        return current;
+    }
+
+    static object? GetElementForIndexer(object? collection, ArrayIndexer indexer)
+    {
+        if (collection is not IEnumerable enumerable)
+        {
+            return null;
+        }
+
+        var elements = enumerable.Cast<object>().ToArray();
+        if (!indexer.IdentifierProperty.IsSet && indexer.Identifier is int index)
+        {
+            return elements.Length > index ? elements[index] : null;
+        }
+
+        return elements
+            .OfType<ExpandoObject>()
+            .Cast<IDictionary<string, object?>>()
+            .SingleOrDefault(_ =>
+                _.TryGetValue(indexer.IdentifierProperty.Path, out var identifier) &&
+                Equals(identifier, indexer.Identifier));
+    }
+}

--- a/Source/Infrastructure/Json/ExpandoObjectConverter.cs
+++ b/Source/Infrastructure/Json/ExpandoObjectConverter.cs
@@ -153,6 +153,15 @@ public class ExpandoObjectConverter(ITypeFormats typeFormats) : IExpandoObjectCo
                 schemaProperty.IsArray ? schemaProperty.Item!.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema);
         }
 
+        // A coarse [PII] value on a whole list/array is blob-encrypted to a single ciphertext string,
+        // even though the schema type stays Array. Serialize it as that scalar string rather than letting
+        // the array branch below treat the string as an enumerable of characters — which would shred the
+        // ciphertext into per-character elements and break the encrypt -> store -> read -> release round trip.
+        if (value is string ciphertext && schemaProperty.Type.HasFlag(JsonObjectType.Array))
+        {
+            return JsonValue.Create(ciphertext);
+        }
+
         if (schemaProperty.Type.HasFlag(JsonObjectType.Array) && value is IEnumerable enumerable)
         {
             var items = new List<JsonNode?>();

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Dynamic;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.ReadModels;
-using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Sinks;
@@ -96,7 +94,7 @@ public class ReducerPipeline(
                 // unindexed array path cannot be applied safely by sinks, so replace that collection.
                 changeset.Add(new PropertiesChanged<ExpandoObject>(
                     null!,
-                    CollapseUnindexedCollectionDifferences(initial, encryptedState, differences)));
+                    differences.Collapse(initial, encryptedState)));
             }
         }
 
@@ -110,113 +108,5 @@ public class ReducerPipeline(
                 throw new InvalidOperationException($"Bulk operation failed for partition {firstFailure.EventSourceId} at sequence number {firstFailure.EventSequenceNumber}");
             }
         }
-    }
-
-    static List<PropertyDifference> CollapseUnindexedCollectionDifferences(
-        ExpandoObject? initial,
-        ExpandoObject changed,
-        IEnumerable<PropertyDifference> differences)
-    {
-        var result = new List<PropertyDifference>();
-        if (differences is null)
-        {
-            return result;
-        }
-
-        var collapsed = new HashSet<(PropertyPath PropertyPath, ArrayIndexers ArrayIndexers)>();
-
-        foreach (var difference in differences)
-        {
-            if (!TryGetUnindexedCollectionPath(difference, out var collectionPath))
-            {
-                result.Add(difference);
-                continue;
-            }
-
-            var collapsedKey = (collectionPath, difference.ArrayIndexers);
-            if (!collapsed.Add(collapsedKey))
-            {
-                continue;
-            }
-
-            result.Add(new PropertyDifference(
-                collectionPath,
-                GetValueAtPath(initial, collectionPath, difference.ArrayIndexers),
-                GetValueAtPath(changed, collectionPath, difference.ArrayIndexers),
-                difference.ArrayIndexers));
-        }
-
-        return result;
-    }
-
-    static bool TryGetUnindexedCollectionPath(PropertyDifference difference, out PropertyPath collectionPath)
-    {
-        collectionPath = PropertyPath.NotSet;
-
-        var currentPath = PropertyPath.Root;
-        var segments = difference.PropertyPath.Segments.ToArray();
-
-        for (var segmentIndex = 0; segmentIndex < segments.Length - 1; segmentIndex++)
-        {
-            var segment = segments[segmentIndex];
-            currentPath += segment;
-
-            if (segment is ArrayProperty && !difference.ArrayIndexers.HasFor(currentPath))
-            {
-                collectionPath = currentPath;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    static object? GetValueAtPath(ExpandoObject? instance, PropertyPath propertyPath, ArrayIndexers arrayIndexers)
-    {
-        object? current = instance;
-        var currentPath = PropertyPath.Root;
-
-        foreach (var segment in propertyPath.Segments)
-        {
-            if (current is not ExpandoObject expandoObject)
-            {
-                return null;
-            }
-
-            if (!(expandoObject as IDictionary<string, object?>).TryGetValue(segment.Value, out current))
-            {
-                return null;
-            }
-
-            currentPath += segment;
-
-            if (segment is ArrayProperty && arrayIndexers.HasFor(currentPath))
-            {
-                current = GetElementForIndexer(current, arrayIndexers.GetFor(currentPath));
-            }
-        }
-
-        return current;
-    }
-
-    static object? GetElementForIndexer(object? collection, ArrayIndexer indexer)
-    {
-        if (collection is not IEnumerable enumerable)
-        {
-            return null;
-        }
-
-        var elements = enumerable.Cast<object>().ToArray();
-        if (!indexer.IdentifierProperty.IsSet && indexer.Identifier is int index)
-        {
-            return elements.Length > index ? elements[index] : null;
-        }
-
-        return elements
-            .OfType<ExpandoObject>()
-            .Cast<IDictionary<string, object?>>()
-            .SingleOrDefault(_ =>
-                _.TryGetValue(indexer.IdentifierProperty.Path, out var identifier) &&
-                Equals(identifier, indexer.Identifier));
     }
 }

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
@@ -51,8 +51,14 @@ public class EncryptChangeset(
             currentState);
 
         var hasDifferences = !objectComparer.Compare(currentState, encrypted, out var differences);
+
+        // Apply re-encrypts the whole snapshot, so the comparer reports a difference for every PII member —
+        // including members inside child collections (e.g. contacts.contactEmail). Those nested differences
+        // carry no array indexers, so collapse them into a single whole-collection replacement; otherwise the
+        // sink emits a non-positional dotted $set that MongoDB rejects with WriteError Code 28. This mirrors
+        // the guarantee the reducer pipeline already relies on for reducer-owned collections.
         var propertyDifferences = hasDifferences && differences is not null
-            ? differences.ToList()
+            ? differences.Collapse(currentState, encrypted).ToList()
             : [];
 
         var encryptedStateAsDictionary = (IDictionary<string, object?>)encrypted;

--- a/Source/Kernel/Core/Projections/Projection.cs
+++ b/Source/Kernel/Core/Projections/Projection.cs
@@ -396,13 +396,14 @@ public class Projection(
     {
         var changesToApply = changes.ToList();
         var collectionPathsWithChildOperations = changesToApply.GetCollectionPathsWithChildOperations();
+        var wholeCollectionReplacementPaths = changesToApply.GetWholeCollectionReplacementPaths();
 
         foreach (var change in changesToApply)
         {
             switch (change)
             {
                 case PropertiesChanged<ExpandoObject> propertiesChanged:
-                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations);
+                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations, wholeCollectionReplacementPaths);
                     break;
 
                 case ChildAdded childAdded:

--- a/Source/Kernel/Core/Projections/ProjectionChangesetNotifier.cs
+++ b/Source/Kernel/Core/Projections/ProjectionChangesetNotifier.cs
@@ -14,6 +14,16 @@ namespace Cratis.Chronicle.Projections;
 /// <see cref="ObserverManager{T}"/> to track and dispatch to subscribed observers.
 /// </summary>
 /// <param name="logger">The <see cref="ILogger{T}"/> for logging.</param>
+/// <remarks>
+/// Marked <c>[KeepAlive]</c> because the observer registrations live only in memory (the
+/// <see cref="ObserverManager{T}"/> below) — there is no persisted state and no re-subscribe
+/// recovery, so a deactivation between a client's <see cref="Subscribe"/> and the projection's
+/// <see cref="Notify"/> silently drops the registration and the appended event's changeset never
+/// reaches the watching client. Every sibling subscription/queue grain (<c>Observer</c>,
+/// <c>AppendedEventsQueue</c>) is already <c>[KeepAlive]</c> for the same reason; KeepAlive grains
+/// also survive <c>ForceActivationCollection</c>.
+/// </remarks>
+[KeepAlive]
 public class ProjectionChangesetNotifier(ILogger<ProjectionChangesetNotifier> logger) : Grain, IProjectionChangesetNotifier
 {
     /// <summary>
@@ -25,9 +35,26 @@ public class ProjectionChangesetNotifier(ILogger<ProjectionChangesetNotifier> lo
     readonly ObserverManager<IProjectionChangesetObserver> _observers = new(TimeSpan.FromDays(365 * 4), logger);
 
     /// <inheritdoc/>
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        logger.Activated(this.GetPrimaryKeyString());
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        // A non-zero observer count here means in-flight Watch subscriptions are being torn down
+        // with the registration — the changeset-delivery-loss failure mode this grain guards against.
+        logger.Deactivated(this.GetPrimaryKeyString(), _observers.Count, reason.ReasonCode);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
     public Task Subscribe(IProjectionChangesetObserver observer)
     {
         _observers.Subscribe(observer, observer);
+        logger.Subscribed(this.GetPrimaryKeyString(), _observers.Count);
         return Task.CompletedTask;
     }
 
@@ -39,6 +66,11 @@ public class ProjectionChangesetNotifier(ILogger<ProjectionChangesetNotifier> lo
     }
 
     /// <inheritdoc/>
-    public async Task Notify(EventStoreNamespaceName namespaceName, ReadModelKey readModelKey, JsonObject readModel) =>
+    public async Task Notify(EventStoreNamespaceName namespaceName, ReadModelKey readModelKey, JsonObject readModel)
+    {
+        // The observer count is the decisive signal: zero here while a client is watching means
+        // the registration was lost (deactivation/wiring) rather than the gRPC push dropping it.
+        logger.Notifying(this.GetPrimaryKeyString(), _observers.Count, namespaceName, readModelKey);
         await _observers.Notify(o => o.OnChangeset(namespaceName, readModelKey, readModel));
+    }
 }

--- a/Source/Kernel/Core/Projections/ProjectionChangesetNotifierLogMessages.cs
+++ b/Source/Kernel/Core/Projections/ProjectionChangesetNotifierLogMessages.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Projections;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class ProjectionChangesetNotifierLogMessages
+{
+    [LoggerMessage(LogLevel.Debug, "Changeset notifier {Notifier} activated")]
+    internal static partial void Activated(this ILogger<ProjectionChangesetNotifier> logger, string notifier);
+
+    [LoggerMessage(LogLevel.Debug, "Changeset notifier {Notifier} deactivated with {ObserverCount} observer(s) still registered (reason: {Reason})")]
+    internal static partial void Deactivated(this ILogger<ProjectionChangesetNotifier> logger, string notifier, int observerCount, DeactivationReasonCode reason);
+
+    [LoggerMessage(LogLevel.Debug, "Observer subscribed to changeset notifier {Notifier}; {ObserverCount} observer(s) now registered")]
+    internal static partial void Subscribed(this ILogger<ProjectionChangesetNotifier> logger, string notifier, int observerCount);
+
+    [LoggerMessage(LogLevel.Debug, "Changeset notifier {Notifier} notifying {ObserverCount} observer(s) for namespace {Namespace} key {ReadModelKey}")]
+    internal static partial void Notifying(this ILogger<ProjectionChangesetNotifier> logger, string notifier, int observerCount, EventStoreNamespaceName @namespace, ReadModelKey readModelKey);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Compliance;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance.given;
+
+/// <summary>
+/// Base for child-collection PII regression scenarios. Builds a real MongoDB sink wired to the real
+/// compliance machinery (encrypt-at-rest plus release), so a derived scenario can drive a projection or
+/// reducer through the full encrypt -> store -> read -> release round trip that the in-memory sink and
+/// the passthrough-compliance parity suite do not exercise. <c>Establish</c> builds the sink stack; the
+/// derived spec drives the scenario in its own <c>Because</c>.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
+public abstract class a_child_collection_compliance_scenario(MongoDBFixture fixture) : Specification
+{
+    protected const string EventStore = "test-store";
+    protected const string EventStoreNamespace = "test-namespace";
+
+    IMongoClient _client = default!;
+    string _databaseName = default!;
+
+    /// <summary>Gets the read-model schema, loaded from <see cref="SchemaJson"/>.</summary>
+    protected JsonSchema Schema { get; private set; } = default!;
+
+    /// <summary>Gets the comparer used to compute changesets.</summary>
+    protected ObjectComparer ObjectComparer { get; } = new();
+
+    /// <summary>Gets the compliance manager performing the actual encryption and release.</summary>
+    protected JsonComplianceManager ComplianceManager { get; private set; } = default!;
+
+    /// <summary>Gets the read-model compliance facade over <see cref="ComplianceManager"/>.</summary>
+    protected ReadModelsCompliance Compliance { get; private set; } = default!;
+
+    /// <summary>Gets the sink collections for the read model.</summary>
+    protected SinkCollections Collections { get; private set; } = default!;
+
+    /// <summary>Gets the real MongoDB sink under test.</summary>
+    protected Sink Sink { get; private set; } = default!;
+
+    /// <summary>Gets the read-model definition the sink and pipelines are built for.</summary>
+    protected ReadModelDefinition ReadModel { get; private set; } = default!;
+
+    /// <summary>Gets the key the read model is stored under.</summary>
+    protected Key Key { get; private set; } = default!;
+
+    /// <summary>Gets the identifier (event source id / compliance subject) for the read model.</summary>
+    protected virtual string Identifier => "subject-1";
+
+    /// <summary>Gets the read-model schema as JSON.</summary>
+    protected abstract string SchemaJson { get; }
+
+    /// <summary>Gets the observer type the read model is built by.</summary>
+    protected abstract ReadModelObserverType ObserverType { get; }
+
+    async Task Establish()
+    {
+        Schema = await JsonSchema.FromJsonAsync(SchemaJson);
+        Key = new Key(Identifier, ArrayIndexers.NoIndexers);
+
+        var typeFormats = new TypeFormats();
+        var sinkConverter = new ExpandoObjectConverter(typeFormats);
+        var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
+        ComplianceManager = new JsonComplianceManager(
+            new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+        Compliance = new ReadModelsCompliance(ComplianceManager, complianceConverter);
+
+        _databaseName = $"chronicle_child_collection_pii_{Guid.NewGuid():N}";
+        _client = new MongoClient(fixture.ConnectionString);
+        var database = _client.GetDatabase(_databaseName);
+
+        ReadModel = new ReadModelDefinition(
+            "child-collection-pii-read-model",
+            $"child_collection_pii_{Guid.NewGuid():N}",
+            "ChildCollectionPiiReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ObserverType,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema> { { ReadModelGeneration.First, Schema } },
+            []);
+
+        Collections = new SinkCollections(ReadModel, database);
+        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, ReadModel);
+        var changesetConverter = new ChangesetConverter(ReadModel, mongoDBConverter, Collections, sinkConverter);
+        Sink = new Sink(ReadModel, mongoDBConverter, Collections, changesetConverter, sinkConverter);
+    }
+
+    async Task Destroy()
+    {
+        if (_databaseName is not null)
+        {
+            await _client.DropDatabaseAsync(_databaseName);
+        }
+    }
+
+    /// <summary>Reads the single stored read-model document straight from MongoDB.</summary>
+    /// <returns>The stored <see cref="BsonDocument"/>.</returns>
+    protected Task<BsonDocument> StoredDocument() =>
+        Collections.GetCollection().Find(Builders<BsonDocument>.Filter.Empty).FirstAsync();
+
+    protected static ExpandoObject Expando(params (string Key, object? Value)[] properties)
+    {
+        var instance = new ExpandoObject();
+        var dictionary = (IDictionary<string, object?>)instance;
+        foreach (var (key, value) in properties)
+        {
+            dictionary[key] = value;
+        }
+
+        return instance;
+    }
+
+    protected static bool IsBase64(string value)
+    {
+        Span<byte> buffer = new byte[value.Length];
+        return Convert.TryFromBase64String(value, buffer, out _);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_adds_a_second_child_to_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_adds_a_second_child_to_a_child_collection_with_pii.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Robustness adjacency for the projection collapse: adding a second child after a child collection with
+/// scalar <c>[PII]</c> already exists. The second add re-encrypts the whole snapshot (yielding a collapsed
+/// whole-collection difference) at the same time as the <c>$push</c> for the new child. The collapsed
+/// <c>$set</c> must be filtered against the child operation so only the <c>$push</c> applies — no Mongo
+/// conflict, no duplicated child, both children ciphertext at rest.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_adds_a_second_child_to_a_child_collection_with_pii(MongoDBFixture fixture)
+    : given.a_child_collection_compliance_scenario(fixture)
+{
+    Exception? _error;
+    int _storedContactCount;
+    bool _bothContactsAreCiphertext;
+
+    protected override string Identifier => "org-1";
+
+    protected override ReadModelObserverType ObserverType => ReadModelObserverType.Projection;
+
+    protected override string SchemaJson =>
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "contacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "contactId": { "type": "string" },
+                  "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    async Task Because()
+    {
+        var projection = Substitute.For<IProjection>();
+        projection.TargetReadModelSchema.Returns(Schema);
+        var step = new EncryptChangeset(Compliance, ObjectComparer, EventStore, EventStoreNamespace);
+
+        await Add(step, projection, EventSequenceNumber.First, new ExpandoObject(), Contact("contact-1", "Jane Doe"));
+
+        var withFirst = Expando(("id", Identifier), ("contacts", new object[] { Contact("contact-1", "Jane Doe") }));
+        _error = await Catch.Exception(() => Add(step, projection, new EventSequenceNumber(1), withFirst, Contact("contact-2", "John Roe")));
+
+        var contacts = (await StoredDocument())["contacts"].AsBsonArray;
+        _storedContactCount = contacts.Count;
+        _bothContactsAreCiphertext = contacts.Count == 2 && contacts.All(c => IsBase64(c.AsBsonDocument["name"].AsString));
+    }
+
+    [Fact] void should_add_the_second_child_without_failing() => _error.ShouldBeNull();
+
+    [Fact] void should_keep_exactly_two_children() => _storedContactCount.ShouldEqual(2);
+
+    [Fact] void should_keep_both_children_ciphertext() => _bothContactsAreCiphertext.ShouldBeTrue();
+
+    async Task Add(EncryptChangeset step, IProjection projection, EventSequenceNumber sequenceNumber, ExpandoObject initialState, ExpandoObject child)
+    {
+        var changeset = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(sequenceNumber), initialState);
+        changeset.AddChild("contacts", child);
+        await step.Perform(projection, new ProjectionEventContext(Key, changeset.Incoming, changeset, ProjectionOperationType.None, false));
+        await Sink.ApplyChanges(Key, changeset, sequenceNumber);
+    }
+
+    AppendedEvent Event(EventSequenceNumber sequenceNumber) =>
+        new(
+            EventContext.From(EventStore, EventStoreNamespace, EventType.Unknown, EventSourceType.Default, Identifier, EventStreamType.All, EventStreamId.Default, sequenceNumber, CorrelationId.NotSet),
+            new ExpandoObject());
+
+    static ExpandoObject Contact(string id, string name) => Expando(("contactId", id), ("name", name));
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_a_child_field_in_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_a_child_field_in_a_child_collection_with_pii.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Robustness adjacency for the projection collapse: positionally updating a non-PII field on an existing
+/// child while the same child collection carries scalar <c>[PII]</c>. The projection emits a positional
+/// <c>$set contacts.$[elem].label</c> while <see cref="EncryptChangeset"/> re-encrypts and collapses the
+/// PII members into a whole-collection <c>$set contacts</c>. Both target the same collection in one update;
+/// the sink must apply them without a Mongo path conflict, with the field updated and the PII ciphertext.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_updates_a_child_field_in_a_child_collection_with_pii(MongoDBFixture fixture)
+    : given.a_child_collection_compliance_scenario(fixture)
+{
+    Exception? _error;
+    string _storedLabel = string.Empty;
+    bool _storedNameIsCiphertext;
+
+    protected override string Identifier => "org-1";
+
+    protected override ReadModelObserverType ObserverType => ReadModelObserverType.Projection;
+
+    protected override string SchemaJson =>
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "contacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "contactId": { "type": "string" },
+                  "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                  "label": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    async Task Because()
+    {
+        var projection = Substitute.For<IProjection>();
+        projection.TargetReadModelSchema.Returns(Schema);
+        var step = new EncryptChangeset(Compliance, ObjectComparer, EventStore, EventStoreNamespace);
+
+        // Insert leg — add the child carrying scalar [PII] with an initial non-PII label.
+        var insert = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(EventSequenceNumber.First), new ExpandoObject());
+        insert.AddChild("contacts", Contact("old"));
+        await step.Perform(projection, new ProjectionEventContext(Key, insert.Incoming, insert, ProjectionOperationType.None, false));
+        await Sink.ApplyChanges(Key, insert, EventSequenceNumber.First);
+
+        // Update leg — a positional child-field update on the existing child (as a projection produces),
+        // alongside the re-encryption of the child's PII over the whole snapshot.
+        var decryptedInitialState = Expando(("id", Identifier), ("contacts", new object[] { Contact("new") }));
+        var update = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(new EventSequenceNumber(1)), decryptedInitialState);
+        var indexers = new ArrayIndexers([new ArrayIndexer(new PropertyPath("[contacts]"), new PropertyPath("contactId"), "contact-1")]);
+        update.Add(new PropertiesChanged<ExpandoObject>(null!, [new PropertyDifference(new PropertyPath("[contacts].label"), "old", "new", indexers)]));
+        await step.Perform(projection, new ProjectionEventContext(Key, update.Incoming, update, ProjectionOperationType.None, false));
+
+        _error = await Catch.Exception(() => Sink.ApplyChanges(Key, update, new EventSequenceNumber(1)));
+
+        var contact = (await StoredDocument())["contacts"].AsBsonArray[0].AsBsonDocument;
+        _storedLabel = contact.Contains("label") ? contact["label"].AsString : string.Empty;
+        _storedNameIsCiphertext = IsBase64(contact["name"].AsString);
+    }
+
+    [Fact] void should_apply_the_update_without_failing() => _error.ShouldBeNull();
+
+    [Fact] void should_apply_the_child_field_update() => _storedLabel.ShouldEqual("new");
+
+    [Fact] void should_keep_the_child_pii_as_ciphertext() => _storedNameIsCiphertext.ShouldBeTrue();
+
+    AppendedEvent Event(EventSequenceNumber sequenceNumber) =>
+        new(
+            EventContext.From(EventStore, EventStoreNamespace, EventType.Unknown, EventSourceType.Default, Identifier, EventStreamType.All, EventStreamId.Default, sequenceNumber, CorrelationId.NotSet),
+            new ExpandoObject());
+
+    static ExpandoObject Contact(string label) => Expando(("contactId", "contact-1"), ("name", "Jane Doe"), ("label", label));
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_an_unrelated_field_with_child_collection_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_an_unrelated_field_with_child_collection_pii.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Regression for the projection sink UPDATE leg of child-collection PII. After a child carrying scalar
+/// <c>[PII]</c> has been added, a later event that only changes an unrelated top-level field re-encrypts
+/// the whole decrypted state again. That re-encryption yields a nested child-PII difference with no array
+/// indexers (<c>contacts.name</c>) which — without the collapse the reducer pipeline already performs —
+/// reaches the sink as a non-positional dotted <c>$set</c> and is rejected with WriteError Code 28.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_updates_an_unrelated_field_with_child_collection_pii(MongoDBFixture fixture)
+    : given.a_child_collection_compliance_scenario(fixture)
+{
+    const string PlaintextName = "Jane Doe";
+    const string PlaintextEmail = "jane@example.com";
+
+    Exception? _error;
+    int _storedContactCount;
+    string _storedStatus = string.Empty;
+    bool _storedNameIsCiphertext;
+
+    protected override string Identifier => "org-1";
+
+    protected override ReadModelObserverType ObserverType => ReadModelObserverType.Projection;
+
+    protected override string SchemaJson =>
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "status": { "type": "string" },
+            "contacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "contactId": { "type": "string" },
+                  "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                  "contactEmail": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    async Task Because()
+    {
+        var projection = Substitute.For<IProjection>();
+        projection.TargetReadModelSchema.Returns(Schema);
+        var step = new EncryptChangeset(Compliance, ObjectComparer, EventStore, EventStoreNamespace);
+
+        // Insert leg ($push) — add a child carrying scalar [PII], encrypting it at rest.
+        var insert = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(EventSequenceNumber.First), new ExpandoObject());
+        insert.AddChild("contacts", Contact());
+        await step.Perform(projection, new ProjectionEventContext(Key, insert.Incoming, insert, ProjectionOperationType.None, false));
+        await Sink.ApplyChanges(Key, insert, EventSequenceNumber.First);
+
+        // Update leg — a later event changes only an unrelated top-level field. The pipeline hands
+        // EncryptChangeset the decrypted (plaintext) state, so re-encryption of the existing child
+        // produces a nested child-PII difference that must not reach the sink as a dotted $set.
+        var decryptedInitialState = Expando(("id", Identifier), ("contacts", new object[] { Contact() }));
+        var update = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(new EventSequenceNumber(1)), decryptedInitialState);
+        update.Add(new PropertiesChanged<ExpandoObject>(null!, [new PropertyDifference("status", null, "approved")]));
+        await step.Perform(projection, new ProjectionEventContext(Key, update.Incoming, update, ProjectionOperationType.None, false));
+
+        _error = await Catch.Exception(() => Sink.ApplyChanges(Key, update, new EventSequenceNumber(1)));
+
+        var stored = await StoredDocument();
+        var contacts = stored["contacts"].AsBsonArray;
+        _storedContactCount = contacts.Count;
+        _storedStatus = stored.Contains("status") ? stored["status"].AsString : string.Empty;
+        _storedNameIsCiphertext = contacts.Count > 0 && IsBase64(contacts[0].AsBsonDocument["name"].AsString);
+    }
+
+    [Fact] void should_apply_the_update_without_failing() => _error.ShouldBeNull();
+
+    [Fact] void should_not_duplicate_the_child() => _storedContactCount.ShouldEqual(1);
+
+    [Fact] void should_apply_the_unrelated_field_update() => _storedStatus.ShouldEqual("approved");
+
+    [Fact] void should_keep_the_child_pii_as_ciphertext() => _storedNameIsCiphertext.ShouldBeTrue();
+
+    AppendedEvent Event(EventSequenceNumber sequenceNumber) =>
+        new(
+            EventContext.From(EventStore, EventStoreNamespace, EventType.Unknown, EventSourceType.Default, Identifier, EventStreamType.All, EventStreamId.Default, sequenceNumber, CorrelationId.NotSet),
+            new ExpandoObject());
+
+    static ExpandoObject Contact() => Expando(("contactId", "contact-1"), ("name", PlaintextName), ("contactEmail", PlaintextEmail));
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_reducer_releases_a_child_collection_with_a_pii_list.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_reducer_releases_a_child_collection_with_a_pii_list.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Observation.Reducers;
+using Cratis.Chronicle.Observation.Reducers.Clients;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Regression for the reducer RELEASE leg of a coarse <c>[PII]</c> list nested inside a reducer-owned
+/// child collection. A coarse <c>[PII]</c> on a whole list is blob-encrypted to a single ciphertext
+/// string even though its schema type stays array; the converters must round-trip it as that scalar
+/// string rather than shredding it into per-character elements, otherwise the next reduce's initial
+/// RELEASE fails to base64-decode it. Two reduces are driven against one key — create, then
+/// read-modify-write — and the second must release the stored state cleanly with the list round-tripping.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_releases_a_child_collection_with_a_pii_list(MongoDBFixture fixture)
+    : given.a_child_collection_compliance_scenario(fixture)
+{
+    const string Criterion = "quality";
+    const int Score = 5;
+
+    Exception? _error;
+    bool _storedScoresAreCiphertextString;
+    bool _storedScoresAreArray;
+    string _releasedScores = string.Empty;
+
+    protected override string Identifier => "req-1";
+
+    protected override ReadModelObserverType ObserverType => ReadModelObserverType.Reducer;
+
+    protected override string SchemaJson =>
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "candidates": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "candidateId": { "type": "string" },
+                  "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                  "evaluationScores": {
+                    "type": "array",
+                    "compliance": [ { "metadataType": "PII", "details": "" } ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "criterion": { "type": "string" },
+                        "score": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    async Task Because()
+    {
+        var pipeline = new ReducerPipeline(ReadModel, Sink, ObjectComparer, Compliance, EventStore, EventStoreNamespace);
+
+        // First reduce creates the candidate child with a coarse [PII] evaluation-scores list.
+        await pipeline.Handle(
+            new ReducerContext([Event()], Key),
+            (_, _) => Task.FromResult(new ReducerSubscriberResult(ObserverSubscriberResult.Ok(EventSequenceNumber.First), WorkSurface("Alice"))));
+
+        // Second reduce reads the stored (encrypted) state and releases it before reducing again.
+        _error = await Catch.Exception(() => pipeline.Handle(
+            new ReducerContext([Event()], Key),
+            (_, _) => Task.FromResult(new ReducerSubscriberResult(ObserverSubscriberResult.Ok(EventSequenceNumber.First), WorkSurface("Alice Smith")))));
+
+        var storedScores = (await StoredDocument())["candidates"].AsBsonArray[0].AsBsonDocument["evaluationScores"];
+        _storedScoresAreCiphertextString = storedScores.IsString && IsBase64(storedScores.AsString);
+        _storedScoresAreArray = storedScores.IsBsonArray;
+
+        if (storedScores.IsString)
+        {
+            // The stored ciphertext must decrypt back to the original list content, mirroring how the
+            // read path releases a coarse [PII] blob to its plaintext (JSON) representation.
+            var released = await ComplianceManager.Release(
+                EventStore,
+                EventStoreNamespace,
+                Schema.GetSchemaForPropertyPath("candidates"),
+                Identifier,
+                new JsonObject { ["candidateId"] = "cand-1", ["evaluationScores"] = storedScores.AsString });
+            _releasedScores = released["evaluationScores"]!.ToString();
+        }
+    }
+
+    [Fact] void should_release_the_stored_state_without_failing() => _error.ShouldBeNull();
+
+    [Fact] void should_store_the_pii_list_as_ciphertext_string() => _storedScoresAreCiphertextString.ShouldBeTrue();
+
+    [Fact] void should_not_shred_the_pii_list_into_an_array() => _storedScoresAreArray.ShouldBeFalse();
+
+    [Fact] void should_round_trip_the_pii_list_to_the_original_content() => _releasedScores.Contains(Criterion).ShouldBeTrue();
+
+    AppendedEvent Event() =>
+        new(
+            EventContext.From(EventStore, EventStoreNamespace, EventType.Unknown, EventSourceType.Default, Identifier, EventStreamType.All, EventStreamId.Default, EventSequenceNumber.First, CorrelationId.NotSet),
+            new ExpandoObject());
+
+    static ExpandoObject WorkSurface(string candidateName)
+    {
+        var score = Expando(("criterion", Criterion), ("score", Score));
+        var candidate = Expando(("candidateId", "cand-1"), ("name", candidateName), ("evaluationScores", new object[] { score }));
+        return Expando(("id", "req-1"), ("candidates", new object[] { candidate }));
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_a_blob_encrypted_list_to_bson.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_a_blob_encrypted_list_to_bson.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+
+namespace Cratis.Chronicle.Storage.MongoDB.for_ExpandoObjectConverter;
+
+public class when_converting_a_blob_encrypted_list_to_bson : Specification
+{
+    const string Blob = "Mv6b9CejjH6U05D7Nzig0gsc1VFd2QvfoOf7axEys4SMGWCb46YYMslJarlr40g==";
+
+    ExpandoObjectConverter _converter;
+    JsonSchema _schema;
+    ExpandoObject _input;
+    BsonDocument _document;
+    ExpandoObject _roundTripped;
+
+    void Establish()
+    {
+        _converter = new(new TypeFormats());
+        _schema = JsonSchema.FromJson(
+            """
+            {
+                "type": "object",
+                "properties": {
+                    "scores": {
+                        "type": "array",
+                        "items": { "type": "object", "properties": { "value": { "type": "integer" } } }
+                    }
+                }
+            }
+            """);
+
+        // A coarse [PII] list is blob-encrypted to a single ciphertext string even though the schema type
+        // stays array. The sink must persist it as that scalar string, not shred it into per-character bson.
+        _input = new ExpandoObject();
+        ((IDictionary<string, object?>)_input)["scores"] = Blob;
+    }
+
+    void Because()
+    {
+        _document = _converter.ToBsonDocument(_input, _schema);
+        _roundTripped = _converter.ToExpandoObject(_document, _schema);
+    }
+
+    [Fact] void should_store_the_blob_as_a_bson_string() => _document["scores"].IsString.ShouldBeTrue();
+
+    [Fact] void should_not_shred_the_blob_into_an_array() => _document["scores"].IsBsonArray.ShouldBeFalse();
+
+    [Fact] void should_round_trip_the_blob_back_to_the_string() => ((IDictionary<string, object?>)_roundTripped)["scores"].ShouldEqual(Blob);
+}

--- a/Source/Kernel/Storage.MongoDB/ExpandoObjectConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/ExpandoObjectConverter.cs
@@ -111,6 +111,15 @@ public class ExpandoObjectConverter(ITypeFormats typeFormats) : IExpandoObjectCo
                 schemaProperty.IsArray ? schemaProperty.Item!.Reference ?? schemaProperty.Item : schemaProperty.ActualTypeSchema);
         }
 
+        // A coarse [PII] value on a whole list/array is blob-encrypted to a single ciphertext string,
+        // even though the schema type stays Array. Persist it as that scalar string rather than letting
+        // the array branch below treat the string as an enumerable of characters — which would shred the
+        // ciphertext into per-character elements and break the encrypt -> store -> read -> release round trip.
+        if (value is string ciphertext && schemaProperty.Type.HasFlag(JsonObjectType.Array))
+        {
+            return new BsonString(ciphertext);
+        }
+
         if (schemaProperty.Type.HasFlag(JsonObjectType.Array) && value is IEnumerable enumerable)
         {
             var items = new List<BsonValue>();

--- a/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
@@ -117,13 +117,14 @@ public class ChangesetConverter(
         var joinTasks = new List<Task>();
         var changesToApply = changes.ToList();
         var collectionPathsWithChildOperations = changesToApply.GetCollectionPathsWithChildOperations();
+        var wholeCollectionReplacementPaths = changesToApply.GetWholeCollectionReplacementPaths();
 
         foreach (var change in changesToApply)
         {
             switch (change)
             {
                 case PropertiesChanged<ExpandoObject> propertiesChanged:
-                    hasChanges |= BuildPropertiesChanged(updateDefinitionBuilder, ref updateBuilder, arrayFiltersForDocument, collectionPathsWithChildOperations, propertiesChanged);
+                    hasChanges |= BuildPropertiesChanged(updateDefinitionBuilder, ref updateBuilder, arrayFiltersForDocument, collectionPathsWithChildOperations, wholeCollectionReplacementPaths, propertiesChanged);
                     break;
 
                 case ChildAdded childAdded:
@@ -174,18 +175,22 @@ public class ChangesetConverter(
         }
     }
 
-    bool BuildPropertiesChanged(UpdateDefinitionBuilder<BsonDocument> updateDefinitionBuilder, ref UpdateDefinition<BsonDocument>? updateBuilder, ArrayFilters arrayFiltersForDocument, ISet<PropertyPath> collectionPathsWithChildOperations, PropertiesChanged<ExpandoObject> propertiesChanged)
+    bool BuildPropertiesChanged(UpdateDefinitionBuilder<BsonDocument> updateDefinitionBuilder, ref UpdateDefinition<BsonDocument>? updateBuilder, ArrayFilters arrayFiltersForDocument, ISet<PropertyPath> collectionPathsWithChildOperations, ISet<PropertyPath> wholeCollectionReplacementPaths, PropertiesChanged<ExpandoObject> propertiesChanged)
     {
         var allArrayFilters = new List<BsonDocumentArrayFilterDefinition<BsonDocument>>();
 
         // Sink-owned system properties (e.g. __lastHandledEventSequenceNumber) are written via a
         // dedicated $max operator in BuildLastHandledEventSequenceNumber. Including them in the
         // generic $set path here produces two operators targeting the same field, which MongoDB
-        // rejects with "Updating the path 'X' would create a conflict at 'X'".
+        // rejects with "Updating the path 'X' would create a conflict at 'X'". The same conflict
+        // arises between a whole-collection $set (e.g. the collapsed compliance difference) and a
+        // positional $set on an element of that collection, so element-level differences under a
+        // wholesale replacement are dropped here — the whole-collection value already carries them.
         var applicableDifferences = propertiesChanged.Differences
             .Where(_ => !_.PropertyPath.IsMongoDBKey()
                 && !_.PropertyPath.IsSinkOwnedSystemProperty()
-                && !_.ConflictsWithChildOperation(collectionPathsWithChildOperations))
+                && !_.ConflictsWithChildOperation(collectionPathsWithChildOperations)
+                && !_.ConflictsWithWholeCollectionReplacement(wholeCollectionReplacementPaths))
             .ToArray();
 
         foreach (var propertyDifference in applicableDifferences)

--- a/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
+++ b/Source/Kernel/Storage/Sinks/InMemory/InMemorySink.cs
@@ -225,13 +225,14 @@ public class InMemorySink(
     {
         var changesToApply = changes.ToList();
         var collectionPathsWithChildOperations = changesToApply.GetCollectionPathsWithChildOperations();
+        var wholeCollectionReplacementPaths = changesToApply.GetWholeCollectionReplacementPaths();
 
         foreach (var change in changesToApply)
         {
             switch (change)
             {
                 case PropertiesChanged<ExpandoObject> propertiesChanged:
-                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations);
+                    state = propertiesChanged.ApplyToStateWithoutChildOperationConflicts(state, collectionPathsWithChildOperations, wholeCollectionReplacementPaths);
                     break;
 
                 case ChildAdded childAdded:


### PR DESCRIPTION
# Summary

Read models that store `[PII]` inside a child collection or list could stop updating once a child existed: a projection failed with a MongoDB write conflict on the next unrelated change, and a reducer with a coarse `[PII]` list (the marker on a whole list) failed to decrypt its stored state on the next update. Both legs now round-trip correctly through encryption at rest.

## Fixed

- Read models with a `[PII]` member inside a `[ChildrenFrom]` / list child collection no longer stop projecting after a child is added and a later event changes an unrelated field.
- Reducer read models with `[PII]` applied to a whole list nested in a child collection no longer fail to release their stored state on subsequent reduces.
- Observable (live) read-model queries no longer occasionally miss updates when the projection changeset notifier is deactivated between a client subscribing and the next change.
