### PR TITLE
Fix model-bound projection and ReadModelScenario fidelity bugs

### DIFF
--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/given/an_ambiguous_children_parent_key_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/given/an_ambiguous_children_parent_key_analyzer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer.given;
+
+public class an_ambiguous_children_parent_key_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using System.Collections.Generic;",
+            "using Cratis.Chronicle.Projections.ModelBound;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Projections.ModelBound",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]",
+            "    public sealed class ChildrenFromAttribute<TEvent> : Attribute",
+            "    {",
+            "        public ChildrenFromAttribute(string? key = null, string? identifiedBy = null, string? parentKey = null) { }",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_only_one_other_property_matches.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_only_one_other_property_matches.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer.when_analyzing_children_from;
+
+public class and_only_one_other_property_matches : given.an_ambiguous_children_parent_key_analyzer
+{
+    const string Usage = """
+    public record Recorded(Guid AccountId, Guid Ticket);
+
+    public record Line(Guid Ticket);
+
+    public record Ledger(
+        Guid Id,
+        [ChildrenFrom<Recorded>(key: "Ticket")] IEnumerable<Line> Items);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_parent_key_is_ambiguous.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_parent_key_is_ambiguous.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer.when_analyzing_children_from;
+
+public class and_parent_key_is_ambiguous : given.an_ambiguous_children_parent_key_analyzer
+{
+    const string Usage = """
+    public record Recorded(Guid AccountId, Guid CustomerId, Guid Ticket);
+
+    public record Line(Guid Ticket);
+
+    public record Ledger(
+        Guid Id,
+        {|#0:[ChildrenFrom<Recorded>(key: "Ticket")] IEnumerable<Line> Items|});
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.AmbiguousChildrenParentKey, DiagnosticSeverity.Warning, "Recorded", "Guid"));
+
+    [Fact] Task should_report_the_ambiguous_parent_key_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_parent_key_is_specified.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_parent_key_is_specified.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer.when_analyzing_children_from;
+
+public class and_parent_key_is_specified : given.an_ambiguous_children_parent_key_analyzer
+{
+    const string Usage = """
+    public record Recorded(Guid AccountId, Guid CustomerId, Guid Ticket);
+
+    public record Line(Guid Ticket);
+
+    public record Ledger(
+        Guid Id,
+        [ChildrenFrom<Recorded>(key: "Ticket", parentKey: "AccountId")] IEnumerable<Line> Items);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_the_child_key_is_the_only_match.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_analyzing_children_from/and_the_child_key_is_the_only_match.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer.when_analyzing_children_from;
+
+public class and_the_child_key_is_the_only_match : given.an_ambiguous_children_parent_key_analyzer
+{
+    const string Usage = """
+    public record Recorded(Guid Ticket, string Name);
+
+    public record Line(Guid Ticket);
+
+    public record Ledger(
+        Guid Id,
+        [ChildrenFrom<Recorded>(key: "Ticket")] IEnumerable<Line> Items);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_AmbiguousChildrenParentKeyAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_AmbiguousChildrenParentKeyAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.AmbiguousChildrenParentKeyAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0023_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.AmbiguousChildrenParentKey).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/AmbiguousChildrenParentKeyAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/AmbiguousChildrenParentKeyAnalyzer.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that warns when a model-bound <c>[ChildrenFrom]</c> collection omits <c>parentKey</c> and the
+/// parent key cannot be inferred unambiguously because the event has more than one property of the parent
+/// read model's identifier type.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AmbiguousChildrenParentKeyAnalyzer : DiagnosticAnalyzer
+{
+    const string ChildrenFromAttributeName = "ChildrenFromAttribute";
+    const string ModelBoundNamespace = "Cratis.Chronicle.Projections.ModelBound";
+    const string KeyParameterName = "key";
+    const string ParentKeyParameterName = "parentKey";
+    const string IdentifierName = "Id";
+
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.AmbiguousChildrenParentKey,
+        title: "Ambiguous parent key for [ChildrenFrom] collection",
+        messageFormat: "Cannot unambiguously infer the parent key for the [ChildrenFrom] collection '{0}': event '{1}' has more than one property of the parent identifier type '{2}'. Specify the parent key explicitly via the 'parentKey' argument.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When a [ChildrenFrom] collection omits parentKey, Chronicle infers it by matching the parent read model's identifier type against the event's properties (excluding the child key). When more than one property still matches, the inference is ambiguous and resolves by declaration order, which is fragile. Specify the parentKey argument to make the relationship explicit.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        var identifierType = GetIdentifierType(typeSymbol);
+        if (identifierType is null)
+        {
+            return;
+        }
+
+        foreach (var (member, attribute) in GetChildrenFromAttributes(typeSymbol))
+        {
+            AnalyzeChildrenFrom(context, member, attribute, identifierType);
+        }
+    }
+
+    static void AnalyzeChildrenFrom(SymbolAnalysisContext context, ISymbol member, AttributeData attribute, ITypeSymbol identifierType)
+    {
+        if (attribute.AttributeClass is not { TypeArguments.Length: 1 } attributeClass ||
+            attributeClass.TypeArguments[0] is not INamedTypeSymbol eventType)
+        {
+            return;
+        }
+
+        var (childKey, parentKey, resolved) = ReadKeyArguments(attribute);
+
+        // Only inference is at risk — an explicit parentKey (or unreadable arguments) is left alone.
+        if (!resolved || parentKey is not null)
+        {
+            return;
+        }
+
+        var matches = eventType.GetMembers()
+            .OfType<IPropertySymbol>()
+            .Where(property =>
+                !property.IsStatic &&
+                SymbolEqualityComparer.Default.Equals(property.Type, identifierType) &&
+                !string.Equals(property.Name, childKey, System.StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (matches.Length < 2)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            member.Locations.FirstOrDefault(),
+            member.Name,
+            eventType.Name,
+            identifierType.Name));
+    }
+
+    static ITypeSymbol? GetIdentifierType(INamedTypeSymbol typeSymbol) =>
+        typeSymbol.GetMembers()
+            .OfType<IPropertySymbol>()
+            .FirstOrDefault(property => !property.IsStatic && string.Equals(property.Name, IdentifierName, System.StringComparison.OrdinalIgnoreCase))
+            ?.Type;
+
+    static IEnumerable<(ISymbol Member, AttributeData Attribute)> GetChildrenFromAttributes(INamedTypeSymbol typeSymbol)
+    {
+        foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>())
+        {
+            foreach (var attribute in property.GetAttributes().Where(IsChildrenFrom))
+            {
+                yield return (property, attribute);
+            }
+        }
+
+        // For a positional record, [ChildrenFrom] without an explicit target lands on the constructor
+        // parameter rather than the generated property, so the parameters must be inspected too.
+        var primaryConstructor = typeSymbol.InstanceConstructors
+            .OrderByDescending(constructor => constructor.Parameters.Length)
+            .FirstOrDefault();
+
+        if (primaryConstructor is not null)
+        {
+            foreach (var parameter in primaryConstructor.Parameters)
+            {
+                foreach (var attribute in parameter.GetAttributes().Where(IsChildrenFrom))
+                {
+                    yield return (parameter, attribute);
+                }
+            }
+        }
+    }
+
+    static bool IsChildrenFrom(AttributeData attribute) =>
+        attribute.AttributeClass is { } attributeClass &&
+        string.Equals(attributeClass.Name, ChildrenFromAttributeName, System.StringComparison.Ordinal) &&
+        attributeClass.ContainingNamespace?.ToDisplayString() == ModelBoundNamespace;
+
+    static (string? ChildKey, string? ParentKey, bool Resolved) ReadKeyArguments(AttributeData attribute)
+    {
+        var constructor = attribute.AttributeConstructor;
+        if (constructor is null)
+        {
+            return (null, null, false);
+        }
+
+        string? childKey = null;
+        string? parentKey = null;
+        var arguments = attribute.ConstructorArguments;
+
+        for (var i = 0; i < constructor.Parameters.Length && i < arguments.Length; i++)
+        {
+            var value = arguments[i].Value as string;
+            switch (constructor.Parameters[i].Name)
+            {
+                case KeyParameterName:
+                    childKey = value;
+                    break;
+
+                case ParentKeyParameterName:
+                    parentKey = value;
+                    break;
+            }
+        }
+
+        return (childKey, parentKey, true);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -117,4 +117,9 @@ public static class DiagnosticIds
     /// Reactor methods that return event side effects must be marked with [OnceOnly] attribute.
     /// </summary>
     public const string ReactorReturningEventsMustBeOnceOnly = "CHR0022";
+
+    /// <summary>
+    /// A [ChildrenFrom] collection that omits parentKey has an ambiguous parent key inference.
+    /// </summary>
+    public const string AmbiguousChildrenParentKey = "CHR0023";
 }

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_multiple_other_properties_match_the_parent_id_type.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_multiple_other_properties_match_the_parent_id_type.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_children_from;
+
+public class and_multiple_other_properties_match_the_parent_id_type : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(MultiGuidRecorded)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(MultiGuidLedger));
+
+    [Fact] void should_have_children_definition() => _result.Children.Count.ShouldEqual(1);
+
+    [Fact]
+    void should_use_the_first_non_child_property_as_parent_key()
+    {
+        // The child key is excluded; among the remaining same-typed candidates the inference is ambiguous,
+        // so the first by declaration order is used (an explicit parentKey disambiguates).
+        var eventType = event_types.GetEventTypeFor(typeof(MultiGuidRecorded)).ToContract();
+        var fromDef = _result.Children[nameof(MultiGuidLedger.Items)].From.Single(kvp => kvp.Key.IsEqual(eventType)).Value;
+        fromDef.ParentKey.ShouldEqual(nameof(MultiGuidRecorded.AccountId));
+    }
+}
+
+[EventType]
+public record MultiGuidRecorded(Guid AccountId, Guid CustomerId, Guid Ticket, decimal Amount);
+
+public record MultiGuidLine([Key] Guid Ticket, decimal Amount);
+
+public record MultiGuidLedger(
+    Guid Id,
+    [ChildrenFrom<MultiGuidRecorded>(key: nameof(MultiGuidRecorded.Ticket), identifiedBy: nameof(MultiGuidLine.Ticket))]
+    IEnumerable<MultiGuidLine> Items);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_one_other_property_matches_the_parent_id_type.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_one_other_property_matches_the_parent_id_type.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_children_from;
+
+public class and_one_other_property_matches_the_parent_id_type : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(OwnedGuidRecorded)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(OwnedGuidLedger));
+
+    [Fact] void should_have_children_definition() => _result.Children.Count.ShouldEqual(1);
+
+    [Fact]
+    void should_use_the_single_non_child_property_as_parent_key()
+    {
+        // The child key is excluded, leaving exactly one Guid-typed candidate (the parent reference).
+        var eventType = event_types.GetEventTypeFor(typeof(OwnedGuidRecorded)).ToContract();
+        var fromDef = _result.Children[nameof(OwnedGuidLedger.Items)].From.Single(kvp => kvp.Key.IsEqual(eventType)).Value;
+        fromDef.ParentKey.ShouldEqual(nameof(OwnedGuidRecorded.OwnerId));
+    }
+}
+
+[EventType]
+public record OwnedGuidRecorded(Guid OwnerId, Guid Ticket, decimal Amount);
+
+public record OwnedGuidLine([Key] Guid Ticket, decimal Amount);
+
+public record OwnedGuidLedger(
+    Guid Id,
+    [ChildrenFrom<OwnedGuidRecorded>(key: nameof(OwnedGuidRecorded.Ticket), identifiedBy: nameof(OwnedGuidLine.Ticket))]
+    IEnumerable<OwnedGuidLine> Items);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_only_the_child_key_matches_the_parent_id_type.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/and_only_the_child_key_matches_the_parent_id_type.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_children_from;
+
+public class and_only_the_child_key_matches_the_parent_id_type : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(SoleGuidRecorded)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(SoleGuidLedger));
+
+    [Fact] void should_have_children_definition() => _result.Children.Count.ShouldEqual(1);
+
+    [Fact]
+    void should_default_parent_key_to_event_source_id()
+    {
+        // The only Guid-typed event property is the child key itself, which is excluded from
+        // parent-key inference — so there is no candidate and it falls back to the event source.
+        var eventType = event_types.GetEventTypeFor(typeof(SoleGuidRecorded)).ToContract();
+        var fromDef = _result.Children[nameof(SoleGuidLedger.Items)].From.Single(kvp => kvp.Key.IsEqual(eventType)).Value;
+        fromDef.ParentKey.ShouldEqual(WellKnownExpressions.EventSourceId);
+    }
+}
+
+[EventType]
+public record SoleGuidRecorded(Guid Ticket, decimal Amount);
+
+public record SoleGuidLine([Key] Guid Ticket, decimal Amount);
+
+public record SoleGuidLedger(
+    Guid Id,
+    [ChildrenFrom<SoleGuidRecorded>(key: nameof(SoleGuidRecorded.Ticket), identifiedBy: nameof(SoleGuidLine.Ticket))]
+    IEnumerable<SoleGuidLine> Items);

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_from_all/and_it_is_on_a_positional_record_property.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_from_all/and_it_is_on_a_positional_record_property.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_from_all;
+
+public class and_it_is_on_a_positional_record_property : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(ThingHappened)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(ThingTimeline));
+
+    [Fact]
+    void should_pick_up_the_property_targeted_from_all()
+    {
+        // [property: FromAll] on a positional record parameter applies to the generated property — the
+        // only way to place the property-only [FromAll] there — and must still be picked up.
+        _result.All.Properties.Count.ShouldEqual(1);
+    }
+
+    [Fact]
+    void should_map_it_as_a_context_property()
+    {
+        // Mapped as a CONTEXT property ($eventContext(...)), not mis-converted into an event-property
+        // lookup — the FromAll to FromEvery argument order must not be swapped.
+        _result.All.Properties.Values.Single().ShouldEqual($"{WellKnownExpressions.EventContext}(Occurred)");
+    }
+}
+
+[EventType]
+public record ThingHappened(string Name);
+
+public record ThingTimeline(
+    Guid Id,
+    string Name,
+    [property: FromAll(contextProperty: nameof(EventContext.Occurred))]
+    DateTimeOffset? LastUpdatedAt);

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -147,7 +147,7 @@ static class ChildrenDefinitionExtensions
 
         var key = keyProperty?.GetValue(attr) as string ?? WellKnownExpressions.EventSourceId;
         var explicitParentKey = parentKeyProperty?.GetValue(attr) as string;
