### PR TITLE
Correct stale net6.0 path in Kernel README (cuts 15.38.3 with #3446 image fix)

### DIFF
--- a/Source/Kernel/Server/README.md
+++ b/Source/Kernel/Server/README.md
@@ -86,7 +86,7 @@ dotnet counters ps
 Find the process for the Kernel:
 
 ```shell
- 2483  Cratis.Ke  /Source/Kernel/Server/bin/Debug/net6.0/Cratis.Chronicle.Server
+ 2483  Cratis.Ke  /Source/Kernel/Server/bin/Debug/net10.0/Cratis.Chronicle.Server
 ```
 
 Then use the process id as parameter for the monitor:


### PR DESCRIPTION
# Summary
Cuts the **15.38.3** patch release that ships the container-image fix from #3446. Chronicle server images published since 15.37.0 failed to start — every image's entrypoint runs the server apphost directly, but the binary shipped without its executable bit, so the container exited with `Permission denied` (exit code 126) and the kernel never started. #3446 restored the bit, but the fix was Docker-only and the Publish workflow triggers only on `Source/**` changes, so it could not publish on its own. This PR makes a small Kernel README correction to trigger the release so the fixed images ship.

## Fixed
- Chronicle server Docker images could not start — they exited with `Permission denied` (exit code 126) because the server executable was missing its executable bit. Restored in #3446 and shipped in this release; all server images published since 15.37.0 were affected.
- Correct a stale `net6.0` output path in the Kernel README `dotnet counters` example (the Kernel targets `net10.0`).
