### PR TITLE
Add client-side GDPR right-to-erasure for PII encryption keys

### DIFF
--- a/.ai/rules/concepts.md
+++ b/.ai/rules/concepts.md
@@ -27,6 +27,7 @@ Never use raw primitives (`string`, `int`, `Guid`) in domain models, commands, e
   - `Guid` → `NotSet` backed by `Guid.Empty`
   - `string` → `NotSet` backed by `string.Empty`
   - `int` / `long` → `NotSet` backed by `0` / `0L`
+- **Reference the sentinel — never reconstruct it.** When you need a concept's empty/unset value — in production code **and** specs — use its `NotSet` (or equivalently named) static property. Never pass a raw `string.Empty` / `Guid.Empty` / `0` (or the underlying primitive's empty) that implicitly converts to the concept: `EventStoreName.NotSet` states intent, reads as the domain value rather than a primitive, and survives a change to the sentinel's backing value (e.g. `EventStoreName.NotSet` is `"[NotSet]"`, not `""`). If a concept you need an empty of lacks a sentinel, add one.
 - For identity concepts, add a `static New()` factory — it reads better than `new AuthorId(Guid.NewGuid())`.
 - Place concepts in the folder they belong to — never a standalone `Concepts/` folder. Slice-specific → slice file; feature-shared → feature folder; module-shared → module folder; app-wide → `Common/`.
 - One concept per file, named after the concept (e.g. `AuthorId.cs`, `AuthorName.cs`).