-        var discoveredParentKey = explicitParentKey is null ? DiscoverEventPropertyForParentId(eventType, parentModelType, namingPolicy) : null;
+        var discoveredParentKey = explicitParentKey is null ? DiscoverEventPropertyForParentId(eventType, parentModelType, key, namingPolicy) : null;
         var parentKey = explicitParentKey ?? discoveredParentKey ?? WellKnownExpressions.EventSourceId;
 
         var childType = GetChildType(memberType);
@@ -687,51 +687,62 @@ static class ChildrenDefinitionExtensions
         return WellKnownExpressions.EventSourceId;
     }
 
-    static string? DiscoverEventPropertyForParentId(Type eventType, Type? parentModelType, INamingPolicy namingPolicy)
+    /// <summary>
+    /// Infers the event property to use as the parent key for a <c>[ChildrenFrom]</c> collection when no
+    /// explicit <c>parentKey</c> is supplied, by matching the parent read model's identifier type.
+    /// </summary>
+    /// <param name="eventType">The event type the children are built from.</param>
+    /// <param name="parentModelType">The parent read model type, or <see langword="null"/> when unavailable.</param>
+    /// <param name="childKey">The child key property name, excluded from the candidates.</param>
+    /// <param name="namingPolicy">The <see cref="INamingPolicy"/> used to shape the resolved property name.</param>
+    /// <returns>
+    /// The inferred parent-key property name, or <see langword="null"/> when no candidate matches (the caller
+    /// then falls back to <see cref="WellKnownExpressions.EventSourceId"/> for the same-event-source case).
+    /// </returns>
+    /// <remarks>
+    /// The child <paramref name="childKey"/> property is excluded from the candidates — a property is the
+    /// child's own key or the parent reference, never both. When more than one property still matches the
+    /// parent identifier type the inference is ambiguous and the first by declaration order is used; supply
+    /// an explicit <c>parentKey</c> to disambiguate.
+    /// </remarks>
+    static string? DiscoverEventPropertyForParentId(Type eventType, Type? parentModelType, string childKey, INamingPolicy namingPolicy)
     {
         if (parentModelType is null)
         {
             return null;
         }
 
-        // First, find the parent model's Id property and its type
-        var parentIdProperty = parentModelType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(p => p.Name.Equals("Id", StringComparison.OrdinalIgnoreCase));
-
-        if (parentIdProperty is null)
+        var parentIdType = GetIdentifierType(parentModelType);
+        if (parentIdType is null)
         {
-            // Check constructor parameters for record types
-            var constructor = parentModelType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
-                .OrderByDescending(c => c.GetParameters().Length)
-                .FirstOrDefault();
-
-            var idParameter = constructor?.GetParameters()
-                .FirstOrDefault(p => p.Name?.Equals("Id", StringComparison.OrdinalIgnoreCase) == true);
-
-            if (idParameter is null)
-            {
-                return null;
-            }
-
-            // Get the type from constructor parameter
-            var parentIdType = idParameter.ParameterType;
-
-            // Search event for a property with matching type
-            var matchingEventProperty = eventType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(p => p.PropertyType == parentIdType);
-
-            return matchingEventProperty is not null
-                ? namingPolicy.GetPropertyName(new PropertyPath(matchingEventProperty.Name))
-                : null;
+            return null;
         }
 
-        // Search event for a property with matching type
-        var eventProperty = eventType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(p => p.PropertyType == parentIdProperty.PropertyType);
+        var match = Array.Find(
+            eventType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
+            p => p.PropertyType == parentIdType && !p.Name.Equals(childKey, StringComparison.OrdinalIgnoreCase));
 
-        return eventProperty is not null
-            ? namingPolicy.GetPropertyName(new PropertyPath(eventProperty.Name))
+        return match is not null
+            ? namingPolicy.GetPropertyName(new PropertyPath(match.Name))
             : null;
+    }
+
+    static Type? GetIdentifierType(Type modelType)
+    {
+        var idProperty = modelType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(p => p.Name.Equals("Id", StringComparison.OrdinalIgnoreCase));
+        if (idProperty is not null)
+        {
+            return idProperty.PropertyType;
+        }
+
+        var constructor = modelType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        return constructor?.GetParameters()
+            .FirstOrDefault(p => p.Name?.Equals("Id", StringComparison.OrdinalIgnoreCase) == true)
+            ?.ParameterType;
     }
 
     static string ConvertValueToInvariantString(object value)

