### PR TITLE
Fix ReadModelScenario fidelity gaps for reducers and removal

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/RemovableWidget.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/RemovableWidget.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Root read model created from <see cref="RemovableWidgetCreated"/> and removed entirely via the
+/// class-level <see cref="RemovedWithAttribute{TEvent}"/> when <see cref="RemovableWidgetDeleted"/> is observed.
+/// </summary>
+/// <param name="Id">Widget identifier (the event source id).</param>
+/// <param name="Name">Widget name.</param>
+[Passive]
+[FromEvent<RemovableWidgetCreated>]
+[RemovedWith<RemovableWidgetDeleted>]
+public sealed record RemovableWidget(
+    [Key] Guid Id,
+    string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/RemovableWidgetCreated.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/RemovableWidgetCreated.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that creates a <see cref="RemovableWidget"/>.
+/// </summary>
+/// <param name="Name">Widget name.</param>
+[EventType]
+public record RemovableWidgetCreated(string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/RemovableWidgetDeleted.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/RemovableWidgetDeleted.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that removes a <see cref="RemovableWidget"/> read model instance.
+/// </summary>
+[EventType]
+public record RemovableWidgetDeleted;

--- a/Source/Clients/Testing.Specs/ReadModels/SequenceProbed.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SequenceProbed.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event whose <see cref="TallyReducer"/> handler records the event's sequence number, used to verify
+/// the harness assigns increasing per-event sequence numbers rather than a constant.
+/// </summary>
+[EventType]
+public record SequenceProbed;

--- a/Source/Clients/Testing.Specs/ReadModels/Tallied.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/Tallied.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that increments a <see cref="Tally"/>.
+/// </summary>
+[EventType]
+public record Tallied;

--- a/Source/Clients/Testing.Specs/ReadModels/Tally.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/Tally.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Reducer-backed read model used to verify that <see cref="ReadModelScenario{TReadModel}"/>
+/// seeds the reducer with the provided initial state.
+/// </summary>
+/// <param name="Id">Identifier.</param>
+/// <param name="Count">Running count, incremented once per <see cref="Tallied"/> event.</param>
+public record Tally(Guid Id, int Count);

--- a/Source/Clients/Testing.Specs/ReadModels/TallyBroke.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TallyBroke.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event whose <see cref="TallyReducer"/> handler throws, used to verify reducer failures surface.
+/// </summary>
+[EventType]
+public record TallyBroke;

--- a/Source/Clients/Testing.Specs/ReadModels/TallyReducer.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TallyReducer.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Reducer that increments <see cref="Tally.Count"/> for each <see cref="Tallied"/> event,
+/// starting a fresh tally at 1 when there is no current state.
+/// </summary>
+public class TallyReducer : IReducerFor<Tally>
+{
+    /// <summary>
+    /// Gets the unique identifier of the reducer.
+    /// </summary>
+    public ReducerId Id => "f3a1c7d2-9b4e-4c1a-8e2f-1d6b5a0c3e90";
+
+    /// <summary>
+    /// Increments the running count.
+    /// </summary>
+    /// <param name="event">The <see cref="Tallied"/> event.</param>
+    /// <param name="current">The current <see cref="Tally"/> state, or <see langword="null"/> if none.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>The next <see cref="Tally"/> state.</returns>
+    public Tally Increment(Tallied @event, Tally? current, EventContext context) =>
+        current is null ? new Tally(Guid.Empty, 1) : current with { Count = current.Count + 1 };
+
+    /// <summary>
+    /// Records the event's sequence number into <see cref="Tally.Count"/>.
+    /// </summary>
+    /// <param name="event">The <see cref="SequenceProbed"/> event.</param>
+    /// <param name="current">The current <see cref="Tally"/> state, or <see langword="null"/> if none.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>The next <see cref="Tally"/> state.</returns>
+    public Tally Probe(SequenceProbed @event, Tally? current, EventContext context) =>
+        new(Guid.Empty, (int)context.SequenceNumber.Value);
+
+    /// <summary>
+    /// Always throws, to simulate a reducer that fails while processing an event.
+    /// </summary>
+    /// <param name="event">The <see cref="TallyBroke"/> event.</param>
+    /// <param name="current">The current <see cref="Tally"/> state, or <see langword="null"/> if none.</param>
+    /// <param name="context">The <see cref="EventContext"/>.</param>
+    /// <returns>Never returns; always throws.</returns>
+    /// <exception cref="InvalidOperationException">Always thrown to simulate a failing reducer.</exception>
+    public Tally Broke(TallyBroke @event, Tally? current, EventContext context) =>
+        throw new InvalidOperationException("Reducer intentionally failed.");
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_reducer_reads_the_event_sequence_number.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_reducer_reads_the_event_sequence_number.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that <see cref="ReadModelScenario{TReadModel}"/> assigns increasing per-event sequence numbers
+/// to a reducer's <see cref="EventContext"/> rather than a constant, so the second of two events is seen as
+/// sequence number 1.
+/// </summary>
+public class when_a_reducer_reads_the_event_sequence_number : Specification
+{
+    ReadModelScenario<Tally> _scenario;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _id = EventSourceId.New();
+        _scenario = new ReadModelScenario<Tally>();
+    }
+
+    async Task Because() =>
+        await _scenario.Given.ForEventSource(_id).Events(new SequenceProbed(), new SequenceProbed());
+
+    [Fact] void should_assign_increasing_sequence_numbers() => _scenario.Instance!.Count.ShouldEqual(1);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_reducer_throws.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_reducer_throws.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that when a reducer raises an error, <see cref="ReadModelScenario{TReadModel}"/> surfaces the
+/// failure rather than returning the partial state as a successful projection.
+/// </summary>
+public class when_a_reducer_throws : Specification
+{
+    ReadModelScenario<Tally> _scenario;
+    EventSourceId _id;
+    Exception _error;
+
+    void Establish()
+    {
+        _id = EventSourceId.New();
+        _scenario = new ReadModelScenario<Tally>();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given.ForEventSource(_id).Events(new TallyBroke());
+        _error = Catch.Exception(() => _ = _scenario.Instance);
+    }
+
+    [Fact] void should_surface_the_reducer_failure() => _error.ShouldBeOfExactType<ReducerFailed>();
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_reducing_with_a_seeded_initial_state.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_reducing_with_a_seeded_initial_state.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that <see cref="ReadModelScenario{TReadModel}"/> seeds the reducer with the provided
+/// initial state, so a reducer reduces incoming events on top of it rather than starting from
+/// <see langword="null"/>.
+/// </summary>
+public class when_reducing_with_a_seeded_initial_state : Specification
+{
+    ReadModelScenario<Tally> _scenario;
+    Guid _idGuid;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _idGuid = Guid.NewGuid();
+        _id = new EventSourceId(_idGuid);
+        _scenario = new ReadModelScenario<Tally>(new Tally(_idGuid, 100));
+    }
+
+    async Task Because() =>
+        await _scenario.Given.ForEventSource(_id).Events(new Tallied());
+
+    [Fact] void should_apply_the_event_on_top_of_the_seeded_state() => _scenario.Instance!.Count.ShouldEqual(101);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_removing_the_root_read_model.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_removing_the_root_read_model.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that <see cref="ReadModelScenario{TReadModel}"/> reflects a root-level removal: a class-level
+/// <c>[RemovedWith]</c> deletes the read model document in the real sink, so <c>Instance</c> resolves to
+/// <see langword="null"/> rather than the stale pre-removal state.
+/// </summary>
+public class when_removing_the_root_read_model : Specification
+{
+    ReadModelScenario<RemovableWidget> _scenario;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _id = EventSourceId.New();
+        _scenario = new ReadModelScenario<RemovableWidget>();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_id)
+            .Events(new RemovableWidgetCreated("My Widget"), new RemovableWidgetDeleted());
+
+    [Fact] void should_reflect_the_removal() => _scenario.Instance.ShouldBeNull();
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -169,6 +169,7 @@ internal static class ProjectionReadModelProcessor
         // we mirror that mapping ourselves before serializing the state — otherwise identifier
         // properties whose only source is the event-source ID surface as null in _scenario.Instance.
         KernelKey? rootKey = null;
+        var removed = false;
 
         using var inMemorySink = new InMemorySink(kernelReadModelDefinition, _typeFormats);
 
@@ -176,9 +177,10 @@ internal static class ProjectionReadModelProcessor
         var deferredEvents = new Queue<KernelAppendedEvent>();
         foreach (var @event in appendedEvents)
         {
-            var (newState, eventKey) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents);
+            var (newState, eventKey, eventRemoved) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents);
             state = newState;
             rootKey ??= eventKey;
+            removed = eventRemoved;
         }
 
         // Retry deferred events once; if still deferred, throw a descriptive exception.
@@ -205,8 +207,24 @@ internal static class ProjectionReadModelProcessor
                 false);
 
             HandleEventFor(engineProjection, context);
-            state = ApplyActualChanges(key, changeset.Changes, state);
+            if (changeset.Changes.Any(change => change is Removed))
+            {
+                state = new ExpandoObject();
+                removed = true;
+            }
+            else
+            {
+                state = ApplyActualChanges(key, changeset.Changes, state);
+            }
+
             await inMemorySink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
+        }
+
+        // A root-level removal (a class-level [RemovedWith]) deletes the read model document in the real
+        // sink; mirror that here by returning null rather than the stale pre-removal state.
+        if (removed)
+        {
+            return null;
         }
 
         InjectIdentifierFromKey<TReadModel>(state, rootKey);
