### PR TITLE
Trigger publish for Docker-only and publish-workflow changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,11 @@ on:
       - "**"
     paths:
       - "Source/**"
+      # Image definitions ship in the published Docker images, so a Docker-only
+      # change (e.g. a Dockerfile or entrypoint fix) must be able to cut a release.
+      - "Docker/**"
+      # Changes to the publish pipeline itself should be exercised by a release.
+      - ".github/workflows/publish.yml"
 
 
 permissions:


### PR DESCRIPTION
# Summary
The Publish workflow triggered only on `Source/**` changes, so a Docker-only fix — like #3446 restoring the server apphost's executable bit — could not cut a release by itself. This adds `Docker/**` and the publish workflow file to the trigger paths so image and pipeline fixes can publish going forward.

_Internal CI change — no user-facing impact; nothing for the changelog._