--- a/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionBuilder.cs
@@ -256,12 +256,21 @@ internal class ModelBoundProjectionBuilder(
     {
         foreach (var property in modelType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
-            if (primaryConstructor?.GetParameters().Any(p => p.Name?.Equals(property.Name, StringComparison.OrdinalIgnoreCase) == true) == true)
-            {
-                continue;
-            }
+            var isConstructorParameter = primaryConstructor?.GetParameters()
+                .Any(p => p.Name?.Equals(property.Name, StringComparison.OrdinalIgnoreCase) == true) == true;
 
-            ProcessMember(property, definition, classLevelFromEvents, isRoot: true, modelType: modelType);
+            // A positional record's properties are also constructor parameters, already handled by
+            // ProcessRecord. But an attribute applied to the generated PROPERTY via `[property:]` — the
+            // only way to place a property-only attribute such as [FromAll] on a positional parameter — is
+            // not visible on the parameter, so it must still be processed here. Parameter-targeted and
+            // property-targeted attributes are disjoint, so this does not double-process. Class-level
+            // FromEvent wiring was already applied by the parameter pass, so pass none for those members.
+            ProcessMember(
+                property,
+                definition,
+                isConstructorParameter ? [] : classLevelFromEvents,
+                isRoot: true,
+                modelType: modelType);
         }
     }
 
@@ -403,7 +412,7 @@ internal class ModelBoundProjectionBuilder(
         var fromAllAttr = parameter.GetCustomAttribute<FromAllAttribute>();
         if (fromAllAttr is not null)
         {
-            _fromEveryAttributes.Add((propertyName, new FromEveryAttribute(fromAllAttr.ContextProperty, fromAllAttr.Property)));
+            _fromEveryAttributes.Add((propertyName, new FromEveryAttribute(property: fromAllAttr.Property, contextProperty: fromAllAttr.ContextProperty)));
         }
     }
 
@@ -529,7 +538,7 @@ internal class ModelBoundProjectionBuilder(
         var fromAllAttr = property.GetCustomAttribute<FromAllAttribute>();
         if (fromAllAttr is not null)
         {
-            _fromEveryAttributes.Add((propertyName, new FromEveryAttribute(fromAllAttr.ContextProperty, fromAllAttr.Property)));
+            _fromEveryAttributes.Add((propertyName, new FromEveryAttribute(property: fromAllAttr.Property, contextProperty: fromAllAttr.ContextProperty)));
         }
     }
 }