--- a/.ai/rules/specs.csharp.md
+++ b/.ai/rules/specs.csharp.md
@@ -94,6 +94,7 @@ From `Cratis.Specifications`: `.ShouldEqual(expected)`, `.ShouldBeTrue()`, `.Sho
 - Common usings come from `GlobalUsings.Specs.cs` (`Xunit`, `NSubstitute`, `Cratis.Specifications`, …) — don't duplicate them, and don't add a using for the system-under-test namespace.
 - **`using` ordering (SA1210/SA1211):** non-aliased namespaces first, then a blank line, then `using <alias> = …` aliases sorted by alias name. Alias a type whose short name collides with a namespace segment (CS0118) — `using RegisterAuthorCmd = …` style, with a domain-meaningful alias, never a technical `Command`/`Event`/`Component` suffix.
 - Single-statement assertion lambdas use expression-body form (RCS1021) — `[Fact] void should_x() => result.ShouldEqual(...)`, not a `{ … }` block. Don't break long `should_` lines; don't add blank lines between `should_` methods.
+- **Prefer a concept's sentinel over a raw empty primitive.** When a `ConceptAs<T>` / `EventSourceId<T>` value is expected — as an argument, a mock setup, or an assertion — use its `NotSet` (or `Empty` / `New()`) static rather than a `string.Empty` / `Guid.Empty` / `0` that implicitly converts. It states intent and survives a sentinel-value change (see [concepts.md](./concepts.md)). Reserve raw `string.Empty` for genuinely non-concept `string` values (e.g. asserting a decrypted-to-empty JSON payload).
 
 ## What NOT to spec
 

--- a/Integration/Client/for_PIIManager/PersonRegistered.cs
+++ b/Integration/Client/for_PIIManager/PersonRegistered.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.for_PIIManager;
+
+/// <summary>
+/// A PII-carrying event whose encryption key is scoped to the person's own compliance subject.
+/// </summary>
+/// <param name="PersonId">The subject the PII is encrypted under.</param>
+/// <param name="Name">A non-PII value that must survive right-to-erasure.</param>
+/// <param name="SocialSecurityNumber">The PII value that must become unreadable after erasure.</param>
+[EventType]
+public record PersonRegistered(
+    [Subject] string PersonId,
+    string Name,
+    [property: PII] string SocialSecurityNumber);

--- a/Integration/Client/for_PIIManager/when_deleting_the_encryption_key_for_a_subject.cs
+++ b/Integration/Client/for_PIIManager/when_deleting_the_encryption_key_for_a_subject.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using context = Cratis.Chronicle.Integration.for_PIIManager.when_deleting_the_encryption_key_for_a_subject.context;
+
+namespace Cratis.Chronicle.Integration.for_PIIManager;
+
+[Collection(ChronicleCollection.Name)]
+public class when_deleting_the_encryption_key_for_a_subject(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
+    {
+        public EventSourceId EventSourceId { get; } = "request-42";
+        public Subject Subject { get; } = "person-42";
+        public PersonRegistered Event { get; private set; }
+        public string SocialSecurityNumberBeforeErasure { get; private set; }
+        public AppendedEvent ReadEventAfterErasure { get; private set; }
+
+        public override IEnumerable<Type> EventTypes => [typeof(PersonRegistered)];
+
+        void Establish() => Event = new PersonRegistered(Subject, "Jane Doe", "111-22-3333");
+
+        async Task Because()
+        {
+            await EventStore.EventLog.Append(EventSourceId, Event);
+
+            // Read back decrypted — proves the PII round-trips before erasure.
+            SocialSecurityNumberBeforeErasure = ((PersonRegistered)(await ReadEvent()).Content).SocialSecurityNumber;
+
+            // Trigger client-side right-to-erasure — the seam a downstream app uses via IPIIManager
+            // (IEventStore.PII resolves the same DI-registered instance) — crypto-shredding the subject's key.
+            await EventStore.PII.DeleteEncryptionKeyFor(Subject);
+
+            // Read again — must not throw; the PII property must now be empty.
+            ReadEventAfterErasure = await ReadEvent();
+        }
+
+        async Task<AppendedEvent> ReadEvent()
+        {
+            var events = await EventStore.EventLog.GetFromSequenceNumber(EventSequenceNumber.First);
+            return events.First(_ => _.Context.SequenceNumber == EventSequenceNumber.First);
+        }
+    }
+
+    [Fact]
+    void should_have_decrypted_the_pii_before_erasure() =>
+        Context.SocialSecurityNumberBeforeErasure.ShouldEqual(Context.Event.SocialSecurityNumber);
+
+    [Fact]
+    void should_be_able_to_read_the_event_after_erasure() =>
+        Context.ReadEventAfterErasure.ShouldNotBeNull();
+
+    [Fact]
+    void should_return_empty_pii_after_erasure() =>
+        ((PersonRegistered)Context.ReadEventAfterErasure.Content).SocialSecurityNumber.ShouldEqual(string.Empty);
+
+    [Fact]
+    void should_retain_non_pii_content_after_erasure() =>
+        ((PersonRegistered)Context.ReadEventAfterErasure.Content).Name.ShouldEqual(Context.Event.Name);
+}

--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -108,6 +108,7 @@ public static class ChronicleClientServiceCollectionExtensions
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Reducers);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Projections);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().ReadModels);
+        services.AddScoped(sp => sp.GetRequiredService<IEventStore>().PII);
 
         services.AddSingleton(_ => chronicleBuilder?.ClientArtifactsProvider ?? DefaultClientArtifactsProvider.Default);
         services.AddSingleton(_ => chronicleBuilder?.NamingPolicy ?? new DefaultNamingPolicy());

--- a/Source/Clients/DotNET.Specs/Compliance/GDPR/for_PIIManager/given/a_pii_manager.cs
+++ b/Source/Clients/DotNET.Specs/Compliance/GDPR/for_PIIManager/given/a_pii_manager.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Compliance;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIIManager.given;
+
+public class a_pii_manager : Specification
+{
+    protected static readonly EventStoreName _eventStore = "the-store";
+    protected static readonly EventStoreNamespaceName _namespace = "the-namespace";
+
+    protected ICompliance _compliance;
+    protected PIIManager _manager;
+
+    void Establish()
+    {
+        _compliance = Substitute.For<ICompliance>();
+
+        var services = Substitute.For<IServices>();
+        services.Compliance.Returns(_compliance);
+
+        var connection = Substitute.For<IChronicleConnection, IChronicleServicesAccessor>();
+        ((IChronicleServicesAccessor)connection).Services.Returns(services);
+
+        _manager = new PIIManager(_eventStore, _namespace, connection);
+    }
+}

--- a/Source/Clients/DotNET.Specs/Compliance/GDPR/for_PIIManager/when_deleting_encryption_key_for_a_subject.cs
+++ b/Source/Clients/DotNET.Specs/Compliance/GDPR/for_PIIManager/when_deleting_encryption_key_for_a_subject.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Compliance;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIIManager;
+
+public class when_deleting_encryption_key_for_a_subject : given.a_pii_manager
+{
+    static readonly Subject _subject = "person-42";
+
+    async Task Because() => await _manager.DeleteEncryptionKeyFor(_subject);
+
+    [Fact]
+    async Task should_delete_the_key_for_the_store() =>
+        await _compliance.Received(1).DeleteEncryptionKey(
+            Arg.Is<DeleteEncryptionKeyRequest>(_ => _.EventStore == _eventStore.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_delete_the_key_for_the_namespace() =>
+        await _compliance.Received(1).DeleteEncryptionKey(
+            Arg.Is<DeleteEncryptionKeyRequest>(_ => _.Namespace == _namespace.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_delete_the_key_for_the_subject_identifier() =>
+        await _compliance.Received(1).DeleteEncryptionKey(
+            Arg.Is<DeleteEncryptionKeyRequest>(_ => _.Identifier == _subject.Value),
+            Arg.Any<CallContext>());
+}

--- a/Source/Clients/DotNET/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/DotNET/ChronicleClientServiceCollectionExtensions.cs
@@ -104,6 +104,7 @@ internal static class ChronicleClientServiceCollectionExtensions
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Reducers);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Projections);
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().ReadModels);
+        services.AddScoped(sp => sp.GetRequiredService<IEventStore>().PII);
 
         services.AddSingleton(_ => chronicleBuilder?.ClientArtifactsProvider ?? DefaultClientArtifactsProvider.Default);
         services.AddSingleton(_ => chronicleBuilder?.NamingPolicy ?? new DefaultNamingPolicy());

--- a/Source/Clients/DotNET/Compliance/GDPR/IPIIManager.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/IPIIManager.cs
@@ -9,14 +9,7 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 public interface IPIIManager
 {
     /// <summary>
-    /// Creates a new encryption key and registers it for the specific identifier.
-    /// </summary>
-    /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to register for.</param>
-    /// <returns>Awaitable task.</returns>
-    Task CreateAndRegisterKeyFor(EncryptionKeyIdentifier identifier);
-
-    /// <summary>
-    /// Deletes a specific encryption key based on th e<see cref="EncryptionKeyIdentifier"/>.
+    /// Deletes a specific encryption key based on the <see cref="EncryptionKeyIdentifier"/>.
     /// </summary>
     /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to delete.</param>
     /// <returns>Awaitable task.</returns>

--- a/Source/Clients/DotNET/Compliance/GDPR/PIIManager.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/PIIManager.cs
@@ -1,23 +1,31 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Compliance;
+
 namespace Cratis.Chronicle.Compliance.GDPR;
 
 /// <summary>
-/// Represents an implementation of <see cref="IPIIManager"/>.
+/// Represents an implementation of <see cref="IPIIManager"/> that proxies to the Chronicle kernel over the client connection.
 /// </summary>
-public class PIIManager : IPIIManager
+/// <param name="eventStore">The <see cref="EventStoreName"/> the manager operates within.</param>
+/// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the manager operates within.</param>
+/// <param name="connection">The <see cref="IChronicleConnection"/> for talking to the kernel.</param>
+public class PIIManager(
+    EventStoreName eventStore,
+    EventStoreNamespaceName @namespace,
+    IChronicleConnection connection) : IPIIManager
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="PIIManager"/> class.
-    /// </summary>
-    public PIIManager()
-    {
-    }
+    readonly IChronicleServicesAccessor _servicesAccessor = (connection as IChronicleServicesAccessor)!;
 
     /// <inheritdoc/>
-    public Task CreateAndRegisterKeyFor(EncryptionKeyIdentifier identifier) => throw new NotImplementedException();
-
-    /// <inheritdoc/>
-    public Task DeleteEncryptionKeyFor(EncryptionKeyIdentifier identifier) => throw new NotImplementedException();
+    public Task DeleteEncryptionKeyFor(EncryptionKeyIdentifier identifier) =>
+        _servicesAccessor.Services.Compliance.DeleteEncryptionKey(new DeleteEncryptionKeyRequest
+        {
+            EventStore = eventStore,
+            Namespace = @namespace,
+            Identifier = identifier
+        });
 }

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -225,6 +225,8 @@ public class EventStore : IEventStore
             artifactActivator,
             loggerFactory.CreateLogger<EventSeeding>());
 
+        PII = new Compliance.GDPR.PIIManager(eventStoreName, @namespace, connection);
+
         if (autoDiscoverAndRegister)
         {
             Connection.Lifecycle.OnConnected += RegisterAll;
@@ -278,6 +280,9 @@ public class EventStore : IEventStore
 
     /// <inheritdoc/>
     public IEventSeeding Seeding { get; }
+
+    /// <inheritdoc/>
+    public Compliance.GDPR.IPIIManager PII { get; }
 
     /// <inheritdoc/>
     public async Task DiscoverAll()

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
@@ -102,6 +103,11 @@ public interface IEventStore
     /// Gets the <see cref="IEventSeeding"/> for the event store.
     /// </summary>
     IEventSeeding Seeding { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IPIIManager"/> for managing PII encryption keys (GDPR right-to-erasure) for the event store.
+    /// </summary>
+    IPIIManager PII { get; }
 
     /// <summary>
     /// Discover all artifacts for the event store.

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Cratis.Chronicle.Auditing;
 using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.Connections;
 using Cratis.Chronicle.Contracts;
 using Cratis.Chronicle.Events;
@@ -76,6 +77,7 @@ public class EventStoreForTesting : IEventStore
     readonly Lazy<IJobs> _jobs;
     readonly Lazy<IUnitOfWorkManager> _unitOfWorkManager;
     readonly Lazy<IEventSeeding> _seeding;
+    readonly Lazy<IPIIManager> _pii;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStoreForTesting"/> class.
@@ -205,6 +207,7 @@ public class EventStoreForTesting : IEventStore
             _serviceProvider,
             _artifactActivator,
             NullLogger<EventSeeding>.Instance));
+        _pii = new Lazy<IPIIManager>(() => new PIIManager(Name, Namespace, Connection));
     }
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
@@ -255,6 +258,9 @@ public class EventStoreForTesting : IEventStore
 
     /// <inheritdoc/>
     public IEventSeeding Seeding => _seeding.Value;
+
+    /// <inheritdoc/>
+    public IPIIManager PII => _pii.Value;
 
     /// <summary>
     /// Gets the <see cref="IJsonSchemaGenerator"/> used by this event store.

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -180,6 +180,7 @@ internal sealed class TestingServices(
 
     readonly Lazy<ICompliance> _compliance = new(() =>
         new KernelComplianceService(
+            grainFactory,
             new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>()),
             NullLogger<KernelComplianceService>.Instance));
 

--- a/Source/Kernel/Contracts/Compliance/DeleteEncryptionKeyRequest.cs
+++ b/Source/Kernel/Contracts/Compliance/DeleteEncryptionKeyRequest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Compliance;
+
+/// <summary>
+/// Represents the request for deleting (crypto-shredding) the encryption key for a specific identifier.
+/// </summary>
+[ProtoContract]
+public class DeleteEncryptionKeyRequest
+{
+    /// <summary>
+    /// Gets or sets the event store name.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the event store namespace.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the encryption key identifier (the subject the PII was encrypted under).
+    /// </summary>
+    [ProtoMember(3)]
+    public string Identifier { get; set; } = string.Empty;
+}

--- a/Source/Kernel/Contracts/Compliance/ICompliance.cs
+++ b/Source/Kernel/Contracts/Compliance/ICompliance.cs
@@ -17,4 +17,13 @@ public interface ICompliance
     /// <returns>A <see cref="ReleaseResponse"/> with the decrypted payload or an error.</returns>
     [Operation]
     Task<ReleaseResponse> Release(ReleaseRequest request, CallContext context = default);
+
+    /// <summary>
+    /// Delete (crypto-shred) the encryption key for the given identifier, making all PII encrypted under it unreadable.
+    /// </summary>
+    /// <param name="request">The <see cref="DeleteEncryptionKeyRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns>Awaitable task.</returns>
+    [Operation]
+    Task DeleteEncryptionKey(DeleteEncryptionKeyRequest request, CallContext context = default);
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/given/a_property_handler.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/given/a_property_handler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text;
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Storage.Compliance;
 
 namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.given;
@@ -21,7 +22,7 @@ public class a_property_handler : Specification
         _keyStore = Substitute.For<IEncryptionKeyStorage>();
         _encryption = Substitute.For<IEncryption>();
         _handler = new(_keyStore, _encryption);
-        _keyStore.HasFor(string.Empty, string.Empty, Identifier).Returns(Task.FromResult(true));
-        _keyStore.GetFor(string.Empty, string.Empty, Identifier).Returns(Task.FromResult(_key));
+        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(true));
+        _keyStore.GetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(_key));
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/given/a_property_handler.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/given/a_property_handler.cs
@@ -22,7 +22,6 @@ public class a_property_handler : Specification
         _keyStore = Substitute.For<IEncryptionKeyStorage>();
         _encryption = Substitute.For<IEncryption>();
         _handler = new(_keyStore, _encryption);
-        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(true));
-        _keyStore.GetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(_key));
+        _keyStore.TryGetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult<EncryptionKey?>(_key));
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
 
 namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler;
 
@@ -20,7 +21,7 @@ public class when_applying : given.a_property_handler
         _encryption.Encrypt(Arg.Any<byte[]>(), _key).Returns(_encryptedBytes);
     }
 
-    async Task Because() => _result = await _handler.Apply(string.Empty, string.Empty, Identifier, _input);
+    async Task Because() => _result = await _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
 
     [Fact] void should_return_encrypted_string() => _result.ToString().ShouldEqual(Convert.ToBase64String(_encryptedBytes));
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
@@ -17,7 +17,7 @@ public class when_applying_and_key_does_not_exist : given.a_property_handler
 
     void Establish()
     {
-        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(false));
+        _keyStore.TryGetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult<EncryptionKey?>(null));
         _generatedKey = new EncryptionKey(Encoding.UTF8.GetBytes("NewPublic"), Encoding.UTF8.GetBytes("NewPrivate"));
         _encryption.GenerateKey().Returns(_generatedKey);
         _encryptedBytes = Encoding.UTF8.GetBytes("encrypted");

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Storage.Compliance;
 
 namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler;
@@ -16,7 +17,7 @@ public class when_applying_and_key_does_not_exist : given.a_property_handler
 
     void Establish()
     {
-        _keyStore.HasFor(string.Empty, string.Empty, Identifier).Returns(Task.FromResult(false));
+        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(false));
         _generatedKey = new EncryptionKey(Encoding.UTF8.GetBytes("NewPublic"), Encoding.UTF8.GetBytes("NewPrivate"));
         _encryption.GenerateKey().Returns(_generatedKey);
         _encryptedBytes = Encoding.UTF8.GetBytes("encrypted");
@@ -24,9 +25,9 @@ public class when_applying_and_key_does_not_exist : given.a_property_handler
         _input = JsonValue.Create("sensitive");
     }
 
-    async Task Because() => _result = await _handler.Apply(string.Empty, string.Empty, Identifier, _input);
+    async Task Because() => _result = await _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
 
     [Fact] void should_generate_a_new_key() => _encryption.Received(1).GenerateKey();
-    [Fact] async Task should_save_the_generated_key_for_the_identifier() => await _keyStore.Received(1).SaveFor(string.Empty, string.Empty, Identifier, _generatedKey);
+    [Fact] async Task should_save_the_generated_key_for_the_identifier() => await _keyStore.Received(1).SaveFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _generatedKey);
     [Fact] void should_return_encrypted_value() => _result.ToString().ShouldEqual(Convert.ToBase64String(_encryptedBytes));
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
 
 namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler;
 
@@ -20,7 +21,7 @@ public class when_releasing : given.a_property_handler
         _encryption.Decrypt(Arg.Any<byte[]>(), _key).Returns(_encryptedBytes);
     }
 
-    async Task Because() => _result = await _handler.Release(string.Empty, string.Empty, Identifier, _input);
+    async Task Because() => _result = await _handler.Release(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
 
     [Fact] void should_return_encrypted_string() => _result.ToString().ShouldEqual(_decryptedString);
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_and_key_has_been_deleted.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_and_key_has_been_deleted.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage.Compliance;
 
 namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler;
 
@@ -15,11 +16,11 @@ public class when_releasing_and_key_has_been_deleted : given.a_property_handler
     void Establish()
     {
         _input = JsonValue.Create(Convert.ToBase64String(Encoding.UTF8.GetBytes("encrypted")));
-        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(false));
+        _keyStore.TryGetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult<EncryptionKey?>(null));
     }
 
-    async Task Because() => _result = await _handler.Release(string.Empty, string.Empty, Identifier, _input);
+    async Task Because() => _result = await _handler.Release(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
 
     [Fact] void should_return_empty() => _result.ToString().ShouldEqual(string.Empty);
-    [Fact] async Task should_not_attempt_to_decrypt() => await _keyStore.DidNotReceive().GetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier);
+    [Fact] void should_not_attempt_to_decrypt() => _encryption.DidNotReceive().Decrypt(Arg.Any<byte[]>(), Arg.Any<EncryptionKey>());
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_and_key_has_been_deleted.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_and_key_has_been_deleted.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler;
+
+public class when_releasing_and_key_has_been_deleted : given.a_property_handler
+{
+    JsonNode _input;
+    JsonNode _result;
+
+    void Establish()
+    {
+        _input = JsonValue.Create(Convert.ToBase64String(Encoding.UTF8.GetBytes("encrypted")));
+        _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult(false));
+    }
+
+    async Task Because() => _result = await _handler.Release(string.Empty, string.Empty, Identifier, _input);
+
+    [Fact] void should_return_empty() => _result.ToString().ShouldEqual(string.Empty);
+    [Fact] async Task should_not_attempt_to_decrypt() => await _keyStore.DidNotReceive().GetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier);
+}

--- a/Source/Kernel/Core/Compliance/GDPR/IPIIManager.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/IPIIManager.cs
@@ -9,14 +9,7 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 public interface IPIIManager : IGrainWithGuidCompoundKey
 {
     /// <summary>
-    /// Creates a new encryption key and registers it for the specific identifier.
-    /// </summary>
-    /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to register for.</param>
-    /// <returns>Awaitable task.</returns>
-    Task CreateAndRegisterKeyFor(EncryptionKeyIdentifier identifier);
-
-    /// <summary>
-    /// Deletes a specific encryption key based on th e<see cref="EncryptionKeyIdentifier"/>.
+    /// Deletes a specific encryption key based on the <see cref="EncryptionKeyIdentifier"/>.
     /// </summary>
     /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to delete.</param>
     /// <returns>Awaitable task.</returns>

--- a/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
@@ -40,6 +40,14 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
     /// <inheritdoc/>
     public async Task<JsonNode> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, string identifier, JsonNode value)
     {
+        // When the encryption key has been deleted (GDPR right-to-erasure / crypto-shredding),
+        // the PII is permanently unreadable. Surface it as empty rather than throwing so that
+        // queries and read models for an erased subject keep working instead of crashing.
+        if (!await _encryptionKeyStore.HasFor(eventStore, eventStoreNamespace, identifier))
+        {
+            return JsonValue.Create(string.Empty);
+        }
+
         var key = await _encryptionKeyStore.GetFor(eventStore, eventStoreNamespace, identifier);
         var encryptedAsString = value.ToString();
         var encrypted = Convert.FromBase64String(encryptedAsString);

--- a/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
@@ -40,15 +40,16 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
     /// <inheritdoc/>
     public async Task<JsonNode> Release(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, string identifier, JsonNode value)
     {
+        var key = await _encryptionKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier);
+
         // When the encryption key has been deleted (GDPR right-to-erasure / crypto-shredding),
         // the PII is permanently unreadable. Surface it as empty rather than throwing so that
         // queries and read models for an erased subject keep working instead of crashing.
-        if (!await _encryptionKeyStore.HasFor(eventStore, eventStoreNamespace, identifier))
+        if (key is null)
         {
             return JsonValue.Create(string.Empty);
         }
 
-        var key = await _encryptionKeyStore.GetFor(eventStore, eventStoreNamespace, identifier);
         var encryptedAsString = value.ToString();
         var encrypted = Convert.FromBase64String(encryptedAsString);
         var decrypted = _encryption.Decrypt(encrypted, key);
@@ -58,9 +59,9 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
 
     async Task<EncryptionKey> EnsureKeyFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier)
     {
-        if (await _encryptionKeyStore.HasFor(eventStore, eventStoreNamespace, identifier))
+        if (await _encryptionKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existing)
         {
-            return await _encryptionKeyStore.GetFor(eventStore, eventStoreNamespace, identifier);
+            return existing;
         }
 
         // Serialize key creation per subject. Appending a batch encrypts all events concurrently
@@ -71,9 +72,9 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
         await gate.WaitAsync();
         try
         {
-            if (await _encryptionKeyStore.HasFor(eventStore, eventStoreNamespace, identifier))
+            if (await _encryptionKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existingAfterGate)
             {
-                return await _encryptionKeyStore.GetFor(eventStore, eventStoreNamespace, identifier);
+                return existingAfterGate;
             }
 
             var key = _encryption.GenerateKey();

--- a/Source/Kernel/Core/Compliance/GDPR/PIIManager.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/PIIManager.cs
@@ -11,20 +11,9 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 /// <remarks>
 /// Initializes a new instance of the <see cref="PIIManager"/> class.
 /// </remarks>
-/// <param name="encryption"><see cref="IEncryption"/> system.</param>
 /// <param name="keyStore">The <see cref="IEncryptionKeyStorage"/>.</param>
-public class PIIManager(IEncryption encryption, IEncryptionKeyStorage keyStore) : Grain, IPIIManager
+public class PIIManager(IEncryptionKeyStorage keyStore) : Grain, IPIIManager
 {
-    /// <inheritdoc/>
-    public async Task CreateAndRegisterKeyFor(EncryptionKeyIdentifier identifier)
-    {
-        _ = this.GetPrimaryKey(out var primaryKeyExtension);
-        var primaryKey = (PIIManagerKey)primaryKeyExtension!;
-
-        var key = encryption.GenerateKey();
-        await keyStore.SaveFor(primaryKey.EventStore, primaryKey.Namespace, identifier, key);
-    }
-
     /// <inheritdoc/>
     public async Task DeleteEncryptionKeyFor(EncryptionKeyIdentifier identifier)
     {

--- a/Source/Kernel/Core/Services/Compliance/ComplianceService.cs
+++ b/Source/Kernel/Core/Services/Compliance/ComplianceService.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Contracts.Compliance;
 using Cratis.Chronicle.Schemas;
@@ -15,9 +16,10 @@ namespace Cratis.Chronicle.Services.Compliance;
 /// <summary>
 /// Represents an implementation of <see cref="ICompliance"/>.
 /// </summary>
+/// <param name="grainFactory">The <see cref="IGrainFactory"/> for resolving the kernel <see cref="IPIIManager"/> grain.</param>
 /// <param name="jsonComplianceManager">The <see cref="IJsonComplianceManager"/> for handling compliance on JSON.</param>
 /// <param name="logger">The <see cref="ILogger{T}"/> for logging.</param>
-internal sealed class ComplianceService(IJsonComplianceManager jsonComplianceManager, ILogger<ComplianceService> logger) : ICompliance
+internal sealed class ComplianceService(IGrainFactory grainFactory, IJsonComplianceManager jsonComplianceManager, ILogger<ComplianceService> logger) : ICompliance
 {
     /// <inheritdoc/>
     public async Task<ReleaseResponse> Release(ReleaseRequest request, CallContext context = default)
@@ -52,4 +54,11 @@ internal sealed class ComplianceService(IJsonComplianceManager jsonComplianceMan
             return new ReleaseResponse { HasError = true, Error = ex.Message };
         }
     }
+
+    /// <inheritdoc/>
+    public Task DeleteEncryptionKey(DeleteEncryptionKeyRequest request, CallContext context = default) =>
+        GetPIIManager(request.EventStore, request.Namespace).DeleteEncryptionKeyFor(request.Identifier);
+
+    IPIIManager GetPIIManager(EventStoreName eventStore, EventStoreNamespaceName @namespace) =>
+        grainFactory.GetGrain<IPIIManager>(Guid.Empty, new PIIManagerKey(eventStore, @namespace));
 }

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -103,6 +103,7 @@ public static class ChronicleServerSiloBuilderExtensions
             var projections = new Cratis.Chronicle.Services.Projections.Projections(grainFactory, expandoObjectConverter, sp.GetRequiredService<ILanguageService>(), sp);
             return new Cratis.Chronicle.Contracts.Services(
                 new Cratis.Chronicle.Services.Compliance.ComplianceService(
+                    grainFactory,
                     sp.GetRequiredService<IJsonComplianceManager>(),
                     sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Compliance.ComplianceService>>()),
                 new Cratis.Chronicle.Services.EventStores(

--- a/Source/Kernel/Storage.AzureKeyVault/AzureKeyVaultEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.AzureKeyVault/AzureKeyVaultEncryptionKeyStorage.cs
@@ -77,7 +77,7 @@ public partial class AzureKeyVaultEncryptionKeyStorage(SecretClient secretClient
     }
 
     /// <inheritdoc/>
-    public async Task<EncryptionKey> GetFor(
+    public async Task<EncryptionKey?> TryGetFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,
         EncryptionKeyIdentifier identifier,
@@ -85,10 +85,14 @@ public partial class AzureKeyVaultEncryptionKeyStorage(SecretClient secretClient
     {
         var targetRevision = IsLatest(revision)
             ? await GetHighestRevision(eventStore, eventStoreNamespace, identifier)
-                ?? throw new MissingEncryptionKey(identifier)
             : revision;
 
-        var name = BuildSecretName(eventStore, eventStoreNamespace, identifier, targetRevision!);
+        if (targetRevision is null)
+        {
+            return null;
+        }
+
+        var name = BuildSecretName(eventStore, eventStoreNamespace, identifier, targetRevision);
         try
         {
             var secret = await secretClient.GetSecretAsync(name);
@@ -97,16 +101,25 @@ public partial class AzureKeyVaultEncryptionKeyStorage(SecretClient secretClient
                 !data.TryGetValue(PublicKeyField, out var publicBase64) || publicBase64 is null ||
                 !data.TryGetValue(PrivateKeyField, out var privateBase64) || privateBase64 is null)
             {
-                throw new MissingEncryptionKey(identifier);
+                return null;
             }
 
             return new EncryptionKey(Convert.FromBase64String(publicBase64), Convert.FromBase64String(privateBase64));
         }
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
-            throw new MissingEncryptionKey(identifier);
+            return null;
         }
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision)
+            ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task DeleteFor(

--- a/Source/Kernel/Storage.MongoDB/Encryption/EncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Encryption/EncryptionKeyStorage.cs
@@ -56,7 +56,7 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
     }
 
     /// <inheritdoc/>
-    public async Task<EncryptionKey> GetFor(
+    public async Task<EncryptionKey?> TryGetFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,
         EncryptionKeyIdentifier identifier,
@@ -79,9 +79,17 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
             keyDoc = await result.SingleOrDefaultAsync();
         }
 
-        ThrowIfMissingEncryptionKey(identifier, keyDoc);
-        return new(keyDoc.PublicKey, keyDoc.PrivateKey);
+        return keyDoc == default ? null : new(keyDoc.PublicKey, keyDoc.PrivateKey);
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision)
+            ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task DeleteFor(
@@ -112,14 +120,6 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
             .FirstOrDefaultAsync();
 
         return latestDoc is null ? (EncryptionKeyRevision)1u : latestDoc.Id.Revision.Value + 1u;
-    }
-
-    void ThrowIfMissingEncryptionKey(EncryptionKeyIdentifier identifier, EncryptionKeyForIdentifier? key)
-    {
-        if (key == default)
-        {
-            throw new MissingEncryptionKey(identifier);
-        }
     }
 
     IMongoCollection<EncryptionKeyForIdentifier> GetCollection(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace)

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKeyStorage.cs
@@ -56,7 +56,7 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
     }
 
     /// <inheritdoc/>
-    public async Task<StoredEncryptionKey> GetFor(
+    public async Task<StoredEncryptionKey?> TryGetFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,
         EncryptionKeyIdentifier identifier,
@@ -68,13 +68,21 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
             ? await scope.DbContext.EncryptionKeys
                 .Where(e => e.Identifier == identifier.Value)
                 .OrderByDescending(e => e.Revision)
-                .FirstOrDefaultAsync() ?? throw new MissingEncryptionKey(identifier)
+                .FirstOrDefaultAsync()
             : await scope.DbContext.EncryptionKeys
-                .SingleOrDefaultAsync(e => e.Identifier == identifier.Value && e.Revision == revision!.Value)
-                ?? throw new MissingEncryptionKey(identifier);
+                .SingleOrDefaultAsync(e => e.Identifier == identifier.Value && e.Revision == revision!.Value);
 
-        return new StoredEncryptionKey(entity.PublicKey, entity.PrivateKey);
+        return entity is null ? null : new StoredEncryptionKey(entity.PublicKey, entity.PrivateKey);
     }
+
+    /// <inheritdoc/>
+    public async Task<StoredEncryptionKey> GetFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision)
+            ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task DeleteFor(

--- a/Source/Kernel/Storage.Vault/VaultEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.Vault/VaultEncryptionKeyStorage.cs
@@ -73,7 +73,7 @@ public class VaultEncryptionKeyStorage(string connectionDetails, string? mountPo
     }
 
     /// <inheritdoc/>
-    public async Task<EncryptionKey> GetFor(
+    public async Task<EncryptionKey?> TryGetFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,
         EncryptionKeyIdentifier identifier,
@@ -81,17 +81,21 @@ public class VaultEncryptionKeyStorage(string connectionDetails, string? mountPo
     {
         var targetRevision = IsLatest(revision)
             ? await GetHighestRevision(eventStore, eventStoreNamespace, identifier)
-                ?? throw new MissingEncryptionKey(identifier)
             : revision;
 
-        var path = BuildPath(eventStore, eventStoreNamespace, identifier, targetRevision!);
+        if (targetRevision is null)
+        {
+            return null;
+        }
+
+        var path = BuildPath(eventStore, eventStoreNamespace, identifier, targetRevision);
         try
         {
             var secret = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(path, mountPoint: _mountPoint);
             if (!secret.Data.Data.TryGetValue(PublicKeyField, out var publicRaw) || publicRaw is null ||
                 !secret.Data.Data.TryGetValue(PrivateKeyField, out var privateRaw) || privateRaw is null)
             {
-                throw new MissingEncryptionKey(identifier);
+                return null;
             }
 
             var publicKey = Convert.FromBase64String(publicRaw.ToString()!);
@@ -100,9 +104,18 @@ public class VaultEncryptionKeyStorage(string connectionDetails, string? mountPo
         }
         catch (VaultApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
         {
-            throw new MissingEncryptionKey(identifier);
+            return null;
         }
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision)
+            ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task DeleteFor(

--- a/Source/Kernel/Storage/Compliance/CacheEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/CacheEncryptionKeyStorage.cs
@@ -40,7 +40,7 @@ public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : I
     }
 
     /// <inheritdoc/>
-    public async Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
+    public async Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
         var cacheRevision = revision ?? EncryptionKeyRevision.Latest;
         var cacheKey = new Key(eventStore, eventStoreNamespace, identifier, cacheRevision);
@@ -50,8 +50,18 @@ public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : I
             return encryptionKey;
         }
 
-        return _keys[cacheKey] = await actualKeyStore.GetFor(eventStore, eventStoreNamespace, identifier, revision);
+        var key = await actualKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier, revision);
+        if (key is not null)
+        {
+            _keys[cacheKey] = key;
+        }
+
+        return key;
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision) ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)

--- a/Source/Kernel/Storage/Compliance/CompositeEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/CompositeEncryptionKeyStorage.cs
@@ -16,7 +16,7 @@ namespace Cratis.Chronicle.Storage.Compliance;
 public class CompositeEncryptionKeyStorage(params IEncryptionKeyStorage[] inner) : IEncryptionKeyStorage
 {
     /// <inheritdoc/>
-    public async Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
+    public async Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
         IEncryptionKeyStorage? store = default;
 
@@ -28,19 +28,23 @@ public class CompositeEncryptionKeyStorage(params IEncryptionKeyStorage[] inner)
             }
         }
 
-        if (store != default)
+        if (store == default)
         {
-            var key = await store.GetFor(eventStore, eventStoreNamespace, identifier, revision);
-            foreach (var storeToSaveIn in inner.Where(_ => _ != store))
-            {
-                await storeToSaveIn.SaveFor(eventStore, eventStoreNamespace, identifier, key, revision);
-            }
-
-            return key;
+            return null;
         }
 
-        throw new MissingEncryptionKey(identifier);
+        var key = await store.GetFor(eventStore, eventStoreNamespace, identifier, revision);
+        foreach (var storeToSaveIn in inner.Where(_ => _ != store))
+        {
+            await storeToSaveIn.SaveFor(eventStore, eventStoreNamespace, identifier, key, revision);
+        }
+
+        return key;
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision) ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public async Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)

--- a/Source/Kernel/Storage/Compliance/IEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/IEncryptionKeyStorage.cs
@@ -33,6 +33,16 @@ public interface IEncryptionKeyStorage
     Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null);
 
     /// <summary>
+    /// Try to get an <see cref="EncryptionKey"/> for a specific <see cref="EncryptionKeyIdentifier"/>.
+    /// </summary>
+    /// <param name="eventStore"><see cref="EventStoreName"/> the key belongs to.</param>
+    /// <param name="eventStoreNamespace"><see cref="EventStoreNamespaceName"/> the key belongs to.</param>
+    /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to get for.</param>
+    /// <param name="revision">Optional <see cref="EncryptionKeyRevision"/>. Defaults to retrieving the latest revision when not specified.</param>
+    /// <returns>The <see cref="EncryptionKey"/>, or <see langword="null"/> when none exists (e.g. it was deleted for right-to-erasure).</returns>
+    Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null);
+
+    /// <summary>
     /// Get an <see cref="EncryptionKey"/> for a specific <see cref="EncryptionKeyIdentifier"/>.
     /// </summary>
     /// <param name="eventStore"><see cref="EventStoreName"/> the key belongs to.</param>
@@ -40,6 +50,7 @@ public interface IEncryptionKeyStorage
     /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to get for.</param>
     /// <param name="revision">Optional <see cref="EncryptionKeyRevision"/>. Defaults to retrieving the latest revision when not specified.</param>
     /// <returns>The <see cref="EncryptionKey"/>.</returns>
+    /// <exception cref="MissingEncryptionKey">Thrown when no key exists for the identifier.</exception>
     Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null);
 
     /// <summary>

--- a/Source/Kernel/Storage/Compliance/InMemoryEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/InMemoryEncryptionKeyStorage.cs
@@ -35,19 +35,24 @@ public class InMemoryEncryptionKeyStorage : IEncryptionKeyStorage
     }
 
     /// <inheritdoc/>
-    public Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
+    public Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
         if (IsLatest(revision))
         {
             var entry = _keys
                 .Where(kv => kv.Key.EventStore == eventStore && kv.Key.EventStoreNamespace == eventStoreNamespace && kv.Key.Identifier == identifier)
                 .OrderByDescending(kv => kv.Key.Revision.Value)
-                .First();
-            return Task.FromResult(entry.Value);
+                .Select(kv => (EncryptionKey?)kv.Value)
+                .FirstOrDefault();
+            return Task.FromResult(entry);
         }
 
-        return Task.FromResult(_keys[new(eventStore, eventStoreNamespace, identifier, revision!)]);
+        return Task.FromResult(_keys.TryGetValue(new(eventStore, eventStoreNamespace, identifier, revision!), out var key) ? key : null);
     }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+        await TryGetFor(eventStore, eventStoreNamespace, identifier, revision) ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
     public Task DeleteFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)


### PR DESCRIPTION
# Summary

Enables GDPR right-to-erasure (crypto-shredding) from a Chronicle client application. Deleting a person's PII encryption key makes every PII value encrypted under that subject permanently unreadable — everywhere it appears. Previously the client `IPIIManager` only threw `NotImplementedException`, so there was no way to trigger erasure from application or ops code.

## Added

- Chronicle clients can delete a subject's PII encryption key to satisfy GDPR right-to-erasure (crypto-shredding), via `IPIIManager.DeleteEncryptionKeyFor` and `IEventStore.PII`. `IPIIManager` can also be injected directly.

## Changed

- Reading a PII value whose encryption key has been deleted now returns an empty value instead of throwing, so read models and queries for an erased subject keep working.

## Removed

- Removed the non-functional `CreateAndRegisterKeyFor` from `IPIIManager`; it only ever threw `NotImplementedException`, and encryption keys are already registered automatically on first use.
