### PR TITLE
Fix re-keyed read-model PII returning as ciphertext on read

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/given/all_dependencies.cs
@@ -100,8 +100,8 @@ public class all_dependencies : Specification
         return new AppendedEvent(context, new ExpandoObject());
     }
 
-    protected ReducerContext CreateContext(string eventSourceId, Subject? subject = null) =>
-        new([CreateEvent(eventSourceId, subject)], new Key(eventSourceId, new ArrayIndexers([])));
+    protected ReducerContext CreateContext(string eventSourceId, Subject? subject = null, string? key = null) =>
+        new([CreateEvent(eventSourceId, subject)], new Key(key ?? eventSourceId, new ArrayIndexers([])));
 
     protected ReducerDelegate CreateReducer(ExpandoObject? returnState) =>
         (_, _) => Task.FromResult(new ReducerSubscriberResult(

--- a/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_is_rekeyed.cs
+++ b/Source/Kernel/Core.Specs/Observation/Reducers/for_ReducerPipeline/when_handling/and_read_model_is_rekeyed.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Observation.Reducers.for_ReducerPipeline.when_handling;
+
+public class and_read_model_is_rekeyed : given.all_dependencies
+{
+    const string ResolvedKey = "resolved-key";
+
+    ExpandoObject _returnedState;
+
+    void Establish()
+    {
+        _schema.Properties["name"] = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                {
+                    ComplianceJsonSchemaExtensions.ComplianceKey,
+                    new[] { new ComplianceSchemaMetadata("PII", string.Empty) }
+                }
+            }
+        };
+
+        _returnedState = new ExpandoObject();
+        _sink.FindOrDefault(Arg.Any<Concepts.Keys.Key>()).Returns(Task.FromResult<ExpandoObject?>(null));
+    }
+
+    async Task Because() => await _pipeline.Handle(
+        CreateContext(EventSourceIdValue, key: ResolvedKey),
+        CreateReducer(_returnedState));
+
+    [Fact] void should_call_apply_with_the_resolved_key_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), ResolvedKey, Arg.Any<JsonObject>());
+    [Fact] void should_not_use_the_event_source_id_as_identifier() => _complianceManager.DidNotReceive().Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/given/all_dependencies.cs
@@ -53,7 +53,7 @@ public class all_dependencies : Specification
         _step = new EncryptChangeset(new ReadModelsCompliance(_complianceManager, _expandoObjectConverter), _objectComparer, EventStore, EventStoreNamespace);
     }
 