--- a/Source/Clients/Testing.Specs/ReadModels/BucketAmountRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/BucketAmountRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a numbered bucket, keyed by an <see cref="int"/>.
+/// </summary>
+/// <param name="Bucket">The bucket number, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record BucketAmountRecorded(int Bucket, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/BucketLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/BucketLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by an <see cref="int"/> payload value (children on the same
+/// event source as the parent), used to verify the in-memory harness materializes <see cref="int"/>-keyed
+/// child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Buckets">Bucket lines keyed by <see cref="BucketAmountRecorded.Bucket"/> (an <see cref="int"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record BucketLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<BucketAmountRecorded>(key: nameof(BucketAmountRecorded.Bucket))]
+    IEnumerable<BucketLine> Buckets);

--- a/Source/Clients/Testing.Specs/ReadModels/BucketLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/BucketLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by an <see cref="int"/> bucket number.
+/// </summary>
+/// <param name="Bucket">The bucket number, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record BucketLine(
+    int Bucket,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/DayEntry.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/DayEntry.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child entry for a single worked day on a <see cref="Sheet"/>.
+/// </summary>
+/// <param name="Day">The business day, used as the child key.</param>
+/// <param name="Hours">The number of hours worked.</param>
+public record DayEntry(
+    DateOnly Day,
+    decimal Hours);