@@ -336,7 +354,7 @@ internal static class ProjectionReadModelProcessor
         return schemas;
     }
 
-    static async Task<(ExpandoObject State, KernelKey? Key)> ProcessSingleEvent(
+    static async Task<(ExpandoObject State, KernelKey? Key, bool Removed)> ProcessSingleEvent(
         KernelProjectionEngine::IProjection projection,
         InMemoryEventSequenceStorage eventSequenceStorage,
         InMemorySink sink,
@@ -350,7 +368,7 @@ internal static class ProjectionReadModelProcessor
         if (keyResult is KernelProjectionEngine::DeferredKey)
         {
             deferredEvents.Enqueue(@event);
-            return (state, null);
+            return (state, null, false);
         }
 
         var key = (keyResult as KernelProjectionEngine::ResolvedKey)!.Key;
@@ -362,9 +380,13 @@ internal static class ProjectionReadModelProcessor
             false);
 
         HandleEventFor(projection, context);
-        var updatedState = ApplyActualChanges(key, changeset.Changes, state);
+
+        // A root-level removal yields a Removed change, which the real sink applies by deleting the
+        // document. Mirror that by resetting the threaded state so any subsequent re-create starts clean.
+        var removed = changeset.Changes.Any(change => change is Removed);
+        var updatedState = removed ? new ExpandoObject() : ApplyActualChanges(key, changeset.Changes, state);
         await sink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
-        return (updatedState, key);
+        return (updatedState, key, removed);
     }
 
     static KernelReadModels::ReadModelDefinition BuildKernelReadModelDefinition(Type readModelType, JsonSchema schema)
