### PR TITLE
Fix intermittent unique-constraint registration on ConceptAs properties and add EventScenario When

### DIFF
--- a/Source/Clients/DotNET.Specs/Events/Constraints/AccountReference.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/AccountReference.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+public record AccountReference(Guid Value) : ConceptAs<Guid>(Value);

--- a/Source/Clients/DotNET.Specs/Events/Constraints/AccountReferenceClaimed.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/AccountReferenceClaimed.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+public record AccountReferenceClaimed(AccountReference Reference);

--- a/Source/Clients/DotNET.Specs/Events/Constraints/AccountRegistered.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/AccountRegistered.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+public record AccountRegistered(EmailAddress Email, AccountReference Reference);

--- a/Source/Clients/DotNET.Specs/Events/Constraints/EmailAddress.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/EmailAddress.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+public record EmailAddress(string Value) : ConceptAs<string>(Value);

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_a_concept_property_registered_from_many_threads.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_a_concept_property_registered_from_many_threads.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueConstraintBuilder.when_building;
+
+/// <summary>
+/// Reproduces the reported failure: registering a unique constraint on a <c>ConceptAs&lt;T&gt;</c> property
+/// intermittently threw <see cref="PropertyDoesNotExistOnEventType"/> because the client hands the same cached
+/// event-type <see cref="JsonSchema"/> to every registration, and flattening its lazy caches concurrently could
+/// observe a half-built cache. Runs many registrations in parallel against one shared schema per round.
+/// </summary>
+public class with_a_concept_property_registered_from_many_threads : given.all_dependencies
+{
+    const int Rounds = 300;
+    const int Threads = 16;
+
+    EventType _eventType;
+    FakeEventTypes _fakeEventTypes;
+    ConcurrentBag<Exception> _failures;
+
+    void Establish()
+    {
+        _eventType = new EventType(nameof(AccountRegistered), EventTypeGeneration.First);
+        _fakeEventTypes = new FakeEventTypes(_eventType, typeof(AccountRegistered));
+    }
+
+    void Because()
+    {
+        _failures = [];
+
+        for (var round = 0; round < Rounds; round++)
+        {
+            // One shared schema instance per round — the same object every registration flattens, exactly as the
+            // client EventTypes cache returns it. Fresh per round so each round races on an uninitialized cache.
+            _fakeEventTypes.Schema = _generator.Generate(typeof(AccountRegistered));
+            using var start = new ManualResetEventSlim(false);
+
+            var registrations = Enumerable.Range(0, Threads).Select(_ => Task.Run(() =>
+            {
+                start.Wait();
+                try
+                {
+                    new UniqueConstraintBuilder(_fakeEventTypes, _namingPolicy).On<AccountRegistered>(e => e.Email);
+                }
+                catch (Exception ex)
+                {
+                    _failures.Add(ex);
+                }
+            })).ToArray();
+
+            start.Set();
+            Task.WaitAll(registrations);
+        }
+    }
+
+    [Fact] void should_register_the_concept_constraint_on_every_thread() => _failures.ShouldBeEmpty();
+
+    sealed class FakeEventTypes(EventType eventType, Type eventClrType) : IEventTypes
+    {
+        public JsonSchema Schema { get; set; } = new();
+
+        public IImmutableList<Type> AllClrTypes => throw new NotSupportedException();
+        public IImmutableList<EventType> All => throw new NotSupportedException();
+        public Task Discover() => throw new NotSupportedException();
+        public Task Register() => throw new NotSupportedException();
+        public bool HasFor(EventTypeId eventTypeId) => throw new NotSupportedException();
+        public bool HasFor(Type clrType) => throw new NotSupportedException();
+        public Type GetClrTypeFor(EventTypeId eventTypeId) => eventClrType;
+        public Type GetClrTypeFor(EventTypeId eventTypeId, EventTypeGeneration generation) => eventClrType;
+        public JsonSchema GetSchemaFor(EventTypeId eventTypeId) => Schema;
+        public EventType GetEventTypeFor(Type clrType) => eventType;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_concept_properties_across_multiple_event_types.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_concept_properties_across_multiple_event_types.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueConstraintBuilder.when_building;
+
+public class with_concept_properties_across_multiple_event_types : given.a_unique_constraint_builder_with_owner
+{
+    UniqueConstraintDefinition _result;
+    Exception _error;
+    EventType _registeredEventType;
+    EventType _claimedEventType;
+
+    void Establish()
+    {
+        _registeredEventType = new EventType(nameof(AccountRegistered), EventTypeGeneration.First);
+        _claimedEventType = new EventType(nameof(AccountReferenceClaimed), EventTypeGeneration.First);
+
+        _eventTypes.GetSchemaFor(_registeredEventType.Id).Returns(_generator.Generate(typeof(AccountRegistered)));
+        _eventTypes.GetSchemaFor(_claimedEventType.Id).Returns(_generator.Generate(typeof(AccountReferenceClaimed)));
+        _eventTypes.GetEventTypeFor(typeof(AccountRegistered)).Returns(_registeredEventType);
+        _eventTypes.GetEventTypeFor(typeof(AccountReferenceClaimed)).Returns(_claimedEventType);
+    }
+
+    void Because() => _error = Catch.Exception(() =>
+    {
+        _constraintBuilder
+            .On<AccountRegistered>(_ => _.Reference)
+            .On<AccountReferenceClaimed>(_ => _.Reference);
+        _result = _constraintBuilder.Build() as UniqueConstraintDefinition;
+    });
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_add_both_event_types() => _result.EventsWithProperties.Select(_ => _.EventTypeId).ShouldContainOnly(_registeredEventType.Id, _claimedEventType.Id);
+    [Fact] void should_use_the_guid_concept_property_on_the_registered_event() => _result.EventsWithProperties.Single(_ => _.EventTypeId == _registeredEventType.Id).Properties.Single().ShouldEqual("Reference");
+    [Fact] void should_use_the_guid_concept_property_on_the_claimed_event() => _result.EventsWithProperties.Single(_ => _.EventTypeId == _claimedEventType.Id).Properties.Single().ShouldEqual("Reference");
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_concept_property_using_generics.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueConstraintBuilder/when_building/with_concept_property_using_generics.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueConstraintBuilder.when_building;
+
+public class with_concept_property_using_generics : given.a_unique_constraint_builder_with_owner
+{
+    UniqueConstraintDefinition _result;
+    Exception _error;
+    EventType _eventType;
+
+    void Establish()
+    {
+        _eventType = new EventType(nameof(AccountRegistered), EventTypeGeneration.First);
+        _eventTypes.GetSchemaFor(_eventType.Id).Returns(_generator.Generate(typeof(AccountRegistered)));
+        _eventTypes.GetEventTypeFor(typeof(AccountRegistered)).Returns(_eventType);
+    }
+
+    void Because() => _error = Catch.Exception(() =>
+    {
+        _constraintBuilder.On<AccountRegistered>(_ => _.Email);
+        _result = _constraintBuilder.Build() as UniqueConstraintDefinition;
+    });
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+    [Fact] void should_add_event_type() => _result.EventsWithProperties.Single().EventTypeId.ShouldEqual(_eventType.Id);
+    [Fact] void should_use_the_concept_property_as_a_single_leaf() => _result.EventsWithProperties.Single().Properties.Single().ShouldEqual("Email");
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_getting_flattened_properties_for_event_with_concept_properties.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_getting_flattened_properties_for_event_with_concept_properties.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+public class when_getting_flattened_properties_for_event_with_concept_properties : given.a_json_schema_generator
+{
+    record EmailValue(string Value) : ConceptAs<string>(Value);
+    record ReferenceValue(Guid Value) : ConceptAs<Guid>(Value);
+    record AccountRegistered(EmailValue Email, ReferenceValue Reference, string Plain);
+
+    JsonSchema _schema;
+    IEnumerable<JsonSchemaProperty> _flattened;
+    JsonSchemaProperty _emailProperty;
+    JsonSchemaProperty _referenceProperty;
+
+    void Establish() => _schema = _generator.Generate(typeof(AccountRegistered));
+
+    void Because()
+    {
+        _flattened = _schema.GetFlattenedProperties();
+        _emailProperty = _schema.GetSchemaPropertyForPropertyPath(new PropertyPath("Email"));
+        _referenceProperty = _schema.GetSchemaPropertyForPropertyPath(new PropertyPath("Reference"));
+    }
+
+    [Fact] void should_flatten_all_three_properties() => _flattened.Select(_ => _.Name).ShouldContainOnly("Email", "Reference", "Plain");
+    [Fact] void should_resolve_the_string_concept_property() => _emailProperty.ShouldNotBeNull();
+    [Fact] void should_treat_the_string_concept_as_a_string_leaf() => _emailProperty.Type.ShouldEqual(JsonObjectType.String);
+    [Fact] void should_resolve_the_guid_concept_property() => _referenceProperty.ShouldNotBeNull();
+    [Fact] void should_treat_the_guid_concept_as_a_string_leaf_with_guid_format() => _referenceProperty.Format.ShouldEqual("guid");
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseIssued.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseIssued.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Event carrying a <see cref="LicenseKey"/> (a <c>ConceptAs&lt;Guid&gt;</c>) constrained for uniqueness by <see cref="UniqueLicenseKey"/>.
+/// </summary>
+/// <param name="Key">The issued license key.</param>
+[EventType]
+public record LicenseIssued(LicenseKey Key);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseKey.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseKey.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// A Guid-backed concept value used by the EventScenario constraint specs.
+/// </summary>
+/// <param name="Value">The license key value.</param>
+public record LicenseKey(Guid Value) : ConceptAs<Guid>(Value);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseReissued.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LicenseReissued.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Second event type sharing the <see cref="UniqueLicenseKey"/> constraint on its <see cref="LicenseKey"/> (a <c>ConceptAs&lt;Guid&gt;</c>) property.
+/// </summary>
+/// <param name="Key">The reissued license key.</param>
+[EventType]
+public record LicenseReissued(LicenseKey Key);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/SubscriberEmail.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/SubscriberEmail.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// A string-backed concept value used by the EventScenario constraint specs.
+/// </summary>
+/// <param name="Value">The email address.</param>
+public record SubscriberEmail(string Value) : ConceptAs<string>(Value);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/SubscriberRegistered.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/SubscriberRegistered.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Event carrying a model-bound <see cref="UniqueAttribute"/> on a <see cref="SubscriberEmail"/> (a <c>ConceptAs&lt;string&gt;</c>) property.
+/// </summary>
+/// <param name="Email">The subscriber's email address; unique across event sources.</param>
+[EventType]
+public record SubscriberRegistered([property: Unique(SubscriberRegistered.UniqueEmailConstraint)] SubscriberEmail Email)
+{
+    /// <summary>
+    /// The name of the uniqueness constraint on <see cref="Email"/>.
+    /// </summary>
+    public const string UniqueEmailConstraint = "UniqueSubscriberEmail";
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/UniqueLicenseKey.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/UniqueLicenseKey.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// A fluent <see cref="IConstraint"/> enforcing a single <see cref="LicenseKey"/> (a <c>ConceptAs&lt;Guid&gt;</c>)
+/// across both <see cref="LicenseIssued"/> and <see cref="LicenseReissued"/>.
+/// </summary>
+public class UniqueLicenseKey : IConstraint
+{
+    /// <summary>
+    /// The name of the constraint.
+    /// </summary>
+    public const string Name = "UniqueLicenseKey";
+
+    /// <inheritdoc/>
+    public void Define(IConstraintBuilder builder) =>
+        builder.Unique(_ => _
+            .On<LicenseIssued>(e => e.Key)
+            .On<LicenseReissued>(e => e.Key)
+            .WithName(Name));
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_acting_with_when : Specification, IDisposable
+{
+    EventScenario _scenario;
+    EventSourceId _eventSourceId;
+    AppendResult _result;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _eventSourceId = EventSourceId.New();
+    }
+
+    async Task Because() =>
+        _result = await _scenario.When
+            .ForEventSource(_eventSourceId)
+            .Events(new TestEvent("acted"));
+
+    [Fact] void should_return_the_append_result() => _result.ShouldNotBeNull();
+    [Fact] void should_be_successful() => _result.ShouldBeSuccessful();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when_and_violating_a_fluent_concept_constraint.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when_and_violating_a_fluent_concept_constraint.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_acting_with_when_and_violating_a_fluent_concept_constraint : Specification, IDisposable
+{
+    EventScenario _scenario;
+    LicenseKey _key;
+    AppendResult _result;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _key = new(Guid.NewGuid());
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(EventSourceId.New())
+            .Events(new LicenseIssued(_key));
+
+        _result = await _scenario.When
+            .ForEventSource(EventSourceId.New())
+            .Events(new LicenseReissued(_key));
+    }
+
+    [Fact] void should_have_failed() => _result.ShouldBeFailed();
+    [Fact] void should_have_the_constraint_violation() => _result.ShouldHaveConstraintViolation(UniqueLicenseKey.Name);
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when_and_violating_a_model_bound_concept_constraint.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_acting_with_when_and_violating_a_model_bound_concept_constraint.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+public class when_acting_with_when_and_violating_a_model_bound_concept_constraint : Specification, IDisposable
+{
+    EventScenario _scenario;
+    AppendResult _result;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(EventSourceId.New())
+            .Events(new SubscriberRegistered(new("duplicate@cratis.io")));
+
+        _result = await _scenario.When
+            .ForEventSource(EventSourceId.New())
+            .Events(new SubscriberRegistered(new("duplicate@cratis.io")));
+    }
+
+    [Fact] void should_have_failed() => _result.ShouldBeFailed();
+    [Fact] void should_have_the_constraint_violation() => _result.ShouldHaveConstraintViolation(SubscriberRegistered.UniqueEmailConstraint);
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing/EventSequences/AppendResultShouldExtensions.cs
+++ b/Source/Clients/Testing/EventSequences/AppendResultShouldExtensions.cs
@@ -130,6 +130,18 @@ public static class AppendResultShouldExtensions
     }
 
     /// <summary>
+    /// Asserts that the result has at least one constraint violation for a specific <see cref="ConstraintName"/>.
+    /// </summary>
+    /// <param name="result">The result to assert on.</param>
+    /// <param name="constraintName">The <see cref="ConstraintName"/> to look for.</param>
+    /// <exception cref="AppendResultAssertionException">Thrown when the expected constraint violation is not present.</exception>
+    /// <remarks>
+    /// Singular convenience alias for <see cref="ShouldHaveConstraintViolationFor"/>.
+    /// </remarks>
+    public static void ShouldHaveConstraintViolation(this IAppendResult result, ConstraintName constraintName) =>
+        result.ShouldHaveConstraintViolationFor(constraintName);
+
+    /// <summary>
     /// Asserts that the result has at least one concurrency violation.
     /// </summary>
     /// <param name="result">The result to assert on.</param>

--- a/Source/Clients/Testing/EventSequences/EventScenario.cs
+++ b/Source/Clients/Testing/EventSequences/EventScenario.cs
@@ -105,6 +105,22 @@ public class EventScenario(
     public EventScenarioGivenBuilder Given => new(_created.EventLog);
 
     /// <summary>
+    /// Gets the fluent builder used to append the event(s) under test during the act phase and return the resulting <see cref="AppendResult"/>.
+    /// </summary>
+    /// <remarks>
+    /// Symmetric to <see cref="Given"/>: where <c>Given</c> seeds pre-existing events, <c>When</c> performs the act being
+    /// tested. Its terminal <see cref="EventSourceWhenBuilder.Events"/> returns the <see cref="AppendResult"/> — the same
+    /// "the act returns its result" shape as <c>CommandScenario.Execute</c>, so constraint/append specs read as
+    /// Given / When / then without binding the raw <see cref="IEventSequence.Append"/> overload by hand.
+    /// <code>
+    /// await scenario.Given.ForEventSource(id).Events(seedEvent);
+    /// var result = await scenario.When.ForEventSource(id).Events(actEvent);
+    /// result.ShouldHaveConstraintViolationFor(name);
+    /// </code>
+    /// </remarks>
+    public EventScenarioWhenBuilder When => new(_created.EventLog);
+
+    /// <summary>
     /// Gets the <see cref="IEventLog"/> backed by the real kernel event sequence grain via the real client event log.
     /// </summary>
     public IEventLog EventLog => _created.EventLog;

--- a/Source/Clients/Testing/EventSequences/EventScenarioWhenBuilder.cs
+++ b/Source/Clients/Testing/EventSequences/EventScenarioWhenBuilder.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// Represents the entry point of the fluent builder for appending the event(s) under test during the act phase of an
+/// <see cref="EventScenario"/> and returning the resulting <see cref="AppendResult"/>.
+/// </summary>
+/// <param name="eventLog">The <see cref="IEventLog"/> to append the acted events to.</param>
+public class EventScenarioWhenBuilder(IEventLog eventLog)
+{
+    /// <summary>
+    /// Specifies the <see cref="EventSourceId"/> that the acted events belong to.
+    /// </summary>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> to append events for.</param>
+    /// <returns>An <see cref="EventSourceWhenBuilder"/> to continue the fluent chain.</returns>
+    public EventSourceWhenBuilder ForEventSource(EventSourceId eventSourceId) =>
+        new(eventLog, eventSourceId);
+}

--- a/Source/Clients/Testing/EventSequences/EventSourceWhenBuilder.cs
+++ b/Source/Clients/Testing/EventSequences/EventSourceWhenBuilder.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// Represents a builder for appending the event(s) under test for a specific <see cref="EventSourceId"/> during the act
+/// phase of an <see cref="EventScenario"/>, returning the resulting <see cref="AppendResult"/>.
+/// </summary>
+/// <param name="eventLog">The <see cref="IEventLog"/> to append the acted events to.</param>
+/// <param name="eventSourceId">The <see cref="EventSourceId"/> to associate the acted events with.</param>
+public class EventSourceWhenBuilder(IEventLog eventLog, EventSourceId eventSourceId)
+{
+    /// <summary>
+    /// Appends the event(s) under test for the current <see cref="EventSourceId"/> through the real kernel
+    /// <c>EventSequence</c> grain and returns the resulting <see cref="AppendResult"/>.
+    /// </summary>
+    /// <param name="event">The event under test — the action being exercised.</param>
+    /// <param name="additionalEvents">Any further events that make up the same action, appended in order.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> resolving to the <see cref="AppendResult"/> of the append. When more than one event
+    /// is supplied, each is appended in order and the result of the final append is returned.
+    /// </returns>
+    public async Task<AppendResult> Events(object @event, params object[] additionalEvents)
+    {
+        var result = await eventLog.Append(eventSourceId, @event);
+        foreach (var additionalEvent in additionalEvents)
+        {
+            result = await eventLog.Append(eventSourceId, additionalEvent);
+        }
+
+        return result;
+    }
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_flattening_concurrently/from_many_threads_on_a_shared_schema.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchema/when_flattening_concurrently/from_many_threads_on_a_shared_schema.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchema.when_flattening_concurrently;
+
+/// <summary>
+/// A single <see cref="JsonSchema"/> instance is cached and shared (for example the event-type schemas held by the
+/// client <c>EventTypes</c>) and flattened concurrently by constraint registration, projections, and key resolvers.
+/// This exercises the lazy <c>Properties</c>/<c>Definitions</c> caches from many threads on a freshly-built schema so
+/// that a reader never observes a half-populated cache (which previously surfaced as a valid property "not existing").
+/// </summary>
+public class from_many_threads_on_a_shared_schema : Specification
+{
+    const string Json = """
+    {
+        "type": "object",
+        "$defs": {
+            "Inner": { "type": "object", "title": "Inner", "properties": { "value": { "type": "string" } } }
+        },
+        "properties": {
+            "email": { "type": "string" },
+            "reference": { "type": "string", "format": "guid" },
+            "inner": { "$ref": "#/$defs/Inner" }
+        }
+    }
+    """;
+
+    const int Rounds = 200;
+    const int Readers = 16;
+
+    ConcurrentBag<string> _anomalies;
+
+    void Because()
+    {
+        _anomalies = [];
+
+        for (var round = 0; round < Rounds; round++)
+        {
+            // Fresh schema each round so every reader in the round races on the same uninitialized lazy caches.
+            var schema = JsonSchema.FromJson(Json);
+            using var start = new ManualResetEventSlim(false);
+
+            var readers = Enumerable.Range(0, Readers).Select(_ => Task.Run(() =>
+            {
+                start.Wait();
+
+                var flattened = schema.GetFlattenedProperties().Select(p => p.Name).ToList();
+                if (!flattened.Contains("email"))
+                {
+                    _anomalies.Add($"flatten dropped 'email': [{string.Join(',', flattened)}]");
+                }
+
+                if (schema.GetSchemaPropertyForPropertyPath(new PropertyPath("email")) is null)
+                {
+                    _anomalies.Add("resolve 'email' returned null");
+                }
+
+                if (schema.GetSchemaPropertyForPropertyPath(new PropertyPath("inner.value")) is null)
+                {
+                    _anomalies.Add("resolve 'inner.value' returned null");
+                }
+            })).ToArray();
+
+            start.Set();
+            Task.WaitAll(readers);
+        }
+    }
+
+    [Fact] void should_resolve_every_property_on_every_thread() => _anomalies.ShouldBeEmpty();
+}

--- a/Source/Infrastructure/Schemas/JsonSchema.cs
+++ b/Source/Infrastructure/Schemas/JsonSchema.cs
@@ -23,13 +23,22 @@ public class JsonSchema
     static readonly TypeFormats _typeFormats = new();
     readonly JsonSchema? _root;
 
-    /// <summary>Lazy caches for parsed schema components.</summary>
-    SyncedPropertiesDictionary? _propertiesCache;
-    List<JsonSchema>? _allOfCache;
-    List<JsonSchema>? _anyOfCache;
-    List<JsonSchema>? _oneOfCache;
-    Dictionary<string, JsonSchema>? _definitionsCache;
-    ExtensionDataDictionary? _extensionDataCache;
+    /// <summary>
+    /// Lazy caches for parsed schema components.
+    /// </summary>
+    /// <remarks>
+    /// A single <see cref="JsonSchema"/> instance is cached and shared (for example the event-type schemas held by the
+    /// client <c>EventTypes</c>) and read concurrently — projections, reducers, key resolvers, the MongoDB converter,
+    /// and constraint registration all flatten the same instance. The caches are therefore published with release
+    /// semantics: each is built fully into a local before the <c>volatile</c> field is assigned, so a concurrent reader
+    /// never observes a half-populated dictionary or list (which previously surfaced as a property "not existing").
+    /// </remarks>
+    volatile SyncedPropertiesDictionary? _propertiesCache;
+    volatile List<JsonSchema>? _allOfCache;
+    volatile List<JsonSchema>? _anyOfCache;
+    volatile List<JsonSchema>? _oneOfCache;
+    volatile Dictionary<string, JsonSchema>? _definitionsCache;
+    volatile ExtensionDataDictionary? _extensionDataCache;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonSchema"/> class (empty schema).
@@ -124,23 +133,29 @@ public class JsonSchema
     {
         get
         {
-            if (_propertiesCache is null)
+            var cached = _propertiesCache;
+            if (cached is not null)
             {
-                _propertiesCache = new SyncedPropertiesDictionary(Node);
-                if (Node["properties"] is JsonObject propsNode)
+                return cached;
+            }
+
+            // Build the dictionary fully into a local before publishing it, so a concurrent reader never sees a
+            // partially-populated cache (which would make a present property appear to be missing).
+            var properties = new SyncedPropertiesDictionary(Node);
+            if (Node["properties"] is JsonObject propsNode)
+            {
+                foreach (var (key, value) in propsNode)
                 {
-                    foreach (var (key, value) in propsNode)
+                    if (value is JsonObject propObj)
                     {
-                        if (value is JsonObject propObj)
-                        {
-                            var propNode = (JsonObject)propObj.DeepClone();
-                            var prop = new JsonSchemaProperty(key, propNode, Root);
-                            _propertiesCache.LoadWithoutSync(key, prop);
-                        }
+                        var propNode = (JsonObject)propObj.DeepClone();
+                        var prop = new JsonSchemaProperty(key, propNode, Root);
+                        properties.LoadWithoutSync(key, prop);
                     }
                 }
             }
-            return _propertiesCache;
+
+            return _propertiesCache = properties;
         }
     }
 
@@ -214,22 +229,28 @@ public class JsonSchema
     {
         get
         {
-            if (_definitionsCache is null)
+            var cached = _definitionsCache;
+            if (cached is not null)
             {
-                _definitionsCache = new Dictionary<string, JsonSchema>(StringComparer.Ordinal);
-                var defsNode = (Node["$defs"] ?? Node["definitions"]) as JsonObject;
-                if (defsNode is not null)
+                return cached;
+            }
+
+            // Build the dictionary fully into a local before publishing it, so a concurrent reader never sees a
+            // partially-populated cache.
+            var definitions = new Dictionary<string, JsonSchema>(StringComparer.Ordinal);
+            var defsNode = (Node["$defs"] ?? Node["definitions"]) as JsonObject;
+            if (defsNode is not null)
+            {
+                foreach (var (key, value) in defsNode)
                 {
-                    foreach (var (key, value) in defsNode)
+                    if (value is JsonObject defObj)
                     {
-                        if (value is JsonObject defObj)
-                        {
-                            _definitionsCache[key] = new JsonSchema((JsonObject)defObj.DeepClone(), this);
-                        }
+                        definitions[key] = new JsonSchema((JsonObject)defObj.DeepClone(), this);
                     }
                 }
             }
-            return _definitionsCache;
+
+            return _definitionsCache = definitions;
         }
     }
 


### PR DESCRIPTION
# Summary

Registering a unique constraint on a `ConceptAs<T>` property could intermittently fail with "Property '\<name\>' does not exist on event type" — most visibly at constraint discovery in the in-process testing harness. The event-type schema is cached and shared, and its lazy property/definition caches were published before being fully built, so a concurrent reader (parallel specs, or any concurrent flatten) could see an empty cache. Building each cache fully before publishing it fixes the race, so uniqueness on strongly-typed domain values now registers and enforces reliably and can be spec-tested in-process.

## Added

- `EventScenario.When` — a fluent act builder mirroring `Given` (`When.ForEventSource(id).Events(...)`) that appends the event(s) under test and returns the `AppendResult`, giving append and constraint specs Given/When/Then symmetry without using the raw `Append` overload.
- `IAppendResult.ShouldHaveConstraintViolation(name)` — a singular alias for `ShouldHaveConstraintViolationFor(name)`.

## Fixed

- Unique constraints on `ConceptAs<T>` event properties no longer intermittently fail to register with "property does not exist"; the shared event-type schema is now flattened safely under concurrent access.