### PR TITLE
Fix MongoDB bare-concept list persistence and add ReadModelScenario instance accessors

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/ConceptDayEntry.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptDayEntry.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child entry for a single worked day on a <see cref="ConceptSheet"/>, carrying a concept-typed value.
+/// </summary>
+/// <param name="Day">The business day, used as the child key.</param>
+/// <param name="Hours">The number of hours worked, as a <see cref="WorkHours"/> concept.</param>
+public record ConceptDayEntry(
+    DateOnly Day,
+    WorkHours Hours);

--- a/Source/Clients/Testing.Specs/ReadModels/ConceptDayWorked.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptDayWorked.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for recording hours worked on a specific day, where the hours are a concept value and
+/// the day (the child key) is a <see cref="DateOnly"/>.
+/// </summary>
+/// <param name="Day">The business day the hours were worked, used as the child key.</param>
+/// <param name="Hours">The number of hours worked, as a <see cref="WorkHours"/> concept.</param>
+[EventType]
+public record ConceptDayWorked(DateOnly Day, WorkHours Hours);

--- a/Source/Clients/Testing.Specs/ReadModels/ConceptSheet.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptSheet.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Root read model projected from <see cref="ConceptSheetStarted"/> with a child collection keyed by a
+/// <see cref="DateOnly"/> value whose children carry a concept-typed value (<see cref="WorkHours"/>).
+/// Used to verify that the in-memory harness materializes child collections keyed by a value-type
+/// primitive even when the child body carries a concept value.
+/// </summary>
+/// <param name="Id">Sheet identifier.</param>
+/// <param name="Year">The year the sheet covers.</param>
+/// <param name="Days">Day entries keyed by <see cref="ConceptDayWorked.Day"/>.</param>
+[Passive]
+[FromEvent<ConceptSheetStarted>]
+public record ConceptSheet(
+    SheetId Id,
+    int Year,
+
+    [ChildrenFrom<ConceptDayWorked>(key: nameof(ConceptDayWorked.Day))]
+    IEnumerable<ConceptDayEntry> Days);

--- a/Source/Clients/Testing.Specs/ReadModels/ConceptSheetStarted.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ConceptSheetStarted.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that starts a <see cref="ConceptSheet"/>.
+/// </summary>
+/// <param name="Year">The year the sheet covers.</param>
+[EventType]
+public record ConceptSheetStarted(int Year);

--- a/Source/Clients/Testing.Specs/ReadModels/ContactAssigned.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ContactAssigned.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event assigning a contact, keyed by a <see cref="ContactId"/> concept over a <see cref="Guid"/>.
+/// </summary>
+/// <param name="ContactId">The contact identifier, used as the child key.</param>
+/// <param name="Name">The contact name.</param>
+[EventType]
+public record ContactAssigned(ContactId ContactId, string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/ContactEntry.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ContactEntry.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child entry for an assigned contact, keyed by a <see cref="ContactId"/> concept.
+/// </summary>
+/// <param name="ContactId">The contact identifier, used as the child key.</param>
+/// <param name="Name">The contact name.</param>
+public record ContactEntry(
+    ContactId ContactId,
+    string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/ContactId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ContactId.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A strongly-typed contact identifier value, backed by a <see cref="Guid"/> concept. Used to verify a
+/// child collection keyed by a <see cref="ConceptAs{T}"/> over a <see cref="Guid"/> materializes alongside
+/// a <see cref="DateOnly"/>-keyed child collection on the same read model.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record ContactId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    /// <summary>
+    /// Implicitly converts a <see cref="Guid"/> to a <see cref="ContactId"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> to convert.</param>
+    public static implicit operator ContactId(Guid value) => new(value);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/DayLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/DayLedger.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="DateOnly"/> day, where the children live on
+/// their own event source and are linked to the parent via an explicit
+/// <see cref="ChildrenFromAttribute{TEvent}.ParentKey"/>. Used to verify the in-memory harness materializes
+/// cross-stream <see cref="DateOnly"/>-keyed child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Days">Day lines keyed by <see cref="DayRaised.Day"/> (a <see cref="DateOnly"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record DayLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<DayRaised>(
+        key: nameof(DayRaised.Day),
+        identifiedBy: nameof(DayLine.Day),
+        parentKey: nameof(DayRaised.LedgerId))]
+    IEnumerable<DayLine> Days);

--- a/Source/Clients/Testing.Specs/ReadModels/DayLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/DayLine.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="DateOnly"/> day, materialized from an event on a separate event source.
+/// </summary>
+/// <param name="Day">The business day, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record DayLine(
+    [Key] DateOnly Day,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/DayRaised.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/DayRaised.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a day on a ledger, where the day (the child key) is a
+/// <see cref="DateOnly"/> and the event lives on its own event source, linked to the parent via
+/// <paramref name="LedgerId"/>.
+/// </summary>
+/// <param name="LedgerId">The parent ledger identifier (used as the parent key).</param>
+/// <param name="Day">The business day, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record DayRaised(Guid LedgerId, DateOnly Day, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/JoinCustomerId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/JoinCustomerId.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// The identifier of a customer that an order joins against for enrichment.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record JoinCustomerId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    /// <summary>
+    /// Implicitly converts a <see cref="Guid"/> to a <see cref="JoinCustomerId"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> to convert.</param>
+    public static implicit operator JoinCustomerId(Guid value) => new(value);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/JoinCustomerRegistered.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/JoinCustomerRegistered.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event registering a customer; lives on the customer's own event source and is joined into orders.
+/// </summary>
+/// <param name="Name">The customer's name.</param>
+[EventType]
+public record JoinCustomerRegistered(string Name);

