### PR TITLE
Fix broken internal links blocking the Documentation site deploy

### DIFF
--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -32,7 +32,7 @@ It's tempting to make one `Customer` read model serve every screen. Resist it. T
 
 ## Reach for the declarative path first
 
-You rarely write code that *updates* a read model — you declare how events map onto it and let Chronicle do the folding. Start with [model-bound projections](../projections/model-bound/index), where attributes on the read model record describe the mapping. When the mapping needs logic the attributes can't express cleanly, step up to the fluent [declarative projection builder](../projections/declarative/index) (`IProjectionFor<T>`), and only reach for a [reducer](../reducers/) when the model is genuinely easier to express as code folding over previous state.
+You rarely write code that *updates* a read model — you declare how events map onto it and let Chronicle do the folding. Start with [model-bound projections](../projections/model-bound/), where attributes on the read model record describe the mapping. When the mapping needs logic the attributes can't express cleanly, step up to the fluent [declarative projection builder](../projections/declarative/) (`IProjectionFor<T>`), and only reach for a [reducer](../reducers/) when the model is genuinely easier to express as code folding over previous state.
 
 ## Design for eventual consistency
 
@@ -52,7 +52,7 @@ When it's time to read, Chronicle gives you a ladder — trade consistency for c
 
 - **`GetInstances<T>()`** rebuilds every instance from the event log at call time, so the result reflects everything appended so far. You can cap the work with an event count (`GetInstances<T>(eventCount)`), but a capped replay may return incomplete results. Replay cost grows with history — great for [reporting and short histories](../read-models/getting-collection-instances), not necessarily your production list view.
 - **`Materialized.GetInstances<T>(skip, take)`** reads what projections have already stored, with paging — cheap and fast, a moment behind. See [Materialized read models](../read-models/materialized-pagination).
-- **Need filtering, sorting, or aggregation?** Go to the sink's native query tools — `IMongoCollection<T>` or your `DbContext` — because a materialized read model is just data in a [database](../sinks/index), shaped for exactly this.
+- **Need filtering, sorting, or aggregation?** Go to the sink's native query tools — `IMongoCollection<T>` or your `DbContext` — because a materialized read model is just data in a [database](../sinks/), shaped for exactly this.
 
 Kotlin and Java currently only support the strongly-consistent single-instance lookup shown above — there's no way to get all instances or page through materialized storage from those two clients yet.
 