--- a/Source/Clients/Testing.Specs/ReadModels/DayWorked.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/DayWorked.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for recording hours worked on a specific day.
+/// </summary>
+/// <param name="Day">The business day the hours were worked, used as the child key.</param>
+/// <param name="Hours">The number of hours worked.</param>
+[EventType]
+public record DayWorked(DateOnly Day, decimal Hours);

--- a/Source/Clients/Testing.Specs/ReadModels/IncidentLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/IncidentLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="Severity"/> enum payload value (children on the
+/// same event source as the parent), used to verify the in-memory harness materializes enum-keyed child
+/// collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Incidents">Incident lines keyed by <see cref="IncidentRecorded.Level"/> (a <see cref="Severity"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record IncidentLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<IncidentRecorded>(key: nameof(IncidentRecorded.Level))]
+    IEnumerable<IncidentLine> Incidents);

--- a/Source/Clients/Testing.Specs/ReadModels/IncidentLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/IncidentLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="Severity"/> enum.
+/// </summary>
+/// <param name="Level">The severity level, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record IncidentLine(
+    Severity Level,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/IncidentRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/IncidentRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a severity, keyed by a <see cref="Severity"/> enum.
+/// </summary>
+/// <param name="Level">The severity level, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record IncidentRecorded(Severity Level, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/LabelLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/LabelLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="string"/> payload value (children on the same
+/// event source as the parent), used to verify the in-memory harness materializes <see cref="string"/>-keyed
+/// child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Labels">Label lines keyed by <see cref="LabelRecorded.Label"/> (a <see cref="string"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record LabelLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<LabelRecorded>(key: nameof(LabelRecorded.Label))]
+    IEnumerable<LabelLine> Labels);

--- a/Source/Clients/Testing.Specs/ReadModels/LabelLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/LabelLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="string"/> label.
+/// </summary>
+/// <param name="Label">The label, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record LabelLine(
+    string Label,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/LabelRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/LabelRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a textual label, keyed by a <see cref="string"/>.
+/// </summary>
+/// <param name="Label">The label, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record LabelRecorded(string Label, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/LedgerOpened.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/LedgerOpened.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for opening a ledger.
+/// </summary>
+/// <param name="Name">The ledger name.</param>
+[EventType]
+public record LedgerOpened(string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/SameSourceTicketLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SameSourceTicketLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a bare (non-concept) <see cref="Guid"/> on the SAME event
+/// source as the parent, with no explicit <c>parentKey</c>. Because the child key is excluded from
+/// parent-key inference, this resolves to the event source — exercising the parent-key discovery fix.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Tickets">Ticket lines keyed by <see cref="TicketLogged.Ticket"/> (a bare <see cref="Guid"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record SameSourceTicketLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<TicketLogged>(key: nameof(TicketLogged.Ticket), identifiedBy: nameof(TicketLine.Ticket))]
+    IEnumerable<TicketLine> Tickets);

--- a/Source/Clients/Testing.Specs/ReadModels/Severity.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/Severity.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Severity classification used as an enum child key.
+/// </summary>
+public enum Severity
+{
+    /// <summary>
+    /// Unset severity.
+    /// </summary>
+    Unset = 0,
+
+    /// <summary>
+    /// Low severity.
+    /// </summary>
+    Low = 1,
+
+    /// <summary>
+    /// High severity.
+    /// </summary>
+    High = 2
+}

--- a/Source/Clients/Testing.Specs/ReadModels/Sheet.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/Sheet.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Root read model projected from <see cref="SheetStarted"/> with a child collection keyed by a
+/// <see cref="DateOnly"/> value, used to verify that the in-memory harness materializes child
+/// collections keyed by non-concept value-type primitives.
+/// </summary>
+/// <param name="Id">Sheet identifier.</param>
+/// <param name="Year">The year the sheet covers.</param>
+/// <param name="Days">Day entries keyed by <see cref="DayWorked.Day"/>.</param>
+[Passive]
+[FromEvent<SheetStarted>]
+public record Sheet(
+    SheetId Id,
+    int Year,
+
+    [ChildrenFrom<DayWorked>(key: nameof(DayWorked.Day))]
+    IEnumerable<DayEntry> Days);