--- a/Source/Clients/Testing.Specs/ReadModels/JoinOrderPlaced.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/JoinOrderPlaced.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event placing an order for a customer; lives on the order's own event source.
+/// </summary>
+/// <param name="CustomerId">The customer the order is for (the join key).</param>
+/// <param name="Amount">The order amount.</param>
+[EventType]
+public record JoinOrderPlaced(JoinCustomerId CustomerId, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/JoinOrderSummary.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/JoinOrderSummary.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model that enriches an order with the customer's name through a <c>[Join]</c> against
+/// <see cref="JoinCustomerRegistered"/> on a separate event source. Used to verify cross-source join
+/// behavior in the in-memory harness and to assert against the intended instance deterministically.
+/// </summary>
+/// <param name="Id">The order identifier.</param>
+/// <param name="CustomerId">The customer the order is for (the join key).</param>
+/// <param name="Amount">The order amount.</param>
+/// <param name="CustomerName">The customer name, joined in from <see cref="JoinCustomerRegistered"/>.</param>
+[Passive]
+[FromEvent<JoinOrderPlaced>]
+public record JoinOrderSummary(
+    [Key] Guid Id,
+
+    [SetFrom<JoinOrderPlaced>]
+    JoinCustomerId CustomerId,
+
+    [SetFrom<JoinOrderPlaced>]
+    decimal Amount,
+
+    [Join<JoinCustomerRegistered>(on: nameof(CustomerId), eventPropertyName: nameof(JoinCustomerRegistered.Name))]
+    string CustomerName);

--- a/Source/Clients/Testing.Specs/ReadModels/LineNote.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/LineNote.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A plain record element used as the item type of a bulk list carried on a child read model, to verify
+/// that a whole <see cref="IReadOnlyList{T}"/> set from a single child-creating event materializes on a
+/// <c>[ChildrenFrom]</c> child.
+/// </summary>
+/// <param name="Text">The note text.</param>
+/// <param name="Order">The ordinal of the note.</param>
+public record LineNote(string Text, int Order);

--- a/Source/Clients/Testing.Specs/ReadModels/MixedKeySheet.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/MixedKeySheet.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model carrying two child collections on the same event source: one keyed by a
+/// <see cref="ContactId"/> concept over a <see cref="Guid"/>, and one keyed by a <see cref="DateOnly"/>.
+/// Used to verify that the presence of a working concept-keyed collection does not stop the
+/// <see cref="DateOnly"/>-keyed collection from materializing (and vice versa).
+/// </summary>
+/// <param name="Id">Sheet identifier.</param>
+/// <param name="Year">The year the sheet covers.</param>
+/// <param name="Contacts">Contact entries keyed by <see cref="ContactAssigned.ContactId"/> (a concept).</param>
+/// <param name="Days">Day entries keyed by <see cref="ConceptDayWorked.Day"/> (a <see cref="DateOnly"/>).</param>
+[Passive]
+[FromEvent<ConceptSheetStarted>]
+public record MixedKeySheet(
+    SheetId Id,
+    int Year,
+
+    [ChildrenFrom<ContactAssigned>(key: nameof(ContactAssigned.ContactId))]
+    IEnumerable<ContactEntry> Contacts,
+
+    [ChildrenFrom<ConceptDayWorked>(key: nameof(ConceptDayWorked.Day))]
+    IEnumerable<ConceptDayEntry> Days);

--- a/Source/Clients/Testing.Specs/ReadModels/MomentAmountRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/MomentAmountRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a moment in time, keyed by a <see cref="DateTimeOffset"/>.
+/// </summary>
+/// <param name="Moment">The moment, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record MomentAmountRecorded(DateTimeOffset Moment, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/MomentLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/MomentLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="DateTimeOffset"/> payload value (children on
+/// the same event source as the parent), used to verify the in-memory harness materializes
+/// <see cref="DateTimeOffset"/>-keyed child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Moments">Moment lines keyed by <see cref="MomentAmountRecorded.Moment"/> (a <see cref="DateTimeOffset"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record MomentLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<MomentAmountRecorded>(key: nameof(MomentAmountRecorded.Moment))]
+    IEnumerable<MomentLine> Moments);

--- a/Source/Clients/Testing.Specs/ReadModels/MomentLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/MomentLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="DateTimeOffset"/> moment.
+/// </summary>
+/// <param name="Moment">The moment, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record MomentLine(
+    DateTimeOffset Moment,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/NotedLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/NotedLine.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line on a <see cref="NotedOrder"/> that carries a whole bulk list of notes, set from a single
+/// child-creating event.
+/// </summary>
+/// <param name="LineNumber">The line number, used as the child key.</param>
+/// <param name="Description">The line description.</param>
+/// <param name="Notes">The whole list of notes for the line.</param>
+/// <param name="Tags">The whole list of bare-concept tags for the line.</param>
+public record NotedLine(
+    [Key] string LineNumber,
+    string Description,
+    IReadOnlyList<LineNote> Notes,
+    IReadOnlyList<ConceptListItem> Tags);

--- a/Source/Clients/Testing.Specs/ReadModels/NotedLineAdded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/NotedLineAdded.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that adds a line to an order, carrying the whole set of notes for the line in a single event.
+/// </summary>
+/// <param name="LineNumber">The line number, used as the child key.</param>
+/// <param name="Description">The line description.</param>
+/// <param name="Notes">The whole list of notes for the line.</param>
+/// <param name="Tags">The whole list of bare-concept tags for the line.</param>
+[EventType]
+public record NotedLineAdded(
+    string LineNumber,
+    string Description,
+    IReadOnlyList<LineNote> Notes,
+    IReadOnlyList<ConceptListItem> Tags);

--- a/Source/Clients/Testing.Specs/ReadModels/NotedOrder.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/NotedOrder.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a <c>[ChildrenFrom]</c> child collection whose children each carry a bulk
+/// <see cref="IReadOnlyList{T}"/> of notes set whole from the child-creating event. Used to verify the
+/// in-memory harness materializes a bulk list nested inside a keyed child (not just at the top level).
+/// </summary>
+/// <param name="Id">Order identifier.</param>
+/// <param name="Reference">The order reference.</param>
+/// <param name="Lines">The order lines keyed by <see cref="NotedLineAdded.LineNumber"/>.</param>
+[Passive]
+[FromEvent<NotedOrderOpened>]
+public record NotedOrder(
+    NotedOrderId Id,
+    string Reference,
+
+    [ChildrenFrom<NotedLineAdded>(key: nameof(NotedLineAdded.LineNumber))]
+    IEnumerable<NotedLine> Lines);