--- a/Documentation/configuration/chronicle-options.mdx
+++ b/Documentation/configuration/chronicle-options.mdx
@@ -119,7 +119,7 @@ In `appsettings.json`:
 { "Cratis": { "Chronicle": { "DefaultSinkTypeId": "SQL" } } }
 ```
 
-See [Sinks](../sinks/index) for detailed guidance on storage backends.
+See [Sinks](../sinks/) for detailed guidance on storage backends.
 
 ### MaxReceiveMessageSize / MaxSendMessageSize
 

--- a/Documentation/constraints/index.md
+++ b/Documentation/constraints/index.md
@@ -33,7 +33,7 @@ Chronicle provides two ways to define constraints:
 | Approach | When to use |
 |---|---|
 | [Model-bound](model-bound/index.md) | Declaring constraints directly on event types using attributes — no separate class needed. **Preferred for most scenarios.** |
-| [Declarative](declarative/index) | Complex rules spanning multiple event types with different property names, or when you need a callback for constraint violation messages. |
+| [Declarative](declarative/) | Complex rules spanning multiple event types with different property names, or when you need a callback for constraint violation messages. |
 
 ## Topics
 

--- a/Documentation/contributing/index.md
+++ b/Documentation/contributing/index.md
@@ -3,5 +3,5 @@
 | Topic | Description |
 | ------- | ----------- |
 | [Integration Tests](./integration-tests.md) | How to run and work with integration tests. |
-| [Clients](./clients/index) | Contributing to the clients. |
+| [Clients](./clients/) | Contributing to the clients. |
 | [Kernel](./kernel/index.md) | Contributing to the Kernel. |

--- a/Documentation/get-started/_includes/common.mdx
+++ b/Documentation/get-started/_includes/common.mdx
@@ -57,7 +57,7 @@ By default Chronicle also **materializes** every projection into the **sink** st
 
 `skip` and `take` are plain paging (they default to `0` and `50`), so you can window through a large collection without ever loading all of it — [Materialized read models](../read-models/materialized-pagination) shows the paging and observing patterns.
 
-Neither call filters, though: `GetInstances` returns everything (you'd filter with LINQ in memory), and `Materialized` only pages. When you need to filter efficiently — "which books are on loan?" — query the [sink](../sinks/index)'s database directly with its native tools. Our sink is MongoDB, so the `Book` read model is an ordinary collection and the driver does what it does best:
+Neither call filters, though: `GetInstances` returns everything (you'd filter with LINQ in memory), and `Materialized` only pages. When you need to filter efficiently — "which books are on loan?" — query the [sink](../sinks/)'s database directly with its native tools. Our sink is MongoDB, so the `Book` read model is an ordinary collection and the driver does what it does best:
 
 <ChronicleClientTabs snippet="get-started/common/mongo-query" clients="csharp" />
 
@@ -69,6 +69,6 @@ Projections build *state*. When you need to *do something* the moment a fact lan
 
 <ChronicleClientTabs snippet="get-started/common/reactor" clients="csharp,kotlin,java,elixir,typescript" />
 
-No registration, no wiring — drop the class in and every `BookReturned` flows to it. Reactors must be idempotent, because the same event may be delivered more than once (during a replay or a recovery). In a real app you'd inject a notification service here — the [tutorial](/chronicle/tutorial/) and the [Reactors](../reactors/index) guide show that, along with how reactors get their dependencies under a host.
+No registration, no wiring — drop the class in and every `BookReturned` flows to it. Reactors must be idempotent, because the same event may be delivered more than once (during a replay or a recovery). In a real app you'd inject a notification service here — the [tutorial](/chronicle/tutorial/) and the [Reactors](../reactors/) guide show that, along with how reactors get their dependencies under a host.
 
-That's the whole loop — **append → project → react**. The [tutorial](/chronicle/tutorial/) builds exactly this library one concept at a time and explains each as you go; the [Projections](../projections/index.md), [Reducers](../reducers/index), and [Reactors](../reactors/index) guides go deeper on each piece.
+That's the whole loop — **append → project → react**. The [tutorial](/chronicle/tutorial/) builds exactly this library one concept at a time and explains each as you go; the [Projections](../projections/index.md), [Reducers](../reducers/), and [Reactors](../reactors/) guides go deeper on each piece.

--- a/Documentation/projections/choosing-a-read-model-style.mdx
+++ b/Documentation/projections/choosing-a-read-model-style.mdx
@@ -55,8 +55,8 @@ with guard logic, temporal state, or calculations that span several previous eve
 
 | Style | Mental model | Strength | Cost |
 | --- | --- | --- | --- |
-| [Model-bound projection](model-bound/index) | The read model declares how events fill its properties. | Least code; best default for straightforward screen models. | Attributes can get dense when the mapping becomes complex. |
-| [Declarative projection](declarative/index) | A separate projection definition maps events to the read model. | Explicit mapping, joins, nested structures, transformations, and a clean read model type. | More ceremony than attributes. |
+| [Model-bound projection](model-bound/) | The read model declares how events fill its properties. | Least code; best default for straightforward screen models. | Attributes can get dense when the mapping becomes complex. |
+| [Declarative projection](declarative/) | A separate projection definition maps events to the read model. | Explicit mapping, joins, nested structures, transformations, and a clean read model type. | More ceremony than attributes. |
 | [Reducer](/chronicle/reducers/) | Event plus current state returns next state. | Complex calculations and temporal logic read naturally as code. | More responsibility: handle missing current state and keep the reducer pure. |
 
 Use the simplest style that keeps the intent obvious. Model-bound first, declarative when the mapping

--- a/Documentation/projections/immediate-projections.md
+++ b/Documentation/projections/immediate-projections.md
@@ -23,4 +23,4 @@ Because immediate projections run synchronously, they can impact the performance
 ## See Also
 
 - [Eventual Consistency](eventual-consistency) - Learn about eventual consistency in projections
-- [Model-Bound Projections](model-bound/index) - How to work with model-bound projections
+- [Model-Bound Projections](model-bound/) - How to work with model-bound projections

--- a/Documentation/projections/index.md
+++ b/Documentation/projections/index.md
@@ -27,8 +27,8 @@ you usually choose between three styles:
 
 | Style | What it looks like | Reach for it when |
 | --- | --- | --- |
-| [Model-bound](model-bound/index) | Attributes on the read model record (`[FromEvent<T>]`, `[Key]`, `[ChildrenFrom<T>]`) | **The default.** Most projections — it's the least boilerplate and reads as the model itself. |
-| [Declarative](declarative/index) | A fluent `IProjectionFor<T>` definition | The mapping needs logic the attributes can't express cleanly. |
+| [Model-bound](model-bound/) | Attributes on the read model record (`[FromEvent<T>]`, `[Key]`, `[ChildrenFrom<T>]`) | **The default.** Most projections — it's the least boilerplate and reads as the model itself. |
+| [Declarative](declarative/) | A fluent `IProjectionFor<T>` definition | The mapping needs logic the attributes can't express cleanly. |
 | [Reducer](/chronicle/reducers/) | An `IReducerFor<T>` that receives the event, current state, and event context | The read model is easier to express as state transitions or calculations over previous state. |
 
 [Choose a read-model style](choosing-a-read-model-style) builds the same read model as a
@@ -54,8 +54,8 @@ read model being a moment behind.
 | ------ | ----------- |
 | [Architecture](architecture) | How the projection engine turns events into read models |
 | [Choose a read-model style](choosing-a-read-model-style) | Compare model-bound, declarative, and reducer approaches on the same read model |
-| [Model-Bound Projections](model-bound/index) | Build read models with attributes — the default style |
-| [Declarative Projections](declarative/index) | Build read models with the fluent `IProjectionFor<T>` API |
+| [Model-Bound Projections](model-bound/) | Build read models with attributes — the default style |
+| [Declarative Projections](declarative/) | Build read models with the fluent `IProjectionFor<T>` API |
 | [Immediate Projections](immediate-projections.md) | Strong consistency — the read model updates before the append returns |
 | [Eventual Consistency](eventual-consistency) | The default — how and when eventual projections catch up |
 | [Tagging Projections](tagging-projections) | Organize and tag projections |

--- a/Documentation/read-models/materialized-pagination.mdx
+++ b/Documentation/read-models/materialized-pagination.mdx
@@ -117,6 +117,6 @@ Do **not** use the `Materialized` API when:
 - [Getting a Collection of Instances](getting-collection-instances) — On-demand collection retrieval via event replay
 - [Watching Read Models](watching-read-models) — Observe event-log-sourced read model changesets
 - [Projections](../projections/index.md) — How read models are produced from events
-- [Reducers](../reducers/index) — Imperative state-building from events
-- [MongoDB Sink](../sinks/index#mongodb-sink) — How read model instances are stored in MongoDB
-- [SQL Sink](../sinks/index#sql-sink) — How read model instances are stored in a SQL database
+- [Reducers](../reducers/) — Imperative state-building from events
+- [MongoDB Sink](../sinks/#mongodb-sink) — How read model instances are stored in MongoDB
+- [SQL Sink](../sinks/#sql-sink) — How read model instances are stored in a SQL database

--- a/Documentation/read-models/watching-read-models.mdx
+++ b/Documentation/read-models/watching-read-models.mdx
@@ -56,4 +56,4 @@ Prefer current-state reads when:
 - [Getting a Single Instance](getting-single-instance) - Read current state on demand
 - [Getting a Collection of Instances](getting-collection-instances) - Replay all current instances
 - [Getting Snapshots](getting-snapshots) - Inspect historical state
-- [Reactors](../reactors/index) - React to events directly
+- [Reactors](../reactors/) - React to events directly

--- a/Documentation/subscriptions/explicit-subscriptions.mdx
+++ b/Documentation/subscriptions/explicit-subscriptions.mdx
@@ -113,5 +113,5 @@ A common pattern is to register all subscriptions once during application startu
 
 - [Implicit Event Store Subscriptions](implicit-subscriptions) — automatic subscription via `[EventStore]` attributes
 - [Outbox and Inbox](outbox-inbox) — conceptual explanation of how events flow between stores
-- [Reactors](../reactors/index) — processing inbox events with reactors
+- [Reactors](../reactors/) — processing inbox events with reactors
 - [Projections](../projections/index.md) — building read models from inbox events

--- a/Documentation/subscriptions/implicit-subscriptions.mdx
+++ b/Documentation/subscriptions/implicit-subscriptions.mdx
@@ -195,5 +195,5 @@ When event types are registered with the kernel, the source event store name is 
 
 - [Explicit Event Store Subscriptions](explicit-subscriptions) — manual subscription using the Subscribe API
 - [Outbox and Inbox](outbox-inbox) — conceptual explanation of how events flow between stores
-- [Reactors](../reactors/index) — processing inbox events with reactors
+- [Reactors](../reactors/) — processing inbox events with reactors
 - [Projections](../projections/index.md) — building read models from inbox events


### PR DESCRIPTION
## Fixed
- 31 broken internal links across the shared Chronicle docs that pointed at a folder's landing page using a literal `/index` path segment (e.g. `../reactors/index`) instead of the folder root (`../reactors/`). Starlight serves a folder's `index.mdx` at the folder root, not at an extra `/index/` segment, so these resolved to 404s and were blocking the Documentation site's link-check gate, which in turn blocked deployment.