### PR TITLE
Fix Chronicle server container images failing to start with Permission denied

### DIFF
--- a/Docker/Local/Dockerfile
+++ b/Docker/Local/Dockerfile
@@ -14,6 +14,10 @@ RUN chmod +x ./entrypoint.sh
 
 COPY /Source/Kernel/Server/out /app
 
+# Restore the executable bit on the apphost — publish artifacts can arrive without it
+# (upload-artifact drops Unix permissions) and the entrypoint runs it directly (exit 126 otherwise).
+RUN chmod +x ./Cratis.Chronicle.Server
+
 # Microsoft.Data.SqlClient does not support Globalization Invariant Mode and throws
 # NotSupportedException on connection open. Server.csproj sets InvariantGlobalization=true
 # for minimal-image mode which bakes the switch into runtimeconfig.json; patch it here so

--- a/Docker/LocalSlim/Dockerfile
+++ b/Docker/LocalSlim/Dockerfile
@@ -30,6 +30,10 @@ RUN chmod +x ./entrypoint.sh
 
 COPY /Source/Kernel/Server/out /app
 
+# Restore the executable bit on the apphost — publish artifacts can arrive without it
+# (upload-artifact drops Unix permissions) and the entrypoint runs it directly (exit 126 otherwise).
+RUN chmod +x ./Cratis.Chronicle.Server
+
 # Microsoft.Data.SqlClient does not support Globalization Invariant Mode and throws
 # NotSupportedException on connection open. Server.csproj sets InvariantGlobalization=true
 # which bakes both switches into runtimeconfig.json; flip them so the MSSQL integration

--- a/Docker/copy-server-files.sh
+++ b/Docker/copy-server-files.sh
@@ -11,4 +11,10 @@ cp ./out/$ARCH_FOLDER/*.json .
 cp ./out/$ARCH_FOLDER/*.xml .
 cp ./out/$ARCH_FOLDER/*.so .
 cp ./out/$ARCH_FOLDER/Cratis.Chronicle.Server .
+
+# Restore the executable bit on the apphost. The published binary loses it in transit
+# (actions/upload-artifact does not preserve Unix permissions), and every entrypoint
+# invokes ./Cratis.Chronicle.Server directly — without +x the container exits 126.
+chmod +x Cratis.Chronicle.Server
+
 rm -rf ./out


### PR DESCRIPTION
# Summary
Container images of the Chronicle server published since 15.37.0 failed to start. Every image's entrypoint runs the server apphost directly, but the binary shipped without its Unix executable bit, so the container exited immediately with `Permission denied` (exit code 126) and the kernel never came up. This affected every server image variant — `-development`, `-development-slim`, and the production image — on both amd64 and arm64. The executable bit is now restored during image assembly, so the images start normally again. If you are pinned to a broken tag, `15.36.1` is the last release that starts without a workaround.

## Fixed
- Chronicle server Docker images could not start — they exited with `Permission denied` (exit code 126) because the server executable was missing its executable bit. The bit is now restored during image assembly; all server images published since 15.37.0 were affected and now start correctly.
