### PR TITLE
Notify Arc on Chronicle publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -303,6 +303,20 @@ jobs:
       - name: Push NuGet packages
         run: dotnet nuget push --skip-duplicate '${{ env.NUGET_OUTPUT }}/*.nupkg' --timeout 900 --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
 
+  notify-arc:
+    if: needs.release.outputs.publish == 'true' && needs.release.outputs.prerelease != 'true'
+    runs-on: ubuntu-latest
+    needs: [release, dotnet-pack-and-publish]
+
+    steps:
+      - name: Trigger Chronicle update on Arc
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_DOCUMENTATION }}
+          repository: cratis/arc
+          event-type: chronicle-published
+          client-payload: '{"version": "${{ needs.release.outputs.version }}"}'
+
   publish-typescript-client:
     if: needs.release.outputs.publish == 'true'
     needs: [release, generate-protos]


### PR DESCRIPTION
## Added
- On a non-prerelease publish, Chronicle now notifies Cratis/Arc of the released version so Arc can update its Chronicle dependency, verify it against its spec suite, and release automatically.

# Summary

Adds a `notify-arc` job to the publish workflow that sends a `chronicle-published` `repository_dispatch` to Cratis/Arc with the released version. It runs after `dotnet-pack-and-publish`, so the NuGet packages are available before Arc reacts, and only on full (non-prerelease) releases.

This is the Chronicle half of an automated Chronicle → Arc update loop; the companion Arc PR (Cratis/Arc#2324) consumes the event, bumps the pins behind a full-spec gate, and auto-merges compatible updates.