--- a/Source/Clients/Testing.Specs/ReadModels/NotedOrderId.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/NotedOrderId.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Identifier for a <see cref="NotedOrder"/>.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record NotedOrderId(Guid Value) : EventSourceId<Guid>(Value)
+{
+    /// <summary>
+    /// Creates a new <see cref="NotedOrderId"/>.
+    /// </summary>
+    /// <returns>A new <see cref="NotedOrderId"/>.</returns>
+    public static NotedOrderId New() => new(Guid.NewGuid());
+
+    /// <summary>
+    /// Implicitly converts a <see cref="Guid"/> to a <see cref="NotedOrderId"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Guid"/> to convert.</param>
+    public static implicit operator NotedOrderId(Guid value) => new(value);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/NotedOrderOpened.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/NotedOrderOpened.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event that opens an order.
+/// </summary>
+/// <param name="Reference">The order reference.</param>
+[EventType]
+public record NotedOrderOpened(string Reference);

--- a/Source/Clients/Testing.Specs/ReadModels/StampAmountRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/StampAmountRecorded.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording an amount against a timestamp, keyed by a <see cref="DateTime"/>.
+/// </summary>
+/// <param name="Stamp">The timestamp, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+[EventType]
+public record StampAmountRecorded(DateTime Stamp, decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/StampLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/StampLedger.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a child collection keyed by a <see cref="DateTime"/> payload value (children on the
+/// same event source as the parent), used to verify the in-memory harness materializes
+/// <see cref="DateTime"/>-keyed child collections.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="Stamps">Stamp lines keyed by <see cref="StampAmountRecorded.Stamp"/> (a <see cref="DateTime"/>).</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record StampLedger(
+    Guid Id,
+    string Name,
+
+    [ChildrenFrom<StampAmountRecorded>(key: nameof(StampAmountRecorded.Stamp))]
+    IEnumerable<StampLine> Stamps);

--- a/Source/Clients/Testing.Specs/ReadModels/StampLine.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/StampLine.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line keyed by a <see cref="DateTime"/> timestamp.
+/// </summary>
+/// <param name="Stamp">The timestamp, used as the child key.</param>
+/// <param name="Amount">The recorded amount.</param>
+public record StampLine(
+    DateTime Stamp,
+    decimal Amount);

--- a/Source/Clients/Testing.Specs/ReadModels/WorkHours.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/WorkHours.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Represents the number of hours worked, as a strongly-typed <see cref="ConceptAs{T}"/> over a
+/// <see cref="decimal"/>. Used to verify that a child collection keyed by a value-type primitive
+/// still materializes when the child carries a concept-typed value.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record WorkHours(decimal Value) : ConceptAs<decimal>(Value)
+{
+    /// <summary>
+    /// Implicitly converts a <see cref="decimal"/> to a <see cref="WorkHours"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="decimal"/> to convert.</param>
+    public static implicit operator WorkHours(decimal value) => new(value);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_multiple_instances_materialize.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_multiple_instances_materialize.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that when events materialize more than one instance — here a join whose join-source event is
+/// seeded first — <see cref="ReadModelScenario{TReadModel}.Instance"/> fails loud rather than returning a
+/// blended result, and the individual instances remain available.
+/// </summary>
+public class when_multiple_instances_materialize : Specification
+{
+    ReadModelScenario<JoinOrderSummary> _scenario;
+    Guid _customerGuid;
+    Exception _instanceError;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<JoinOrderSummary>();
+        _customerGuid = Guid.NewGuid();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(_customerGuid))
+            .Events(new JoinCustomerRegistered("Ada"));
+
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(Guid.NewGuid()))
+            .Events(new JoinOrderPlaced(new JoinCustomerId(_customerGuid), 100m));
+
+        _instanceError = Catch.Exception(() => _ = _scenario.Instance);
+    }
+
+    [Fact] void should_reject_the_ambiguous_single_instance() => _instanceError.ShouldBeOfExactType<MultipleInstancesMaterialized>();
+    [Fact] void should_expose_all_instances() => _scenario.Instances.Count.ShouldEqual(2);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_bulk_list_on_a_child.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_bulk_list_on_a_child.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that a whole <see cref="IReadOnlyList{T}"/> carried on a <c>[ChildrenFrom]</c> child — set from
+/// a single child-creating event — materializes on the child, mirroring how a top-level bulk list projects.
+/// </summary>
+public class when_projecting_a_bulk_list_on_a_child : Specification
+{
+    ReadModelScenario<NotedOrder> _scenario;
+    NotedOrderId _orderId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<NotedOrder>();
+        _orderId = NotedOrderId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_orderId)
+            .Events(
+                new NotedOrderOpened("ORD-1"),
+                new NotedLineAdded("L1", "First line", [new LineNote("alpha", 1), new LineNote("beta", 2)], [new ConceptListItem("red"), new ConceptListItem("green")]),
+                new NotedLineAdded("L2", "Second line", [new LineNote("gamma", 1)], [new ConceptListItem("blue")]));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_lines() => _scenario.Instance!.Lines.Count().ShouldEqual(2);
+    [Fact] void should_carry_first_line_notes() => _scenario.Instance!.Lines.First().Notes.Count.ShouldEqual(2);
+    [Fact] void should_map_first_note_text() => _scenario.Instance!.Lines.First().Notes[0].Text.ShouldEqual("alpha");
+    [Fact] void should_map_first_note_order() => _scenario.Instance!.Lines.First().Notes[0].Order.ShouldEqual(1);
+    [Fact] void should_carry_second_line_notes() => _scenario.Instance!.Lines.Last().Notes.Count.ShouldEqual(1);
+    [Fact] void should_map_second_line_note_text() => _scenario.Instance!.Lines.Last().Notes[0].Text.ShouldEqual("gamma");
+    [Fact] void should_carry_first_line_concept_tags() => _scenario.Instance!.Lines.First().Tags.Count.ShouldEqual(2);
+    [Fact] void should_round_trip_first_concept_tag() => _scenario.Instance!.Lines.First().Tags[0].Value.ShouldEqual("red");
+    [Fact] void should_round_trip_second_concept_tag() => _scenario.Instance!.Lines.First().Tags[1].Value.ShouldEqual("green");
+    [Fact] void should_carry_second_line_concept_tag() => _scenario.Instance!.Lines.Last().Tags[0].Value.ShouldEqual("blue");
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_a_join.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_a_join.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Verifies that a cross-source <c>[Join]</c> enriches the intended read-model instance, even when the
+/// join-source event is seeded before the entity-under-test — the join source must not shadow the entity.
+/// </summary>
+public class when_projecting_with_a_join : Specification
+{
+    ReadModelScenario<JoinOrderSummary> _scenario;
+    EventSourceId _orderId;
+    Guid _orderGuid;
+    Guid _customerGuid;
+    JoinOrderSummary? _order;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<JoinOrderSummary>();
+        _orderGuid = Guid.NewGuid();
+        _orderId = new EventSourceId(_orderGuid);
+        _customerGuid = Guid.NewGuid();
+    }
+
+    async Task Because()
+    {
+        // Seed the JOIN SOURCE (customer) first — deliberately exercising the order that previously let
+        // the join-source event shadow the entity-under-test. InstanceForEventSourceId resolves the
+        // intended order instance regardless of seed order.
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(_customerGuid))
+            .Events(new JoinCustomerRegistered("Ada"));
+
+        await _scenario.Given
+            .ForEventSource(_orderId)
+            .Events(new JoinOrderPlaced(new JoinCustomerId(_customerGuid), 100m));
+
+        _order = _scenario.InstanceForEventSourceId(_orderId);
+    }
+
+    [Fact] void should_resolve_the_order_instance() => _order.ShouldNotBeNull();
+    [Fact] void should_key_the_order_by_its_own_id() => _order!.Id.ShouldEqual(_orderGuid);
+    [Fact] void should_have_the_amount() => _order!.Amount.ShouldEqual(100m);
+    [Fact] void should_join_the_customer_name() => _order!.CustomerName.ShouldEqual("Ada");
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only_on_separate_event_sources.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only_on_separate_event_sources.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Verifies that a <see cref="DateOnly"/>-keyed child collection whose children live on their own event
+/// source (linked to the parent via an explicit parent key) materializes correctly — exercising the sink
+/// parent-hierarchy lookup that matches a child by its <see cref="DateOnly"/> key value.
+/// </summary>
+public class and_child_keyed_by_date_only_on_separate_event_sources : Specification
+{
+    ReadModelScenario<DayLedger> _scenario;
+    EventSourceId _ledgerId;
+    Guid _ledgerGuid;
+    DateOnly _firstDay;
+    DateOnly _secondDay;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<DayLedger>();
+        _ledgerGuid = Guid.NewGuid();
+        _ledgerId = new EventSourceId(_ledgerGuid);
+        _firstDay = new DateOnly(2026, 6, 1);
+        _secondDay = new DateOnly(2026, 6, 2);
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(new LedgerOpened("Operations"));
+
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(Guid.NewGuid()))
+            .Events(new DayRaised(_ledgerGuid, _firstDay, 100m));
+
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(Guid.NewGuid()))
+            .Events(new DayRaised(_ledgerGuid, _secondDay, 200m));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_day_lines() => _scenario.Instance!.Days.Count().ShouldEqual(2);
+    [Fact] void should_map_first_day_key() => _scenario.Instance!.Days.First().Day.ShouldEqual(_firstDay);
+    [Fact] void should_map_first_day_amount() => _scenario.Instance!.Days.First().Amount.ShouldEqual(100m);
+    [Fact] void should_map_second_day_key() => _scenario.Instance!.Days.Last().Day.ShouldEqual(_secondDay);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only_with_concept_value.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_only_with_concept_value.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_date_only_with_concept_value : Specification
+{
+    ReadModelScenario<ConceptSheet> _scenario;
+    SheetId _sheetId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ConceptSheet>();
+        _sheetId = SheetId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sheetId)
+            .Events(
+                new ConceptSheetStarted(2026),
+                new ConceptDayWorked(new DateOnly(2026, 6, 1), new WorkHours(7.5m)),
+                new ConceptDayWorked(new DateOnly(2026, 6, 2), new WorkHours(8m)));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_day_entries() => _scenario.Instance!.Days.Count().ShouldEqual(2);
+    [Fact] void should_map_first_day() => _scenario.Instance!.Days.First().Day.ShouldEqual(new DateOnly(2026, 6, 1));
+    [Fact] void should_map_first_day_hours() => _scenario.Instance!.Days.First().Hours.ShouldEqual(new WorkHours(7.5m));
+    [Fact] void should_map_second_day() => _scenario.Instance!.Days.Last().Day.ShouldEqual(new DateOnly(2026, 6, 2));
+    [Fact] void should_map_second_day_hours() => _scenario.Instance!.Days.Last().Hours.ShouldEqual(new WorkHours(8m));
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_time.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_time.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_date_time : Specification
+{
+    ReadModelScenario<StampLedger> _scenario;
+    EventSourceId _ledgerId;
+    DateTime _first;
+    DateTime _second;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<StampLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+        _first = new DateTime(2026, 6, 1, 9, 0, 0, DateTimeKind.Utc);
+        _second = new DateTime(2026, 6, 2, 13, 30, 0, DateTimeKind.Utc);
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new StampAmountRecorded(_first, 1.5m),
+                new StampAmountRecorded(_second, 2.25m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_stamp_lines() => _scenario.Instance!.Stamps.Count().ShouldEqual(2);
+    [Fact] void should_map_first_stamp_key() => _scenario.Instance!.Stamps.First().Stamp.ShouldEqual(_first);
+    [Fact] void should_map_first_stamp_amount() => _scenario.Instance!.Stamps.First().Amount.ShouldEqual(1.5m);
+    [Fact] void should_map_second_stamp_key() => _scenario.Instance!.Stamps.Last().Stamp.ShouldEqual(_second);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_time_offset.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_keyed_by_date_time_offset.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+public class and_child_keyed_by_date_time_offset : Specification
+{
+    ReadModelScenario<MomentLedger> _scenario;
+    EventSourceId _ledgerId;
+    DateTimeOffset _first;
+    DateTimeOffset _second;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<MomentLedger>();
+        _ledgerId = new EventSourceId(Guid.NewGuid());
+        _first = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero);
+        _second = new DateTimeOffset(2026, 6, 2, 13, 30, 0, TimeSpan.Zero);
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Operations"),
+                new MomentAmountRecorded(_first, 1.5m),
+                new MomentAmountRecorded(_second, 2.25m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_moment_lines() => _scenario.Instance!.Moments.Count().ShouldEqual(2);
+    [Fact] void should_map_first_moment_key() => _scenario.Instance!.Moments.First().Moment.ShouldEqual(_first);
+    [Fact] void should_map_first_moment_amount() => _scenario.Instance!.Moments.First().Amount.ShouldEqual(1.5m);
+    [Fact] void should_map_second_moment_key() => _scenario.Instance!.Moments.Last().Moment.ShouldEqual(_second);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_date_only_and_concept_keyed_collections_coexist.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_date_only_and_concept_keyed_collections_coexist.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Verifies that a <see cref="DateOnly"/>-keyed child collection materializes even when a concept-keyed
+/// child collection is present on the same read model — the shape a consumer reported, where the
+/// concept-keyed collection populated but the <see cref="DateOnly"/>-keyed one appeared empty.
+/// </summary>
+public class and_date_only_and_concept_keyed_collections_coexist : Specification
+{
+    ReadModelScenario<MixedKeySheet> _scenario;
+    SheetId _sheetId;
+    ContactId _firstContact;
+    ContactId _secondContact;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<MixedKeySheet>();
+        _sheetId = SheetId.New();
+        _firstContact = new ContactId(Guid.NewGuid());
+        _secondContact = new ContactId(Guid.NewGuid());
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sheetId)
+            .Events(
+                new ConceptSheetStarted(2026),
+                new ContactAssigned(_firstContact, "Ada"),
+                new ConceptDayWorked(new DateOnly(2026, 6, 1), new WorkHours(7.5m)),
+                new ContactAssigned(_secondContact, "Grace"),
+                new ConceptDayWorked(new DateOnly(2026, 6, 2), new WorkHours(8m)));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_two_contacts() => _scenario.Instance!.Contacts.Count().ShouldEqual(2);
+    [Fact] void should_have_two_days() => _scenario.Instance!.Days.Count().ShouldEqual(2);
+    [Fact] void should_map_first_day() => _scenario.Instance!.Days.First().Day.ShouldEqual(new DateOnly(2026, 6, 1));
+    [Fact] void should_map_first_contact() => _scenario.Instance!.Contacts.First().ContactId.ShouldEqual(_firstContact);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_events_share_a_date_only_child_key.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_events_share_a_date_only_child_key.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Verifies child-identity matching for a <see cref="DateOnly"/> key: two events carrying the SAME
+/// <see cref="DateOnly"/> resolve to the SAME child (an update), not two duplicate children — the same
+/// behavior as the real runtime sink.
+/// </summary>
+public class and_two_events_share_a_date_only_child_key : Specification
+{
+    ReadModelScenario<ConceptSheet> _scenario;
+    SheetId _sheetId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<ConceptSheet>();
+        _sheetId = SheetId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sheetId)
+            .Events(
+                new ConceptSheetStarted(2026),
+                new ConceptDayWorked(new DateOnly(2026, 6, 1), new WorkHours(7.5m)),
+                new ConceptDayWorked(new DateOnly(2026, 6, 1), new WorkHours(9m)));
+
+    [Fact] void should_have_a_single_merged_child() => _scenario.Instance!.Days.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_shared_key() => _scenario.Instance!.Days.Single().Day.ShouldEqual(new DateOnly(2026, 6, 1));
+    [Fact] void should_apply_the_latest_value() => _scenario.Instance!.Days.Single().Hours.ShouldEqual(new WorkHours(9m));
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_reducing_with_a_seeded_initial_state.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_reducing_with_a_seeded_initial_state.cs
@@ -27,4 +27,5 @@ public class when_reducing_with_a_seeded_initial_state : Specification
         await _scenario.Given.ForEventSource(_id).Events(new Tallied());
 
     [Fact] void should_apply_the_event_on_top_of_the_seeded_state() => _scenario.Instance!.Count.ShouldEqual(101);
+    [Fact] void should_expose_the_reduced_instance_by_event_source_id() => _scenario.InstanceForEventSourceId(_id)!.Count.ShouldEqual(101);
 }

--- a/Source/Clients/Testing/ReadModels/MultipleInstancesMaterialized.cs
+++ b/Source/Clients/Testing/ReadModels/MultipleInstancesMaterialized.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// The exception that is thrown when <see cref="ReadModelScenario{TReadModel}.Instance"/> is accessed but
+/// the seeded events materialized more than one read model instance, making a single result ambiguous.
+/// </summary>
+/// <remarks>
+/// Assert against a specific instance with <see cref="ReadModelScenario{TReadModel}.InstanceForEventSourceId(EventSourceId)"/>,
+/// or enumerate <see cref="ReadModelScenario{TReadModel}.Instances"/>, instead of <see cref="ReadModelScenario{TReadModel}.Instance"/>.
+/// </remarks>
+/// <param name="readModelType">The read model type under test.</param>
+/// <param name="eventSourceIds">The event source ids of the materialized instances.</param>
+public class MultipleInstancesMaterialized(Type readModelType, IEnumerable<EventSourceId> eventSourceIds)
+    : Exception(BuildMessage(readModelType, [.. eventSourceIds]))
+{
+    static string BuildMessage(Type readModelType, IReadOnlyCollection<EventSourceId> eventSourceIds) =>
+        $"Events materialized {eventSourceIds.Count} instances of '{readModelType.Name}' ({string.Join(", ", eventSourceIds)}). " +
+        "'Instance' is ambiguous — use InstanceForEventSourceId(id) or Instances to select the intended one.";
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -79,9 +79,14 @@ internal static class ProjectionReadModelProcessor
     /// <param name="eventTypes"><see cref="IEventTypes"/> for looking up event type metadata.</param>
     /// <param name="jsonSchemaGenerator"><see cref="IJsonSchemaGenerator"/> for building the read model schema.</param>
     /// <param name="initialState">Optional initial read model state.</param>
-    /// <returns>The projected read model, or <see langword="null"/> if the projection did not apply any changes.</returns>
+    /// <returns>
+    /// A tuple of the primary projected read model (the threaded result exposed as <c>Instance</c>, or
+    /// <see langword="null"/> if the projection did not apply any changes) and a dictionary of every
+    /// materialized instance keyed by its event source id (read per-key from the sink, so a multi-source
+    /// projection such as a join can be asserted against the intended instance deterministically).
+    /// </returns>
     /// <exception cref="InvalidOperationException">Thrown when a deferred key cannot be resolved after retrying all events.</exception>
-    public static async Task<TReadModel?> Process<TReadModel>(
+    public static async Task<(TReadModel? Primary, IReadOnlyDictionary<EventSourceId, TReadModel> Instances)> Process<TReadModel>(
         Contracts.Projections.ProjectionDefinition projectionDefinition,
         IEnumerable<(EventSourceId EventSourceId, object Event)> events,
         IEventTypes eventTypes,
@@ -226,11 +231,17 @@ internal static class ProjectionReadModelProcessor
             await inMemorySink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
         }
 
+        // Read every materialized instance per-key from the sink. Unlike the single threaded `state`
+        // (which blends events across sources into one object), the sink keeps one document per resolved
+        // root key — so a multi-source projection (e.g. a join whose join-source event was seeded first)
+        // can be asserted against the intended instance via InstanceForEventSourceId.
+        var instances = BuildInstancesFromSink<TReadModel>(inMemorySink);
+
         // A root-level removal (a class-level [RemovedWith]) deletes the read model document in the real
         // sink; mirror that here by returning null rather than the stale pre-removal state.
         if (removed)
         {
-            return null;
+            return (null, instances);
         }
 
         InjectIdentifierFromKey<TReadModel>(state, rootKey);
@@ -241,7 +252,39 @@ internal static class ProjectionReadModelProcessor
         // ({ "value": ... }), which the concept-aware deserializer then rejects when it expects the
         // underlying primitive.
         var json = JsonSerializer.Serialize(state, Globals.JsonSerializerOptions);
-        return JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
+        var primary = JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
+        return (primary, instances);
+    }
+
+    /// <summary>
+    /// Deserializes every per-key document held by the in-memory sink into a <typeparamref name="TReadModel"/>,
+    /// keyed by its event source id — the faithful per-instance view the single threaded state cannot provide.
+    /// </summary>
+    /// <typeparam name="TReadModel">The read model type being projected.</typeparam>
+    /// <param name="sink">The in-memory sink populated during processing.</param>
+    /// <returns>A dictionary of every materialized instance keyed by its <see cref="EventSourceId"/>.</returns>
+    static Dictionary<EventSourceId, TReadModel> BuildInstancesFromSink<TReadModel>(InMemorySink sink)
+        where TReadModel : class
+    {
+        var instances = new Dictionary<EventSourceId, TReadModel>();
+        foreach (var (keyValue, document) in sink.Collection)
+        {
+            if (keyValue is null)
+            {
+                continue;
+            }
+
+            var json = JsonSerializer.Serialize(document, Globals.JsonSerializerOptions);
+            var instance = JsonSerializer.Deserialize<TReadModel>(json, Globals.JsonSerializerOptions);
+            if (instance is null)
+            {
+                continue;
+            }
+
+            instances[new EventSourceId(keyValue.ToString()!)] = instance;
+        }
+
+        return instances;
     }
 
     /// <summary>

--- a/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
+++ b/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
@@ -57,6 +57,7 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
     readonly EventStoreForTesting _eventStore = new(serviceProvider);
     readonly IServiceProvider _serviceProvider = serviceProvider ?? new DefaultServiceProvider();
     TReadModel? _instance;
+    IReadOnlyDictionary<EventSourceId, TReadModel> _instances = new Dictionary<EventSourceId, TReadModel>();
     bool _processed;
 
     /// <summary>
@@ -96,18 +97,42 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
     /// the events produced no state changes. Accessing this property triggers event processing the first
     /// time it is called after events have been collected via <see cref="CollectEventsFor"/> or
     /// <see cref="ProcessEventsFor"/>.
+    /// When the seeded events materialize more than one instance — for example a multi-source join —
+    /// a single result is ambiguous, so this throws <see cref="MultipleInstancesMaterialized"/>; select the
+    /// intended instance with <see cref="InstanceForEventSourceId(EventSourceId)"/> or <see cref="Instances"/>.
     /// </remarks>
+    /// <exception cref="MultipleInstancesMaterialized">Thrown when more than one instance materialized.</exception>
     public TReadModel? Instance
     {
         get
         {
-            if (!_processed && _collectedEvents.Count > 0)
+            EnsureProcessed();
+            if (_instances.Count > 1)
             {
-                _instance = ProcessEvents(_collectedEvents).GetAwaiter().GetResult();
-                _processed = true;
+                throw new MultipleInstancesMaterialized(typeof(TReadModel), _instances.Keys);
             }
 
             return _instance;
+        }
+    }
+
+    /// <summary>
+    /// Gets every materialized read model instance, keyed by its event source id.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Instance"/> — which returns a single threaded result and blends events across
+    /// sources into one object — this reads one document per resolved root key from the sink. Use it (or
+    /// <see cref="InstanceForEventSourceId"/>) for multi-source projections, such as a join whose
+    /// join-source event was seeded before the entity under test, to assert against the intended instance
+    /// deterministically. It is populated for projections; reducers are single-instance and expose their
+    /// result through <see cref="Instance"/> only.
+    /// </remarks>
+    public IReadOnlyDictionary<EventSourceId, TReadModel> Instances
+    {
+        get
+        {
+            EnsureProcessed();
+            return _instances;
         }
     }
 
@@ -138,6 +163,21 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
     /// <c>Given.ForEventSourceId(...).ReadModel(...)</c>.
     /// </remarks>
     public IReadModels ReadModels => _eventStore.ReadModels;
+
+    /// <summary>
+    /// Gets the materialized read model instance for a specific event source id.
+    /// </summary>
+    /// <param name="eventSourceId">The <see cref="EventSourceId"/> of the instance to return.</param>
+    /// <returns>The instance for the given event source id, or <see langword="null"/> if none was materialized.</returns>
+    /// <remarks>
+    /// This resolves a specific instance from the sink regardless of seed order, so a join/cross-stream
+    /// spec can assert against the intended entity even when another source's event was seeded first.
+    /// </remarks>
+    public TReadModel? InstanceForEventSourceId(EventSourceId eventSourceId)
+    {
+        EnsureProcessed();
+        return _instances.TryGetValue(eventSourceId, out var instance) ? instance : null;
+    }
 
     /// <summary>
     /// Registers a pre-built read model instance for a specific event source, making it available via
@@ -187,7 +227,16 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
         return Task.CompletedTask;
     }
 
-    async Task<TReadModel?> ProcessEvents(IEnumerable<(EventSourceId EventSourceId, object Event)> events)
+    void EnsureProcessed()
+    {
+        if (!_processed && _collectedEvents.Count > 0)
+        {
+            (_instance, _instances) = ProcessEvents(_collectedEvents).GetAwaiter().GetResult();
+            _processed = true;
+        }
+    }
+
+    async Task<(TReadModel? Primary, IReadOnlyDictionary<EventSourceId, TReadModel> Instances)> ProcessEvents(IEnumerable<(EventSourceId EventSourceId, object Event)> events)
     {
         var eventsList = events.ToList();
         var readModelType = typeof(TReadModel);
@@ -195,7 +244,7 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
         var reducerType = FindReducerType(readModelType);
         if (reducerType is not null)
         {
-            return await ReducerReadModelProcessor.Process<TReadModel>(
+            var reduced = await ReducerReadModelProcessor.Process<TReadModel>(
                 reducerType,
                 eventsList.Select(e => new EventForEventSourceId(e.EventSourceId, e.Event, Causation.Unknown())),
                 _eventTypes,
@@ -203,6 +252,18 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
                 _serviceProvider,
                 _namingPolicy,
                 _initialState);
+
+            // A reducer is single-instance; key its result by the event source id it reduced so that
+            // InstanceForEventSourceId / Instances behave the same as for a projection. Only the single-source
+            // case is keyed — reducing events across more than one source is misuse of a single-instance API.
+            var reducerInstances = new Dictionary<EventSourceId, TReadModel>();
+            var distinctEventSourceIds = eventsList.Select(e => e.EventSourceId).Distinct().ToList();
+            if (reduced is not null && distinctEventSourceIds.Count == 1)
+            {
+                reducerInstances[distinctEventSourceIds[0]] = reduced;
+            }
+
+            return (reduced, reducerInstances);
         }
 
         var projectionDefinition = FindProjectionDefinition(readModelType);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/TagConcept.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/TagConcept.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter;
+
+/// <summary>
+/// A bare string concept used as the element type of a read-model collection.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record TagConcept(string Value) : ConceptAs<string>(Value);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/TaggedReadModel.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/TaggedReadModel.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter;
+
+/// <summary>
+/// A read model carrying a top-level list of bare string concepts.
+/// </summary>
+/// <param name="Id">Identifier.</param>
+/// <param name="Tags">The list of bare string concepts.</param>
+public record TaggedReadModel(Guid Id, IEnumerable<TagConcept> Tags);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_a_concept_list_to_bson_value.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_a_concept_list_to_bson_value.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter;
+
+/// <summary>
+/// Reproduces the changeset conversion path (ChangesetConverter -> MongoDBConverter.ToBsonValue) for a
+/// property that is a list of bare concepts, ensuring each element persists as its underlying value.
+/// </summary>
+public class when_converting_a_concept_list_to_bson_value : Specification
+{
+    MongoDBConverter _converter;
+    BsonValue _result;
+
+    void Establish()
+    {
+        var typeFormats = new TypeFormats();
+        var model = new ReadModelDefinition(
+            typeof(TaggedReadModel).FullName,
+            nameof(TaggedReadModel),
+            nameof(TaggedReadModel),
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, JsonSchema.FromType<TaggedReadModel>() },
+            },
+            []);
+        _converter = new(new ExpandoObjectConverter(typeFormats), typeFormats, model);
+    }
+
+    void Because() => _result = _converter.ToBsonValue(
+        new object[] { new TagConcept("red"), new TagConcept("green") },
+        new PropertyPath("tags"));
+
+    [Fact] void should_be_an_array() => _result.IsBsonArray.ShouldBeTrue();
+    [Fact] void should_have_two_elements() => _result.AsBsonArray.Count.ShouldEqual(2);
+    [Fact] void should_store_first_as_underlying_string() => _result.AsBsonArray[0].AsString.ShouldEqual("red");
+    [Fact] void should_store_second_as_underlying_string() => _result.AsBsonArray[1].AsString.ShouldEqual("green");
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/BareStringConcept.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/BareStringConcept.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.for_ExpandoObjectConverter;
+
+/// <summary>
+/// A bare string concept used as the element type of a read-model collection, to verify the MongoDB
+/// converter persists a list of bare concepts rather than dropping it.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record BareStringConcept(string Value) : ConceptAs<string>(Value);

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/ConceptListTargetType.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/ConceptListTargetType.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.for_ExpandoObjectConverter;
+
+/// <summary>
+/// A read model with top-level lists of bare concepts — over both a <see cref="string"/> and a
+/// <see cref="Guid"/> — used to verify the MongoDB converter round-trips a concept collection by its
+/// underlying value instead of persisting it empty, for any concept underlying type.
+/// </summary>
+/// <param name="Id">Identifier.</param>
+/// <param name="Tags">The list of bare string concepts.</param>
+/// <param name="Refs">The list of bare <see cref="Guid"/> concepts.</param>
+public record ConceptListTargetType(Guid Id, IEnumerable<BareStringConcept> Tags, IEnumerable<GuidConcept> Refs);

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/GuidConcept.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/GuidConcept.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.for_ExpandoObjectConverter;
+
+/// <summary>
+/// A bare <see cref="System.Guid"/> concept, used to verify the converter persists a collection of
+/// concepts over a non-string primitive (not just <see cref="string"/>) by its underlying value.
+/// </summary>
+/// <param name="Value">The underlying value.</param>
+public record GuidConcept(Guid Value) : ConceptAs<Guid>(Value);

--- a/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_expando_object_with_a_concept_list_to_bson_document.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/for_ExpandoObjectConverter/when_converting_expando_object_with_a_concept_list_to_bson_document.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+
+namespace Cratis.Chronicle.Storage.MongoDB.for_ExpandoObjectConverter;
+
+/// <summary>
+/// Reproduces the reported "bare-concept list persists empty to MongoDB" behavior at the sink's BSON
+/// conversion layer (no MongoDB server needed — the conversion is a pure in-process operation).
+/// </summary>
+public class when_converting_expando_object_with_a_concept_list_to_bson_document : Specification
+{
+    ExpandoObjectConverter _converter;
+    JsonSchema _schema;
+    ExpandoObject _source;
+    Guid _id;
+    Guid _firstRef;
+    BsonDocument _result;
+
+    void Establish()
+    {
+        _converter = new(new TypeFormats());
+        _schema = JsonSchema.FromType<ConceptListTargetType>();
+        _id = Guid.NewGuid();
+        _firstRef = Guid.NewGuid();
+
+        dynamic expando = new ExpandoObject();
+        expando.id = _id;
+        expando.tags = new List<object> { new BareStringConcept("red"), new BareStringConcept("green") };
+        expando.refs = new List<object> { new GuidConcept(_firstRef), new GuidConcept(Guid.NewGuid()) };
+        _source = expando;
+    }
+
+    ExpandoObject _roundTripped;
+
+    void Because()
+    {
+        _result = _converter.ToBsonDocument(_source, _schema);
+        _roundTripped = _converter.ToExpandoObject(_result, _schema);
+    }
+
+    [Fact] void should_have_a_tags_array() => _result.GetElement("tags").Value.IsBsonArray.ShouldBeTrue();
+    [Fact] void should_have_two_tags() => _result.GetElement("tags").Value.AsBsonArray.Count.ShouldEqual(2);
+    [Fact] void should_persist_first_tag_as_its_underlying_string() => _result.GetElement("tags").Value.AsBsonArray[0].AsString.ShouldEqual("red");
+    [Fact] void should_persist_second_tag_as_its_underlying_string() => _result.GetElement("tags").Value.AsBsonArray[1].AsString.ShouldEqual("green");
+    [Fact] void should_round_trip_the_tags() => ((IEnumerable<object>)((IDictionary<string, object?>)_roundTripped)["tags"]!).Count().ShouldEqual(2);
+    [Fact] void should_round_trip_first_tag_value() => ((IEnumerable<object>)((IDictionary<string, object?>)_roundTripped)["tags"]!).First().ToString().ShouldEqual("red");
+    [Fact] void should_have_two_refs() => _result.GetElement("refs").Value.AsBsonArray.Count.ShouldEqual(2);
+    [Fact] void should_persist_first_ref_as_its_underlying_guid() => _result.GetElement("refs").Value.AsBsonArray[0].AsGuid.ShouldEqual(_firstRef);
+}

--- a/Source/Kernel/Storage.MongoDB/BsonValueExtensions.cs
+++ b/Source/Kernel/Storage.MongoDB/BsonValueExtensions.cs
@@ -336,7 +336,12 @@ public static class BsonValueExtensions
                 return new BsonDouble(value is double actualDouble ? actualDouble : double.Parse(value.ToString()!));
         }
 
-        return BsonNull.Value;
+        // The schema type gives no usable primitive mapping — for example a concept whose reference schema
+        // resolves to no primitive type, or any other value the switch does not recognize. Convert by the
+        // value's runtime type instead of silently dropping it to null: ToBsonValue unwraps concepts and
+        // handles primitives, enums, GUIDs and dates. Losing the value here is how a bare-concept collection
+        // (e.g. IReadOnlyList<ConceptAs<string>>) previously persisted empty to MongoDB.
+        return value.ToBsonValue();
     }
 
     static bool TryConvertNullPrimitive(Type targetType, out object? result)


### PR DESCRIPTION
## Added

- `ReadModelScenario<T>.Instances` and `InstanceForEventSourceId(id)` for asserting a specific materialized read model when a projection spans multiple event sources — for example a `[Join]` whose join-source event is seeded before the entity under test, which previously shadowed it in `Instance`.

## Fixed

- Read-model properties that are collections of bare concepts (for example `IReadOnlyList<ConceptAs<string>>`) no longer persist empty to MongoDB — the concept elements are now stored as their underlying values, matching the in-memory sink.
