### PR TITLE
Harden read-model child-collection PII coverage and de-duplicate conflict filtering

### DIFF
--- a/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
+++ b/Source/Infrastructure/Changes/ChangeCollectionPathExtensions.cs
@@ -101,6 +101,27 @@ public static class ChangeCollectionPathExtensions
     }
 
     /// <summary>
+    /// Filters property differences, dropping those that target an element inside a collection that is
+    /// concurrently modified by a child operation (push/pull) or replaced wholesale by a single $set.
+    /// </summary>
+    /// <param name="differences">The property differences to filter.</param>
+    /// <param name="collectionPathsWithChildOperations">Collection paths with child operations.</param>
+    /// <param name="wholeCollectionReplacementPaths">Optional collection paths replaced wholesale; element-level differences under them are dropped.</param>
+    /// <returns>The non-conflicting property differences.</returns>
+    /// <remarks>
+    /// A sink cannot apply both a collection-level operation and an element-level update to the same path in
+    /// one operation — MongoDB rejects it as a path conflict — so the element-level difference is dropped;
+    /// the child operation or whole-collection replacement already carries the latest element value.
+    /// </remarks>
+    public static IEnumerable<PropertyDifference> WithoutCollectionConflicts(
+        this IEnumerable<PropertyDifference> differences,
+        ISet<PropertyPath> collectionPathsWithChildOperations,
+        ISet<PropertyPath>? wholeCollectionReplacementPaths = null) =>
+        differences.Where(_ =>
+            !_.ConflictsWithChildOperation(collectionPathsWithChildOperations) &&
+            (wholeCollectionReplacementPaths is null || !_.ConflictsWithWholeCollectionReplacement(wholeCollectionReplacementPaths)));
+
+    /// <summary>
     /// Applies property differences to an existing state object while excluding properties that conflict with child operations.
     /// </summary>
     /// <param name="propertiesChanged">The property change to apply.</param>