--- a/Source/Clients/Testing.Specs/ReadModels/SheetId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SheetId.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Identifier for a <see cref="Sheet"/>.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record SheetId(Guid Value) : EventSourceId<Guid>(Value)
+{
+    /// <summary>
+    /// Represents an unset <see cref="SheetId"/>.
+    /// </summary>
+    public static readonly SheetId NotSet = new(Guid.Empty);
+
+    /// <summary>
+    /// Creates a new <see cref="SheetId"/>.
+    /// </summary>
+    /// <returns>A new <see cref="SheetId"/>.</returns>
+    public static SheetId New() => new(Guid.NewGuid());
+
+    /// <summary>
+    /// Implicitly converts a <see cref="Guid"/> to a <see cref="SheetId"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> to convert.</param>
+    public static implicit operator SheetId(Guid value) => new(value);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/SheetStarted.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SheetStarted.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for starting a timesheet.
+/// </summary>
+/// <param name="Year">The year the sheet covers.</param>
+[EventType]
+public record SheetStarted(int Year);

--- a/Source/Clients/Testing.Specs/ReadModels/SlotAmountRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SlotAmountRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a time-of-day slot, keyed by a <see cref="TimeOnly"/>.
+/// </summary>
+/// <param name="Slot">The time-of-day slot, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record SlotAmountRecorded(TimeOnly Slot, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/SlotLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SlotLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="TimeOnly"/> slot.
+/// </summary>
+/// <param name="Slot">The time-of-day slot, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record SlotLine(
+    TimeOnly Slot,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/ThingActivity.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ThingActivity.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a <c>[property: FromEvery]</c> context mapping on a positional record parameter, used
+/// to verify the harness fires <c>[FromEvery]</c> — the sibling of <c>[FromAll]</c> — for every event.
+/// </summary>
+/// <param name="Id">Thing identifier.</param>
+/// <param name="Name">The thing's name.</param>
+/// <param name="LastActivityAt">When the thing last saw ANY event — projected from every event.</param>
+[Passive]
+[FromEvent<ThingOpened>]
+[FromEvent<ThingTouched>]
+public record ThingActivity(
+    Guid Id,
+    string Name,
+
+    [property: FromEvery(contextProperty: nameof(EventContext.Occurred))]
+    DateTimeOffset? LastActivityAt);

--- a/Source/Clients/Testing.Specs/ReadModels/ThingOpened.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ThingOpened.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event opening a thing — an explicitly-subscribed event for the FromAll harness specs.
+/// </summary>
+/// <param name="Name">The thing's name.</param>
+[EventType]
+public record ThingOpened(string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/ThingSummary.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ThingSummary.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model that mixes an explicitly-subscribed mapping (<see cref="OpenedAt"/> via
+/// <c>[SetFromContext]</c>) with a global <c>[FromAll]</c> mapping (<see cref="LastUpdatedAt"/>), used to
+/// verify the in-memory harness fires <c>[FromAll]</c> for every event the same way the real runtime does.
+/// </summary>
+/// <param name="Id">Thing identifier.</param>
+/// <param name="Name">The thing's name.</param>
+/// <param name="OpenedAt">When the thing was opened — set from the opening event's context.</param>
+/// <param name="LastUpdatedAt">When the thing was last touched by ANY event — projected from all events.</param>
+[Passive]
+[FromEvent<ThingOpened>]
+[FromEvent<ThingTouched>]
+public record ThingSummary(
+    Guid Id,
+    string Name,
+
+    [property: SetFromContext<ThingOpened>(nameof(EventContext.Occurred))]
+    DateTimeOffset OpenedAt,
+
+    [property: FromAll(contextProperty: nameof(EventContext.Occurred))]
+    DateTimeOffset? LastUpdatedAt);

--- a/Source/Clients/Testing.Specs/ReadModels/ThingTouched.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ThingTouched.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event touching a thing — an event the read model only observes via <c>[FromAll]</c>, never an
+/// explicit <c>[FromEvent]</c> subscription.
+/// </summary>
+/// <param name="Note">A note about the touch.</param>
+[EventType]
+public record ThingTouched(string Note);

--- a/Source/Clients/Testing.Specs/ReadModels/TicketLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TicketLedger.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a bare (non-concept) <see cref="Guid"/>, used to verify
+/// the in-memory harness materializes <see cref="Guid"/>-keyed child collections. A bare <see cref="Guid"/>
+/// child key is treated by Chronicle as an event-source reference, so — matching the real runtime — the
+/// children are appended to their own event source and linked to the parent via an explicit
+/// <see cref="ChildrenFromAttribute{TEvent}.ParentKey"/>.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Tickets">Ticket lines keyed by <see cref="TicketRaised.Ticket"/> (a bare <see cref="Guid"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record TicketLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<TicketRaised>(
+        key: nameof(TicketRaised.Ticket),
+        identifiedBy: nameof(TicketLine.Ticket),
+        parentKey: nameof(TicketRaised.LedgerId))]
+    IEnumerable<TicketLine> Tickets);

