### PR TITLE
Fix Docker image publishing by granting actions:write cache scope

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,11 @@ permissions:
   contents: write
   deployments: write
   id-token: write
+  # Required so cache-saving build jobs (dotnet-x64/arm64, workbench) can write to
+  # the GitHub Actions cache service, which enforces the `actions` write scope. The
+  # publish-docker-* jobs consume those caches with fail-on-cache-miss, so without
+  # this they fail with "cache write denied: token has no writable scopes".
+  actions: write
 
 jobs:
   release:


### PR DESCRIPTION
# Summary

The 15.36.0 publish succeeded for NuGet and the language clients but **failed to push the Docker images**. GitHub's new Actions cache service now enforces the `actions` write scope, and the Publish workflow declares an explicit `permissions:` block that omits it. The cache-saving build jobs were therefore denied (`cache write denied: token has no writable scopes`) and silently produced no cache, so the `publish-docker-*` jobs failed on `fail-on-cache-miss` and a missing `Source/Workbench/wwwroot`.

This grants `actions: write` at the workflow level so the build jobs can save their artifacts and the Docker images publish again.

## Fixed

- Docker images are published again from the release pipeline. The cache-saving build jobs (`dotnet-x64`/`arm64`, `workbench`) were being denied cache writes under GitHub's new Actions cache service, which caused every `publish-docker-*` job to fail with a cache miss and no images to be pushed.