@@ -112,9 +133,7 @@ public static class ChangeCollectionPathExtensions
     {
         var result = state.Clone();
 
-        foreach (var difference in propertiesChanged.Differences.Where(_ =>
-            !_.ConflictsWithChildOperation(collectionPathsWithChildOperations) &&
-            (wholeCollectionReplacementPaths is null || !_.ConflictsWithWholeCollectionReplacement(wholeCollectionReplacementPaths))))
+        foreach (var difference in propertiesChanged.Differences.WithoutCollectionConflicts(collectionPathsWithChildOperations, wholeCollectionReplacementPaths))
         {
             difference.PropertyPath.SetValue(result, difference.Changed!, difference.ArrayIndexers);
         }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_a_field_with_multiple_child_collections_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_updates_a_field_with_multiple_child_collections_with_pii.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionCompliance;
+
+/// <summary>
+/// Edge case for the projection collapse with more than one PII child collection. An unrelated top-level
+/// update re-encrypts every PII member across both collections, yielding two independent whole-collection
+/// replacements (<c>$set contacts</c> and <c>$set tags</c>). They target different collections so there is
+/// no conflict; both must apply, leaving both collections intact and ciphertext at rest.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_updates_a_field_with_multiple_child_collections_with_pii(MongoDBFixture fixture)
+    : given.a_child_collection_compliance_scenario(fixture)
+{
+    Exception? _error;
+    int _storedContactCount;
+    int _storedTagCount;
+    string _storedStatus = string.Empty;
+    bool _contactIsCiphertext;
+    bool _tagIsCiphertext;
+
+    protected override string Identifier => "org-1";
+
+    protected override ReadModelObserverType ObserverType => ReadModelObserverType.Projection;
+
+    protected override string SchemaJson =>
+        """
+        {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "status": { "type": "string" },
+            "contacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "contactId": { "type": "string" },
+                  "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] }
+                }
+              }
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "tagId": { "type": "string" },
+                  "label": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+    async Task Because()
+    {
+        var projection = Substitute.For<IProjection>();
+        projection.TargetReadModelSchema.Returns(Schema);
+        var step = new EncryptChangeset(Compliance, ObjectComparer, EventStore, EventStoreNamespace);
+
+        var insert = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(EventSequenceNumber.First), new ExpandoObject());
+        insert.AddChild("contacts", Contact());
+        insert.AddChild("tags", Tag());
+        await step.Perform(projection, new ProjectionEventContext(Key, insert.Incoming, insert, ProjectionOperationType.None, false));
+        await Sink.ApplyChanges(Key, insert, EventSequenceNumber.First);
+
+        var decryptedInitialState = Expando(
+            ("id", Identifier),
+            ("contacts", new object[] { Contact() }),
+            ("tags", new object[] { Tag() }));
+        var update = new Changeset<AppendedEvent, ExpandoObject>(ObjectComparer, Event(new EventSequenceNumber(1)), decryptedInitialState);
+        update.Add(new PropertiesChanged<ExpandoObject>(null!, [new PropertyDifference("status", null, "approved")]));
+        await step.Perform(projection, new ProjectionEventContext(Key, update.Incoming, update, ProjectionOperationType.None, false));
+
+        _error = await Catch.Exception(() => Sink.ApplyChanges(Key, update, new EventSequenceNumber(1)));
+
+        var stored = await StoredDocument();
+        var contacts = stored["contacts"].AsBsonArray;
+        var tags = stored["tags"].AsBsonArray;
+        _storedContactCount = contacts.Count;
+        _storedTagCount = tags.Count;
+        _storedStatus = stored.Contains("status") ? stored["status"].AsString : string.Empty;
+        _contactIsCiphertext = contacts.Count > 0 && IsBase64(contacts[0].AsBsonDocument["name"].AsString);
+        _tagIsCiphertext = tags.Count > 0 && IsBase64(tags[0].AsBsonDocument["label"].AsString);
+    }
+
+    [Fact] void should_apply_the_update_without_failing() => _error.ShouldBeNull();
+
+    [Fact] void should_keep_the_contact() => _storedContactCount.ShouldEqual(1);
+
+    [Fact] void should_keep_the_tag() => _storedTagCount.ShouldEqual(1);
+
+    [Fact] void should_apply_the_unrelated_field_update() => _storedStatus.ShouldEqual("approved");
+
+    [Fact] void should_keep_the_contact_pii_ciphertext() => _contactIsCiphertext.ShouldBeTrue();
+
+    [Fact] void should_keep_the_tag_pii_ciphertext() => _tagIsCiphertext.ShouldBeTrue();
+
+    AppendedEvent Event(EventSequenceNumber sequenceNumber) =>
+        new(
+            EventContext.From(EventStore, EventStoreNamespace, EventType.Unknown, EventSourceType.Default, Identifier, EventStreamType.All, EventStreamId.Default, sequenceNumber, CorrelationId.NotSet),
+            new ExpandoObject());
+
+    static ExpandoObject Contact() => Expando(("contactId", "contact-1"), ("name", "Jane Doe"));
+
+    static ExpandoObject Tag() => Expando(("tagId", "tag-1"), ("label", "Sensitive"));
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
@@ -26,7 +26,7 @@ namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity.given;
 /// are compared so that any divergence in how the two sinks apply a changeset fails the spec.
 /// </summary>
 /// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
-public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
+public abstract class a_parity_scenario(MongoDBFixture fixture) : Specification
 {
     readonly ObjectComparer _objectComparer = new();
 
@@ -36,17 +36,29 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
     Sink _mongoSink = default!;
     ReducerPipeline _inMemoryPipeline = default!;
     ReducerPipeline _mongoPipeline = default!;
+    IReadModelsCompliance _compliance = default!;
     JsonSchema _schema = default!;
     Key _key = default!;
 
-    /// <summary>Gets the read-model type whose schema drives the sinks.</summary>
-    protected abstract Type ReadModelType { get; }
+    /// <summary>Gets the read-model type whose schema drives the sinks (when <see cref="CreateSchema"/> is not overridden).</summary>
+    protected virtual Type ReadModelType => typeof(object);
 
     /// <summary>Gets the key value the read model is stored under.</summary>
     protected virtual object KeyValue => "root-1";
 
     /// <summary>Gets the ordered projected states applied (each factory produces a fresh instance per sink).</summary>
     protected abstract IReadOnlyList<Func<ExpandoObject>> States { get; }
+
+    /// <summary>Creates the read-model schema. Override to build from JSON (e.g. to carry compliance metadata).</summary>
+    /// <returns>The read-model <see cref="JsonSchema"/>.</returns>
+    protected virtual JsonSchema CreateSchema() => JsonSchema.FromType(ReadModelType);
+
+    /// <summary>Creates the compliance used by both pipelines. Override to drive real encrypt-at-rest.</summary>
+    /// <returns>The <see cref="IReadModelsCompliance"/> shared by both sinks.</returns>
+    protected virtual IReadModelsCompliance CreateCompliance() => new PassthroughReadModelsCompliance();
+
+    /// <summary>Gets a value indicating whether stored state is released (decrypted) before the cross-sink comparison.</summary>
+    protected virtual bool ReleaseBeforeComparing => false;
 
     public ExpandoObject? InMemoryResult { get; private set; }
 
@@ -57,12 +69,12 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
     /// <summary>Gets a human-readable description of any divergence, or empty when the sinks match.</summary>
     public string ParityReport { get; private set; } = string.Empty;
 
-    public async Task InitializeAsync()
+    async Task Establish()
     {
         _databaseName = $"chronicle_sink_parity_{Guid.NewGuid():N}";
         _client = new MongoClient(fixture.ConnectionString);
         var database = _client.GetDatabase(_databaseName);
-        _schema = JsonSchema.FromType(ReadModelType);
+        _schema = CreateSchema();
         _key = new Key(KeyValue, ArrayIndexers.NoIndexers);
 
         var typeFormats = new TypeFormats();
@@ -76,9 +88,9 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
         _mongoSink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
 
-        var compliance = new PassthroughReadModelsCompliance();
-        _inMemoryPipeline = new ReducerPipeline(readModel, _inMemorySink, _objectComparer, compliance, "test-store", "test-namespace");
-        _mongoPipeline = new ReducerPipeline(readModel, _mongoSink, _objectComparer, compliance, "test-store", "test-namespace");
+        _compliance = CreateCompliance();
+        _inMemoryPipeline = new ReducerPipeline(readModel, _inMemorySink, _objectComparer, _compliance, "test-store", "test-namespace");
+        _mongoPipeline = new ReducerPipeline(readModel, _mongoSink, _objectComparer, _compliance, "test-store", "test-namespace");
 
         foreach (var state in States)
         {
@@ -90,10 +102,15 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
 
         if (InMemoryResult is not null && MongoResult is not null)
         {
+            // With real encryption the two sinks store non-deterministic ciphertext, so a meaningful
+            // cross-sink comparison is of the released (decrypted) read models, not the bytes at rest.
+            var inMemory = ReleaseBeforeComparing ? await _compliance.Release("test-store", "test-namespace", _schema, InMemoryResult) : InMemoryResult;
+            var mongo = ReleaseBeforeComparing ? await _compliance.Release("test-store", "test-namespace", _schema, MongoResult) : MongoResult;
+
             // Compare the read-model data only. Sink-internal metadata (the '__'-prefixed
             // last-handled-sequence-number and friends) is not part of the projected read model
             // and is legitimately tracked differently by each sink.
-            _objectComparer.Compare(WithoutMetadata(InMemoryResult), WithoutMetadata(MongoResult), out var differences);
+            _objectComparer.Compare(WithoutMetadata(inMemory), WithoutMetadata(mongo), out var differences);
             ParityDifferences = differences.ToArray();
             ParityReport = string.Join(
                 " || ",
@@ -116,7 +133,7 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : IAsyncLifetime
         return clone;
     }
 
-    public async Task DisposeAsync()
+    async Task Destroy()
     {
         _inMemorySink?.Dispose();
         if (_databaseName is not null)

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_adds_a_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_adds_a_child.cs
@@ -6,26 +6,23 @@ using System.Dynamic;
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
 [Collection(MongoDBCollection.Name)]
-public class when_a_reducer_adds_a_child(when_a_reducer_adds_a_child.context ctx) : IClassFixture<when_a_reducer_adds_a_child.context>
+public class when_a_reducer_adds_a_child(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
 {
-    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
-    {
-        protected override Type ReadModelType => typeof(Team);
+    protected override Type ReadModelType => typeof(Team);
 
-        protected override IReadOnlyList<Func<ExpandoObject>> States =>
-        [
-            () => CreateTeam("member-1"),
-            () => CreateTeam("member-1", "member-2")
-        ];
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => CreateTeam("member-1"),
+        () => CreateTeam("member-1", "member-2")
+    ];
 
-        static ExpandoObject CreateTeam(params string[] memberIds) =>
-            Expando(
-                ("id", "root-1"),
-                ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
+    [Fact] void should_apply_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
 
-        record Member(string MemberId, string Status);
-        record Team(string Id, IEnumerable<Member> Members);
-    }
+    static ExpandoObject CreateTeam(params string[] memberIds) =>
+        Expando(
+            ("id", "root-1"),
+            ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
 
-    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+    record Member(string MemberId, string Status);
+    record Team(string Id, IEnumerable<Member> Members);
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_removes_a_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_removes_a_child.cs
@@ -6,26 +6,23 @@ using System.Dynamic;
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
 [Collection(MongoDBCollection.Name)]
-public class when_a_reducer_removes_a_child(when_a_reducer_removes_a_child.context ctx) : IClassFixture<when_a_reducer_removes_a_child.context>
+public class when_a_reducer_removes_a_child(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
 {
-    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
-    {
-        protected override Type ReadModelType => typeof(Team);
+    protected override Type ReadModelType => typeof(Team);
 
-        protected override IReadOnlyList<Func<ExpandoObject>> States =>
-        [
-            () => CreateTeam("member-1", "member-2", "member-3"),
-            () => CreateTeam("member-1", "member-3")
-        ];
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => CreateTeam("member-1", "member-2", "member-3"),
+        () => CreateTeam("member-1", "member-3")
+    ];
 
-        static ExpandoObject CreateTeam(params string[] memberIds) =>
-            Expando(
-                ("id", "root-1"),
-                ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
+    [Fact] void should_apply_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
 
-        record Member(string MemberId, string Status);
-        record Team(string Id, IEnumerable<Member> Members);
-    }
+    static ExpandoObject CreateTeam(params string[] memberIds) =>
+        Expando(
+            ("id", "root-1"),
+            ("members", memberIds.Select(id => (object)Expando(("memberId", id), ("status", "active"))).ToArray()));
 
-    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+    record Member(string MemberId, string Status);
+    record Team(string Id, IEnumerable<Member> Members);
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_round_trips_pii_through_both_sinks.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_round_trips_pii_through_both_sinks.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
+
+/// <summary>
+/// Cross-sink parity for a read model carrying real PII — a child collection whose children hold a scalar
+/// <c>[PII]</c> name and a coarse <c>[PII]</c> list. The same two reduces are driven through both sinks
+/// with the real compliance machinery (encrypt at rest), and the released (decrypted) read models are
+/// compared. This is the gap that let the child-collection PII bugs ship green: the suite previously used
+/// passthrough compliance and never exercised the encrypt-at-rest round trip through both sinks.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/>.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_reducer_round_trips_pii_through_both_sinks(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
+{
+    protected override bool ReleaseBeforeComparing => true;
+
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => Surface("Alice", 5),
+        () => Surface("Alice Smith", 7)
+    ];
+
+    protected override JsonSchema CreateSchema() =>
+        JsonSchema.FromJson(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "candidates": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "candidateId": { "type": "string" },
+                      "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] },
+                      "scores": {
+                        "type": "array",
+                        "compliance": [ { "metadataType": "PII", "details": "" } ],
+                        "items": { "type": "object", "properties": { "value": { "type": "integer" } } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+    protected override IReadModelsCompliance CreateCompliance() =>
+        new ReadModelsCompliance(
+            new JsonComplianceManager(
+                new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
+                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption()))),
+            new Cratis.Chronicle.Json.ExpandoObjectConverter(new TypeFormats()));
+
+    [Fact] void should_round_trip_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
+
+    [Fact] void should_have_a_result_from_both_sinks() => (InMemoryResult is not null && MongoResult is not null).ShouldBeTrue();
+
+    static ExpandoObject Surface(string name, int score)
+    {
+        var scores = new object[] { Expando(("value", score)) };
+        var candidate = Expando(("candidateId", "c1"), ("name", name), ("scores", scores));
+        return Expando(("id", "root-1"), ("candidates", new object[] { candidate }));
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_child_field.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_child_field.cs
@@ -6,27 +6,24 @@ using System.Dynamic;
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
 [Collection(MongoDBCollection.Name)]
-public class when_a_reducer_updates_a_child_field(when_a_reducer_updates_a_child_field.context ctx) : IClassFixture<when_a_reducer_updates_a_child_field.context>
+public class when_a_reducer_updates_a_child_field(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
 {
-    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
-    {
-        protected override Type ReadModelType => typeof(Team);
+    protected override Type ReadModelType => typeof(Team);
 
-        protected override IReadOnlyList<Func<ExpandoObject>> States =>
-        [
-            () => CreateTeam("pending"),
-            () => CreateTeam("approved")
-        ];
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => CreateTeam("pending"),
+        () => CreateTeam("approved")
+    ];
 
-        static ExpandoObject CreateTeam(string status) =>
-            Expando(
-                ("id", "root-1"),
-                ("members", new object[] { Expando(("memberId", "member-1"), ("status", status)) }));
+    [Fact] void should_apply_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
+    [Fact] void should_have_a_result_from_both_sinks() => (InMemoryResult is not null && MongoResult is not null).ShouldBeTrue();
 
-        record Member(string MemberId, string Status);
-        record Team(string Id, IEnumerable<Member> Members);
-    }
+    static ExpandoObject CreateTeam(string status) =>
+        Expando(
+            ("id", "root-1"),
+            ("members", new object[] { Expando(("memberId", "member-1"), ("status", status)) }));
 
-    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
-    [Fact] void should_have_a_result_from_both_sinks() => (ctx.InMemoryResult is not null && ctx.MongoResult is not null).ShouldBeTrue();
+    record Member(string MemberId, string Status);
+    record Team(string Id, IEnumerable<Member> Members);
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_nested_object.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_a_nested_object.cs
@@ -6,26 +6,23 @@ using System.Dynamic;
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
 [Collection(MongoDBCollection.Name)]
-public class when_a_reducer_updates_a_nested_object(when_a_reducer_updates_a_nested_object.context ctx) : IClassFixture<when_a_reducer_updates_a_nested_object.context>
+public class when_a_reducer_updates_a_nested_object(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
 {
-    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
-    {
-        protected override Type ReadModelType => typeof(Profile);
+    protected override Type ReadModelType => typeof(Profile);
 
-        protected override IReadOnlyList<Func<ExpandoObject>> States =>
-        [
-            () => CreateProfile("Oslo", "Norway"),
-            () => CreateProfile("Bergen", "Norway")
-        ];
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => CreateProfile("Oslo", "Norway"),
+        () => CreateProfile("Bergen", "Norway")
+    ];
 
-        static ExpandoObject CreateProfile(string city, string country) =>
-            Expando(
-                ("id", "root-1"),
-                ("home", Expando(("city", city), ("country", country))));
+    [Fact] void should_apply_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
 
-        record Address(string City, string Country);
-        record Profile(string Id, Address Home);
-    }
+    static ExpandoObject CreateProfile(string city, string country) =>
+        Expando(
+            ("id", "root-1"),
+            ("home", Expando(("city", city), ("country", country))));
 
-    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+    record Address(string City, string Country);
+    record Profile(string Id, Address Home);
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_one_among_several_children.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_updates_one_among_several_children.cs
@@ -6,26 +6,23 @@ using System.Dynamic;
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
 [Collection(MongoDBCollection.Name)]
-public class when_a_reducer_updates_one_among_several_children(when_a_reducer_updates_one_among_several_children.context ctx) : IClassFixture<when_a_reducer_updates_one_among_several_children.context>
+public class when_a_reducer_updates_one_among_several_children(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
 {
-    public class context(MongoDBFixture fixture) : given.a_parity_scenario(fixture)
-    {
-        protected override Type ReadModelType => typeof(Team);
+    protected override Type ReadModelType => typeof(Team);
 
-        protected override IReadOnlyList<Func<ExpandoObject>> States =>
-        [
-            () => CreateTeam(("member-1", "active"), ("member-2", "active"), ("member-3", "active")),
-            () => CreateTeam(("member-1", "active"), ("member-2", "promoted"), ("member-3", "active"))
-        ];
+    protected override IReadOnlyList<Func<ExpandoObject>> States =>
+    [
+        () => CreateTeam(("member-1", "active"), ("member-2", "active"), ("member-3", "active")),
+        () => CreateTeam(("member-1", "active"), ("member-2", "promoted"), ("member-3", "active"))
+    ];
 
-        static ExpandoObject CreateTeam(params (string Id, string Status)[] members) =>
-            Expando(
-                ("id", "root-1"),
-                ("members", members.Select(m => (object)Expando(("memberId", m.Id), ("status", m.Status))).ToArray()));
+    [Fact] void should_apply_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);
 
-        record Member(string MemberId, string Status);
-        record Team(string Id, IEnumerable<Member> Members);
-    }
+    static ExpandoObject CreateTeam(params (string Id, string Status)[] members) =>
+        Expando(
+            ("id", "root-1"),
+            ("members", members.Select(m => (object)Expando(("memberId", m.Id), ("status", m.Status))).ToArray()));
 
-    [Fact] void should_apply_identically_across_sinks() => ctx.ParityReport.ShouldEqual(string.Empty);
+    record Member(string MemberId, string Status);
+    record Team(string Id, IEnumerable<Member> Members);
 }

--- a/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/ChangesetConverter.cs
@@ -182,15 +182,12 @@ public class ChangesetConverter(
         // Sink-owned system properties (e.g. __lastHandledEventSequenceNumber) are written via a
         // dedicated $max operator in BuildLastHandledEventSequenceNumber. Including them in the
         // generic $set path here produces two operators targeting the same field, which MongoDB
-        // rejects with "Updating the path 'X' would create a conflict at 'X'". The same conflict
-        // arises between a whole-collection $set (e.g. the collapsed compliance difference) and a
-        // positional $set on an element of that collection, so element-level differences under a
-        // wholesale replacement are dropped here — the whole-collection value already carries them.
+        // rejects with "Updating the path 'X' would create a conflict at 'X'". WithoutCollectionConflicts
+        // applies the same rule to element-level differences that collide with a child operation or a
+        // whole-collection replacement on the same collection.
         var applicableDifferences = propertiesChanged.Differences
-            .Where(_ => !_.PropertyPath.IsMongoDBKey()
-                && !_.PropertyPath.IsSinkOwnedSystemProperty()
-                && !_.ConflictsWithChildOperation(collectionPathsWithChildOperations)
-                && !_.ConflictsWithWholeCollectionReplacement(wholeCollectionReplacementPaths))
+            .Where(_ => !_.PropertyPath.IsMongoDBKey() && !_.PropertyPath.IsSinkOwnedSystemProperty())
+            .WithoutCollectionConflicts(collectionPathsWithChildOperations, wholeCollectionReplacementPaths)
             .ToArray();
 
         foreach (var propertyDifference in applicableDifferences)


### PR DESCRIPTION
# Summary

Internal hardening for the read-model child-collection PII work — no user-facing behavior change. Stacked on #3428.

- Extends the cross-sink parity suite to drive real encrypt-at-rest round trips through both sinks (it previously used passthrough compliance, which is why the child-collection PII bugs shipped green), and adds a multiple-PII-child-collections regression spec.
- De-duplicates the collection-conflict filtering (child operations + whole-collection replacement) into one shared `WithoutCollectionConflicts` helper used by the sink converter and the in-memory / immediate-projection paths. The sink-level filtering remains an intentional, unit-tested layer — moving it into changeset consolidation would have removed that defensive guarantee, so it was kept.
- Converts the sink-parity suite to the Specification BDD base for consistency with the rest of the C# specs.

No public API, behavior, or generated-output changes.