@@ -428,6 +450,10 @@ internal static class ProjectionReadModelProcessor
 
                 case ChildRemoved childRemoved:
                     ApplyChildRemoved(state, childRemoved);
+                    break;
+
+                case NestedCleared nestedCleared:
+                    ((IDictionary<string, object?>)state)[nestedCleared.NestedProperty.LastSegment.Value] = null;
                     break;
 
                 case Joined joined:

--- a/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
+++ b/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
@@ -201,7 +201,8 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
                 _eventTypes,
                 _artifactsActivator,
                 _serviceProvider,
-                _namingPolicy);
+                _namingPolicy,
+                _initialState);
         }
 
         var projectionDefinition = FindProjectionDefinition(readModelType);

--- a/Source/Clients/Testing/ReadModels/ReducerFailed.cs
+++ b/Source/Clients/Testing/ReadModels/ReducerFailed.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// The exception that is thrown when a reducer raises an error while processing events in a <see cref="ReadModelScenario{TReadModel}"/>.
+/// </summary>
+/// <param name="readModelType">The read model type whose reducer failed.</param>
+/// <param name="errorMessages">The error messages reported by the reducer.</param>
+/// <param name="stackTrace">The stack trace reported by the reducer, if any.</param>
+public class ReducerFailed(Type readModelType, IEnumerable<string> errorMessages, string stackTrace)
+    : Exception($"Reducer for read model type '{readModelType.FullName}' failed: {string.Join("; ", errorMessages)}{(string.IsNullOrEmpty(stackTrace) ? string.Empty : Environment.NewLine + stackTrace)}");

