### PR TITLE
Fix event-store lock contention and observer replay activation violation

### DIFF
--- a/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientServiceCollectionExtensions.cs
@@ -22,13 +22,7 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class ChronicleClientServiceCollectionExtensions
 {
-#if NET8_0
-    static readonly object _eventStoreInitLock = new();
-#else
-    static readonly Lock _eventStoreInitLock = new();
-#endif
-
-    static readonly ConcurrentDictionary<EventStoreNamespaceName, IEventStore> _eventStores = new();
+    static readonly ConcurrentDictionary<EventStoreNamespaceName, Lazy<IEventStore>> _eventStores = new();
 
     /// <summary>
     /// Add the <see cref="IChronicleClient"/> to the services.
@@ -83,22 +77,24 @@ public static class ChronicleClientServiceCollectionExtensions
 
         services.AddScoped(sp =>
         {
-            lock (_eventStoreInitLock)
-            {
-                var options = sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value;
-                var namespaceResolver = sp.GetRequiredService<IEventStoreNamespaceResolver>();
-                var namespaceName = namespaceResolver.Resolve();
+            var options = sp.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>().Value;
+            var namespaceResolver = sp.GetRequiredService<IEventStoreNamespaceResolver>();
+            var namespaceName = namespaceResolver.Resolve();
 
-                if (_eventStores.TryGetValue(namespaceName, out var eventStore))
-                {
-                    return eventStore;
-                }
+            // Lazy<T> with ExecutionAndPublication guarantees the value factory runs at most once per
+            // namespace, without holding a lock shared across unrelated namespaces or requests. A single
+            // process-wide lock here previously serialized every scoped IEventStore resolution - including
+            // cache hits - across the whole app, and held that lock across the blocking GetAwaiter().GetResult()
+            // below. Under concurrent request load that starves the thread pool and can make unrelated
+            // namespaces stall behind a single in-flight GetEventStore() call.
+            var lazyEventStore = _eventStores.GetOrAdd(
+                namespaceName,
+                static (_, arg) => new Lazy<IEventStore>(
+                    () => arg.ServiceProvider.GetRequiredService<IChronicleClient>().GetEventStore(arg.EventStoreName).GetAwaiter().GetResult(),
+                    LazyThreadSafetyMode.ExecutionAndPublication),
+                (ServiceProvider: sp, EventStoreName: options.EventStore));
 
-                var client = sp.GetRequiredService<IChronicleClient>();
-
-                eventStore = client.GetEventStore(options.EventStore).GetAwaiter().GetResult();
-                return _eventStores[namespaceName] = eventStore;
-            }
+            return lazyEventStore.Value;
         });
 
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Constraints);