-    protected ProjectionEventContext CreateContext(string eventSourceId, Subject? subject = null)
+    protected ProjectionEventContext CreateContext(string eventSourceId, Subject? subject = null, string? key = null)
     {
         var @event = new AppendedEvent(
             EventContext.From(
@@ -72,7 +72,7 @@ public class all_dependencies : Specification
         var changeset = new Changeset<AppendedEvent, ExpandoObject>(_objectComparer, @event, new ExpandoObject());
 
         return new ProjectionEventContext(
-            new Key(eventSourceId, new ArrayIndexers([])),
+            new Key(key ?? eventSourceId, new ArrayIndexers([])),
             @event,
             changeset,
             ProjectionOperationType.None,

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_projection_is_rekeyed.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_projection_is_rekeyed.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
+
+public class and_projection_is_rekeyed : given.all_dependencies
+{
+    const string ResolvedKey = "resolved-key";
+
+    ProjectionEventContext _context;
+    ProjectionEventContext _result;
+
+    void Establish()
+    {
+        _schema.Properties["name"] = new JsonSchemaProperty
+        {
+            ExtensionData = new Dictionary<string, object?>
+            {
+                { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata("PII", string.Empty) } }
+            }
+        };
+
+        // A re-keyed projection: the document key (resolved key) differs from the source event's event source id.
+        _context = CreateContext(EventSourceIdValue, key: ResolvedKey);
+    }
+
+    async Task Because() => _result = await _step.Perform(_projection, _context);
+
+    [Fact] void should_use_the_resolved_key_as_identifier() => _complianceManager.Received(1).Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), ResolvedKey, Arg.Any<JsonObject>());
+    [Fact] void should_not_use_the_event_source_id() => _complianceManager.DidNotReceive().Apply(EventStore, EventStoreNamespace, Arg.Any<JsonSchema>(), EventSourceIdValue, Arg.Any<JsonObject>());
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/given/an_event_context.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/given/an_event_context.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.ReadModels.for_ComplianceIdentifierExtensions.given;
+
+public class an_event_context : Specification
+{
+    protected const string EventSourceIdValue = "event-source-id";
+    protected const string ResolvedKeyValue = "resolved-key";
+    protected const string ExplicitSubjectValue = "explicit-subject";
+
+    protected static EventContext EventContextFor(string eventSourceId, Subject? subject = null) =>
+        EventContext.From(
+            "test-store",
+            "test-namespace",
+            EventType.Unknown,
+            EventSourceType.Default,
+            eventSourceId,
+            EventStreamType.All,
+            EventStreamId.Default,
+            EventSequenceNumber.First,
+            CorrelationId.NotSet,
+            subject: subject);
+
+    protected static Key KeyFor(string value) => new(value, ArrayIndexers.NoIndexers);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_the_document_is_rekeyed.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_the_document_is_rekeyed.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ComplianceIdentifierExtensions.when_resolving_the_compliance_identifier;
+
+public class and_the_document_is_rekeyed : given.an_event_context
+{
+    string _result;
+
+    void Because() => _result = EventContextFor(EventSourceIdValue).ResolveComplianceIdentifier(KeyFor(ResolvedKeyValue));
+
+    [Fact] void should_use_the_resolved_document_key() => _result.ShouldEqual(ResolvedKeyValue);
+    [Fact] void should_not_use_the_event_source_id() => _result.ShouldNotEqual(EventSourceIdValue);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_there_is_an_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_there_is_an_explicit_subject.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.ReadModels.for_ComplianceIdentifierExtensions.when_resolving_the_compliance_identifier;
+
+public class and_there_is_an_explicit_subject : given.an_event_context
+{
+    string _result;
+
+    void Because()
+    {
+        // The document is re-keyed, yet an explicit subject that differs from the event source id still wins.
+        _result = EventContextFor(EventSourceIdValue, (Subject)ExplicitSubjectValue).ResolveComplianceIdentifier(KeyFor(ResolvedKeyValue));
+    }
+
+    [Fact] void should_use_the_explicit_subject() => _result.ShouldEqual(ExplicitSubjectValue);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_there_is_no_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ComplianceIdentifierExtensions/when_resolving_the_compliance_identifier/and_there_is_no_explicit_subject.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ComplianceIdentifierExtensions.when_resolving_the_compliance_identifier;
+
+public class and_there_is_no_explicit_subject : given.an_event_context
+{
+    string _result;
+
+    void Because() => _result = EventContextFor(EventSourceIdValue).ResolveComplianceIdentifier(KeyFor(EventSourceIdValue));
+
+    [Fact] void should_use_the_document_key() => _result.ShouldEqual(EventSourceIdValue);
+}

--- a/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
+++ b/Source/Kernel/Core/Observation/Reducers/ReducerPipeline.cs
@@ -69,7 +69,7 @@ public class ReducerPipeline(
 
         if (result.ObserverResult.State != ObserverSubscriberState.Ok) return;
 
-        var identifier = context.Events.First().Context.Subject.Value;
+        var identifier = context.Events.First().Context.ResolveComplianceIdentifier(context.Key);
 
         var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, context.Events.First(), initial ?? new ExpandoObject());
         if (result.ReadModelState is null)

--- a/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
+++ b/Source/Kernel/Core/Projections/Engine/Pipelines/Steps/EncryptChangeset.cs
@@ -33,9 +33,7 @@ public class EncryptChangeset(
             return context;
         }
 
-        var identifier = context.Event.Context.Subject?.IsSet == true
-            ? context.Event.Context.Subject.Value
-            : context.Event.Context.EventSourceId.Value;
+        var identifier = context.Event.Context.ResolveComplianceIdentifier(context.Key);
 
         var schema = projection.TargetReadModelSchema;
         var currentState = context.Changeset.CurrentState;

--- a/Source/Kernel/Core/ReadModels/ComplianceIdentifierExtensions.cs
+++ b/Source/Kernel/Core/ReadModels/ComplianceIdentifierExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+
+namespace Cratis.Chronicle.ReadModels;
+
+/// <summary>
+/// Extension methods for resolving the compliance subject identifier of a read-model document.
+/// </summary>
+public static class ComplianceIdentifierExtensions
+{
+    /// <summary>
+    /// Resolves the compliance subject identifier for the read-model document an event projects into.
+    /// </summary>
+    /// <param name="context">The <see cref="EventContext"/> of the event being projected or reduced.</param>
+    /// <param name="key">The resolved <see cref="Key"/> the read-model document is stored under.</param>
+    /// <returns>The identifier to encrypt PII under and to stamp as the document's compliance subject.</returns>
+    /// <remarks>
+    /// A read-model document must encrypt and release its PII under a single, stable subject for its whole
+    /// lifetime; otherwise the stored subject and the identity the PII was encrypted under diverge and the
+    /// PII no longer decrypts on read. For a re-keyed projection or reducer the document key differs from the
+    /// source event's event source id, and a single document can be fed by events from several source
+    /// streams — so the per-event event source id is not a stable document identity. The resolved document
+    /// key is, so it is used whenever the event's subject is simply its event source id. An explicit
+    /// compliance subject (one that differs from the event source id) is honored as-is, preserving a
+    /// caller-provided subject.
+    /// </remarks>
+    public static string ResolveComplianceIdentifier(this EventContext context, Key key) =>
+        context.Subject?.IsSet == true && context.Subject.Value != context.EventSourceId.Value
+            ? context.Subject.Value
+            : key.Value?.ToString() ?? context.EventSourceId.Value;
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.Pipelines.Steps;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Compliance;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelRekeyedCompliance;
+
+/// <summary>
+/// Regression for a re-keyed projection returning <c>[PII]</c> as ciphertext on read. The read model is
+/// keyed by a property other than the source event's event source id, so the document key (<c>_id</c>) and
+/// the source event's compliance subject diverge. The document must encrypt PII under, and stamp its
+/// <c>__subject</c> as, its own resolved key — otherwise the identity the PII is encrypted under is not the
+/// one the read path releases it with, and the value never decrypts. Runs the real projection encryption
+/// step through a real MongoDB sink.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_rekeyed_projection_persists_pii(MongoDBFixture fixture) : Specification
+{
+    const string EventStore = "test-store";
+    const string EventStoreNamespace = "test-namespace";
+    const string DocumentKey = "member-1";
+    const string SourceEventSourceId = "group-1";
+    const string PlaintextName = "Ada Lovelace";
+
+    IMongoClient _client = default!;
+    string _databaseName = default!;
+    SinkCollections _collections = default!;
+    Sink _sink = default!;
+    JsonComplianceManager _complianceManager = default!;
+    ReadModelsCompliance _compliance = default!;
+    JsonSchema _schema = default!;
+    Key _key = default!;
+    EncryptChangeset _step = default!;
+    IProjection _projection = default!;
+
+    string _storedId = default!;
+    string? _storedSubject;
+    string _storedName = default!;
+    string? _releasedNameUnderDocumentKey;
+
+    async Task Establish()
+    {
+        _schema = await JsonSchema.FromJsonAsync(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string", "compliance": [ { "metadataType": "PII", "details": "" } ] }
+              }
+            }
+            """);
+
+        var typeFormats = new TypeFormats();
+        var sinkConverter = new ExpandoObjectConverter(typeFormats);
+        var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
+        _complianceManager = new JsonComplianceManager(
+            new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+        _compliance = new ReadModelsCompliance(_complianceManager, complianceConverter);
+
+        _databaseName = $"chronicle_rekeyed_pii_{Guid.NewGuid():N}";
+        _client = new MongoClient(fixture.ConnectionString);
+        var database = _client.GetDatabase(_databaseName);
+
+        var readModel = new ReadModelDefinition(
+            "rekeyed-pii-read-model",
+            $"rekeyed_pii_{Guid.NewGuid():N}",
+            "RekeyedPiiReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema> { { ReadModelGeneration.First, _schema } },
+            []);
+
+        _collections = new SinkCollections(readModel, database);
+        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+        var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, _collections, sinkConverter);
+        _sink = new Sink(readModel, mongoDBConverter, _collections, changesetConverter, sinkConverter);
+
+        _projection = Substitute.For<IProjection>();
+        _projection.TargetReadModelSchema.Returns(_schema);
+        _step = new EncryptChangeset(_compliance, new ObjectComparer(), EventStore, EventStoreNamespace);
+        _key = new Key(DocumentKey, ArrayIndexers.NoIndexers);
+    }
+
+    async Task Because()
+    {
+        // The projected state for the re-keyed document, built from the decrypted event.
+        var state = new ExpandoObject();
+        var stateValues = (IDictionary<string, object?>)state;
+        stateValues["id"] = DocumentKey;
+        stateValues["name"] = PlaintextName;
+
+        // The event was appended to the parent (group) stream, so its event source id / subject is the group,
+        // not the member the read model is re-keyed by.
+        var @event = new AppendedEvent(
+            EventContext.From(
+                EventStore,
+                EventStoreNamespace,
+                EventType.Unknown,
+                EventSourceType.Default,
+                SourceEventSourceId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                CorrelationId.NotSet),
+            new ExpandoObject());
+
+        var changeset = new Changeset<AppendedEvent, ExpandoObject>(new ObjectComparer(), @event, state);
+        var context = new ProjectionEventContext(_key, @event, changeset, ProjectionOperationType.None, false);
+
+        await _step.Perform(_projection, context);
+        await _sink.ApplyChanges(_key, changeset, EventSequenceNumber.First);
+
+        var stored = await _collections.GetCollection().Find(Builders<BsonDocument>.Filter.Empty).FirstAsync();
+        _storedId = stored["_id"].AsString;
+        _storedSubject = stored.Contains(WellKnownProperties.Subject) ? stored[WellKnownProperties.Subject].AsString : null;
+        _storedName = stored["name"].AsString;
+
+        // Release the stored PII under the document's own key — the identity a re-keyed document is stored
+        // under. When the encryption identity matches the document key this returns the plaintext; when they
+        // diverge (the bug) the key for the document id does not exist and release fails.
+        try
+        {
+            var released = await _complianceManager.Release(
+                EventStore,
+                EventStoreNamespace,
+                _schema,
+                _storedId,
+                new JsonObject { ["name"] = _storedName });
+            _releasedNameUnderDocumentKey = released["name"]!.GetValue<string>();
+        }
+        catch
+        {
+            _releasedNameUnderDocumentKey = null;
+        }
+    }
+
+    async Task Destroy()
+    {
+        if (_databaseName is not null)
+        {
+            await _client.DropDatabaseAsync(_databaseName);
+        }
+    }
+
+    [Fact] void should_store_pii_as_ciphertext_not_plaintext() => _storedName.ShouldNotEqual(PlaintextName);
+
+    [Fact] void should_stamp_the_document_subject_as_the_resolved_key() => _storedSubject.ShouldEqual(_storedId);
+
+    [Fact] void should_encrypt_pii_under_the_document_key() => _releasedNameUnderDocumentKey.ShouldEqual(PlaintextName);
+}


### PR DESCRIPTION
## Fixed

- Read models keyed by a property other than their event source id (for example `[FromEvent<T>(key: nameof(...))]`, or a re-keyed reducer) now decrypt their `[PII]` properties on read. Previously the value was encrypted under the source event's subject while the document was stored under a different key, so queries and command-side reads returned it as ciphertext. The read-model document now encrypts and releases its PII under its own resolved key, so it stays decryptable for the document's whole lifetime.