--- a/Source/Clients/Testing/ReadModels/ReducerReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ReducerReadModelProcessor.cs
@@ -25,21 +25,24 @@ internal static class ReducerReadModelProcessor
     /// <param name="artifactsActivator"><see cref="IClientArtifactsActivator"/> for instantiating the reducer.</param>
     /// <param name="serviceProvider"><see cref="IServiceProvider"/> used when invoking the reducer.</param>
     /// <param name="namingPolicy">The <see cref="INamingPolicy"/> for deriving the read model container name.</param>
+    /// <param name="initialState">Optional initial read model state the reducer reduces on top of.</param>
     /// <returns>The projected read model, or <see langword="null"/> if the reducer removed the instance.</returns>
+    /// <exception cref="ReducerFailed">Thrown when the reducer raises an error while processing the events.</exception>
     public static async Task<TReadModel?> Process<TReadModel>(
         Type reducerType,
         IEnumerable<EventForEventSourceId> events,
         IEventTypes eventTypes,
         IClientArtifactsActivator artifactsActivator,
         IServiceProvider serviceProvider,
-        INamingPolicy namingPolicy)
+        INamingPolicy namingPolicy,
+        TReadModel? initialState = null)
         where TReadModel : class
     {
         var readModelType = typeof(TReadModel);
         var containerName = (ReadModelContainerName)namingPolicy.GetReadModelName(readModelType);
         var invoker = new ReducerInvoker(eventTypes, artifactsActivator, reducerType, readModelType, containerName);
 
-        var eventsAndContexts = events.Select(@event =>
+        var eventsAndContexts = events.Select((@event, index) =>
         {
             var context = EventContext.From(
                 EventStoreName.NotSet,
@@ -49,13 +52,22 @@ internal static class ReducerReadModelProcessor
                 @event.EventSourceId,
                 @event.EventStreamType,
                 @event.EventStreamId,
-                EventSequenceNumber.First,
+                (EventSequenceNumber)(ulong)index,
                 CorrelationId.NotSet);
 
             return new EventAndContext(@event.Event, context);
         });
 
-        var result = await invoker.Invoke(serviceProvider, eventsAndContexts, null);
+        var result = await invoker.Invoke(serviceProvider, eventsAndContexts, initialState);
+
+        // A reducer that raised an error must not surface its partial state as a successful projection —
+        // the real reducer pipeline discards the result and pauses the partition. Fail loud instead so the
+        // reducer bug is visible in the spec rather than masquerading as a (wrong) read model.
+        if (!result.IsSuccess)
+        {
+            throw new ReducerFailed(readModelType, result.ErrorMessages, result.StackTrace);
+        }
+
         return result.ReadModelState as TReadModel;
     }
 }


### PR DESCRIPTION
# Summary
`ReadModelScenario`, the in-process read model testing harness, diverged from the real Chronicle runtime in a few ways that could let read model specs pass while the modeled behavior was actually wrong — and could hide reducer bugs entirely. These fixes bring it in line with runtime behavior for read model removal, reducer initial state, reducer failures, and event sequence numbers.

## Fixed
- `ReadModelScenario` now reflects a root-level removal: a class-level `[RemovedWith]` (and `[ClearWith]` on a `[Nested]`) makes `Instance` resolve to `null` instead of returning the stale pre-removal state.
- `ReadModelScenario` now seeds reducer-backed read models with the provided initial state instead of always starting the reducer from `null`.
- `ReadModelScenario` now surfaces a failing reducer (throwing `ReducerFailed`) instead of returning the reducer's partial state as a successful result.
- `ReadModelScenario` now assigns increasing per-event sequence numbers to a reducer's `EventContext` instead of the first sequence number for every event.