--- a/Source/Clients/DotNET/ChronicleClientServiceCollectionExtensions.cs
+++ b/Source/Clients/DotNET/ChronicleClientServiceCollectionExtensions.cs
@@ -24,13 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </remarks>
 internal static class ChronicleClientServiceCollectionExtensions
 {
-#if NET8_0
-    static readonly object _eventStoreInitLock = new();
-#else
-    static readonly Lock _eventStoreInitLock = new();
-#endif
-
-    static readonly ConcurrentDictionary<EventStoreNamespaceName, IEventStore> _eventStores = new();
+    static readonly ConcurrentDictionary<EventStoreNamespaceName, Lazy<IEventStore>> _eventStores = new();
 
     /// <summary>
     /// Add the Chronicle client services to the <see cref="IServiceCollection"/>.
@@ -79,22 +73,24 @@ internal static class ChronicleClientServiceCollectionExtensions
 
         services.AddScoped(sp =>
         {
-            lock (_eventStoreInitLock)
-            {
-                var options = sp.GetRequiredService<IOptions<ChronicleClientOptions>>().Value;
-                var namespaceResolver = sp.GetRequiredService<IEventStoreNamespaceResolver>();
-                var namespaceName = namespaceResolver.Resolve();
+            var options = sp.GetRequiredService<IOptions<ChronicleClientOptions>>().Value;
+            var namespaceResolver = sp.GetRequiredService<IEventStoreNamespaceResolver>();
+            var namespaceName = namespaceResolver.Resolve();
 
-                if (_eventStores.TryGetValue(namespaceName, out var eventStore))
-                {
-                    return eventStore;
-                }
+            // Lazy<T> with ExecutionAndPublication guarantees the value factory runs at most once per
+            // namespace, without holding a lock shared across unrelated namespaces or requests. A single
+            // process-wide lock here previously serialized every scoped IEventStore resolution - including
+            // cache hits - across the whole app, and held that lock across the blocking GetAwaiter().GetResult()
+            // below. Under concurrent request load that starves the thread pool and can make unrelated
+            // namespaces stall behind a single in-flight GetEventStore() call.
+            var lazyEventStore = _eventStores.GetOrAdd(
+                namespaceName,
+                static (_, arg) => new Lazy<IEventStore>(
+                    () => arg.ServiceProvider.GetRequiredService<IChronicleClient>().GetEventStore(arg.EventStoreName).GetAwaiter().GetResult(),
+                    LazyThreadSafetyMode.ExecutionAndPublication),
+                (ServiceProvider: sp, EventStoreName: options.EventStore));
 
-                var client = sp.GetRequiredService<IChronicleClient>();
-
-                eventStore = client.GetEventStore(options.EventStore).GetAwaiter().GetResult();
-                return _eventStores[namespaceName] = eventStore;
-            }
+            return lazyEventStore.Value;
         });
 
         services.AddScoped(sp => sp.GetRequiredService<IEventStore>().Constraints);

--- a/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/TestableHandleEventsForObserver.cs
+++ b/Source/Kernel/Core.Specs/Observation/Jobs/for_HandleEventsForObserver/TestableHandleEventsForObserver.cs
@@ -19,6 +19,7 @@ namespace Cratis.Chronicle.Observation.Jobs.for_HandleEventsForObserver;
 /// <param name="throttle">The throttle for limiting parallel execution.</param>
 /// <param name="storage">The storage for the cluster.</param>
 /// <param name="eventCompliance">The <see cref="IEventCompliance"/> for decrypting PII event content.</param>
+/// <param name="grainFactory">The <see cref="IGrainFactory"/> for resolving subscriber grains.</param>
 /// <param name="logger">The logger.</param>
 public class TestableHandleEventsForObserver(
     [PersistentState(nameof(JobStepState), WellKnownGrainStorageProviders.JobSteps)]
@@ -26,8 +27,9 @@ public class TestableHandleEventsForObserver(
     IJobStepThrottle throttle,
     IStorage storage,
     IEventCompliance eventCompliance,
+    IGrainFactory grainFactory,
     ILogger<HandleEventsForObserver> logger)
-    : HandleEventsForObserver(state, throttle, storage, eventCompliance, logger), IGrainType
+    : HandleEventsForObserver(state, throttle, storage, eventCompliance, grainFactory, logger), IGrainType
 {
     static readonly FieldInfo _observerField = typeof(HandleEventsForObserver).GetField("_observer", BindingFlags.NonPublic | BindingFlags.Instance)!;
     static readonly FieldInfo _subscriptionField = typeof(HandleEventsForObserver).GetField("_subscription", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
+++ b/Source/Kernel/Core/Observation/Jobs/HandleEventsForObserver.cs
@@ -25,6 +25,7 @@ namespace Cratis.Chronicle.Observation.Jobs;
 /// <param name="throttle">The <see cref="IJobStepThrottle"/> for limiting parallel execution.</param>
 /// <param name="storage"><see cref="IStorage"/> for accessing storage for the cluster.</param>
 /// <param name="eventCompliance"><see cref="IEventCompliance"/> for decrypting PII event content before dispatching to subscribers.</param>
+/// <param name="grainFactory">The <see cref="IGrainFactory"/> for resolving subscriber grains off the activation thread.</param>
 /// <param name="logger">The logger.</param>
 public class HandleEventsForObserver(
     [PersistentState(nameof(JobStepState), WellKnownGrainStorageProviders.JobSteps)]
@@ -32,6 +33,7 @@ public class HandleEventsForObserver(
     IJobStepThrottle throttle,
     IStorage storage,
     IEventCompliance eventCompliance,
+    IGrainFactory grainFactory,
     ILogger<HandleEventsForObserver> logger) : JobStep<HandleEventsForObserverArguments, HandleEventsForPartitionResult, HandleEventsForObserverState>(state, throttle, logger), IHandleEventsForObserver
 {
     const string SubscriberDisconnected = "Subscriber is disconnected";
@@ -392,7 +394,13 @@ public class HandleEventsForObserver(
         try
         {
             var decryptedEvents = await DecryptEvents(events);
-            var subscriber = GrainFactory.GetGrain(_subscription.SubscriberType, GetObserverSubscriberKey(partition)) as IObserverSubscriber;
+
+            // PerformStep (and everything it calls, including this method) runs off the grain's activation
+            // thread - see the <remarks> on JobStep.PerformStep. The ambient Grain.GrainFactory property
+            // validates the Orleans activation context on the calling thread and throws "Activation access
+            // violation" when accessed here, so an explicitly injected IGrainFactory (a plain thread-safe
+            // service) is used instead of the ambient property.
+            var subscriber = grainFactory.GetGrain(_subscription.SubscriberType, GetObserverSubscriberKey(partition)) as IObserverSubscriber;
             var result = await subscriber!.OnNext(partition, decryptedEvents, subscriberContext);
             return (result, decryptedEvents);
         }


### PR DESCRIPTION
## Summary

Two related concurrency bugs in the client/kernel that surface together as intermittent failures under load — a stalled Chronicle client and stuck replay observers.

## Fixed

- Fixed lock contention in the client's scoped `IEventStore` resolution: a single process-wide lock serialized every resolution across all namespaces and requests, and held that lock across a blocking call, which could stall unrelated requests and surface as `Cannot access a disposed object: GrpcChannel` under concurrent load.
- Fixed an activation access violation in the projection replay job step (`HandleEventsForObserver`): it read the ambient `Grain.GrainFactory` property from code that runs off the grain's activation thread, throwing "Activation access violation" and leaving the observer stuck without processing new events even though they were present in the log.

## Test plan

- [x] `dotnet build` (Debug + Release) for the affected client and kernel projects — zero warnings, zero errors
- [x] `dotnet test Source/Kernel/Core.Specs` — 1612 passed, 1 pre-existing skip, 0 failures
- [x] Verified against a downstream consumer app under Aspire-orchestrated concurrent startup — repeated onboarding flow runs now produce identical, deterministic pass/fail results instead of the prior non-deterministic 6-10/30 range with silent disposed-channel failures