--- a/Source/Clients/Testing.Specs/ReadModels/TicketLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TicketLine.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a bare (non-concept) <see cref="Guid"/> ticket identifier.
+/// </summary>
+/// <param name="Ticket">The ticket identifier, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record TicketLine(
+    [Key] Guid Ticket,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/TicketLogged.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TicketLogged.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording a ticket on the same event source as its parent ledger, carrying only the
+/// bare (non-concept) <see cref="Guid"/> child key and no parent reference.
+/// </summary>
+/// <param name="Ticket">The ticket identifier, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record TicketLogged(Guid Ticket, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/TicketRaised.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TicketRaised.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording a ticket against a ledger, keyed by a bare (non-concept) <see cref="Guid"/>.
+/// The ticket is appended to its own event source; <paramref name="LedgerId"/> links it to the parent.
+/// </summary>
+/// <param name="LedgerId">The parent ledger identifier (used as the parent key).</param>
+/// <param name="Ticket">The ticket identifier, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record TicketRaised(Guid LedgerId, Guid Ticket, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/TimeLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/TimeLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="TimeOnly"/> payload value (children on the
+/// same event source as the parent), used to verify the in-memory harness materializes
+/// <see cref="TimeOnly"/>-keyed child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Slots">Slot lines keyed by <see cref="SlotAmountRecorded.Slot"/> (a <see cref="TimeOnly"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record TimeLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<SlotAmountRecorded>(key: nameof(SlotAmountRecorded.Slot))]
+    IEnumerable<SlotLine> Slots);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_from_all/a_from_all_property_maps_a_context_property.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_from_all/a_from_all_property_maps_a_context_property.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_from_all;
+
+/// <summary>
+/// A read model with a <c>[FromAll]</c> property must update that property for EVERY driven event — both
+/// the explicitly-subscribed one and the one observed only through <c>[FromAll]</c> — exactly like runtime.
+/// </summary>
+public class a_from_all_property_maps_a_context_property : Specification
+{
+    ReadModelScenario<ThingSummary> _scenario;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ThingSummary>();
+        _id = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_id)
+            .Events(
+                new ThingOpened("Acme"),
+                new ThingTouched("poke"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_map_the_explicitly_subscribed_property() => _scenario.Instance!.Name.ShouldEqual("Acme");
+    [Fact] void should_capture_opened_at_from_the_opening_event() => _scenario.Instance!.OpenedAt.ShouldNotEqual(default);
+    [Fact] void should_populate_the_from_all_property() => _scenario.Instance!.LastUpdatedAt.ShouldNotBeNull();
+    [Fact] void should_track_the_latest_event_in_the_from_all_property() => (_scenario.Instance!.LastUpdatedAt > _scenario.Instance!.OpenedAt).ShouldBeTrue();
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_from_all/a_from_every_property_maps_a_context_property.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_from_all/a_from_every_property_maps_a_context_property.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_from_all;
+
+/// <summary>
+/// A <c>[FromEvery]</c> property — the sibling of <c>[FromAll]</c> — must update for every driven event,
+/// the same way the real runtime does.
+/// </summary>
+public class a_from_every_property_maps_a_context_property : Specification
+{
+    ReadModelScenario<ThingActivity> _scenario;
+    EventSourceId _id;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ThingActivity>();
+        _id = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_id)
+            .Events(
+                new ThingOpened("Acme"),
+                new ThingTouched("poke"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_populate_the_from_every_property() => _scenario.Instance!.LastActivityAt.ShouldNotBeNull();
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_date_only : Specification
+{
+    ReadModelScenario<Sheet> _scenario;
+    SheetId _sheetId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<Sheet>();
+        _sheetId = SheetId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sheetId)
+            .Events(
+                new SheetStarted(2026),
+                new DayWorked(new DateOnly(2026, 6, 1), 7.5m),
+                new DayWorked(new DateOnly(2026, 6, 2), 8m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_day_entries() => _scenario.Instance!.Days.Count().ShouldEqual(2);
+    [Fact] void should_map_first_day() => _scenario.Instance!.Days.First().Day.ShouldEqual(new DateOnly(2026, 6, 1));
+    [Fact] void should_map_first_day_hours() => _scenario.Instance!.Days.First().Hours.ShouldEqual(7.5m);
+    [Fact] void should_map_second_day() => _scenario.Instance!.Days.Last().Day.ShouldEqual(new DateOnly(2026, 6, 2));
+    [Fact] void should_map_second_day_hours() => _scenario.Instance!.Days.Last().Hours.ShouldEqual(8m);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_enum.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_enum.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_enum : Specification
+{
+    ReadModelScenario<IncidentLedger> _scenario;
+    EventSourceId _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<IncidentLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new IncidentRecorded(Severity.Low, 1m),
+                new IncidentRecorded(Severity.High, 2m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_incident_lines() => _scenario.Instance!.Incidents.Count().ShouldEqual(2);
+    [Fact] void should_map_first_incident_key() => _scenario.Instance!.Incidents.First().Level.ShouldEqual(Severity.Low);
+    [Fact] void should_map_first_incident_amount() => _scenario.Instance!.Incidents.First().Amount.ShouldEqual(1m);
+    [Fact] void should_map_second_incident_key() => _scenario.Instance!.Incidents.Last().Level.ShouldEqual(Severity.High);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_guid.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_guid.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_guid : Specification
+{
+    ReadModelScenario<TicketLedger> _scenario;
+    EventSourceId _ledgerId;
+    Guid _ledgerGuid;
+    Guid _firstTicket;
+    Guid _secondTicket;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<TicketLedger>();
+        _ledgerGuid = Guid.NewGuid();
+        _ledgerId = new EventSourceId(_ledgerGuid);
+        _firstTicket = Guid.NewGuid();
+        _secondTicket = Guid.NewGuid();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(new LedgerOpened("Operations"));
+
+        await _scenario.Given
+            .ForEventSource(_firstTicket)
+            .Events(new TicketRaised(_ledgerGuid, _firstTicket, 100m));
+
+        await _scenario.Given
+            .ForEventSource(_secondTicket)
+            .Events(new TicketRaised(_ledgerGuid, _secondTicket, 200m));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_ticket_lines() => _scenario.Instance!.Tickets.Count().ShouldEqual(2);
+    [Fact] void should_map_first_ticket_key() => _scenario.Instance!.Tickets.First().Ticket.ShouldEqual(_firstTicket);
+    [Fact] void should_map_first_ticket_amount() => _scenario.Instance!.Tickets.First().Amount.ShouldEqual(100m);
+    [Fact] void should_map_second_ticket_key() => _scenario.Instance!.Tickets.Last().Ticket.ShouldEqual(_secondTicket);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_guid_on_the_same_event_source.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_guid_on_the_same_event_source.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// A bare <see cref="Guid"/> child key on the same event source as the parent, with no explicit parentKey.
+/// Parent-key inference excludes the child key, finds no other candidate, and falls back to the event
+/// source — so the children resolve. (Before the discovery fix this deferred forever.)
+/// </summary>
+public class and_child_keyed_by_guid_on_the_same_event_source : Specification
+{
+    ReadModelScenario<SameSourceTicketLedger> _scenario;
+    EventSourceId _ledgerId;
+    Guid _firstTicket;
+    Guid _secondTicket;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SameSourceTicketLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+        _firstTicket = Guid.NewGuid();
+        _secondTicket = Guid.NewGuid();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new TicketLogged(_firstTicket, 100m),
+                new TicketLogged(_secondTicket, 200m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_ticket_lines() => _scenario.Instance!.Tickets.Count().ShouldEqual(2);
+    [Fact] void should_map_first_ticket_key() => _scenario.Instance!.Tickets.First().Ticket.ShouldEqual(_firstTicket);
+    [Fact] void should_map_first_ticket_amount() => _scenario.Instance!.Tickets.First().Amount.ShouldEqual(100m);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_int.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_int.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_int : Specification
+{
+    ReadModelScenario<BucketLedger> _scenario;
+    EventSourceId _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<BucketLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new BucketAmountRecorded(1, 10m),
+                new BucketAmountRecorded(2, 20m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_bucket_lines() => _scenario.Instance!.Buckets.Count().ShouldEqual(2);
+    [Fact] void should_map_first_bucket_key() => _scenario.Instance!.Buckets.First().Bucket.ShouldEqual(1);
+    [Fact] void should_map_first_bucket_amount() => _scenario.Instance!.Buckets.First().Amount.ShouldEqual(10m);
+    [Fact] void should_map_second_bucket_key() => _scenario.Instance!.Buckets.Last().Bucket.ShouldEqual(2);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_string.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_string.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_string : Specification
+{
+    ReadModelScenario<LabelLedger> _scenario;
+    EventSourceId _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<LabelLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new LabelRecorded("alpha", 1m),
+                new LabelRecorded("beta", 2m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_label_lines() => _scenario.Instance!.Labels.Count().ShouldEqual(2);
+    [Fact] void should_map_first_label_key() => _scenario.Instance!.Labels.First().Label.ShouldEqual("alpha");
+    [Fact] void should_map_first_label_amount() => _scenario.Instance!.Labels.First().Amount.ShouldEqual(1m);
+    [Fact] void should_map_second_label_key() => _scenario.Instance!.Labels.Last().Label.ShouldEqual("beta");
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_time_only.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_time_only.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_time_only : Specification
+{
+    ReadModelScenario<TimeLedger> _scenario;
+    EventSourceId _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<TimeLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new SlotAmountRecorded(new TimeOnly(9, 0), 1.5m),
+                new SlotAmountRecorded(new TimeOnly(13, 30), 2.25m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_slot_lines() => _scenario.Instance!.Slots.Count().ShouldEqual(2);
+    [Fact] void should_map_first_slot_key() => _scenario.Instance!.Slots.First().Slot.ShouldEqual(new TimeOnly(9, 0));
+    [Fact] void should_map_first_slot_amount() => _scenario.Instance!.Slots.First().Amount.ShouldEqual(1.5m);
+    [Fact] void should_map_second_slot_key() => _scenario.Instance!.Slots.Last().Slot.ShouldEqual(new TimeOnly(13, 30));
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_events_share_a_child_key.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_events_share_a_child_key.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Verifies child-identity matching: two events carrying the SAME key value resolve to the SAME child
+/// (an update), not two duplicate children — the same behavior as the real runtime sink.
+/// </summary>
+public class and_two_events_share_a_child_key : Specification
+{
+    ReadModelScenario<LabelLedger> _scenario;
+    EventSourceId _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<LabelLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new LabelRecorded("alpha", 1m),
+                new LabelRecorded("alpha", 9m));
+
+    [Fact] void should_have_a_single_merged_child() => _scenario.Instance!.Labels.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_shared_key() => _scenario.Instance!.Labels.Single().Label.ShouldEqual("alpha");
+    [Fact] void should_apply_the_latest_value() => _scenario.Instance!.Labels.Single().Amount.ShouldEqual(9m);
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -111,7 +111,13 @@ internal static class ProjectionReadModelProcessor
                 {
                     EventType = kernelEventType,
                     EventSourceId = eventSourceId,
-                    SequenceNumber = (KernelConceptsNs::Events.EventSequenceNumber)(uint)index
+                    SequenceNumber = (KernelConceptsNs::Events.EventSequenceNumber)(uint)index,
+
+                    // Give each event a distinct, monotonically increasing occurred time so time-based
+                    // projections (e.g. a [FromAll] "last updated" mapped from EventContext.Occurred)
+                    // reflect append order the same way the real runtime does — rather than every event
+                    // sharing one timestamp.
+                    Occurred = KernelConceptsNs::Events.EventContext.Empty.Occurred.AddTicks(index)
                 };
                 return new KernelAppendedEvent(context, content);
             })

--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -329,10 +329,12 @@ public static class ExpandoObjectExtensions
             !valueType.IsEnum &&
             valueType != typeof(string) &&
             valueType != typeof(Guid) &&
+            valueType != typeof(decimal) &&
             valueType != typeof(DateOnly) &&
             valueType != typeof(DateTime) &&
             valueType != typeof(DateTimeOffset) &&
             valueType != typeof(TimeOnly) &&
+            valueType != typeof(TimeSpan) &&
             !valueType.IsConcept())
         {
             if (value is IEnumerable enumerableValue)


### PR DESCRIPTION
# Summary

Fixes correctness bugs in model-bound projections and the `ReadModelScenario<T>` test harness, so projections that are valid in production also build and project correctly. Two of these (`[FromAll]`/`[FromEvery]` on positional records, and `[ChildrenFrom]` parent-key inference) affect the real runtime, not only the test harness. Also adds a compile-time analyzer for the ambiguous `[ChildrenFrom]` parent-key case.

## Added

- A `CHR0023` analyzer that warns when a `[ChildrenFrom]` collection omits `parentKey` and the parent key cannot be inferred unambiguously — the event has more than one property of the parent read model's identifier type besides the child key. Specify `parentKey` to resolve it.

## Changed

- The `ReadModelScenario<T>` test harness gives each driven event a distinct, monotonically increasing occurred time, so a time-based `[FromAll]` (for example a last-updated value mapped from `EventContext.Occurred`) reflects append order.

## Fixed

- `[FromAll]` and `[FromEvery]` are now applied when declared on a positional record property (`[property: FromAll(...)]`). Previously the attribute was dropped, so the property was never projected, and `[FromAll(contextProperty: ...)]` was additionally mis-converted into a non-existent event-property lookup.
- `[ChildrenFrom]` with an omitted `parentKey` no longer mis-infers the child key as the parent key when the parent identifier and the event's child key share a type (such as a raw `Guid`), so the children resolve. When more than one event property still matches, the first by declaration order is used; specify `parentKey` to disambiguate.
- `[ChildrenFrom]` child collections now project in `ReadModelScenario<T>` when a child value is a `decimal` or `TimeSpan`; previously such collections materialized empty.
