### PR TITLE
Drop the clients attribute from ChronicleClientTabs placeholders

### DIFF
--- a/Documentation/closing-streams/index.mdx
+++ b/Documentation/closing-streams/index.mdx
@@ -18,7 +18,7 @@ Closing a stream is useful when a logical unit of work is complete and no furthe
 
 Call `CompleteStream` on the event log with the stream type and stream identifier you want to close:
 
-<ChronicleClientTabs snippet="closing-streams/index/complete-stream" clients="csharp" />
+<ChronicleClientTabs snippet="closing-streams/index/complete-stream" />
 
 The method returns `Result<EventSequenceNumber, CompleteStreamError>`.
 
@@ -33,6 +33,6 @@ The method returns `Result<EventSequenceNumber, CompleteStreamError>`.
 
 After a stream is closed, any append targeting that stream is rejected with a `StreamClosed` constraint violation:
 
-<ChronicleClientTabs snippet="closing-streams/index/append-rejected" clients="csharp" />
+<ChronicleClientTabs snippet="closing-streams/index/append-rejected" />
 
 The rejection is enforced by the `ClosedStreamConstraintValidator` which is automatically active for every event sequence — no additional configuration is required.

--- a/Documentation/code-analysis/CHR0001.mdx
+++ b/Documentation/code-analysis/CHR0001.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0001/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0001/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0001/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0001/fix" />
 
 ## Quick Fix
 

--- a/Documentation/code-analysis/CHR0002.mdx
+++ b/Documentation/code-analysis/CHR0002.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0002/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0002/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0002/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0002/fix" />
 
 ## Quick Fix
 

--- a/Documentation/code-analysis/CHR0003.mdx
+++ b/Documentation/code-analysis/CHR0003.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0003/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0003/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0003/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0003/fix" />
 
 ## Applicable Attributes
 

--- a/Documentation/code-analysis/CHR0004.mdx
+++ b/Documentation/code-analysis/CHR0004.mdx
@@ -16,7 +16,7 @@ Warning
 
 ## Allowed Signatures
 
-<ChronicleClientTabs snippet="code-analysis/chr0004/allowed-signatures" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0004/allowed-signatures" />
 
 Where `TEvent` is a type marked with `[EventType]`, and `TReadModel` is a type that has a reducer or projection.
 
@@ -24,11 +24,11 @@ Where `TEvent` is a type marked with `[EventType]`, and `TReadModel` is a type t
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0004/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0004/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0004/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0004/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0005.mdx
+++ b/Documentation/code-analysis/CHR0005.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0005/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0005/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0005/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0005/fix" />
 
 ## Quick Fix
 

--- a/Documentation/code-analysis/CHR0006.mdx
+++ b/Documentation/code-analysis/CHR0006.mdx
@@ -12,7 +12,7 @@ Warning
 
 Event handler methods in reducers must have one of the following signatures:
 
-<ChronicleClientTabs snippet="code-analysis/chr0006/allowed-signatures" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0006/allowed-signatures" />
 
 Where `TEvent` is a type marked with `[EventType]`.
 
@@ -20,11 +20,11 @@ Where `TEvent` is a type marked with `[EventType]`.
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0006/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0006/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0006/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0006/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0007.mdx
+++ b/Documentation/code-analysis/CHR0007.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0007/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0007/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0007/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0007/fix" />
 
 ## Quick Fix
 

--- a/Documentation/code-analysis/CHR0012.mdx
+++ b/Documentation/code-analysis/CHR0012.mdx
@@ -12,11 +12,11 @@ Warning
 
 ### Warning
 
-<ChronicleClientTabs snippet="code-analysis/chr0012/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0012/violation" />
 
 ### Preferred
 
-<ChronicleClientTabs snippet="code-analysis/chr0012/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0012/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0013.mdx
+++ b/Documentation/code-analysis/CHR0013.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0013/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0013/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0013/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0013/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0014.mdx
+++ b/Documentation/code-analysis/CHR0014.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0014/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0014/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0014/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0014/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0015.mdx
+++ b/Documentation/code-analysis/CHR0015.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0015/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0015/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0015/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0015/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0016.mdx
+++ b/Documentation/code-analysis/CHR0016.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0016/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0016/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0016/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0016/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0017.mdx
+++ b/Documentation/code-analysis/CHR0017.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0017/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0017/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0017/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0017/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0018.mdx
+++ b/Documentation/code-analysis/CHR0018.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0018/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0018/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0018/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0018/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0019.mdx
+++ b/Documentation/code-analysis/CHR0019.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0019/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0019/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0019/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0019/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0020.mdx
+++ b/Documentation/code-analysis/CHR0020.mdx
@@ -12,11 +12,11 @@ Error
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0020/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0020/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0020/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0020/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0021.mdx
+++ b/Documentation/code-analysis/CHR0021.mdx
@@ -12,15 +12,15 @@ Warning
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0021/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0021/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0021/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0021/fix" />
 
 Or with init-only property syntax for events with many properties:
 
-<ChronicleClientTabs snippet="code-analysis/chr0021/fix-init" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0021/fix-init" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0022.mdx
+++ b/Documentation/code-analysis/CHR0022.mdx
@@ -14,11 +14,11 @@ Warning
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0022/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0022/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0022/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0022/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/code-analysis/CHR0023.mdx
+++ b/Documentation/code-analysis/CHR0023.mdx
@@ -14,11 +14,11 @@ Warning
 
 ### Violation
 
-<ChronicleClientTabs snippet="code-analysis/chr0023/violation" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0023/violation" />
 
 ### Fix
 
-<ChronicleClientTabs snippet="code-analysis/chr0023/fix" clients="csharp" />
+<ChronicleClientTabs snippet="code-analysis/chr0023/fix" />
 
 ## Why This Rule Exists
 

--- a/Documentation/coming-from-crud.mdx
+++ b/Documentation/coming-from-crud.mdx
@@ -48,17 +48,17 @@ var current = await db.Customers.FindAsync(id);
 
 Chronicle: the same change is a fact you append and a read side you declare. First, define the verbs as event types:
 
-<ChronicleClientTabs snippet="coming-from-crud/events" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="coming-from-crud/events" />
 
 Then declare the read side. This is the [projection](/chronicle/concepts/projection.md) — and notice it is *not* a 1:1 copy of the CRUD `Customer` entity. It's shaped for the screen that reads it, and it answers something the overwritten row never could:
 
-<ChronicleClientTabs snippet="coming-from-crud/read-model" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="coming-from-crud/read-model" />
 
 `[FromEvent<T>]` (`@fromEvent` in TypeScript) maps event properties onto the record by name — the name arrives with `CustomerRegistered`, and the address is kept current by every `AddressChanged`. The counter tracks the moves. There is no `UPDATE` statement anywhere: Chronicle derives the card from the facts.
 
 Now the write and the read-back:
 
-<ChronicleClientTabs snippet="coming-from-crud/write-and-read" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="coming-from-crud/write-and-read" />
 
 `GetInstanceById` computes the card from its events on demand, so this read already reflects the append above — `TimesRelocated` included, a fact the CRUD row lost the moment `SaveChanges` ran.
 

--- a/Documentation/compliance/client.mdx
+++ b/Documentation/compliance/client.mdx
@@ -14,7 +14,7 @@ Property-level PII annotation (Option 1) is real in Kotlin and Elixir too — se
 
 Apply `[PII]` directly to individual properties on your event records. This is the simplest starting point and works well when a value is PII only in the context of one specific event.
 
-<ChronicleClientTabs snippet="compliance/client/property-annotation" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="compliance/client/property-annotation" />
 
 `FirstName` and `LastName` are encrypted when the event is written. `Department` and `StartDate` are stored as plaintext.
 
@@ -34,11 +34,11 @@ The main drawback of property-level annotation is that you must remember to add 
 
 Apply `[PII]` to a `ConceptAs<T>` concept type. Chronicle then encrypts every event property that uses that type, automatically, across all events.
 
-<ChronicleClientTabs snippet="compliance/client/concept-annotation" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/client/concept-annotation" />
 
 Any event that uses `PersonName` is automatically encrypted — no further annotation is needed:
 
-<ChronicleClientTabs snippet="compliance/client/concept-usage" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/client/concept-usage" />
 
 > [!TIP]
 > For the full `ConceptAs<T>` declaration pattern and placement rules, see [Applying PII to ConceptAs types](pii-with-concepts) and <xref:Fundamentals.Concepts>.
@@ -57,13 +57,13 @@ This is the **recommended approach** for any value that is personal by nature.
 
 The two approaches complement each other. Use concept types for inherently personal domain values, and use property-level annotation for one-off cases where creating a concept type is not warranted.
 
-<ChronicleClientTabs snippet="compliance/client/combining" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/client/combining" />
 
 ## EventSourceId cannot be marked PII
 
 Do not apply `[PII]` to types that inherit from `EventSourceId` or `EventSourceId<T>`. Chronicle throws `PIINotSupportedOnEventSourceId` because event source identifiers are required for key lookup and cannot be encrypted.
 
-<ChronicleClientTabs snippet="compliance/client/event-source-id-restriction" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/client/event-source-id-restriction" />
 
 If the identifier itself is sensitive, use a non-sensitive surrogate key as the event source identifier (a randomly generated `Guid` works well) and store the sensitive value in a `[PII]`-marked event property.
 
@@ -71,6 +71,6 @@ If the identifier itself is sensitive, use a non-sensitive surrogate key as the 
 
 Compliance support is registered with a single extension method in your ASP.NET Core setup:
 
-<ChronicleClientTabs snippet="compliance/client/registering-compliance" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/client/registering-compliance" />
 
 This registers `PIIMetadataProvider` and all supporting infrastructure needed for the kernel to discover and encrypt PII properties.

--- a/Documentation/compliance/pii-with-concepts.mdx
+++ b/Documentation/compliance/pii-with-concepts.mdx
@@ -20,17 +20,17 @@ If a new event is added months later and the developer forgets the annotation, a
 
 A concept type solves this by making the protection part of the type's identity. You cannot use `PersonName` without the encryption — the two are inseparable.
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/why-concept-level" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/why-concept-level" />
 
 ## Defining a PII concept type
 
 Follow the standard `ConceptAs<T>` pattern and add `[PII]` to the record declaration:
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/defining-concept" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/defining-concept" />
 
 Another example, documenting why the value is sensitive with the optional `details` parameter:
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/national-id" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/national-id" />
 
 ## Placement
 
@@ -50,7 +50,7 @@ Features/
 
 Use the optional `details` parameter on `[PII]` to document the legal basis or purpose of the PII classification. This is stored in the event schema and can be surfaced by compliance tooling.
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/with-details" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/with-details" />
 
 ## What cannot be marked PII
 
@@ -58,8 +58,8 @@ Use the optional `details` parameter on `[PII]` to document the legal basis or p
 
 Any type inheriting from `EventSourceId` or `EventSourceId<T>` cannot be marked with `[PII]`. Chronicle throws `PIINotSupportedOnEventSourceId` if you attempt this.
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/event-source-id-restriction" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/event-source-id-restriction" />
 
 Use a non-sensitive surrogate key as the event source identifier and store sensitive identity values in a separate event property:
 
-<ChronicleClientTabs snippet="compliance/pii-with-concepts/surrogate-key" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii-with-concepts/surrogate-key" />

--- a/Documentation/compliance/pii.mdx
+++ b/Documentation/compliance/pii.mdx
@@ -6,7 +6,7 @@ uid: Chronicle.Compliance.PII
 
 The `[PII]` attribute marks data as personally identifiable information (PII) under GDPR. When Chronicle sees this attribute on an event property or a `ConceptAs<T>` type, it encrypts the value automatically when the event is written to the event log and decrypts it transparently on read.
 
-<ChronicleClientTabs snippet="compliance/pii/import" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii/import" />
 
 :::note[Client coverage]
 Kotlin (`@Pii`), Elixir (`pii/1,2`), and TypeScript (`@pii()`) all have a real, working equivalent for marking an **event property** as PII — see [Applying to an event property](#applying-to-an-event-property) below. The **class-level** form (marking a `ConceptAs<T>` type itself as PII, so every property using that type is covered) is tied to C#'s `ConceptAs<T>` pattern specifically; Kotlin/Java/Elixir have no equivalent typed-wrapper convention established in this corpus, so those tabs — and the two runtime restrictions that only make sense in that context (`EventSourceId`, non-`ConceptAs` classes) — stay C#-only for now.
@@ -27,7 +27,7 @@ export function pii(details?: string): PropertyDecorator & ClassDecorator
 
 The optional `details` parameter lets you record *why* the value is classified as PII — for example, the legal basis under which it is collected or the retention period. This information is stored in the event schema and can be used by compliance reporting tools.
 
-<ChronicleClientTabs snippet="compliance/pii/with-details" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii/with-details" />
 
 ## Where the attribute is valid
 
@@ -42,7 +42,7 @@ The optional `details` parameter lets you record *why* the value is classified a
 
 You can mark a single property on an event record as PII. This is useful when the property type is a primitive and you cannot or do not want to introduce a dedicated concept type.
 
-<ChronicleClientTabs snippet="compliance/pii/property-level" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="compliance/pii/property-level" />
 
 When this event is written, `FirstName` and `LastName` are encrypted. `Department` is stored as plaintext.
 
@@ -50,7 +50,7 @@ When this event is written, `FirstName` and `LastName` are encrypted. `Departmen
 
 The preferred approach is to mark the `ConceptAs<T>` type itself as PII. Every property across every event that uses this type is then automatically encrypted — you declare the rule once and it applies everywhere.
 
-<ChronicleClientTabs snippet="compliance/pii/concept-level" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii/concept-level" />
 
 > [!TIP]
 > Use <xref:Fundamentals.Concepts> as a reference for the full `ConceptAs<T>` pattern. For guidance on declaring compliance on concept types, see [Applying PII to ConceptAs types](pii-with-concepts).
@@ -61,7 +61,7 @@ The preferred approach is to mark the `ConceptAs<T>` type itself as PII. Every p
 
 Applying `[PII]` to a type that inherits from `EventSourceId` or `EventSourceId<T>` throws `PIINotSupportedOnEventSourceId` at runtime:
 
-<ChronicleClientTabs snippet="compliance/pii/event-source-id-restriction" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii/event-source-id-restriction" />
 
 Event source identifiers are used to look up encryption keys and group events. Encrypting them would make key lookup impossible. If the identifier itself is sensitive, use a non-sensitive surrogate (such as a random `Guid`) as the event source identifier and store the sensitive value in a `[PII]`-marked event property.
 
@@ -69,7 +69,7 @@ Event source identifiers are used to look up encryption keys and group events. E
 
 Applying `[PII]` to a class that does not inherit from `ConceptAs<T>` throws `PIIAppliedToNonConceptAsType` at runtime:
 
-<ChronicleClientTabs snippet="compliance/pii/non-concept-class" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/pii/non-concept-class" />
 
 This restriction is .NET-client-specific — the TypeScript `@pii()` decorator does not check that its target extends `ConceptAs<T>`.
 
@@ -79,4 +79,4 @@ The `[PII]` attribute at the class level is reserved for `ConceptAs<T>` types. U
 
 The `details` parameter is a free-text description stored in the event schema. It is never used for encryption — it exists solely to record *why* a value is classified as PII for compliance documentation and auditing purposes.
 
-<ChronicleClientTabs snippet="compliance/pii/legal-name-details" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="compliance/pii/legal-name-details" />

--- a/Documentation/compliance/read-models.mdx
+++ b/Documentation/compliance/read-models.mdx
@@ -20,7 +20,7 @@ The compliance identifier used for key lookup follows this rule: if an explicit 
 
 Projection-backed read models benefit from automatic PII lineage. The kernel knows which read model properties are mapped from PII event properties and encrypts them transparently before writing to storage. No `[PII]` attribute is needed on the read model type.
 
-<ChronicleClientTabs snippet="compliance/read-models/projection-lineage" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/read-models/projection-lineage" />
 
 The `Name` property is stored encrypted in MongoDB because `PersonName` is a PII-marked type. When a query returns `Employee` records, the kernel decrypts the values before they reach the caller.
 
@@ -28,7 +28,7 @@ The `Name` property is stored encrypted in MongoDB because `PersonName` is a PII
 
 Reducers use arbitrary C# logic to compute state. The kernel cannot infer which properties derive from PII fields because the transformation is opaque. You must annotate PII properties on the read model record with `[PII]`.
 
-<ChronicleClientTabs snippet="compliance/read-models/reducer-explicit-pii" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/read-models/reducer-explicit-pii" />
 
 The `[PII]` attribute on `Name` tells the kernel to encrypt that property before storage and decrypt it on retrieval.
 
@@ -56,6 +56,6 @@ For full erasure of event content, combine key deletion with [event redaction](.
 
 Read model queries are transparent to PII encryption. No changes to query code are needed:
 
-<ChronicleClientTabs snippet="compliance/read-models/querying" clients="csharp" />
+<ChronicleClientTabs snippet="compliance/read-models/querying" />
 
 Chronicle decrypts PII fields automatically before returning results to the caller. When the encryption key has been deleted for a subject, `Name` returns an empty string — the caller receives an `Employee` record with an empty name, never an exception or partial result.

--- a/Documentation/concepts/correlation-identity-causation.mdx
+++ b/Documentation/concepts/correlation-identity-causation.mdx
@@ -13,19 +13,19 @@ All three are set once at the start of an operation (a request, a background job
 
 ## Correlation ID
 
-<ChronicleClientTabs snippet="concepts/correlation-identity-causation/correlation" clients="csharp,kotlin,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/correlation-identity-causation/correlation" />
 
 Kotlin's correlation manager scopes the id per-thread (`ThreadLocal`); Elixir and TypeScript scope it per logical call context (Elixir's process dictionary, TypeScript's `AsyncLocalStorage`) — in both cases automatically, without extra code, as long as you don't spawn new threads/processes/async contexts without carrying the value across explicitly.
 
 ## Identity
 
-<ChronicleClientTabs snippet="concepts/correlation-identity-causation/identity" clients="csharp,kotlin,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/correlation-identity-causation/identity" />
 
 Every client provides the same three sentinel identities for well-known cases — `System`, `NotSet`, and `Unknown` — and supports on-behalf-of delegation chains (an identity that acted *for* another identity) via a `withoutDuplicates()`/`without_duplicates/1` helper that collapses repeated subjects in a long chain.
 
 ## Causation
 
-<ChronicleClientTabs snippet="concepts/correlation-identity-causation/causation" clients="csharp,kotlin,elixir" />
+<ChronicleClientTabs snippet="concepts/correlation-identity-causation/causation" />
 
 TypeScript also has a real `causationManager.add(type, properties)` — the client-specific pages linked below cover it, along with more Kotlin/Elixir/TypeScript causation detail than fits here (defining/redefining the root cause, reading the full chain, framework-integration examples for scoping context per request).
 

--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -40,7 +40,7 @@ A *materialized* read model updates *after* the event is appended, so what's sto
 
 Eventual is the default, though — not a law. The `IReadModels` API can also compute a read model on demand by replaying its events, giving you a strongly consistent read that includes an event you appended a millisecond ago:
 
-<ChronicleClientTabs snippet="concepts/designing-read-models/strongly-consistent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/designing-read-models/strongly-consistent" />
 
 [Deep dive: consistency](./consistency.md) covers when each model is the right call.
 
@@ -48,7 +48,7 @@ Eventual is the default, though — not a law. The `IReadModels` API can also co
 
 When it's time to read, Chronicle gives you a ladder — trade consistency for cost as you descend:
 
-<ChronicleClientTabs snippet="concepts/designing-read-models/query-ladder" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/designing-read-models/query-ladder" />
 
 - **`GetInstances<T>()`** rebuilds every instance from the event log at call time, so the result reflects everything appended so far. You can cap the work with an event count (`GetInstances<T>(eventCount)`), but a capped replay may return incomplete results. Replay cost grows with history — great for [reporting and short histories](../read-models/getting-collection-instances), not necessarily your production list view.
 - **`Materialized.GetInstances<T>(skip, take)`** reads what projections have already stored, with paging — cheap and fast, a moment behind. See [Materialized read models](../read-models/materialized-pagination).

--- a/Documentation/concepts/event-type-migrations.mdx
+++ b/Documentation/concepts/event-type-migrations.mdx
@@ -20,7 +20,7 @@ Chronicle's migration system allows you to:
 
 To define a migration, extend the `EventTypeMigration<TUpgrade, TPrevious>` base class (it handles generation extraction and validation for you) and override `Upcast`/`Downcast`:
 
-<ChronicleClientTabs snippet="concepts/event-type-migrations/defining-migrations" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/event-type-migrations/defining-migrations" />
 
 Kotlin and Java don't currently have a migration API — there's no equivalent to `EventTypeMigration<TUpgrade, TPrevious>` in the Kotlin client SDK.
 
@@ -32,25 +32,25 @@ The migration builder supports the following operations:
 
 Splits a source property into parts using a separator:
 
-<ChronicleClientTabs snippet="concepts/event-type-migrations/split" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/event-type-migrations/split" />
 
 ### Combine
 
 Combines multiple source properties into a single value using a separator:
 
-<ChronicleClientTabs snippet="concepts/event-type-migrations/combine" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/event-type-migrations/combine" />
 
 ### Rename
 
 Renames a property from a previous name using `RenamedFrom`:
 
-<ChronicleClientTabs snippet="concepts/event-type-migrations/rename" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/event-type-migrations/rename" />
 
 ### Default Value
 
 Sets a default value for a new property:
 
-<ChronicleClientTabs snippet="concepts/event-type-migrations/default-value" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/event-type-migrations/default-value" />
 
 ## How Migrations Work
 

--- a/Documentation/concepts/geospatial.mdx
+++ b/Documentation/concepts/geospatial.mdx
@@ -10,7 +10,7 @@ Geospatial types are currently C#-only — Kotlin, Elixir, and TypeScript don't 
 
 The three geospatial types are records defined in the `Cratis.Geospatial` namespace:
 
-<ChronicleClientTabs snippet="concepts/geospatial/types" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/geospatial/types" />
 
 - **Point** represents a single geographic location in longitude-then-latitude order (GeoJSON standard).
 - **LineString** represents a connected series of points forming a line or path.
@@ -21,11 +21,11 @@ The three geospatial types are records defined in the `Cratis.Geospatial` namesp
 
 Import the namespace and use the geospatial types as any other property type:
 
-<ChronicleClientTabs snippet="concepts/geospatial/events-and-read-models" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/geospatial/events-and-read-models" />
 
 Projections and reducers handle geospatial types like any other value type. AutoMap picks them up automatically:
 
-<ChronicleClientTabs snippet="concepts/geospatial/projection" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/geospatial/projection" />
 
 ## JSON Schema
 

--- a/Documentation/concepts/modeling-events.mdx
+++ b/Documentation/concepts/modeling-events.mdx
@@ -11,19 +11,19 @@ The guiding principle behind all of it: **an event is a fact — an immutable re
 
 An event states what *happened*, so its name is a past-tense verb phrase in the language of the domain: `OrderPlaced`, `AddressChanged`, `PaymentCaptured`, `BookReturned`. Not `CreateOrder` (that's a command — an intent), not `OrderState` (that's a model). If you can't name it in the past tense, it isn't an event yet.
 
-<ChronicleClientTabs snippet="concepts/modeling-events/fact-vs-intent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/modeling-events/fact-vs-intent" />
 
 ## One event, one purpose
 
 Each event captures a single, meaningful change. Resist the "kitchen-sink" event that carries everything about an entity with most fields irrelevant on any given change. Multipurpose events force every consumer to figure out *which* change actually happened.
 
-<ChronicleClientTabs snippet="concepts/modeling-events/single-purpose" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/modeling-events/single-purpose" />
 
 ## Never nullable — if it's optional, you need a second event
 
 This is the rule that trips up newcomers most, and it's the most important. An event records what *was true* at the moment it happened. A nullable property means "this fact sometimes didn't happen" — which is a contradiction. If a value is sometimes present and sometimes not, that's **two different facts**, so model two events.
 
-<ChronicleClientTabs snippet="concepts/modeling-events/no-nullable" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/modeling-events/no-nullable" />
 
 ## Capture the decision, not the field write
 

--- a/Documentation/concepts/subject.mdx
+++ b/Documentation/concepts/subject.mdx
@@ -28,14 +28,14 @@ flowchart TB
 When you don't specify a subject, Chronicle uses the `EventSourceId` as the subject. This is
 the right default for most slices where the aggregate and the subject coincide:
 
-<ChronicleClientTabs snippet="concepts/subject/default" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/subject/default" />
 
 ## Specifying an explicit subject
 
 When the event source is different from the subject, pass `Subject` explicitly. `Subject` has
 an implicit conversion from `EventSourceId`, so mixing the two is painless:
 
-<ChronicleClientTabs snippet="concepts/subject/explicit" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/subject/explicit" />
 
 `Subject` also converts implicitly from `string` and `Guid`. Kotlin, Java, and TypeScript don't currently expose a `subject` append option at all — only C# and Elixir do.
 
@@ -45,7 +45,7 @@ Rather than threading `subject` through every call site, decorate the relevant p
 event type with `[Subject]`. Chronicle will read the property value automatically when no
 explicit subject is provided:
 
-<ChronicleClientTabs snippet="concepts/subject/implicit-with-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/subject/implicit-with-attribute" />
 
 An explicit `subject` argument always takes precedence over a `[Subject]` property. This declarative form is C#-only — Elixir requires passing `subject:` explicitly on every append (shown above); Kotlin, Java, and TypeScript don't support a subject at all yet.
 

--- a/Documentation/concepts/tagging-reactors.mdx
+++ b/Documentation/concepts/tagging-reactors.mdx
@@ -16,25 +16,25 @@ You can tag reactors in multiple ways:
 
 Apply a single tag to your reactor:
 
-<ChronicleClientTabs snippet="concepts/tagging-reactors/single-tag" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging-reactors/single-tag" />
 
 ### Multiple Tags (Single Attribute)
 
 Use the params feature to specify multiple tags in a single attribute:
 
-<ChronicleClientTabs snippet="concepts/tagging-reactors/multiple-tags-single-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging-reactors/multiple-tags-single-attribute" />
 
 ### Multiple Tags (Multiple Attributes)
 
 Apply multiple `[Tag]` attributes:
 
-<ChronicleClientTabs snippet="concepts/tagging-reactors/multiple-tags-multiple-attributes" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging-reactors/multiple-tags-multiple-attributes" />
 
 ### Mixed Approach
 
 Combine both approaches:
 
-<ChronicleClientTabs snippet="concepts/tagging-reactors/mixed-approach" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging-reactors/mixed-approach" />
 
 ## Best Practices
 
@@ -47,7 +47,7 @@ Combine both approaches:
 
 Here are some common patterns for tagging reactors:
 
-<ChronicleClientTabs snippet="concepts/tagging-reactors/tag-categories" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging-reactors/tag-categories" />
 
 ## Querying by Tag
 

--- a/Documentation/concepts/tagging.mdx
+++ b/Documentation/concepts/tagging.mdx
@@ -28,13 +28,13 @@ Events can be tagged in two ways: statically using attributes, or dynamically wh
 
 Apply the `[Tag]` or `[Tags]` attribute to your event types to assign static tags that will always be associated with that event type:
 
-<ChronicleClientTabs snippet="concepts/tagging/static-event-tags" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/static-event-tags" />
 
 ### Dynamic Event Tags
 
 When appending events, you can provide additional tags that will be merged with any static tags:
 
-<ChronicleClientTabs snippet="concepts/tagging/dynamic-event-tags" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="concepts/tagging/dynamic-event-tags" />
 
 In this example, the event will have four tags: `["analytics", "user-action", "production", "critical"]`.
 
@@ -42,7 +42,7 @@ In this example, the event will have four tags: `["analytics", "user-action", "p
 
 All tags (both static and dynamic) are available on the `EventContext` when processing events:
 
-<ChronicleClientTabs snippet="concepts/tagging/tags-in-event-context" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/tags-in-event-context" />
 
 ## Tagging Observers
 
@@ -50,29 +50,29 @@ Observers (reactors, reducers, and projections) can be tagged to organize and ca
 
 ### Single Tag
 
-<ChronicleClientTabs snippet="concepts/tagging/observer-single-tag" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/observer-single-tag" />
 
 ### Multiple Tags (Single Attribute)
 
 You can use either `[Tag]` or `[Tags]` (plural) for convenience:
 
-<ChronicleClientTabs snippet="concepts/tagging/observer-multiple-tags-single-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/observer-multiple-tags-single-attribute" />
 
 ### Multiple Tags (Multiple Attributes)
 
-<ChronicleClientTabs snippet="concepts/tagging/observer-multiple-tags-multiple-attributes" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/observer-multiple-tags-multiple-attributes" />
 
 ### Mixed Approach
 
 You can mix both `[Tag]` and `[Tags]` attributes - all tags will be merged:
 
-<ChronicleClientTabs snippet="concepts/tagging/observer-mixed-approach" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/observer-mixed-approach" />
 
 ## Tagging Read Models
 
 Read models and projections can also be tagged:
 
-<ChronicleClientTabs snippet="concepts/tagging/read-model-tags" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/read-model-tags" />
 
 ## Best Practices
 
@@ -88,27 +88,27 @@ Here are some common patterns for organizing tags:
 
 ### By Domain
 
-<ChronicleClientTabs snippet="concepts/tagging/by-domain" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/by-domain" />
 
 ### By Purpose
 
-<ChronicleClientTabs snippet="concepts/tagging/by-purpose" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/by-purpose" />
 
 ### By Integration Type
 
-<ChronicleClientTabs snippet="concepts/tagging/by-integration-type" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/by-integration-type" />
 
 ### By Communication Channel
 
-<ChronicleClientTabs snippet="concepts/tagging/by-communication-channel" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/by-communication-channel" />
 
 ### By Stakeholder
 
-<ChronicleClientTabs snippet="concepts/tagging/by-stakeholder" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/by-stakeholder" />
 
 ### By Environment or Context
 
-<ChronicleClientTabs snippet="concepts/tagging/dynamic-tags-patterns" clients="csharp" />
+<ChronicleClientTabs snippet="concepts/tagging/dynamic-tags-patterns" />
 
 ## Using Tags
 

--- a/Documentation/configuration/camel-casing.mdx
+++ b/Documentation/configuration/camel-casing.mdx
@@ -14,7 +14,7 @@ By default, Chronicle uses property names as they appear in C# (PascalCase). Ena
 
 For direct `ChronicleClient` usage outside of a hosted application, pass a `CamelCaseNamingPolicy` instance via the named `namingPolicy` constructor argument:
 
-<ChronicleClientTabs snippet="configuration/camel-casing/direct-client" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/direct-client" />
 
 ## Using ASP.NET Core
 
@@ -24,19 +24,19 @@ When building ASP.NET Core applications, use the dependency injection extensions
 
 In your `Program.cs` file, configure Chronicle with camel case naming policy using the `IChronicleBuilder` callback:
 
-<ChronicleClientTabs snippet="configuration/camel-casing/aspnetcore-basic" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/aspnetcore-basic" />
 
 ### Dependency Injection Configuration
 
 You can combine camel case naming policy with other Chronicle configuration options:
 
-<ChronicleClientTabs snippet="configuration/camel-casing/aspnetcore-with-options" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/aspnetcore-with-options" />
 
 ## Using .NET Host (Worker Services)
 
 For worker services or other non-web hosts using `IHostApplicationBuilder`:
 
-<ChronicleClientTabs snippet="configuration/camel-casing/worker-host" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/worker-host" />
 
 ## Impact on Projections
 
@@ -54,17 +54,17 @@ When projections project to read models, the property names used will follow the
 
 #### Event Definition
 
-<ChronicleClientTabs snippet="configuration/camel-casing/event" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/event" />
 
 #### Read Model Definition
 
-<ChronicleClientTabs snippet="configuration/camel-casing/read-model" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/read-model" />
 
 #### Projection with Camel Case Naming Policy
 
 With camel case naming policy configured, Chronicle will use camel case property names when building the projection:
 
-<ChronicleClientTabs snippet="configuration/camel-casing/projection" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/camel-casing/projection" />
 
 The resulting read model data will have camel case property names: `firstName`, `lastName`, `emailAddress`, `registrationDate`.
 

--- a/Documentation/configuration/chronicle-options.mdx
+++ b/Documentation/configuration/chronicle-options.mdx
@@ -56,7 +56,7 @@ Asks the Kernel to enforce strict migration chain validation when registering ev
 
 To opt in to strict validation during development (recommended once your event schemas are stable), set the flag to `true`:
 
-<ChronicleClientTabs snippet="configuration/chronicle-options/enable-validation" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/chronicle-options/enable-validation" />
 
 In `appsettings.json`: `"EnableEventTypeGenerationValidation": true`.
 
@@ -71,7 +71,7 @@ The gRPC endpoint for Chronicle Server.
 | Type | `ChronicleConnectionString` |
 | Default | Development connection string (`chronicle://localhost:35000` with default dev credentials) |
 
-<ChronicleClientTabs snippet="configuration/chronicle-options/connection-string" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/chronicle-options/connection-string" />
 
 In `appsettings.json`: `"ConnectionString": "chronicle://myserver:35000"`.
 
@@ -111,7 +111,7 @@ Controls which sink type is used when registering projections and reducers with 
 
 To use SQL as the storage backend for all read models:
 
-<ChronicleClientTabs snippet="configuration/chronicle-options/sql-sink" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/chronicle-options/sql-sink" />
 
 In `appsettings.json`:
 

--- a/Documentation/configuration/grpc-message-size.mdx
+++ b/Documentation/configuration/grpc-message-size.mdx
@@ -10,7 +10,7 @@ By default, Chronicle sets both `MaxReceiveMessageSize` and `MaxSendMessageSize`
 
 You can configure the message sizes when creating a `ChronicleClient` or through options:
 
-<ChronicleClientTabs snippet="configuration/grpc-message-size/configure" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/grpc-message-size/configure" />
 
 ## Configuration via appsettings.json
 
@@ -58,4 +58,4 @@ This indicates that the response from the server exceeds `MaxReceiveMessageSize`
 
 Setting either property to `null` will use the gRPC default (4 MB), which is generally not recommended for Chronicle applications:
 
-<ChronicleClientTabs snippet="configuration/grpc-message-size/null-values" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/grpc-message-size/null-values" />

--- a/Documentation/configuration/index.mdx
+++ b/Documentation/configuration/index.mdx
@@ -29,7 +29,7 @@ A minimal `appsettings.json`:
 
 The matching registration on the host — `AddCratisChronicle` reads the section above, and the callback overrides it:
 
-<ChronicleClientTabs snippet="configuration/index/register" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/index/register" />
 
 `AddCratisChronicle` is an extension on the host builder — `IHostApplicationBuilder` for worker and console hosts, `WebApplicationBuilder` for ASP.NET Core. See the [getting-started host guides](../get-started/toc.yml) for the full setup of each.
 

--- a/Documentation/configuration/structural-dependencies.mdx
+++ b/Documentation/configuration/structural-dependencies.mdx
@@ -18,7 +18,7 @@ Services and providers that must be resolved at registration time (before the DI
 
 For console applications or other non-DI scenarios, pass structural dependencies as named constructor parameters:
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/direct-client" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/direct-client" />
 
 All parameters are optional. Any parameter you omit uses the default shown in the table above.
 
@@ -26,11 +26,11 @@ All parameters are optional. Any parameter you omit uses the default shown in th
 
 In DI-hosted applications (ASP.NET Core, worker services, or any `IHostApplicationBuilder`-based host), use the `configure` callback on `AddCratisChronicle` to set structural dependencies via the `IChronicleBuilder` fluent API. This callback runs at registration time, before the DI container is built.
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/chronicle-builder" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/chronicle-builder" />
 
 The same pattern works with `WebApplicationBuilder` in ASP.NET Core:
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/aspnetcore-builder" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/aspnetcore-builder" />
 
 The two callbacks are intentionally separate:
 - `configureOptions` feeds the options pipeline and can be overridden by `appsettings.json` or `IConfiguration`.
@@ -49,15 +49,15 @@ The two callbacks are intentionally separate:
 
 Implement `IClientArtifactsProvider` when you need to control exactly which types Chronicle discovers. This is useful in modular applications or when using assembly scanning that differs from the default:
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/custom-artifacts-provider" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/custom-artifacts-provider" />
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/custom-artifacts-provider-usage" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/custom-artifacts-provider-usage" />
 
 ## DefaultClientArtifactsProvider
 
 `DefaultClientArtifactsProvider` scans loaded assemblies for artifacts at first access (lazy initialization). You can construct it with a custom assembly provider:
 
-<ChronicleClientTabs snippet="configuration/structural-dependencies/default-artifacts-provider" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/structural-dependencies/default-artifacts-provider" />
 
 The static `DefaultClientArtifactsProvider.Default` instance is used when no provider is supplied.
 

--- a/Documentation/configuration/tls.mdx
+++ b/Documentation/configuration/tls.mdx
@@ -22,7 +22,7 @@ For server-side TLS configuration, see [TLS Configuration (Server)](../hosting/c
 
 ## Client options
 
-<ChronicleClientTabs snippet="configuration/tls/client-options" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/tls/client-options" />
 
 ## Properties
 
@@ -36,7 +36,7 @@ For server-side TLS configuration, see [TLS Configuration (Server)](../hosting/c
 
 TLS can also be disabled through the connection string in development:
 
-<ChronicleClientTabs snippet="configuration/tls/connection-string-disable" clients="csharp" />
+<ChronicleClientTabs snippet="configuration/tls/connection-string-disable" />
 
 ## Development vs production
 

--- a/Documentation/connection-strings/configuration.mdx
+++ b/Documentation/connection-strings/configuration.mdx
@@ -19,7 +19,7 @@ The .NET client reads its connection string from configuration. A typical setup 
 
 **Program.cs:**
 
-<ChronicleClientTabs snippet="connection-strings/configuration/register" clients="csharp" />
+<ChronicleClientTabs snippet="connection-strings/configuration/register" />
 
 `AddCratisChronicle` is an extension on the host builder — `IHostApplicationBuilder` for worker and console hosts, `WebApplicationBuilder` for ASP.NET Core. It binds the `Cratis:Chronicle` section automatically, so the connection string comes from configuration rather than code. See [Add Chronicle to a worker service](../get-started/worker) and [Add Chronicle to an ASP.NET Core app](../get-started/aspnetcore) for the full host setup.
 

--- a/Documentation/connection-strings/dotnet-client.mdx
+++ b/Documentation/connection-strings/dotnet-client.mdx
@@ -6,11 +6,11 @@ Chronicle uses connection strings to configure the .NET client. You can pass a c
 
 The `ChronicleConnectionString.Development` constant provides a pre-configured development connection string. Default constructors also use this value:
 
-<ChronicleClientTabs snippet="connection-strings/dotnet-client/development-defaults" clients="csharp" />
+<ChronicleClientTabs snippet="connection-strings/dotnet-client/development-defaults" />
 
 This is equivalent to:
 
-<ChronicleClientTabs snippet="connection-strings/dotnet-client/development-defaults-equivalent" clients="csharp" />
+<ChronicleClientTabs snippet="connection-strings/dotnet-client/development-defaults-equivalent" />
 
 > [!NOTE]
 > In development, you can use `chronicle://localhost:35000` without credentials. The .NET client automatically attempts the built-in development credentials (`chronicle-dev-client` / `chronicle-dev-secret`).
@@ -19,13 +19,13 @@ Use explicit configuration for production environments.
 
 ## From connection string
 
-<ChronicleClientTabs snippet="connection-strings/dotnet-client/from-connection-string" clients="csharp" />
+<ChronicleClientTabs snippet="connection-strings/dotnet-client/from-connection-string" />
 
 ## Fluent builder
 
 Use `ChronicleConnectionStringBuilder` to construct a connection string programmatically:
 
-<ChronicleClientTabs snippet="connection-strings/dotnet-client/fluent-builder" clients="csharp" />
+<ChronicleClientTabs snippet="connection-strings/dotnet-client/fluent-builder" />
 
 ## Authentication validation
 

--- a/Documentation/constraints/declarative/index.mdx
+++ b/Documentation/constraints/declarative/index.mdx
@@ -23,7 +23,7 @@ Use declarative constraints when you need:
 
 Implement `IConstraint` and call the builder in `Define`:
 
-<ChronicleClientTabs snippet="constraints/declarative/index/defining" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/index/defining" />
 
 ## Discovery
 

--- a/Documentation/constraints/declarative/unique-event-type.mdx
+++ b/Documentation/constraints/declarative/unique-event-type.mdx
@@ -6,23 +6,23 @@ Chronicle discovers all `IConstraint` implementations automatically — no regis
 
 ## Defining a unique event type constraint
 
-<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/basic" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/basic" />
 
 ## Violation message
 
 Provide a static message string:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/violation-message" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/violation-message" />
 
 Or use a callback to compose the message dynamically from violation context:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/violation-message-callback" clients="csharp" />
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/violation-message-callback" />
 
 ## Constraint name
 
 An optional name can be provided to identify the constraint. When not provided, Chronicle uses the event type name as the default constraint name:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/constraint-name" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/constraint-name" />
 
 ## How constraints are enforced
 

--- a/Documentation/constraints/declarative/unique.mdx
+++ b/Documentation/constraints/declarative/unique.mdx
@@ -8,41 +8,41 @@ Chronicle discovers all `IConstraint` implementations automatically — no regis
 
 Implement `IConstraint` and call the builder in `Define`:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/basic" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/basic" />
 
 ## Uniqueness across multiple event types
 
 Use multiple `.On` calls when several event types each contribute to the same logical uniqueness rule. The constraint fires if any of the tracked events would introduce a duplicate value:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/multiple-event-types" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/multiple-event-types" />
 
 ## Constraint name
 
 Use `.WithName(...)` to give the constraint an explicit name. When not provided, Chronicle uses the class name of the `IConstraint` implementation:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/constraint-name" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/constraint-name" />
 
 ## Releasing a constraint
 
 Call `.RemovedWith<T>()` to register the event type that releases the constraint. When that event is appended, the previously held value is freed and can be claimed again:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/releasing" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/releasing" />
 
 ## Ignoring casing
 
 Call `.IgnoreCasing()` to make the uniqueness check case-insensitive:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/ignore-casing" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/ignore-casing" />
 
 ## Violation message
 
 Call `.WithMessage(...)` to provide a custom message when the constraint is violated:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/violation-message" clients="csharp,kotlin,java,typescript" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/violation-message" />
 
 Use a callback to compose the message dynamically from violation context:
 
-<ChronicleClientTabs snippet="constraints/declarative/unique/violation-message-callback" clients="csharp" />
+<ChronicleClientTabs snippet="constraints/declarative/unique/violation-message-callback" />
 
 ## How constraints are enforced
 

--- a/Documentation/constraints/model-bound/unique-event-type.mdx
+++ b/Documentation/constraints/model-bound/unique-event-type.mdx
@@ -6,13 +6,13 @@ Chronicle discovers `[Unique]`-adorned types automatically and registers the con
 
 ## Defining a unique event type constraint
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/basic" />
 
 ## Constraint name and violation message
 
 An optional constraint name and violation message can be provided:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/name-and-message" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/name-and-message" />
 
 The `message` parameter is optional. Chronicle produces a default violation message when one is not supplied.
 
@@ -20,7 +20,7 @@ The `message` parameter is optional. Chronicle produces a default violation mess
 
 Apply `[RemoveConstraint]` to the event type that signals a domain object has been removed. When this event is appended, Chronicle releases the constraint, and the event source can accept a new event of this type:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/releasing" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique-event-type/releasing" />
 
 The constraint name must exactly match the name provided to the `[Unique]` attribute. When no name was provided to `[Unique]`, Chronicle uses the event type name as the default constraint name.
 

--- a/Documentation/constraints/model-bound/unique.mdx
+++ b/Documentation/constraints/model-bound/unique.mdx
@@ -6,19 +6,19 @@ Chronicle discovers `[Unique]`-adorned properties automatically and registers th
 
 ## Defining a unique property constraint
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/basic" />
 
 ## Strongly-typed properties
 
 `[Unique]` works on `ConceptAs<T>` properties — the idiomatic way to model a domain value in Cratis. Chronicle treats the concept as the underlying primitive it wraps (`string`, `Guid`, and so on), so a uniqueness rule on a strongly-typed `EmailAddress` or `OrganizationNumber` behaves exactly like one on the raw primitive, and registers and enforces identically through the [declarative](../declarative/unique) form too:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/strongly-typed" clients="csharp" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/strongly-typed" />
 
 ## Grouping constraints across event types
 
 When multiple event types share the same constraint `name`, Chronicle groups them into a single constraint. A value introduced by any of the participating events is checked against all others:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/grouping" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/grouping" />
 
 Both events now participate in the same `UniqueEmail` constraint, so neither `UserRegistered` nor `UserEmailChanged` can introduce an email address that already exists.
 
@@ -26,19 +26,19 @@ Both events now participate in the same `UniqueEmail` constraint, so neither `Us
 
 The `message` parameter is optional. Chronicle produces a default violation message when one is not supplied. A custom violation message is currently C#-only — none of the other clients' constraint declarations (model-bound or declarative) support one:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/violation-message" clients="csharp" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/violation-message" />
 
 ## Releasing a constraint
 
 Apply `[RemoveConstraint]` to the event type that signals a domain object has been removed. When this event is appended, Chronicle releases the named constraint and its previously held values can be claimed again:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/releasing" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/releasing" />
 
 The constraint name must exactly match the name used in the `[Unique]` attribute that established it.
 
 An event type can release more than one constraint by stacking multiple attributes:
 
-<ChronicleClientTabs snippet="constraints/model-bound/unique/multiple-remove-constraints" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="constraints/model-bound/unique/multiple-remove-constraints" />
 
 ## How constraints are enforced
 

--- a/Documentation/contributing/clients/index.mdx
+++ b/Documentation/contributing/clients/index.mdx
@@ -50,11 +50,7 @@ Chronicle.TypeScript/Documentation/client-snippets/events/appending/example.md
 
 Use one fenced code block in each snippet file unless the language needs more than one block. The fenced language must match the owning client, for example `csharp`, `java`, `kotlin`, `elixir`, or `typescript`.
 
-Use `clients="csharp,elixir"` when only some clients expose the concept:
-
-```mdx
-<ChronicleClientTabs snippet="events/appending/occurred" clients="csharp,elixir" />
-```
+`<ChronicleClientTabs />` has no `clients` property. Chronicle's shared docs never declare which clients apply to an example — the sync discovers that itself: it checks every registered client's snippet root for a file at that id and renders a tab only for the clients where one exists. When only some clients expose a concept, simply don't add a snippet file for the others; there is nothing to configure on the placeholder.
 
 When a shared workflow should be visible for a client but that client does not support it yet, keep the tab visible with an explicit unsupported snippet instead of omitting the client:
 
@@ -121,13 +117,12 @@ To add another client language later:
 
 1. Add the client repo to the Documentation repo checkout/submodule setup.
 2. Add it to `Documentation/web/chronicle-client-docs.yml`.
-3. Mark `includeByDefault: false` when the client should be opt-in per tab group rather than required by every existing placeholder.
-4. Add `Documentation/client-snippets/**` to the client repo when it participates in shared tabs.
-5. Add `Documentation/validate-client-snippets.py` that compiles snippets against that client.
-6. Add a `Client Snippet Verification` workflow in the client repo.
-7. Add the documentation sync workflow that triggers the Documentation repo after `Documentation/**` changes land on `main`.
-8. Add the new language's snippet files for the shared Chronicle pages that should include it.
-9. Run the affected snippet validators, `npm run chronicle-client-docs:check`, and `npm run build` in `Documentation/web`.
+3. Add `Documentation/client-snippets/**` to the client repo when it participates in shared tabs. A new client only shows up in a tab group once it has a matching snippet file — no other wiring makes it opt-in or required.
+4. Add `Documentation/validate-client-snippets.py` that compiles snippets against that client.
+5. Add a `Client Snippet Verification` workflow in the client repo.
+6. Add the documentation sync workflow that triggers the Documentation repo after `Documentation/**` changes land on `main`.
+7. Add the new language's snippet files for the shared Chronicle pages that should include it.
+8. Run the affected snippet validators, `npm run chronicle-client-docs:check`, and `npm run build` in `Documentation/web`.
 
 ### Migration audit
 

--- a/Documentation/contributing/clients/typescript-grpc-package.mdx
+++ b/Documentation/contributing/clients/typescript-grpc-package.mdx
@@ -108,23 +108,23 @@ yarn add @cratis/chronicle.contracts
 
 Use the generated service definitions from your gRPC transport code:
 
-<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/event-stores-definition" clients="typescript" />
+<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/event-stores-definition" />
 
 The package also includes generated request and response message helpers:
 
-<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/request-messages" clients="typescript" />
+<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/request-messages" />
 
 ### Service Definitions
 
 Service definitions expose the protobuf service name and generated method definitions:
 
-<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/namespaces-definition" clients="typescript" />
+<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/namespaces-definition" />
 
 ### Typed Clients
 
 When a gRPC transport creates clients from the generated definitions, use the generated client interfaces for type safety:
 
-<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/service-types" clients="typescript" />
+<ChronicleClientTabs snippet="contributing/clients/typescript-grpc-package/service-types" />
 
 ## Publishing a New Version
 

--- a/Documentation/contributing/kernel/contracts.mdx
+++ b/Documentation/contributing/kernel/contracts.mdx
@@ -17,7 +17,7 @@ indicating the field's position in the contract.
 
 Example:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/data-contract" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/data-contract" />
 
 Always add new properties at the end, without reordering existing ones.
 
@@ -25,7 +25,7 @@ For service contracts, use the `[Service]` and `[Operation]` attributes.
 
 Example:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/service-contract" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/service-contract" />
 
 ## Streaming APIs
 
@@ -34,7 +34,7 @@ consistent with our implementation, and provides expressive power through the fl
 
 Example:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/streaming" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/streaming" />
 
 ## SerializableDateTimeOffset
 
@@ -47,11 +47,11 @@ This type serializes a `DateTimeOffset` as an ISO 8601 string (round-trip format
 
 Example:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/serializable-datetimeoffset" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/serializable-datetimeoffset" />
 
 The implicit conversions allow natural usage:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/datetimeoffset-usage" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/datetimeoffset-usage" />
 
 ## OneOf
 
@@ -63,13 +63,13 @@ returns whichever value is set, or throws `NoValueSetForOneOf` if none are set.
 
 Example with a service returning either a result or an error:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-service" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-service" />
 
 Example with a message containing different content types:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-message" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-message" />
 
 Usage on the client side:
 
-<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-usage" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/contracts/oneof-usage" />
 

--- a/Documentation/contributing/kernel/patches/index.mdx
+++ b/Documentation/contributing/kernel/patches/index.mdx
@@ -40,7 +40,7 @@ Patches are tracked in MongoDB:
 
 Create a patch by implementing `ICanApplyPatch`:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/basic-structure" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/basic-structure" />
 
 ### Patch Naming Conventions
 
@@ -52,7 +52,7 @@ Create a patch by implementing `ICanApplyPatch`:
 
 Patches can inject any services registered in the DI container:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/dependencies" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/dependencies" />
 
 ## Best Practices
 
@@ -60,25 +60,25 @@ Patches can inject any services registered in the DI container:
 
 Use proper semantic logging with `LoggerMessage` attributes:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/semantic-logging" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/semantic-logging" />
 
 ### 2. Implement Down() for Safety
 
 Always implement `Down()` to support rollback scenarios:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/implement-down" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/implement-down" />
 
 ### 3. Handle Idempotency
 
 Patches should be idempotent where possible. The system prevents re-execution, but defensive coding helps:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/idempotency" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/idempotency" />
 
 ### 4. Test Thoroughly
 
 Write comprehensive specs for your patches:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/spec" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/spec" />
 
 ## Runtime Behavior
 
@@ -113,7 +113,7 @@ Patches are applied based on version comparison:
 
 The `RenameReactors` patch (version 15.3.0) demonstrates a real-world migration:
 
-<ChronicleClientTabs snippet="contributing/kernel/patches/index/rename-reactors-example" clients="csharp" />
+<ChronicleClientTabs snippet="contributing/kernel/patches/index/rename-reactors-example" />
 
 ## Troubleshooting
 

--- a/Documentation/event-seeding/seeding-with-csharp.mdx
+++ b/Documentation/event-seeding/seeding-with-csharp.mdx
@@ -6,27 +6,27 @@ This page shows how to seed events using the Chronicle .NET client. Seeding is s
 
 Use `record` types for event definitions in examples:
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/events" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/events" />
 
 ## Implement a seeder
 
 Implement `ICanSeedEvents` and use `IEventSeedingBuilder` to define events to append:
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seeder" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seeder" />
 
 ## Seed multiple events of the same type
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seed-multiple-same-type" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seed-multiple-same-type" />
 
 ## Seed mixed event types
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seed-mixed-types" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/seed-mixed-types" />
 
 ## Development-only seeding
 
 If seed data should only run in development, use conditional compilation or runtime configuration:
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/development-only" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/development-only" />
 
 Chronicle does not distinguish between development and production seed data. Decide when to seed based on build configuration or runtime settings.
 
@@ -34,13 +34,13 @@ Chronicle does not distinguish between development and production seed data. Dec
 
 For larger solutions, split seeders by domain or feature:
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/organize-by-feature" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/organize-by-feature" />
 
 ## Namespace-scoped seed data
 
 By default, seed data applies to all namespaces in the event store. To target a specific namespace, use `ForNamespace` to get a scoped builder:
 
-<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/namespace-scoped" clients="csharp" />
+<ChronicleClientTabs snippet="event-seeding/seeding-with-csharp/namespace-scoped" />
 
 The scoped builder supports the same `For<TEvent>` and `ForEventSource` methods as the global builder. Each namespace receives only its own scoped events in addition to any global events.
 

--- a/Documentation/events/appending-many.mdx
+++ b/Documentation/events/appending-many.mdx
@@ -22,4 +22,4 @@ Use this approach when you already have a set of events that should be appended 
 
 ## Example
 
-<ChronicleClientTabs snippet="events/appending-many/transfer" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/appending-many/transfer" />

--- a/Documentation/events/appending-with-tags.mdx
+++ b/Documentation/events/appending-with-tags.mdx
@@ -19,10 +19,10 @@ Custom tags are simple strings that you provide when appending. They are merged 
 
 ## Append with tags
 
-<ChronicleClientTabs snippet="events/appending-with-tags/append" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/appending-with-tags/append" />
 
 ## AppendMany with tags
 
 `AppendMany` applies the provided tags to each event in the batch.
 
-<ChronicleClientTabs snippet="events/appending-with-tags/append-many" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/appending-with-tags/append-many" />

--- a/Documentation/events/appending.mdx
+++ b/Documentation/events/appending.mdx
@@ -30,7 +30,7 @@ Appending returns an `AppendResult` that describes whether the operation succeed
 
 Chronicle validates every event's content against its registered JSON schema before persisting it. If the content does not conform to the schema — for example, a required property is missing or has the wrong type — the append fails and the errors appear in `AppendResult.Errors`.
 
-<ChronicleClientTabs snippet="events/appending/schema-validation" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/appending/schema-validation" />
 
 Schema validation runs before any other checks, so a schema error is returned immediately without touching the event sequence.
 
@@ -38,7 +38,7 @@ Schema validation runs before any other checks, so a schema error is returned im
 
 By default, Chronicle assigns the current server time as the event's `Occurred` timestamp when it persists the event. Some clients expose an explicit timestamp override for import and replay scenarios.
 
-<ChronicleClientTabs snippet="events/appending/occurred" clients="csharp,elixir" syncKey="chronicle-client-occurred" />
+<ChronicleClientTabs snippet="events/appending/occurred" syncKey="chronicle-client-occurred" />
 
 > [!WARNING]
 > Specifying `occurred` bypasses the automatic server timestamp. Use this only for importing historical events or replaying data from an external system. Incorrect timestamps can break projections and reactors that rely on event ordering by time.
@@ -49,4 +49,4 @@ Appending is lightweight and intended for single domain decisions that produce o
 
 ## Example
 
-<ChronicleClientTabs snippet="events/appending/example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/appending/example" />

--- a/Documentation/events/concurrency.mdx
+++ b/Documentation/events/concurrency.mdx
@@ -25,13 +25,13 @@ Chronicle uses the following formalized, indexed metadata tags to scope concurre
 
 The most basic form of concurrency control scopes to a specific sequence number for an event source:
 
-<ChronicleClientTabs snippet="events/concurrency/basic" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="events/concurrency/basic" />
 
 ### Using ConcurrencyScopeBuilder
 
 For more complex scenarios, use the `ConcurrencyScopeBuilder` to fluently construct concurrency scopes:
 
-<ChronicleClientTabs snippet="events/concurrency/builder" clients="csharp,elixir" />
+<ChronicleClientTabs snippet="events/concurrency/builder" />
 
 ## Scoping by Event Metadata Tags
 
@@ -39,37 +39,37 @@ For more complex scenarios, use the `ConcurrencyScopeBuilder` to fluently constr
 
 You can scope concurrency to specific event source types and stream types:
 
-<ChronicleClientTabs snippet="events/concurrency/source-and-stream-type" clients="csharp,elixir" />
+<ChronicleClientTabs snippet="events/concurrency/source-and-stream-type" />
 
 ### EventStreamId
 
 Use event stream IDs to scope concurrency to specific streams within a stream type:
 
-<ChronicleClientTabs snippet="events/concurrency/stream-id" clients="csharp,elixir" />
+<ChronicleClientTabs snippet="events/concurrency/stream-id" />
 
 ### Event Types
 
 Scope concurrency to specific event types to allow concurrent operations on different types of events:
 
-<ChronicleClientTabs snippet="events/concurrency/event-types" clients="csharp,elixir" />
+<ChronicleClientTabs snippet="events/concurrency/event-types" />
 
 ## AppendMany with Concurrency Scopes
 
 When appending multiple events, you can specify different concurrency scopes for different event sources:
 
-<ChronicleClientTabs snippet="events/concurrency/append-many" clients="csharp,elixir" />
+<ChronicleClientTabs snippet="events/concurrency/append-many" />
 
 ## Event Source Operations with Concurrency
 
 You can also use concurrency scopes with event source operations:
 
-<ChronicleClientTabs snippet="events/concurrency/for-event-source-operations" clients="csharp" />
+<ChronicleClientTabs snippet="events/concurrency/for-event-source-operations" />
 
 ## Handling Concurrency Violations
 
 When a concurrency violation occurs, Chronicle will return a `ConcurrencyViolation` in the append result:
 
-<ChronicleClientTabs snippet="events/concurrency/handling-violations" clients="csharp" />
+<ChronicleClientTabs snippet="events/concurrency/handling-violations" />
 
 ## Concurrency Strategies
 
@@ -79,7 +79,7 @@ Chronicle provides built-in concurrency strategies:
 
 This strategy gets the current tail sequence number and uses it as the expected sequence number:
 
-<ChronicleClientTabs snippet="events/concurrency/strategies" clients="csharp" />
+<ChronicleClientTabs snippet="events/concurrency/strategies" />
 
 > **Note**: `[EventStreamType]` on a reactor or reducer scopes which events an *observer* receives (see [Filter by event stream type](filtering/by-event-stream-type)) — it does not set the `EventStreamType` used for concurrency scoping on an *append* call. Set `eventStreamType` explicitly on `Append`/`AppendMany`, or through `ConcurrencyScopeBuilder.WithEventStreamType(...)`, when you need concurrency scoped to a specific stream type.
 

--- a/Documentation/events/cross-cutting-properties.mdx
+++ b/Documentation/events/cross-cutting-properties.mdx
@@ -4,7 +4,7 @@ You can add properties to all events that are appended without requiring each ev
 
 To provide cross-cutting properties, implement `ICanProvideAdditionalEventInformation`:
 
-<ChronicleClientTabs snippet="events/cross-cutting-properties/provider" clients="csharp" />
+<ChronicleClientTabs snippet="events/cross-cutting-properties/provider" />
 
 Chronicle will discover providers automatically and apply the additional properties during event append.
 

--- a/Documentation/events/event-source-id.mdx
+++ b/Documentation/events/event-source-id.mdx
@@ -10,7 +10,7 @@ Internally, Chronicle represents all event source identifiers as plain strings. 
 
 The `EventSourceId` record is the primary type used throughout the Chronicle API. It wraps a `string` value and provides implicit conversions from both `string` and `Guid`, so you can pass either directly wherever an `EventSourceId` is expected.
 
-<ChronicleClientTabs snippet="events/event-source-id/conversions" clients="csharp" />
+<ChronicleClientTabs snippet="events/event-source-id/conversions" />
 
 The `Unspecified` sentinel value signals the absence of a meaningful identifier and corresponds to an empty string. Use it when an identifier is structurally required but contextually irrelevant.
 
@@ -18,7 +18,7 @@ The `Unspecified` sentinel value signals the absence of a meaningful identifier 
 
 The generic `EventSourceId<T>` type lets you carry a strongly-typed value through the client-side API while remaining wire-compatible with the plain `EventSourceId` that the server expects.
 
-<ChronicleClientTabs snippet="events/event-source-id/typed" clients="csharp" />
+<ChronicleClientTabs snippet="events/event-source-id/typed" />
 
 Because `EventSourceId<T>` carries an implicit conversion to `EventSourceId`, you can pass a typed identifier anywhere the untyped form is expected — including directly to `IEventLog.Append` — without any manual conversion. The typed form is most useful when you want the identifier to carry its concrete type through multiple layers so that callers always see the domain concept rather than a plain string.
 

--- a/Documentation/events/filtering/by-event-source-type.mdx
+++ b/Documentation/events/filtering/by-event-source-type.mdx
@@ -8,13 +8,13 @@ Chronicle compares the observer attribute to the `eventSourceType:` value used w
 
 ## Filter a reactor by event source type
 
-<ChronicleClientTabs snippet="events/filtering/by-event-source-type/reactor" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-event-source-type/reactor" />
 
 The reactor is only invoked for events appended with `eventSourceType: "customer"`.
 
 ## Filter a reducer by event source type
 
-<ChronicleClientTabs snippet="events/filtering/by-event-source-type/reducer" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-event-source-type/reducer" />
 
 If you append the same event with `eventSourceType: "supplier"`, this reducer does not receive it.
 

--- a/Documentation/events/filtering/by-event-stream-type.mdx
+++ b/Documentation/events/filtering/by-event-stream-type.mdx
@@ -8,13 +8,13 @@ Chronicle compares the observer attribute to the `eventStreamType:` value used w
 
 ## Filter a reactor by event stream type
 
-<ChronicleClientTabs snippet="events/filtering/by-event-stream-type/reactor" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-event-stream-type/reactor" />
 
 The reactor only handles events appended to the `payments` stream type.
 
 ## Filter a reducer by event stream type
 
-<ChronicleClientTabs snippet="events/filtering/by-event-stream-type/reducer" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-event-stream-type/reducer" />
 
 If the same event is appended with another stream type, such as `eventStreamType: "returns"`, this reducer does not receive it.
 

--- a/Documentation/events/filtering/by-tag.mdx
+++ b/Documentation/events/filtering/by-tag.mdx
@@ -13,13 +13,13 @@ Chronicle compares the filter tag against the tags on the appended event. Those 
 
 ## Filter a reactor by tag
 
-<ChronicleClientTabs snippet="events/filtering/by-tag/reactor" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-tag/reactor" />
 
 The reactor receives the event because the append call added the `vip` tag.
 
 ## Filter a reducer by tag
 
-<ChronicleClientTabs snippet="events/filtering/by-tag/reducer" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-tag/reducer" />
 
 The reducer only updates when the appended event carries the `priority` tag.
 
@@ -27,6 +27,6 @@ The reducer only updates when the appended event carries the `priority` tag.
 
 Multiple `[FilterEventsByTag]` attributes widen the match:
 
-<ChronicleClientTabs snippet="events/filtering/by-tag/multiple-filters" clients="csharp" />
+<ChronicleClientTabs snippet="events/filtering/by-tag/multiple-filters" />
 
 Chronicle dispatches the event if it has either `vip` or `priority`.

--- a/Documentation/events/getting-events.mdx
+++ b/Documentation/events/getting-events.mdx
@@ -13,19 +13,19 @@ Use the client APIs to select the pattern that best matches your scenario, such 
 
 ### Read events for a single event source
 
-<ChronicleClientTabs snippet="events/getting-events/for-event-source" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/getting-events/for-event-source" />
 
 Kotlin, Java, and TypeScript don't currently expose a way to read raw events back for an event source — their public event sequence APIs only support appending and checking for existence.
 
 ### Read from a checkpoint
 
-<ChronicleClientTabs snippet="events/getting-events/from-checkpoint" clients="csharp" />
+<ChronicleClientTabs snippet="events/getting-events/from-checkpoint" />
 
 This is currently a C#-only capability — no other client exposes a way to resume reading from an arbitrary sequence number.
 
 ### Read the last events in a sequence
 
-<ChronicleClientTabs snippet="events/getting-events/tail" clients="csharp" />
+<ChronicleClientTabs snippet="events/getting-events/tail" />
 
 Reading the tail this way also relies on resuming from a sequence number, so it's currently C#-only too. Kotlin, Java, and TypeScript can still get the tail sequence *number* (see [Getting state](./getting-state)), just not the events at it.
 

--- a/Documentation/events/getting-state.mdx
+++ b/Documentation/events/getting-state.mdx
@@ -18,18 +18,18 @@ Related reading:
 
 ### Capture the tail for a checkpoint
 
-<ChronicleClientTabs snippet="events/getting-state/tail" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/getting-state/tail" />
 
 Kotlin and Java don't currently expose a way to read the tail sequence number at all — their public event sequence APIs only support appending and checking for existence.
 
 ### Capture the tail for a specific event source and event types
 
-<ChronicleClientTabs snippet="events/getting-state/tail-for-event-source" clients="csharp" />
+<ChronicleClientTabs snippet="events/getting-state/tail-for-event-source" />
 
 This scoped form (filtering by event source and event types) is currently C#-only. Elixir and TypeScript can capture the *overall* tail (see above), but neither exposes a way to scope it to specific event types.
 
 ### Check whether an observer is caught up
 
-<ChronicleClientTabs snippet="events/getting-state/tail-for-observer" clients="csharp" />
+<ChronicleClientTabs snippet="events/getting-state/tail-for-observer" />
 
 Computing the relevant tail for a specific observer is currently a C#-only capability.

--- a/Documentation/events/index.mdx
+++ b/Documentation/events/index.mdx
@@ -9,7 +9,7 @@ flowchart LR
     S --> O["Observers (projections · reducers · reactors)"]
 ```
 
-<ChronicleClientTabs snippet="events/index/event-type" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="events/index/event-type" />
 
 ## Event Sequences and the Event Log
 
@@ -17,7 +17,7 @@ Events live in event sequences, which are ordered, append-only streams. Each eve
 
 Chronicle includes a specialized event sequence called the event log. It is the default sequence used throughout the system and is exposed through the `IEventLog` API.
 
-<ChronicleClientTabs snippet="events/index/event-log" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="events/index/event-log" />
 
 ## Working with Events
 

--- a/Documentation/events/observing-appends.mdx
+++ b/Documentation/events/observing-appends.mdx
@@ -9,7 +9,7 @@ events in real time — without polling the event log.
 
 ## AppendOperations
 
-<ChronicleClientTabs snippet="events/observing-appends/shape" clients="csharp" />
+<ChronicleClientTabs snippet="events/observing-appends/shape" />
 
 The observable emits a collection of `AppendedEventWithResult` after each operation:
 
@@ -32,7 +32,7 @@ This observable does not fire for transactional appends through `ITransactionalE
 
 Inject `IEventSequence` (or `IEventLog`) and subscribe to `AppendOperations`:
 
-<ChronicleClientTabs snippet="events/observing-appends/subscribing" clients="csharp" />
+<ChronicleClientTabs snippet="events/observing-appends/subscribing" />
 
 Always dispose the subscription when you no longer need it to avoid resource leaks.
 
@@ -52,8 +52,8 @@ If any affected observer fails while catching up, the returned result includes f
 
 ### Append
 
-<ChronicleClientTabs snippet="events/observing-appends/wait-for-completion-append" clients="csharp" />
+<ChronicleClientTabs snippet="events/observing-appends/wait-for-completion-append" />
 
 ### AppendMany
 
-<ChronicleClientTabs snippet="events/observing-appends/wait-for-completion-append-many" clients="csharp" />
+<ChronicleClientTabs snippet="events/observing-appends/wait-for-completion-append-many" />

--- a/Documentation/events/redaction.mdx
+++ b/Documentation/events/redaction.mdx
@@ -26,21 +26,21 @@ Do not use redaction as a way to undo domain decisions. If a correction is being
 
 To redact one specific event by its sequence number, call `Redact` on the event sequence and provide a reason:
 
-<ChronicleClientTabs snippet="events/redaction/by-sequence-number-unknown" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/by-sequence-number-unknown" />
 
 Always provide a meaningful reason when possible:
 
-<ChronicleClientTabs snippet="events/redaction/by-sequence-number-with-reason" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/by-sequence-number-with-reason" />
 
 ## Redacting all events for an event source
 
 To redact every event associated with a particular event source — for example, to erase all data for a specific user — pass the event source identifier and a reason:
 
-<ChronicleClientTabs snippet="events/redaction/by-event-source" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/by-event-source" />
 
 If you only want to redact a specific type of event rather than all events for the event source, provide the event types:
 
-<ChronicleClientTabs snippet="events/redaction/by-event-source-and-types" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/by-event-source-and-types" />
 
 ## How it works
 
@@ -68,7 +68,7 @@ When an event is redacted, the `EventRedacted` event is dispatched to any observ
 
 Add a handler method that accepts `EventRedacted` alongside the event type(s) you already handle. The Kernel will only dispatch `EventRedacted` to your Reactor when the redacted event belongs to a type that your Reactor is also subscribed to.
 
-<ChronicleClientTabs snippet="events/redaction/reactor" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/reactor" />
 
 The `EventRedacted` record is defined in `Cratis.Chronicle.Events` and carries:
 
@@ -85,7 +85,7 @@ The `EventRedacted` record is defined in `Cratis.Chronicle.Events` and carries:
 
 The same approach applies to Reducers. Include `EventRedacted` handling inside the `IReducerFor<TReadModel>` implementation to update the read model when a source event is erased.
 
-<ChronicleClientTabs snippet="events/redaction/reducer" clients="csharp" />
+<ChronicleClientTabs snippet="events/redaction/reducer" />
 
 ### Filtering guarantee
 

--- a/Documentation/events/transactions.mdx
+++ b/Documentation/events/transactions.mdx
@@ -19,7 +19,7 @@ Do not use a unit of work to hide modeling problems. If two facts can happen ind
 
 Create a unit of work, append through the transactional event sequence, and commit when every event has been staged.
 
-<ChronicleClientTabs snippet="events/transactions/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="events/transactions/basic" />
 
 ## Roll Back
 

--- a/Documentation/get-started/_includes/common.mdx
+++ b/Documentation/get-started/_includes/common.mdx
@@ -4,7 +4,7 @@ Everything in Chronicle starts with a fact. You model facts as `record` types ma
 
 Here are the facts of a small library — a book arrives, gets borrowed, and comes back:
 
-<ChronicleClientTabs snippet="get-started/common/a-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/a-events" />
 
 `BookReturned` carries no data at all — that it *happened*, on a particular book's stream, is the whole story. Not every fact needs a payload.
 
@@ -12,7 +12,7 @@ Here are the facts of a small library — a book arrives, gets borrowed, and com
 
 You record a fact by **appending** it to an [event sequence](../concepts/event-sequence.md). Chronicle gives you one by default — the **event log**, the main sequence you'll use, much like the `main` branch of a Git repository. Reach it through the event store:
 
-<ChronicleClientTabs snippet="get-started/common/append" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/append" />
 
 That first argument is the [event source id](../concepts/event-source.md) — the identity of the thing this fact is about, like a primary key. Every event you append against `bookId` becomes part of *that book's* stream of history.
 
@@ -30,7 +30,7 @@ Run your app, then open the <a href="http://localhost:8080" target="_blank" rel=
 
 Events are the **write** side — the source of truth. To *read* current state you don't query the log directly; you let Chronicle fold the events into a **read model** for you. The declarative way to do that is a [projection](../concepts/projection.md): you declare the shape you want and which events feed each field, and Chronicle keeps it in sync — no update code, ever.
 
-<ChronicleClientTabs snippet="get-started/common/book-read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/book-read-model" />
 
 Read the attributes as a sentence: a book comes into the view from `BookAdded`; `OnLoan` is `false` when it's added, `true` when borrowed, `false` again when returned; `BorrowedBy` is whoever borrowed it. You're *declaring* how facts map onto the view — Chronicle replays the events in order and applies the mapping.
 
@@ -39,7 +39,7 @@ Read the attributes as a sentence: a book comes into the view from `BookAdded`; 
 
 One view rarely answers every question. The librarian's next one is "what's out on loan right now?" — and rather than filtering `Book`, you declare a second, purpose-built read model whose very *existence* tracks the loan:
 
-<ChronicleClientTabs snippet="get-started/common/borrowed-book-read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/borrowed-book-read-model" />
 
 The moment a `BookBorrowed` lands, a `BorrowedBook` instance appears — keyed by the book's id, its `MemberName` mapped by the same naming convention. When the matching `BookReturned` arrives, `[RemovedWith<BookReturned>]` removes the instance from the view again. The collection always holds exactly the books that are out *right now* — no flag to maintain, no filter to remember, no cleanup job. Kotlin and Java don't currently have an equivalent to `[RemovedWith<T>]`.
 
@@ -47,19 +47,19 @@ The moment a `BookBorrowed` lands, a `BorrowedBook` instance appears — keyed b
 
 The most direct way to look at a read model is to ask Chronicle itself. `IReadModels` — reached through `eventStore.ReadModels` — hands you every instance of a read model, one call per view:
 
-<ChronicleClientTabs snippet="get-started/common/query-read-models" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/query-read-models" />
 
 These results are **strongly consistent**: Chronicle replays the read model's events on demand, so what comes back reflects every event appended up to that instant — including the one you appended a moment ago. That replay is also the cost: every call processes *all* the events feeding the read model, which is perfect for a quickstart but not necessarily what you'd put on a hot path in production. You can cap the work by passing an event count — `GetInstances<Book>(eventCount: 1_000)` — but a capped replay can stop before the newest events and hand you incomplete results. [Getting a collection of instances](../read-models/getting-collection-instances) covers the details. Kotlin and Java currently only support fetching a single instance by key (`getInstanceByKey`) — fetching every instance of a read model isn't available yet.
 
 By default Chronicle also **materializes** every projection into the **sink** storage configured for the event store — MongoDB unless you change it — under a database named after the event store and a collection named after the read model. Materialization happens in the background as events arrive, so it's **eventually consistent**: a freshly appended event may take a moment to show up. In exchange, a query costs nothing but a database fetch. The `Materialized` API reads those stored instances back, a page at a time. Kotlin and Java don't currently have a materialized/paging query API at all; Elixir's equivalent pages by page number rather than skip/take:
 
-<ChronicleClientTabs snippet="get-started/common/materialized-paging" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/materialized-paging" />
 
 `skip` and `take` are plain paging (they default to `0` and `50`), so you can window through a large collection without ever loading all of it — [Materialized read models](../read-models/materialized-pagination) shows the paging and observing patterns.
 
 Neither call filters, though: `GetInstances` returns everything (you'd filter with LINQ in memory), and `Materialized` only pages. When you need to filter efficiently — "which books are on loan?" — query the [sink](../sinks/)'s database directly with its native tools. Our sink is MongoDB, so the `Book` read model is an ordinary collection and the driver does what it does best:
 
-<ChronicleClientTabs snippet="get-started/common/mongo-query" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/common/mongo-query" />
 
 Append a `BookBorrowed` against the same `bookId`, query again, and `OnLoan` is `true` with `BorrowedBy` set — and a `BorrowedBook` now sits in its collection. Append a `BookReturned` and both flip back: the flag clears, the `BorrowedBook` disappears. You never wrote an `UPDATE`. The trade-offs between the on-demand and materialized paths are laid out in [read model consistency](../read-models/consistency.md).
 
@@ -67,7 +67,7 @@ Append a `BookBorrowed` against the same `bookId`, query again, and `OnLoan` is 
 
 Projections build *state*. When you need to *do something* the moment a fact lands — notify someone, call another system — you write a **reactor**. `IReactor` is a marker; you just add a method whose first parameter is the event you care about, and Chronicle routes matching events to it:
 
-<ChronicleClientTabs snippet="get-started/common/reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/common/reactor" />
 
 No registration, no wiring — drop the class in and every `BookReturned` flows to it. Reactors must be idempotent, because the same event may be delivered more than once (during a replay or a recovery). In a real app you'd inject a notification service here — the [tutorial](/chronicle/tutorial/) and the [Reactors](../reactors/) guide show that, along with how reactors get their dependencies under a host.
 

--- a/Documentation/get-started/_includes/mongodb.mdx
+++ b/Documentation/get-started/_includes/mongodb.mdx
@@ -4,6 +4,6 @@ When leveraging the Reducer and Projection capabilities of Chronicle, your Mongo
 to match how it produces documents and naming conventions. By adding the following code, you'll have something that
 matches:
 
-<ChronicleClientTabs snippet="get-started/mongodb/conventions" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/mongodb/conventions" />
 
 [Snippet source](https://github.com/cratis/samples/blob/main/Chronicle/Quickstart/Common/MongoDBDefaults.cs#L16-L27)

--- a/Documentation/get-started/aspnetcore.mdx
+++ b/Documentation/get-started/aspnetcore.mdx
@@ -31,7 +31,7 @@ dotnet add package Cratis.Chronicle.AspNetCore
 
 ASP.NET Core builds your app through the `WebApplicationBuilder`, which already has a dependency-injection container. Chronicle hooks straight into it — two calls in `Program.cs` are the entire integration:
 
-<ChronicleClientTabs snippet="get-started/aspnetcore/register" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/aspnetcore/register" />
 
 `AddCratisChronicle` registers Chronicle's services and names the event store to use; `UseCratisChronicle` hooks it into the request pipeline. Unlike the bare-bones [console](./console) version, all discovery and registration of your artifacts happens automatically — the container finds your reactors, reducers, and projections for you.
 
@@ -49,7 +49,7 @@ flowchart LR
 
 In a web app you usually append events from a route handler rather than inline. Take `IEventLog` as a dependency and append — the container injects it:
 
-<ChronicleClientTabs snippet="get-started/aspnetcore/endpoint" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/aspnetcore/endpoint" />
 
 The `bookId` from the route is the [event source](../concepts/event-source.md) — the book this fact is about — and `memberName` is the event's payload. That one `Append` is all it takes; the projections pick it up from there — `Book` flips to on loan and a `BorrowedBook` instance appears — along with any reactors.
 
@@ -57,11 +57,11 @@ The `bookId` from the route is the [event source](../concepts/event-source.md) �
 
 Chronicle creates its discovered artifacts — reactors, reducers, projections — through the container, so they need to be registered as services. For a handful, register them explicitly:
 
-<ChronicleClientTabs snippet="get-started/aspnetcore/register-artifact" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/aspnetcore/register-artifact" />
 
 As the solution grows this gets tedious, so Cratis Fundamentals can do it by convention:
 
-<ChronicleClientTabs snippet="get-started/aspnetcore/register-by-convention" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/aspnetcore/register-by-convention" />
 
 `AddBindingsByConvention` registers any service that implements an interface of the same name prefixed with `I` (`IFoo` → `Foo`); `AddSelfBindings` registers concrete classes as themselves, so you can depend on them directly without registering each one.
 
@@ -73,7 +73,7 @@ The `Books` query reads documents Chronicle wrote, so the MongoDB driver needs t
 
 Then register the database and the collections you want to inject, so a type can take an `IMongoCollection<Book>` dependency without ever touching `MongoClient`:
 
-<ChronicleClientTabs snippet="get-started/aspnetcore/mongo-registration" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/aspnetcore/mongo-registration" />
 
 Now the `Books` query from the querying section above resolves its collection straight from the container.
 

--- a/Documentation/get-started/choose-hosting-model.mdx
+++ b/Documentation/get-started/choose-hosting-model.mdx
@@ -291,7 +291,7 @@ dotnet add package Cratis.Chronicle.Aspire
 For development, one line gives you the same batteries-included kernel as the `docker run` above —
 `AddCratisChronicle()` uses the development image with embedded MongoDB:
 
-<ChronicleClientTabs snippet="get-started/choose-hosting-model/basic-apphost" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/choose-hosting-model/basic-apphost" />
 
 To choose a database, pass a configure callback. Aspire then switches to the slim image (no embedded
 MongoDB) and the `With*` method you pick sets the kernel's storage type and connection string from the
@@ -301,7 +301,7 @@ your app model instead of hand-written:
 <Tabs syncKey="database">
 <TabItem label="MongoDB">
 
-<ChronicleClientTabs snippet="get-started/choose-hosting-model/mongo-database" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/choose-hosting-model/mongo-database" />
 
 `mongo` can be any resource with a connection string — a MongoDB Atlas connection string as shown, or a
 container added directly in the AppHost with `builder.AddMongoDB("mongo")`.
@@ -309,19 +309,19 @@ container added directly in the AppHost with `builder.AddMongoDB("mongo")`.
 </TabItem>
 <TabItem label="PostgreSQL">
 
-<ChronicleClientTabs snippet="get-started/choose-hosting-model/postgres-database" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/choose-hosting-model/postgres-database" />
 
 </TabItem>
 <TabItem label="SQL Server">
 
-<ChronicleClientTabs snippet="get-started/choose-hosting-model/sqlserver-database" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/choose-hosting-model/sqlserver-database" />
 
 </TabItem>
 <TabItem label="SQLite">
 
 SQLite is file-based, so you pass the connection string directly instead of a resource:
 
-<ChronicleClientTabs snippet="get-started/choose-hosting-model/sqlite-database" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/choose-hosting-model/sqlite-database" />
 
 </TabItem>
 </Tabs>

--- a/Documentation/get-started/console.mdx
+++ b/Documentation/get-started/console.mdx
@@ -31,7 +31,7 @@ dotnet add package Cratis.Chronicle
 
 Everything in Chronicle is reached through a `ChronicleClient`. From a client you ask for the **event store** you want to work with — here, one named `Quickstart`. Because there's no DI container to do it for you, you create the client yourself:
 
-<ChronicleClientTabs snippet="get-started/console/connect" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/console/connect" />
 
 `ChronicleConnectionString.Development` is the built-in connection string for the local development kernel — the same one `new ChronicleClient()` uses when you call it with no arguments. Spelling it out keeps the console version explicit; point it elsewhere with `ChronicleConnectionString.Default` (no credentials) or your own `new ChronicleConnectionString("chronicle://…")`.
 

--- a/Documentation/get-started/index.mdx
+++ b/Documentation/get-started/index.mdx
@@ -71,21 +71,21 @@ tf 03 pcr Demo.TestReactor
 
 Each client has its own syntax, but the Chronicle shape is the same: create a client, choose an event store, and append a fact to the event log.
 
-<ChronicleClientTabs snippet="get-started/client-flow" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/client-flow" />
 
 Reading top to bottom: the client connects to the kernel, asks for an **event store** by name, and **appends** a `TestEvent` to its event log. That append is the only operation that changes the event store. Everything else reacts to the recorded fact.
 
 The event itself is just a record marked as a fact:
 
-<ChronicleClientTabs snippet="get-started/test-event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/test-event" />
 
 A **projection** folds that event into a read model: state you can query, rebuild, and store in a sink:
 
-<ChronicleClientTabs snippet="get-started/test-projection" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/test-projection" />
 
 A **reactor** does something when the event arrives:
 
-<ChronicleClientTabs snippet="get-started/test-reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="get-started/test-reactor" />
 
 Discovery and registration are client-specific. Some hosts discover annotated artifacts; others register modules, classes, or functions explicitly. The invariant is the same: events are facts, projections derive read models, and reactors observe events to produce side effects.
 

--- a/Documentation/get-started/worker.mdx
+++ b/Documentation/get-started/worker.mdx
@@ -32,7 +32,7 @@ dotnet add package Cratis.Chronicle
 
 The generic host builds your app through `IHostApplicationBuilder`, which already has a dependency-injection container. One call hooks Chronicle into it and names the event store to use:
 
-<ChronicleClientTabs snippet="get-started/worker/register" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/worker/register" />
 
 Like the [ASP.NET Core](./aspnetcore) host, `AddCratisChronicle` registers Chronicle's services — `IEventStore`, `IEventLog`, `IReactors`, `IReducers`, `IProjections` — and automatically discovers and registers your artifacts (reactors, reducers, projections) from the loaded assemblies. It reads its connection settings from the `Cratis:Chronicle` section of `appsettings.json`:
 
@@ -60,7 +60,7 @@ flowchart LR
 
 In a worker you append from your `BackgroundService` rather than inline. Inject `IEventStore` (or `IEventLog` directly) and append inside `ExecuteAsync`:
 
-<ChronicleClientTabs snippet="get-started/worker/worker-service" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/worker/worker-service" />
 
 The projections and the `BookReturnedNotifier` reactor pick those events up from the kernel — the worker stays alive to keep processing them.
 
@@ -72,13 +72,13 @@ The `Books` query reads documents Chronicle wrote, so the MongoDB driver needs t
 
 Then register the database and the collection so a type can take an `IMongoCollection<Book>` dependency:
 
-<ChronicleClientTabs snippet="get-started/worker/mongo-registration" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/worker/mongo-registration" />
 
 ## Register your artifacts
 
 Chronicle creates its discovered artifacts through the container, so they need to be registered as services. For a handful, register them explicitly; as the solution grows, let Cratis Fundamentals do it by convention:
 
-<ChronicleClientTabs snippet="get-started/worker/register-by-convention" clients="csharp" />
+<ChronicleClientTabs snippet="get-started/worker/register-by-convention" />
 
 `AddBindingsByConvention` registers any service that implements an interface of the same name prefixed with `I` (`IFoo` → `Foo`); `AddSelfBindings` registers concrete classes as themselves.
 

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -14,7 +14,7 @@ dotnet add package Cratis.Chronicle.Aspire
 
 For local development, call `AddCratisChronicle()` without arguments. This uses the Chronicle development image (`cratis/chronicle:latest-development`), which bundles MongoDB, so no external database is required.
 
-<ChronicleClientTabs snippet="hosting/aspire/dev-mode" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/dev-mode" />
 
 The development image is ideal for:
 
@@ -27,7 +27,7 @@ For production or staging environments, use the configure callback. This switche
 
 ### MongoDB
 
-<ChronicleClientTabs snippet="hosting/aspire/mongo" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/mongo" />
 
 The `WithMongoDB` method sets the `Cratis__Chronicle__Storage__Type` and `Cratis__Chronicle__Storage__ConnectionDetails` environment variables on the Chronicle container using the connection string from the provided MongoDB resource.
 
@@ -39,7 +39,7 @@ The `WithMongoDB` method sets the `Cratis__Chronicle__Storage__Type` and `Cratis
 
 ### PostgreSQL
 
-<ChronicleClientTabs snippet="hosting/aspire/postgres" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/postgres" />
 
 `postgres` can be any `IResourceBuilder<IResourceWithConnectionString>`, including:
 
@@ -48,7 +48,7 @@ The `WithMongoDB` method sets the `Cratis__Chronicle__Storage__Type` and `Cratis
 
 ### Microsoft SQL Server
 
-<ChronicleClientTabs snippet="hosting/aspire/sqlserver" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/sqlserver" />
 
 `sql` can be any `IResourceBuilder<IResourceWithConnectionString>`, including:
 
@@ -59,13 +59,13 @@ The `WithMongoDB` method sets the `Cratis__Chronicle__Storage__Type` and `Cratis
 
 For SQLite, provide the connection string directly (SQLite is file-based and does not require a network resource):
 
-<ChronicleClientTabs snippet="hosting/aspire/sqlite" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/sqlite" />
 
 ## Connecting a .NET Client
 
 Pass the Chronicle resource as a connection string reference to your application projects so they receive the correct endpoint at runtime:
 
-<ChronicleClientTabs snippet="hosting/aspire/connecting-client" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/connecting-client" />
 
 The connection string exposed by `ChronicleResource` uses the `chronicle://` scheme and points to the gRPC port (35000 by default), matching the format expected by `ChronicleOptions.FromConnectionString()`.
 
@@ -84,11 +84,11 @@ Both endpoints are registered automatically when you call `AddCratisChronicle()`
 
 A typical Aspire AppHost `Program.cs` for a production setup with MongoDB:
 
-<ChronicleClientTabs snippet="hosting/aspire/complete-example" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/complete-example" />
 
 For development, simplify further by dropping the MongoDB wiring:
 
-<ChronicleClientTabs snippet="hosting/aspire/complete-example-dev" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/aspire/complete-example-dev" />
 
 ## Docker Images
 

--- a/Documentation/hosting/local-certificates.mdx
+++ b/Documentation/hosting/local-certificates.mdx
@@ -195,7 +195,7 @@ services:
 
 When connecting to a Chronicle server with a self-signed certificate, configure the client:
 
-<ChronicleClientTabs snippet="hosting/local-certificates/client-configuration" clients="csharp" />
+<ChronicleClientTabs snippet="hosting/local-certificates/client-configuration" />
 
 ## Security Considerations
 

--- a/Documentation/jobs/index.mdx
+++ b/Documentation/jobs/index.mdx
@@ -7,11 +7,11 @@ Jobs represent long-running operations the Chronicle Kernel performs in the back
 
 ## List all jobs
 
-<ChronicleClientTabs snippet="jobs/index/list-all" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="jobs/index/list-all" />
 
 ## Get a single job
 
-<ChronicleClientTabs snippet="jobs/index/get-one" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="jobs/index/get-one" />
 
 A missing job resolves to nothing rather than an error — check for that before using the result.
 
@@ -19,11 +19,11 @@ A missing job resolves to nothing rather than an error — check for that before
 
 A job is made up of one or more steps. Get them to see fine-grained progress:
 
-<ChronicleClientTabs snippet="jobs/index/get-steps" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="jobs/index/get-steps" />
 
 ## Stop, resume, and delete
 
-<ChronicleClientTabs snippet="jobs/index/stop-resume-delete" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="jobs/index/stop-resume-delete" />
 
 Kotlin and Java don't currently have a jobs API — there's no equivalent anywhere in the Kotlin client SDK yet.
 

--- a/Documentation/migrations/dotnet-client.mdx
+++ b/Documentation/migrations/dotnet-client.mdx
@@ -11,7 +11,7 @@ This guide covers how to declare event type migrations in a .NET client, the ope
 
 Every `[EventType]` that has evolved past its first version must declare its current generation. You keep both the old and new record types in your codebase — Chronicle identifies them by the shared event type identifier, not the C# class name.
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/generations" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/generations" />
 
 Both records carry the same event type identifier (derived from the type name base). The generation number is what tells Chronicle how to route migrations.
 
@@ -19,7 +19,7 @@ Both records carry the same event type identifier (derived from the type name ba
 
 Extend `EventTypeMigration<TUpgrade, TPrevious>` where `TUpgrade` is the **newer** generation and `TPrevious` is the **older** one:
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/migrator" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/migrator" />
 
 The `From` and `To` generation numbers are read automatically from the `[EventType]` attributes on `TPrevious` and `TUpgrade`. You do not declare them yourself, and the base class validates at construction time that `To == From + 1`, preventing accidental generation gaps.
 
@@ -33,7 +33,7 @@ All operations are called on the property builder inside `builder.Properties(pb 
 
 Extracts one segment of a string property by splitting on a separator and taking the part at a given index.
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/split" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/split" />
 
 `PropertySeparator.Space` is a built-in constant. Any string is also implicitly convertible to a `PropertySeparator`, so `":"` works directly for colon-delimited fields. `SplitPartIndex.First` (index 0) and `SplitPartIndex.Second` (index 1) cover the most common cases; pass any `int` for deeper splits.
 
@@ -41,25 +41,25 @@ Extracts one segment of a string property by splitting on a separator and taking
 
 Concatenates multiple source properties into a single string target property, joining with a separator. The second argument is a `PropertySeparator` — use the built-in `PropertySeparator.Space` or pass any string (e.g. `":"`).
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/combine" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/combine" />
 
 ### RenamedFrom
 
 Maps a property from its old name in the source generation to its new name in the target generation.
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/renamed-from" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/renamed-from" />
 
 ### DefaultValue
 
 Provides a literal default for a property that did not exist in the source generation. Chronicle applies this value to any event stored before the property was introduced.
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/default-value" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/default-value" />
 
 ## Multi-generation migrations
 
 If your event type spans more than two generations, define one migrator per generation pair. Chronicle chains them automatically.
 
-<ChronicleClientTabs snippet="migrations/dotnet-client/multi-generation" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/dotnet-client/multi-generation" />
 
 When a generation 1 event arrives, the Kernel chains the upcasts: 1→2, then 2→3, and stores all three generations.
 

--- a/Documentation/migrations/validation.mdx
+++ b/Documentation/migrations/validation.mdx
@@ -50,7 +50,7 @@ This throws `MissingEventTypeMigrators`.
 
 When a new generation adds a property that did not exist in older events, declare a default value for it in the upcast. Chronicle applies this default to any event stored before the property was introduced.
 
-<ChronicleClientTabs snippet="migrations/validation/default-value" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="migrations/validation/default-value" />
 
 `DefaultValue` tells Chronicle: "if this property is absent from the event when upcasting, fill it with this value." Properties that already carry a value are left unchanged.
 
@@ -72,7 +72,7 @@ Strict validation is **always enforced in the production image** of the Kernel. 
 
 `EnableEventTypeGenerationValidation` defaults to `false` in `ChronicleOptions`, so no extra configuration is needed during early development. When your event schemas are stable, opt into strict validation by setting it to `true`:
 
-<ChronicleClientTabs snippet="migrations/validation/enable-validation" clients="csharp" />
+<ChronicleClientTabs snippet="migrations/validation/enable-validation" />
 
 Alternatively, set it in `appsettings.json` under the `Cratis:Chronicle` section:
 

--- a/Documentation/namespaces/aspnetcore.mdx
+++ b/Documentation/namespaces/aspnetcore.mdx
@@ -10,7 +10,7 @@ If your multi-tenant setup is based on Arc Tenancy, you can map the current tena
 
 The default resolver reads the namespace from an HTTP header. Configure it through `ChronicleAspNetCoreOptions`:
 
-<ChronicleClientTabs snippet="namespaces/aspnetcore/http-header-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/aspnetcore/http-header-resolver" />
 
 When the header is present, its value becomes the namespace for the request. If the header is missing, the default namespace is used.
 
@@ -18,7 +18,7 @@ When the header is present, its value becomes the namespace for the request. If 
 
 The subdomain resolver extracts the namespace from the request host (for example, `tenant1.example.com`).
 
-<ChronicleClientTabs snippet="namespaces/aspnetcore/subdomain-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/aspnetcore/subdomain-resolver" />
 
 ## Custom resolvers
 
@@ -28,13 +28,13 @@ You can configure a custom resolver either by type (DI) or using the `IChronicle
 
 Pass a resolver instance using the `IChronicleBuilder` configure callback:
 
-<ChronicleClientTabs snippet="namespaces/aspnetcore/builder-custom-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/aspnetcore/builder-custom-resolver" />
 
 ### Using type-based DI resolution
 
 Configure the resolver type through `ChronicleAspNetCoreOptions` to let the DI container resolve it:
 
-<ChronicleClientTabs snippet="namespaces/aspnetcore/type-based-custom-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/aspnetcore/type-based-custom-resolver" />
 
 ## Configuration priority
 
@@ -44,7 +44,7 @@ Configure the resolver type through `ChronicleAspNetCoreOptions` to let the DI c
 
 ## Example: Web app setup
 
-<ChronicleClientTabs snippet="namespaces/aspnetcore/web-app-example" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/aspnetcore/web-app-example" />
 
 For non-web contexts, see [DotNET client usage](dotnet-client).
 

--- a/Documentation/namespaces/dotnet-client.mdx
+++ b/Documentation/namespaces/dotnet-client.mdx
@@ -8,7 +8,7 @@ This page and [ASP.NET Core namespace resolution](./aspnetcore) are intentionall
 
 ## IEventStoreNamespaceResolver
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/resolver-shape" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/resolver-shape" />
 
 The resolver returns the namespace name to use for the current context.
 
@@ -23,7 +23,7 @@ This is the default when no resolver is supplied.
 
 Resolves the namespace from the current principal's claims. This is useful when you have an authenticated user and want to map the tenant from a claim.
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/claims-based" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/claims-based" />
 
 If the claim is not found or the user is not authenticated, the default namespace is used.
 
@@ -31,13 +31,13 @@ If the claim is not found or the user is not authenticated, the default namespac
 
 For console or direct-client scenarios, pass the resolver as a constructor parameter:
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/default-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/default-resolver" />
 
 ## Configuring in a hosted application
 
 When using `IHostApplicationBuilder` (worker service or web app), configure the resolver through `ChronicleClientOptions` or directly via `IChronicleBuilder`:
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/hosted-app-configuration" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/hosted-app-configuration" />
 
 ## Custom resolvers
 
@@ -45,9 +45,9 @@ Implement a resolver when your namespace comes from a custom context, such as a 
 
 If your application uses Arc Tenancy, you can resolve the namespace from its tenant context. See [Arc Tenancy](xref:Arc.Tenancy).
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/tenant-resolver" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/tenant-resolver" />
 
-<ChronicleClientTabs snippet="namespaces/dotnet-client/tenant-resolver-usage" clients="csharp" />
+<ChronicleClientTabs snippet="namespaces/dotnet-client/tenant-resolver-usage" />
 
 ## Best practices
 

--- a/Documentation/projections/architecture.mdx
+++ b/Documentation/projections/architecture.mdx
@@ -76,7 +76,7 @@ Model-bound projections use attributes or annotations on your read model classes
 
 **Example:**
 
-<ChronicleClientTabs snippet="projections/architecture/model-bound" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/architecture/model-bound" />
 
 **Benefits:**
 - Type-safe at compile time
@@ -98,7 +98,7 @@ Declarative projections use a fluent API to define projections programmatically 
 
 **Example:**
 
-<ChronicleClientTabs snippet="projections/architecture/declarative" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/architecture/declarative" />
 
 **Benefits:**
 - Full programmatic control

--- a/Documentation/projections/choosing-a-read-model-style.mdx
+++ b/Documentation/projections/choosing-a-read-model-style.mdx
@@ -9,18 +9,18 @@ problems read better in different shapes.
 
 Let's keep one library read model up to date. A book is registered, borrowed, and returned:
 
-<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/events" />
 
 The read model we want is deliberately small:
 
-<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/read-model" />
 
 ## Model-bound projection: put the mapping on the model
 
 For simple property mapping, model-bound projections are the shortest route. The read model declares how
 events populate it:
 
-<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/model-bound" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/model-bound" />
 
 Chronicle discovers the projection from the attributes. There is no separate projection class, and the
 mapping sits directly next to the read model the UI or query will read. Reach for this first when the
@@ -31,7 +31,7 @@ events set, add, subtract, count, or clear properties in a way the attributes ca
 When the mapping needs to be more explicit, keep the read model clean and define the projection with
 `IProjectionFor<T>`:
 
-<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/fluent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/fluent" />
 
 This produces the same `BookStatus` documents as the model-bound version, but the trade-off is different:
 more code, more room for explicit mapping, and the read model stays free of Chronicle attributes. Use it
@@ -43,7 +43,7 @@ logic that would make attributes hard to scan.
 Reducers build read models too, but the shape is imperative: Chronicle passes the event and the current
 state into a method, and you return the next state.
 
-<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/reducer" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/choosing-a-read-model-style/reducer" />
 
 > **TypeScript note:** the C# reducer also receives the `EventContext` (used above to read the event source ID into `Id`) — the TypeScript reducer's handler methods only receive `(event, currentState)`, with no context parameter, so the TypeScript example omits the `Id` field.
 

--- a/Documentation/projections/declarative/auto-map.mdx
+++ b/Documentation/projections/declarative/auto-map.mdx
@@ -8,7 +8,7 @@ Use explicit mapping when the event shape and read model shape intentionally dif
 
 When event and read model property names match, declare the events and let AutoMap fill the matching properties.
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/basic" />
 
 ## How AutoMap Works
 
@@ -27,7 +27,7 @@ AutoMap is evaluated when the projection definition is built. It does not add a 
 
 Disable AutoMap when a projection should map only the properties you name explicitly.
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/disable" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/disable" />
 
 ## Re-enable AutoMap In A Child Scope
 
@@ -37,25 +37,25 @@ Calling the AutoMap enable method is redundant at the top level. It is useful in
 This scoped re-enable only makes sense in a client that supports child projection scopes at all. Kotlin, Java, Elixir, and TypeScript do not yet support declarative child collections (see [Children](./children)), so there is no child builder scope to re-enable AutoMap on. This example is C#-only until child projection scopes land elsewhere.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/re-enable-child-scope" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/re-enable-child-scope" />
 
 ## Combine With Explicit Mappings
 
 AutoMap and explicit mappings can be used together. Let convention handle the properties that match, and map the exceptional properties directly.
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/explicit-mappings" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/explicit-mappings" />
 
 ## AutoMap With Joins
 
 Joined events can also contribute matching properties through AutoMap. Use the join condition to connect the joined event to the read model; matching joined-event properties can then flow into the model.
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/join" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/join" />
 
 ## Aggregate-Only Events
 
 An event a projection subscribes to **only to aggregate** — `Count`, `Increment`, `Decrement`, `Add`, or `Subtract` — does not contribute its other properties to AutoMap. Aggregating an event does not copy its unrelated fields onto the read model, so a property on it that happens to share a name with one you set from another event cannot overwrite that value. You do not need to disable AutoMap for this — it is the default behavior.
 
-<ChronicleClientTabs snippet="projections/declarative/auto-map/aggregate-only" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/auto-map/aggregate-only" />
 
 ## When To Use AutoMap
 

--- a/Documentation/projections/declarative/children.mdx
+++ b/Documentation/projections/declarative/children.mdx
@@ -10,19 +10,19 @@ Declarative child-collection builders (`Children()`/`IdentifiedBy()`/`RemovedWit
 
 Use the child-collection builder to select the collection property, declare how each child is identified, and map the events that add, update, or remove items.
 
-<ChronicleClientTabs snippet="projections/declarative/children/basic" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/basic" />
 
 ## Read model with children
 
 The read model includes a collection property for the children:
 
-<ChronicleClientTabs snippet="projections/declarative/children/read-model" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/read-model" />
 
 ## Event definitions
 
 Events that affect children use keys to identify which child to update:
 
-<ChronicleClientTabs snippet="projections/declarative/children/events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/events" />
 
 ## How children work
 
@@ -40,11 +40,11 @@ By default, when a child event is processed, the framework uses the **EventSourc
 
 In most scenarios, you don't need to specify the parent key explicitly:
 
-<ChronicleClientTabs snippet="projections/declarative/children/default-parent-key" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/default-parent-key" />
 
 When you append the event:
 
-<ChronicleClientTabs snippet="projections/declarative/children/default-parent-key-append" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/default-parent-key-append" />
 
 The `groupId` (EventSourceId) is automatically used to find the parent `Group`.
 
@@ -52,11 +52,11 @@ The `groupId` (EventSourceId) is automatically used to find the parent `Group`.
 
 If your event contains the parent key as a property (instead of using EventSourceId), use `UsingParentKey()`:
 
-<ChronicleClientTabs snippet="projections/declarative/children/event-parent-key" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/event-parent-key" />
 
 When you append the event:
 
-<ChronicleClientTabs snippet="projections/declarative/children/event-parent-key-append" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/event-parent-key-append" />
 
 The `groupId` property from the event content is used to find the parent `Group`.
 
@@ -64,7 +64,7 @@ The `groupId` property from the event content is used to find the parent `Group`
 
 In some advanced scenarios, you might want to explicitly indicate that the EventSourceId should be used as the parent key (e.g., for documentation clarity):
 
-<ChronicleClientTabs snippet="projections/declarative/children/context-parent-key" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/context-parent-key" />
 
 This is functionally equivalent to not specifying the parent key at all, but can make the intent clearer in complex projections.
 
@@ -84,7 +84,7 @@ This is functionally equivalent to not specifying the parent key at all, but can
 
 The `RemovedWith<>()` method specifies how to remove child items from collections:
 
-<ChronicleClientTabs snippet="projections/declarative/children/removing" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/removing" />
 
 When a `UserRemovedFromGroup` event is processed:
 
@@ -98,6 +98,6 @@ You can also remove children conditionally or based on other criteria by using m
 
 A single projection can have multiple child collections:
 
-<ChronicleClientTabs snippet="projections/declarative/children/multiple-collections" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/children/multiple-collections" />
 
 This pattern allows you to build rich, hierarchical read models from events.

--- a/Documentation/projections/declarative/composite-keys.mdx
+++ b/Documentation/projections/declarative/composite-keys.mdx
@@ -6,45 +6,45 @@ When a single property isn't sufficient to uniquely identify a projection instan
 
 Define a key made up of multiple properties when one event value is not enough to identify the read model instance:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/basic" />
 
 ## Composite key type
 
 Define a record or class to represent your composite key:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/key-type" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/key-type" />
 
 ## Read model with composite key
 
 The read model's `Id` property should match your composite key type:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/read-model" />
 
 ## Composite keys with event context
 
 You can combine event properties with event context properties in composite keys:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/context-key" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/context-key" />
 
 The corresponding key and read model:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/audit-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/audit-model" />
 
 ## Composite keys in child collections
 
 Composite keys work with child collections too:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/child-collection" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/child-collection" />
 
 ## Joins with composite keys
 
 Composite keys can be used in join scenarios:
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/join" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/join" />
 
 ## Event definitions
 
-<ChronicleClientTabs snippet="projections/declarative/composite-keys/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/composite-keys/events" />
 
 ## Key composition rules
 

--- a/Documentation/projections/declarative/constant-key.mdx
+++ b/Documentation/projections/declarative/constant-key.mdx
@@ -6,7 +6,7 @@ A constant key allows all events of a given type to accumulate into a **single**
 
 Use `UsingConstantKey(string value)` to specify a fixed key value for a `from` block. The read model is a normal record or class — the constant key becomes its `_id` in the underlying store:
 
-<ChronicleClientTabs snippet="projections/declarative/constant-key/basic" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/constant-key/basic" />
 
 Every `OrderPlaced` event, from every event source, updates the single `GlobalCounter` instance with the key `"global"`.
 
@@ -16,7 +16,7 @@ Every `OrderPlaced` event, from every event source, updates the single `GlobalCo
 
 Constant keys work with all counting and arithmetic functions, making them ideal for global aggregates. The TypeScript example below tracks only `activeSessions` via `increment()`/`decrement()` — it omits the C# example's `count()`-based `totalUsers`, since `count()` isn't implemented in TypeScript yet:
 
-<ChronicleClientTabs snippet="projections/declarative/constant-key/increment-decrement" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/constant-key/increment-decrement" />
 
 ## Constant parent keys
 
@@ -26,7 +26,7 @@ Use `UsingConstantParentKey(string value)` when working with child collections a
 This example depends on declarative child collections, which are currently C#-only (see [Children](./children)). It stays C#-only until child projection scopes are available in the other clients.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/constant-key/constant-parent-key" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/constant-key/constant-parent-key" />
 
 ## Comparison to other key strategies
 
@@ -40,6 +40,6 @@ This example depends on declarative child collections, which are currently C#-on
 
 ## Full example
 
-<ChronicleClientTabs snippet="projections/declarative/constant-key/multi-event-metrics" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/constant-key/multi-event-metrics" />
 
 This projection collects engagement events from all users and event sources into a single `EngagementMetrics` document with the key `"metrics"`.

--- a/Documentation/projections/declarative/event-context.mdx
+++ b/Documentation/projections/declarative/event-context.mdx
@@ -21,19 +21,19 @@ The `EventContext` contains the following properties you can map to:
 
 Use `ToEventSourceId()` to map the event source ID to a property:
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/basic" />
 
 ## Mapping to event context properties
 
 Use `ToEventContextProperty()` to map any event context property:
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/automap-with-context" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/automap-with-context" />
 
 ## Read models with context data
 
 Your read models can include properties for event metadata:
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/read-models" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/read-models" />
 
 ## Composite keys with event context
 
@@ -43,7 +43,7 @@ Event context properties can be part of composite keys:
 Composite keys are currently a C#-only mechanism — Kotlin, Java, TypeScript, and Elixir have no working composite-key builder yet (see [Composite Keys](./composite-keys)). This example stays C#-only until that lands elsewhere.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/composite-key" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/composite-key" />
 
 ## Event context in children and joins
 
@@ -53,11 +53,11 @@ Event context properties work in child collections and joins:
 This example depends on declarative child collections, which are currently C#-only (see [Children](./children)). It stays C#-only until child projection scopes are available in the other clients.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/children-context" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/children-context" />
 
 ## Event definitions
 
-<ChronicleClientTabs snippet="projections/declarative/event-context/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/event-context/events" />
 
 ## Common use cases
 

--- a/Documentation/projections/declarative/from-all.mdx
+++ b/Documentation/projections/declarative/from-all.mdx
@@ -6,21 +6,21 @@ Use `FromAll` in .NET when the projection should express that a mapping belongs 
 
 ## Basic Usage
 
-<ChronicleClientTabs snippet="projections/declarative/from-all/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-all/basic" />
 
 ## Event Context Fields
 
-<ChronicleClientTabs snippet="projections/declarative/from-all/context-fields" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-all/context-fields" />
 
 ## Event Source Id
 
-<ChronicleClientTabs snippet="projections/declarative/from-all/event-source-id" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-all/event-source-id" />
 
 ## With Event-Specific Mappings
 
 `FromAll` can sit beside event-specific `From` mappings. Use event-specific mappings for business state, and reserve `FromAll` for metadata that should update for every projected event.
 
-<ChronicleClientTabs snippet="projections/declarative/from-all/with-specific-mappings" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-all/with-specific-mappings" />
 
 ## FromAll And FromEvery
 

--- a/Documentation/projections/declarative/from-event-sequence.mdx
+++ b/Documentation/projections/declarative/from-event-sequence.mdx
@@ -6,7 +6,7 @@ The `FromEventSequence()` method allows you to specify which event sequence a pr
 
 Use `FromEventSequence()` to specify the event sequence to source events from:
 
-<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/basic" />
 
 This projection:
 
@@ -18,19 +18,19 @@ This projection:
 
 Event sequences can be identified using string names or EventSequenceId:
 
-<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/using-constant" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/using-constant" />
 
 ## Read model definition
 
 The read model remains the same regardless of the event sequence:
 
-<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/read-model" />
 
 ## Event definitions
 
 Events should be designed to work within the specific sequence context:
 
-<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/events" />
 
 ## How it works
 
@@ -45,7 +45,7 @@ When using `FromEventSequence()`:
 
 You can create different projections for different event sequences:
 
-<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/multiple-sequences" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-event-sequence/multiple-sequences" />
 
 ## When to use FromEventSequence
 

--- a/Documentation/projections/declarative/from-every.mdx
+++ b/Documentation/projections/declarative/from-every.mdx
@@ -8,25 +8,25 @@ The exact API name depends on the client. .NET and TypeScript expose `FromEvery`
 
 Map event context metadata when the read model needs to know when it was last touched.
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/basic" />
 
 ## Event Context Fields
 
 Every-event mappings can map more than one context field.
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/context-fields" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/context-fields" />
 
 ## Event Source Id
 
 Map the event source id when the read model's primary identifier is not otherwise populated from each event payload.
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/event-source-id" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/event-source-id" />
 
 ## Child Projection Inclusion
 
 Some clients let the projection decide whether child projection events should update parent-level every-event fields.
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/exclude-children" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/exclude-children" />
 
 When child projections are included, parent metadata can update for events that only affect a child item.
 
@@ -34,7 +34,7 @@ When child projections are included, parent metadata can update for events that 
 This example depends on declarative child collections, which are currently C#-only (see [Children](./children)). It stays C#-only until child projection scopes are available in the other clients.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/with-children" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/with-children" />
 
 ## Multiple Declarations
 
@@ -44,7 +44,7 @@ Clients that support multiple every-event declarations merge the property mappin
 Elixir's `from_every/1` macro accumulates multiple declarations, but the registration coordinator currently only sends the first one to the kernel — a second `from_every` call is silently dropped. Use a single `from_every` call with all of the property mappings combined instead.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/from-every/multiple-declarations" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/from-every/multiple-declarations" />
 
 ## Common Use Cases
 

--- a/Documentation/projections/declarative/functions.mdx
+++ b/Documentation/projections/declarative/functions.mdx
@@ -8,13 +8,13 @@ Projections support several built-in functions for mathematical operations and c
 
 Use `Count()` to increment a counter each time an event is processed:
 
-<ChronicleClientTabs snippet="projections/declarative/functions/count" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/functions/count" />
 
 ## Increment and decrement
 
 Use `Increment()` and `Decrement()` to add or subtract 1 from a property:
 
-<ChronicleClientTabs snippet="projections/declarative/functions/increment-decrement" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/functions/increment-decrement" />
 
 These functions always change the value by exactly 1.
 
@@ -22,7 +22,7 @@ These functions always change the value by exactly 1.
 
 Use `Add()` and `Subtract()` to add or subtract specific values from event properties:
 
-<ChronicleClientTabs snippet="projections/declarative/functions/add-subtract" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/functions/add-subtract" />
 
 ## Supported types
 
@@ -47,6 +47,6 @@ The functions automatically handle type conversion and maintain the target prope
 
 You can use multiple functions in a single projection:
 
-<ChronicleClientTabs snippet="projections/declarative/functions/combined" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/functions/combined" />
 
 These functions provide powerful aggregation capabilities while keeping projection logic simple and declarative.

--- a/Documentation/projections/declarative/index.mdx
+++ b/Documentation/projections/declarative/index.mdx
@@ -8,7 +8,7 @@ Declarative projections implement `IProjectionFor<TReadModel>` and use an `IProj
 
 ## Basic Example
 
-<ChronicleClientTabs snippet="projections/declarative/index/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/index/basic" />
 
 Auto-mapping is enabled by default at the top level, so matching properties are mapped automatically. When you need explicit mappings, you can use `.Set()`, `.Add()`, `.Subtract()`, and other builder operations.
 

--- a/Documentation/projections/declarative/initial-values.mdx
+++ b/Documentation/projections/declarative/initial-values.mdx
@@ -10,7 +10,7 @@ Provide a factory that returns a fresh read model instance with the desired defa
 
 Kotlin and Elixir don't have a `WithInitialValues`-style builder call, but they achieve the same result idiomatically: the read model's own constructor/struct default values become its initial state (see [Collections](#collections) below for a working example that doesn't need event context). This particular example also maps an event context property (`Occurred`), which neither client's fluent projection API can access yet.
 
-<ChronicleClientTabs snippet="projections/declarative/initial-values/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/initial-values/basic" />
 
 ## Why Use Initial Values
 
@@ -29,13 +29,13 @@ Initial values are useful for:
 
 Set defaults that describe the domain state before the first relevant event changes it.
 
-<ChronicleClientTabs snippet="projections/declarative/initial-values/business-defaults" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/initial-values/business-defaults" />
 
 ## Collections
 
 Initialize collections so consumers can treat them as empty collections instead of checking for missing values.
 
-<ChronicleClientTabs snippet="projections/declarative/initial-values/collections" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/initial-values/collections" />
 
 ## Events That Do Not Cover Every Property
 
@@ -43,7 +43,7 @@ Initial values are useful when events update operational fields but leave config
 
 > **TypeScript note:** this example uses `Add()`/`With()`, the fluent builder's variable-delta accumulation operators. TypeScript's `add()`/`subtract()` are not implemented yet (`FromBuilder.ts` throws at runtime even though the call type-checks), so this specific example is unsupported in TypeScript for now. Elixir's `add:`/`subtract:` property options **do** work, so this example is also shown there.
 
-<ChronicleClientTabs snippet="projections/declarative/initial-values/partial-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/initial-values/partial-events" />
 
 ## Best Practices
 

--- a/Documentation/projections/declarative/joins.mdx
+++ b/Documentation/projections/declarative/joins.mdx
@@ -6,19 +6,19 @@ Joins allow projections to incorporate data from events that don't share the sam
 
 Use the `Join()` method to include data from events with different keys:
 
-<ChronicleClientTabs snippet="projections/declarative/joins/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/joins/basic" />
 
 ## Read model with joined data
 
 The read model includes properties populated from different event sources:
 
-<ChronicleClientTabs snippet="projections/declarative/joins/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/joins/read-model" />
 
 ## Event definitions
 
 Events come from different streams but are joined based on common identifiers:
 
-<ChronicleClientTabs snippet="projections/declarative/joins/events" clients="csharp,kotlin,java,elixir" />
+<ChronicleClientTabs snippet="projections/declarative/joins/events" />
 
 ## How joins work
 
@@ -41,7 +41,7 @@ Joins match events based on their event source ID and the join property — `.Jo
 
 A projection can join with multiple streams:
 
-<ChronicleClientTabs snippet="projections/declarative/joins/multiple-joins" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/joins/multiple-joins" />
 
 ### Joining children
 
@@ -51,7 +51,7 @@ Joins can also be used within child collections:
 This example depends on declarative child collections, which are currently C#-only (see [Children](./children)). It stays C#-only until child projection scopes are available in the other clients.
 :::
 
-<ChronicleClientTabs snippet="projections/declarative/joins/children-join" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/joins/children-join" />
 
 ## Performance considerations
 

--- a/Documentation/projections/declarative/nested.mdx
+++ b/Documentation/projections/declarative/nested.mdx
@@ -10,17 +10,17 @@ Declarative nested-object projections (`Nested()`/`ClearWith()`) are currently a
 
 Use the `Nested()` method with `ClearWith<TEvent>()` to define the nested relationship:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/basic" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/basic" />
 
 ## Read model with a nested property
 
 The nested property must be nullable on the read model:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/read-model" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/read-model" />
 
 ## Event definitions
 
-<ChronicleClientTabs snippet="projections/declarative/nested/events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/events" />
 
 ## How nested objects work
 
@@ -32,7 +32,7 @@ The nested property must be nullable on the read model:
 
 Call `From<TEvent>()` multiple times to update the nested object from several event types:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/multiple-from-events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/multiple-from-events" />
 
 Each `From<TEvent>()` call updates only the properties it explicitly maps or auto-maps — it does not replace the entire nested object.
 
@@ -40,33 +40,33 @@ Each `From<TEvent>()` call updates only the properties it explicitly maps or aut
 
 AutoMap is enabled on the nested builder and inherits from the parent. Properties on the nested read model that share a name with properties on the event are mapped automatically:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/automap" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/automap" />
 
 ## Multiple nested objects
 
 A single projection can have multiple independent nested properties:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/multiple-nested" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/multiple-nested" />
 
 ## Nested within children
 
 You can call `Nested()` from within a `Children()` builder to define a nested object on each child item:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/nested-in-children" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/nested-in-children" />
 
 ## Examples
 
 ### Employee with optional active contract
 
-<ChronicleClientTabs snippet="projections/declarative/nested/employee-contract" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/employee-contract" />
 
 Events:
 
-<ChronicleClientTabs snippet="projections/declarative/nested/employee-contract-events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/employee-contract-events" />
 
 ### Product with optional promotion
 
-<ChronicleClientTabs snippet="projections/declarative/nested/product-promotion" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/nested/product-promotion" />
 
 ## See Also
 

--- a/Documentation/projections/declarative/not-rewindable.mdx
+++ b/Documentation/projections/declarative/not-rewindable.mdx
@@ -10,7 +10,7 @@ Marking a projection as not-rewindable is currently supported in C# and TypeScri
 
 Use `NotRewindable()` to mark a projection as forward-only:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/basic" />
 
 This projection:
 
@@ -23,13 +23,13 @@ This projection:
 
 The read model can include timestamp and audit information:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/read-model" />
 
 ## Event definitions
 
 Events should be designed for forward-only processing:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/events" />
 
 ## How it works
 
@@ -47,19 +47,19 @@ When a projection is marked as `NotRewindable()`:
 
 Perfect for audit logs where you want to preserve the exact timing and sequence:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/audit-use-case" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/audit-use-case" />
 
 ### Performance monitoring
 
 For real-time performance metrics that don't need historical accuracy:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/performance-use-case" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/performance-use-case" />
 
 ### Financial transactions
 
 For append-only financial records where replay could cause confusion:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/financial-use-case" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/financial-use-case" />
 
 ## When to use NotRewindable
 
@@ -86,7 +86,7 @@ Avoid `NotRewindable()` when:
 
 NotRewindable can be combined with other projection features:
 
-<ChronicleClientTabs snippet="projections/declarative/not-rewindable/combined-features" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/not-rewindable/combined-features" />
 
 This combines non-rewindable behavior with event sequence specification, passive mode, and event-context timestamp mapping.
 

--- a/Documentation/projections/declarative/passive.mdx
+++ b/Documentation/projections/declarative/passive.mdx
@@ -6,7 +6,7 @@ A passive projection is a projection that is not actively materialized to a pers
 
 Use the `.Passive()` method to mark a projection as passive:
 
-<ChronicleClientTabs snippet="projections/declarative/passive/projection" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/passive/projection" />
 
 This projection:
 
@@ -18,19 +18,19 @@ This projection:
 
 Passive projections are accessed through the event store's `ReadModels` using the `GetInstanceById` method:
 
-<ChronicleClientTabs snippet="projections/declarative/passive/service" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/passive/service" />
 
 ## Read model definition
 
 The read model is defined the same way as for regular projections:
 
-<ChronicleClientTabs snippet="projections/declarative/passive/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/passive/read-model" />
 
 ## Event definitions
 
 Events should match the read model structure or use explicit mapping:
 
-<ChronicleClientTabs snippet="projections/declarative/passive/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/passive/events" />
 
 ## How it works
 

--- a/Documentation/projections/declarative/remove-with-join.mdx
+++ b/Documentation/projections/declarative/remove-with-join.mdx
@@ -15,7 +15,7 @@ Every example on this page combines declarative child collections with joins, bo
 
 Use `RemovedWithJoin<>()` in child projections to specify which events should trigger child removal:
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/basic" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/basic" />
 
 In this example:
 
@@ -39,13 +39,13 @@ When using `RemovedWithJoin<>()`:
 
 You can specify which property to use as the key for removal:
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/explicit-keys" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/explicit-keys" />
 
 ## Real-world example: User groups
 
 Consider a system where users can be members of groups, and groups can be deleted:
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/user-groups-example" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/user-groups-example" />
 
 In this example:
 
@@ -54,7 +54,7 @@ In this example:
 
 ## Complex scenario: Project assignments
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/project-assignments-example" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/project-assignments-example" />
 
 This handles three removal scenarios:
 
@@ -64,11 +64,11 @@ This handles three removal scenarios:
 
 ## Read model examples
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/read-models" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/read-models" />
 
 ## Event definitions
 
-<ChronicleClientTabs snippet="projections/declarative/remove-with-join/events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/declarative/remove-with-join/events" />
 
 ## Best practices
 

--- a/Documentation/projections/declarative/set-properties.mdx
+++ b/Documentation/projections/declarative/set-properties.mdx
@@ -6,13 +6,13 @@ When auto-mapping isn't sufficient, you can explicitly map properties from event
 
 Instead of using `AutoMap()`, use `Set()` methods to explicitly define property mappings:
 
-<ChronicleClientTabs snippet="projections/declarative/set-properties/explicit" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/set-properties/explicit" />
 
 ## Combining AutoMap with explicit mapping
 
 You can use `AutoMap()` at the top level to automatically map matching properties, then add explicit mappings for specific transformations:
 
-<ChronicleClientTabs snippet="projections/declarative/set-properties/combined-automap" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/set-properties/combined-automap" />
 
 `AutoMap()` works recursively, automatically mapping:
 
@@ -26,13 +26,13 @@ You can use `AutoMap()` at the top level to automatically map matching propertie
 
 The read model can have different property names and types than the events:
 
-<ChronicleClientTabs snippet="projections/declarative/set-properties/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/set-properties/read-model" />
 
 ## Event definitions
 
 Events can have different structures than the read model:
 
-<ChronicleClientTabs snippet="projections/declarative/set-properties/events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/set-properties/events" />
 
 ## Property mapping options
 

--- a/Documentation/projections/declarative/simple-projection.mdx
+++ b/Documentation/projections/declarative/simple-projection.mdx
@@ -6,7 +6,7 @@ A projection in Cratis is a way to create read models from events in the event s
 
 A projection implements `IProjectionFor<TReadModel>` and defines its behavior in the `Define` method:
 
-<ChronicleClientTabs snippet="projections/declarative/simple-projection/projection" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/simple-projection/projection" />
 
 This projection:
 
@@ -20,13 +20,13 @@ This projection:
 
 The read model is a simple record or class representing the projected data:
 
-<ChronicleClientTabs snippet="projections/declarative/simple-projection/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/simple-projection/read-model" />
 
 ## Event definition
 
 The event should match the read model structure for auto-mapping to work:
 
-<ChronicleClientTabs snippet="projections/declarative/simple-projection/event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/declarative/simple-projection/event" />
 
 ## How it works
 

--- a/Documentation/projections/eventual-consistency.mdx
+++ b/Documentation/projections/eventual-consistency.mdx
@@ -59,13 +59,13 @@ graph TD
 
 Structure your application to work naturally with eventual consistency:
 
-<ChronicleClientTabs snippet="projections/eventual-consistency/design-for-async" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/eventual-consistency/design-for-async" />
 
 ### 2. Watch Projection Changes
 
 Chronicle provides a `.Watch<TReadModel>()` API that allows you to observe projection changes in real-time:
 
-<ChronicleClientTabs snippet="projections/eventual-consistency/watch" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/eventual-consistency/watch" />
 
 ### 3. Monitor Database Changes
 
@@ -79,7 +79,7 @@ For applications that need to respond to database changes from external sources,
 
 Separate operations that create data from those that read data:
 
-<ChronicleClientTabs snippet="projections/eventual-consistency/cqs" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/eventual-consistency/cqs" />
 
 ## Best Practices
 

--- a/Documentation/projections/filtering.mdx
+++ b/Documentation/projections/filtering.mdx
@@ -6,7 +6,7 @@ Projections build read models by mapping events to fields. They observe all even
 
 A projection declares the event types it observes through its event mappings:
 
-<ChronicleClientTabs snippet="projections/filtering/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/filtering/basic" />
 
 This projection receives every `OrderPlaced` and `OrderShipped` event regardless of any metadata attached during append. Metadata such as tags or stream type does not affect which events flow into a projection.
 
@@ -14,7 +14,7 @@ This projection receives every `OrderPlaced` and `OrderShipped` event regardless
 
 `[Tag]` and `[Tags]` on a projection label the projection definition for organizational purposes. They do not filter incoming events:
 
-<ChronicleClientTabs snippet="projections/filtering/tagging" clients="csharp" />
+<ChronicleClientTabs snippet="projections/filtering/tagging" />
 
 :::note[Client coverage]
 Labeling a projection with `[Tag]`/`[Tags]`, and metadata-based observer filtering with `[FilterEventsByTag]`/`[EventSourceType]`/`[EventStreamType]` on a reactor or reducer, are currently C#-only. Kotlin, Elixir, and TypeScript have no equivalent tag or filter mechanism on their projection, reactor, or reducer registration APIs.
@@ -26,11 +26,11 @@ When you need a side effect or secondary read model that reacts only to a subset
 
 The following example shows an `OrderSummaryProjection` that builds the full read model for all orders, alongside a `PremiumOrderNotifier` reactor that fires only when an order is appended with the `premium` tag:
 
-<ChronicleClientTabs snippet="projections/filtering/with-reactor" clients="csharp" />
+<ChronicleClientTabs snippet="projections/filtering/with-reactor" />
 
 The same pattern works with a reducer instead of a reactor:
 
-<ChronicleClientTabs snippet="projections/filtering/with-reducer" clients="csharp" />
+<ChronicleClientTabs snippet="projections/filtering/with-reducer" />
 
 Use this pattern whenever you need both a projection-based read model (covering all events) and a metadata-filtered view or side effect (covering a subset).
 
@@ -38,7 +38,7 @@ Use this pattern whenever you need both a projection-based read model (covering 
 
 The metadata you provide at append time drives the filters on any accompanying reducers or reactors:
 
-<ChronicleClientTabs snippet="projections/filtering/appending-with-metadata" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/filtering/appending-with-metadata" />
 
 ## See also
 

--- a/Documentation/projections/model-bound/basic-mapping.mdx
+++ b/Documentation/projections/model-bound/basic-mapping.mdx
@@ -8,25 +8,25 @@ The exact syntax belongs to each client. The projection definition sent to Chron
 
 Set mappings copy a value from an event into the read model. This is the most common model-bound operation.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from" />
 
 When the event property and read model property have the same name, the client can use its convention-based form instead of repeating the property name.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-convention" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-convention" />
 
 Use multiple set mappings when different events can update the same read model property.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-multiple-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-multiple-events" />
 
 ## Add And Subtract Values
 
 Add mappings increase a numeric read model property by a value from an event. They are useful for balances, totals, counters, and other accumulated values.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/add-from" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/add-from" />
 
 Subtract mappings decrease a numeric read model property by a value from an event. Combine add and subtract mappings when the read model should track a net value.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/subtract-from" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/subtract-from" />
 
 The event flow for a balance-style read model is:
 
@@ -35,17 +35,17 @@ The event flow for a balance-style read model is:
 3. Withdrawal events subtract from the balance.
 4. Rename or profile events update descriptive properties without changing the balance.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/complete" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/complete" />
 
 ## Set A Property From Event Context
 
 Event context contains metadata such as when the event occurred, which event source it belongs to, sequence information, and correlation metadata. Map context fields when the read model needs audit or lifecycle information.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-context" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/set-from-context" />
 
 Use an every-event mapping when a read model property should reflect the latest event that affected the projection, rather than one specific event type.
 
-<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/context-vs-from-every" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/basic-mapping/context-vs-from-every" />
 
 ## Choosing The Mapping
 

--- a/Documentation/projections/model-bound/children.mdx
+++ b/Documentation/projections/model-bound/children.mdx
@@ -6,7 +6,7 @@ Model-bound projections support child collections through the `ChildrenFrom` att
 
 The `ChildrenFrom` attribute defines how child entities are added to a collection:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/basic" />
 
 In this example, the `[Key]` attribute on the `LineItem.Id` property is automatically discovered by Chronicle, so you don't need to specify `identifiedBy` explicitly in the `ChildrenFrom` attribute.
 
@@ -29,11 +29,11 @@ Auto-mapping is enabled by default. To disable it for a child model, apply the `
 
 By default, `ChildrenFrom` automatically maps properties from the event to the child model when property names match. This behavior is similar to the `FromEvent` attribute:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/automap" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/automap" />
 
 You can disable auto-mapping if you want to control property mapping explicitly:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/no-automap" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/children/no-automap" />
 
 :::note[Client coverage]
 Disabling auto-mapping for a child type is a .NET-only mechanism today — Kotlin, Java, Elixir, and TypeScript model-bound child collections do not expose a `NoAutoMap`-equivalent switch.
@@ -43,7 +43,7 @@ Disabling auto-mapping for a child type is a .NET-only mechanism today — Kotli
 
 All projection attributes work recursively on child types. The child type's properties are automatically scanned for projection attributes:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/with-counters" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/with-counters" />
 
 When an `ItemAddedToCart` event occurs:
 
@@ -60,7 +60,7 @@ When a `QuantityIncreased` event occurs later:
 
 Use a class-level `FromEvent` on the child type when later child events should auto-map into the existing child instance. If those events come from the child's own event source, specify `parentKey` so Chronicle can still resolve the parent document:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/child-from-event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/child-from-event" />
 
 `ChildrenFrom` handles how the child is first added to the collection. The child type's own `FromEvent` handles later updates, and `parentKey` is the equivalent of `.UsingParentKey(...)` in a fluent child projection. You do not need `identifiedBy` here because `Configuration.Id` is marked with `[Key]`.
 
@@ -70,19 +70,19 @@ Use `RemovedWith` to remove children from collections. You can apply it either o
 
 ### Property-Level Removal
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removal-property-level" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removal-property-level" />
 
 ### Class-Level Removal
 
 Apply `RemovedWith` directly on the child type for better separation of concerns:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removal-class-level" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removal-class-level" />
 
 ### RemovedWithJoin
 
 For removal based on events from different streams (joins), use `RemovedWithJoin` on the collection property (it also works at the child type's class level, the same way `RemovedWith` does above):
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removed-with-join" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removed-with-join" />
 
 > **Note**: For comprehensive documentation on removal options including removing root read models, see [Removal](./removal).
 
@@ -90,7 +90,7 @@ For removal based on events from different streams (joins), use `RemovedWithJoin
 
 Here's a comprehensive example showing children with full attribute support:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/full-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/full-example" />
 
 ## Event Processing Flow
 
@@ -103,7 +103,7 @@ Here's a comprehensive example showing children with full attribute support:
 
 Children can have their own children, creating deeply nested structures. All projection attributes (joins, removal, counters, context mapping, etc.) work recursively at every level:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/nested-hierarchy" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/nested-hierarchy" />
 
 ### What Works Recursively
 

--- a/Documentation/projections/model-bound/constant-key.mdx
+++ b/Documentation/projections/model-bound/constant-key.mdx
@@ -6,7 +6,7 @@ A constant key fixes the read model key to a literal string value, so all events
 
 Use `ConstantKey` on the `[FromEvent]` attribute at the class level to route all matching events to a fixed read model instance:
 
-<ChronicleClientTabs snippet="projections/model-bound/constant-key/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/constant-key/basic" />
 
 Every `OrderPlaced` event from every event source updates the same `GlobalOrderSummary` instance.
 
@@ -14,7 +14,7 @@ Every `OrderPlaced` event from every event source updates the same `GlobalOrderS
 
 `Count`, `Increment`, and `Decrement` attributes also support `ConstantKey` for collecting events from all event sources into a single document:
 
-<ChronicleClientTabs snippet="projections/model-bound/constant-key/counters" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/constant-key/counters" />
 
 All three properties converge on the `"metrics"` document regardless of which user or order they come from.
 
@@ -22,12 +22,12 @@ All three properties converge on the `"metrics"` document regardless of which us
 
 You can mix regular key-based events with constant key events on the same read model:
 
-<ChronicleClientTabs snippet="projections/model-bound/constant-key/mixed-keys" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/constant-key/mixed-keys" />
 
 > **Note:** When `ConstantKey` is set on a counter attribute, it affects *which read model instance the counter updates* — not the key of the read model the attribute belongs to. In this example, `PlatformTotalOrders` would update the document with key `"global-stats"`, not the `UserDashboard` instance.
 
 ## Complete example
 
-<ChronicleClientTabs snippet="projections/model-bound/constant-key/full-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/constant-key/full-example" />
 
 All events from all users and products accumulate into the single `StoreMetrics` document with key `"store"`.

--- a/Documentation/projections/model-bound/convention-based.mdx
+++ b/Documentation/projections/model-bound/convention-based.mdx
@@ -20,23 +20,23 @@ The client syntax differs, but the Chronicle projection definition still contain
 
 Apply the client's model-bound "from event" marker at the read model level. Matching properties are then mapped without per-property set mappings.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/basic" />
 
 This is equivalent to writing explicit set mappings for every property:
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/explicit-equivalent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/explicit-equivalent" />
 
 ## Multiple Events
 
 A read model can use convention mapping from more than one event type. Each event updates the matching properties it contains and leaves the rest unchanged.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/multiple-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/multiple-events" />
 
 ## Custom Keys
 
 By default, convention-based mappings use the event source id as the read model key. Use a custom key when the event carries the identifier of the read model instance in its content.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/custom-key" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/custom-key" />
 
 Custom keys are useful when:
 
@@ -48,7 +48,7 @@ Custom keys are useful when:
 
 Convention-based model-bound mapping and declarative AutoMap describe the same mapping behavior through different APIs.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/automap-equivalent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/automap-equivalent" />
 
 Use the model-bound form when the mapping belongs naturally on the read model. Use a declarative projection when you need joins, richer key selection, or a projection definition that should stay separate from the read model shape.
 
@@ -56,13 +56,13 @@ Use the model-bound form when the mapping belongs naturally on the read model. U
 
 Convention mapping also works for nested values and collections when the names and shapes match.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/matching-structures" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/matching-structures" />
 
 ## Partial Events
 
 Events do not need to contain every read model property. Chronicle maps the properties that exist on each event.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/partial-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/partial-events" />
 
 ## Excluding A Property From Mapping
 
@@ -72,13 +72,13 @@ Convention mapping applies to every event the read model subscribes to — inclu
 
 An event a read model subscribes to **only to aggregate** — `[Count]`, `[Increment]`, `[Decrement]`, `[Add]`, or `[Subtract]` — does not contribute its other properties to convention mapping. Counting an event does not copy its unrelated fields onto the read model, so a same-named property on it cannot overwrite an explicit value. No annotation is needed.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/aggregate-only" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/aggregate-only" />
 
 ### `[NoAutoMap]` On A Property
 
 For the collisions Chronicle cannot infer — a value-mapped (`[SetFrom]`) or `[Join]`ed event that carries an identically named property — apply `[NoAutoMap]` to the read model property (or record parameter). That property is then set only from its explicit source; convention mapping never touches it, while every other property keeps mapping.
 
-<ChronicleClientTabs snippet="projections/model-bound/convention-based/no-auto-map-property" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/convention-based/no-auto-map-property" />
 
 `[NoAutoMap]` also works at the read model (class) level to disable convention mapping for the whole read model. Use the property form when you only need to protect a single property and want convention mapping everywhere else.
 

--- a/Documentation/projections/model-bound/counters.mdx
+++ b/Documentation/projections/model-bound/counters.mdx
@@ -6,7 +6,7 @@ Model-bound projections provide three counter operations for tracking occurrence
 
 The `Increment` attribute increments a numeric property when an event occurs. This is useful for tracking counters that increase with specific events.
 
-<ChronicleClientTabs snippet="projections/model-bound/counters/basic-increment" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/counters/basic-increment" />
 
 Each time a `UserLoggedIn` event occurs, `LoginCount` is incremented by 1.
 
@@ -14,7 +14,7 @@ Each time a `UserLoggedIn` event occurs, `LoginCount` is incremented by 1.
 
 The `Decrement` attribute decrements a numeric property when an event occurs. This is useful for tracking decreasing counters.
 
-<ChronicleClientTabs snippet="projections/model-bound/counters/increment-decrement" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/counters/increment-decrement" />
 
 When a `UserConnected` event occurs, `ActiveConnections` increases by 1. When a `UserDisconnected` event occurs, it decreases by 1.
 
@@ -22,19 +22,19 @@ When a `UserConnected` event occurs, `ActiveConnections` increases by 1. When a 
 
 The `Count` attribute counts the total number of times an event occurs. Unlike Increment, Count doesn't increment from a current value—it maintains an absolute count.
 
-<ChronicleClientTabs snippet="projections/model-bound/counters/count" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/counters/count" />
 
 ## Multiple Events
 
 You can use multiple attributes on the same property to respond to different events:
 
-<ChronicleClientTabs snippet="projections/model-bound/counters/combined" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/counters/combined" />
 
 ## Complete Example
 
 Here's a complete example tracking various metrics:
 
-<ChronicleClientTabs snippet="projections/model-bound/counters/full-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/counters/full-example" />
 
 ## Counter vs Count
 

--- a/Documentation/projections/model-bound/event-sequence-source.mdx
+++ b/Documentation/projections/model-bound/event-sequence-source.mdx
@@ -2,11 +2,11 @@
 
 By default, model-bound projections read from the event log. Use `[EventSequence]` to specify a different event sequence:
 
-<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/model-bound" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/model-bound" />
 
 This corresponds to the fluent API for declarative projections:
 
-<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/fluent" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/fluent" />
 
 :::note[Client coverage]
 Explicitly overriding the event sequence a projection reads from is a .NET and TypeScript mechanism today — Kotlin, Java, and Elixir client projections always register against the event log and do not yet expose an `[EventSequence]`-equivalent override.
@@ -16,7 +16,7 @@ Explicitly overriding the event sequence a projection reads from is a .NET and T
 
 Use `[EventLog]` when you want to be explicit that the projection reads from the default event log, even when other event types in the assembly carry a `[EventStore]` attribute:
 
-<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/event-log" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/event-sequence-source/event-log" />
 
 ## Automatic Inbox Routing
 

--- a/Documentation/projections/model-bound/from-all.mdx
+++ b/Documentation/projections/model-bound/from-all.mdx
@@ -8,13 +8,13 @@ Use `FromAll` in .NET when you want a property mapping to apply across the event
 
 The fluent `.FromAll(...)` API maps read model properties from event context for all events in the projection definition.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-all/fluent-context" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/from-all/fluent-context" />
 
 ## Model-Bound Attribute
 
 The `[FromAll]` attribute is also available in the .NET model-bound API. Use the no-argument form when the read model property name matches the event payload property name by convention.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-all/attribute-convention" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/from-all/attribute-convention" />
 
 For explicit model-bound event payload or event context mappings, prefer `[FromEvery(...)]`. It creates the same every-event projection definition while making the source kind explicit. See [From Every Event](./from-every) for examples.
 

--- a/Documentation/projections/model-bound/from-every.mdx
+++ b/Documentation/projections/model-bound/from-every.mdx
@@ -8,27 +8,27 @@ Every-event mappings are different from event-specific mappings. A set mapping a
 
 Event context is the most common source for every-event mappings because every event has the same context shape. This keeps audit fields independent from the event payloads.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/context-property" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/context-property" />
 
 You can map multiple context fields when the read model needs a small audit trail.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/context-fields" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/context-fields" />
 
 ## Map Event Payload Properties
 
 Every-event mappings can also read from event payload properties. Use this only when each event in the projection carries the same property name and compatible value type.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/event-property" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/event-property" />
 
 If a client supports convention-based property mapping, omitting the source property uses the read model property name.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/convention" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/convention" />
 
 ## Combine With Event-Specific Mappings
 
 When an event is processed, Chronicle applies the event-specific mappings for that event and the every-event mappings for the projection. This lets the read model update business fields and audit metadata in the same event pass.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/combined" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/combined" />
 
 For example, when the name-change event in the examples above is processed:
 
@@ -39,7 +39,7 @@ For example, when the name-change event in the examples above is processed:
 
 Every-event mappings are part of the projection definition Chronicle receives. Clients that expose both model-bound and standalone projection definitions send the same kind of every-event definition to Chronicle.
 
-<ChronicleClientTabs snippet="projections/model-bound/from-every/declarative-equivalent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/from-every/declarative-equivalent" />
 
 ## Use Cases
 

--- a/Documentation/projections/model-bound/index.mdx
+++ b/Documentation/projections/model-bound/index.mdx
@@ -8,7 +8,7 @@ Start with convention-based mapping and add explicit attributes only where the e
 
 ## Basic Example
 
-<ChronicleClientTabs snippet="projections/model-bound/index/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/index/basic" />
 
 In this example:
 
@@ -74,21 +74,21 @@ Use fluent projections (`IProjectionFor<T>`) as a fallback when the projection c
 
 **Fluent Projection:**
 
-<ChronicleClientTabs snippet="projections/model-bound/index/explicit-mapping-fluent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/index/explicit-mapping-fluent" />
 
 **Model-Bound Projection:**
 
-<ChronicleClientTabs snippet="projections/model-bound/index/explicit-mapping-model-bound" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/index/explicit-mapping-model-bound" />
 
 ### Automatic Property Mapping
 
 **Fluent Projection with AutoMap:**
 
-<ChronicleClientTabs snippet="projections/model-bound/index/automap-fluent" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/index/automap-fluent" />
 
 **Model-Bound Projection with FromEvent:**
 
-<ChronicleClientTabs snippet="projections/model-bound/index/automap-model-bound" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/index/automap-model-bound" />
 
 Both approaches produce the same result. Model-bound projections with `FromEvent` are particularly concise when property names match between events and read models, providing the same automatic mapping benefits as `.AutoMap()` in fluent projections.
 

--- a/Documentation/projections/model-bound/joins.mdx
+++ b/Documentation/projections/model-bound/joins.mdx
@@ -6,7 +6,7 @@ Model-bound projections support joining data from different events using the `Jo
 
 The `Join` attribute maps properties from events that are related through a common key:
 
-<ChronicleClientTabs snippet="projections/model-bound/joins/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/joins/basic" />
 
 ### Parameters
 
@@ -17,25 +17,25 @@ The `Join` attribute maps properties from events that are related through a comm
 
 Joins work within child collections. When used in children, the `on` parameter is optional if the child has an `identifiedBy` property:
 
-<ChronicleClientTabs snippet="projections/model-bound/joins/children" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/joins/children" />
 
 ## Multiple Joins
 
 You can join with multiple different events:
 
-<ChronicleClientTabs snippet="projections/model-bound/joins/multiple-joins" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/joins/multiple-joins" />
 
 ## Recursive Join Processing
 
 Join attributes on related types are processed recursively:
 
-<ChronicleClientTabs snippet="projections/model-bound/joins/multiple-join-sources" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/joins/multiple-join-sources" />
 
 ## Complete Example
 
 Here's a comprehensive example showing joins at multiple levels:
 
-<ChronicleClientTabs snippet="projections/model-bound/joins/full-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/joins/full-example" />
 
 ## Event Processing Flow
 

--- a/Documentation/projections/model-bound/nested.mdx
+++ b/Documentation/projections/model-bound/nested.mdx
@@ -8,7 +8,7 @@ The current model-bound nested API is available in the .NET client. TypeScript c
 
 Mark the nullable parent property as nested. The nested type declares the events that populate it and, optionally, the events that clear it.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/basic-lifecycle" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/basic-lifecycle" />
 
 The lifecycle is:
 
@@ -20,7 +20,7 @@ The lifecycle is:
 
 The nested marker belongs on the single nullable property that holds the child object.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/parent-property" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/parent-property" />
 
 The nested type is scanned for its own model-bound projection annotations, including `FromEvent`, `ClearWith`, and property mappings.
 
@@ -28,45 +28,45 @@ The nested type is scanned for its own model-bound projection annotations, inclu
 
 Apply a clear annotation to the nested type when one event should remove the nested object from the parent.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/clear-with" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/clear-with" />
 
 Use multiple clear annotations when more than one event should clear the same nested object.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-clear-events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-clear-events" />
 
 ## Updating From Multiple Events
 
 A nested type can be populated or updated by several events. Matching property names are auto-mapped by default.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-from-events" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-from-events" />
 
 When event property names differ from nested object property names, add explicit property mappings to the nested type.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/explicit-mapping" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/explicit-mapping" />
 
 ## Auto-Mapping
 
 AutoMap is enabled by default for nested types. Disable it on the nested type when every property should be mapped explicitly.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/no-automap" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/no-automap" />
 
 ## Multiple Nested Objects
 
 A parent can hold more than one nested object. Each nested property points to a type with its own event lifecycle.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-nested" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/multiple-nested" />
 
 ## Nested Objects Inside Children
 
 Nested objects can also appear inside child collection items.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/nested-in-children" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/nested-in-children" />
 
 ## Complete Example
 
 This example shows a parent read model with a command definition that can be set, renamed, updated, and cleared.
 
-<ChronicleClientTabs snippet="projections/model-bound/nested/complete" clients="csharp" />
+<ChronicleClientTabs snippet="projections/model-bound/nested/complete" />
 
 | Event | Effect on the nested object |
 | --- | --- |

--- a/Documentation/projections/model-bound/not-rewindable.mdx
+++ b/Documentation/projections/model-bound/not-rewindable.mdx
@@ -2,7 +2,7 @@
 
 Mark a projection as not rewindable (forward-only) using `[NotRewindable]`:
 
-<ChronicleClientTabs snippet="projections/model-bound/not-rewindable/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/not-rewindable/basic" />
 
 ## When to use
 

--- a/Documentation/projections/model-bound/passive.mdx
+++ b/Documentation/projections/model-bound/passive.mdx
@@ -2,7 +2,7 @@
 
 Mark a projection as passive (not actively observing) using `[Passive]`:
 
-<ChronicleClientTabs snippet="projections/model-bound/passive/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/passive/basic" />
 
 ## When to use
 

--- a/Documentation/projections/model-bound/removal.mdx
+++ b/Documentation/projections/model-bound/removal.mdx
@@ -6,7 +6,7 @@ Model-bound projections support removing read models and child items through the
 
 Use `RemovedWith` at the class level to specify which event removes the entire read model instance:
 
-<ChronicleClientTabs snippet="projections/model-bound/removal/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/removal/basic" />
 
 When an `AccountClosed` event occurs, the corresponding `Account` read model is removed from the store.
 
@@ -14,13 +14,13 @@ When an `AccountClosed` event occurs, the corresponding `Account` read model is 
 
 You can specify which property on the event identifies the read model to remove:
 
-<ChronicleClientTabs snippet="projections/model-bound/removal/with-key" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/removal/with-key" />
 
 ## Multiple Removal Options
 
 A read model can be removed by multiple different events:
 
-<ChronicleClientTabs snippet="projections/model-bound/removal/multiple-triggers" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/removal/multiple-triggers" />
 
 In this example, an account can be removed by:
 
@@ -32,7 +32,7 @@ In this example, an account can be removed by:
 
 Use `RemovedWithJoin` when the removal event comes from a different stream (join relationship):
 
-<ChronicleClientTabs snippet="projections/model-bound/removal/join-on-class" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/removal/join-on-class" />
 
 When the company is dissolved, all employees associated with that company are removed.
 
@@ -44,13 +44,13 @@ Children can be removed in two ways:
 
 Apply `RemovedWith` on the collection property alongside `ChildrenFrom`:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removal-property-level" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removal-property-level" />
 
 ### Class-Level Removal on Child Types
 
 Apply `RemovedWith` directly on the child type. This is particularly useful when the same child model is used in multiple parents or when you want to keep removal logic with the child definition:
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removal-class-level" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removal-class-level" />
 
 Both approaches produce the same result. The class-level approach keeps the removal definition with the child type, while the property-level approach keeps it with the parent.
 
@@ -65,13 +65,13 @@ For child removal, you can specify:
 
 For children that should be removed based on join events, apply `RemovedWithJoin` on the collection property (it also works at the child type's class level, the same way `RemovedWith` does above):
 
-<ChronicleClientTabs snippet="projections/model-bound/children/removed-with-join" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/children/removed-with-join" />
 
 ## Complete Example
 
 Here's a comprehensive example showing both root and child removal:
 
-<ChronicleClientTabs snippet="projections/model-bound/removal/full-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/removal/full-example" />
 
 ## Best Practices
 

--- a/Documentation/projections/model-bound/set-value.mdx
+++ b/Documentation/projections/model-bound/set-value.mdx
@@ -4,7 +4,7 @@ The `SetValue` attribute sets a property to a compile-time constant whenever an 
 
 ## Basic Usage
 
-<ChronicleClientTabs snippet="projections/model-bound/set-value/order" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/set-value/order" />
 
 When an `OrderPlaced` event occurs, `Status` is set to `"active"`. When an `OrderCanceled` event occurs, `Status` is set to `"canceled"`.
 
@@ -12,13 +12,13 @@ When an `OrderPlaced` event occurs, `Status` is set to `"active"`. When an `Orde
 
 `SetValue` accepts any compile-time constant: strings, integers, longs, doubles, booleans, and enum values.
 
-<ChronicleClientTabs snippet="projections/model-bound/set-value/thing" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/set-value/thing" />
 
 ## Multiple Events
 
 Apply the attribute more than once to respond to multiple event types:
 
-<ChronicleClientTabs snippet="projections/model-bound/set-value/subscription" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/set-value/subscription" />
 
 ## SetValue vs SetFrom
 
@@ -29,4 +29,4 @@ Apply the attribute more than once to respond to multiple event types:
 
 Combine both on the same read model when different properties come from different sources:
 
-<ChronicleClientTabs snippet="projections/model-bound/set-value/invoice" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/model-bound/set-value/invoice" />

--- a/Documentation/projections/nested-objects-design.mdx
+++ b/Documentation/projections/nested-objects-design.mdx
@@ -97,7 +97,7 @@ Two new keywords are introduced: `nested` (block opener) and `clear with` (lifec
 
 The fluent builder exposes `Nested(...)` symmetrical to `Children(...)`, taking a property expression and a configuration callback. The callback receives an `INestedBuilder<TParent, TNested>` that inherits every method of the root projection builder and adds `ClearWith<TEvent>()`:
 
-<ChronicleClientTabs snippet="projections/nested-objects-design/declarative" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/nested-objects-design/declarative" />
 
 See [Declarative Nested Objects](declarative/nested) for the full surface.
 
@@ -108,7 +108,7 @@ Two attributes drive the model-bound surface:
 - `[Nested]` — placed on a nullable property or record parameter, marks it as a nested object on the parent.
 - `[ClearWith<TEvent>]` — placed on the nested type (or its properties), declares the event that nulls the parent's property.
 
-<ChronicleClientTabs snippet="projections/nested-objects-design/model-bound" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/nested-objects-design/model-bound" />
 
 The nested type is scanned for `[FromEvent<T>]`, `[ClearWith<T>]`, `[SetFrom<T>]`, `[AddFrom<T>]`, `[Nested]`, `[ChildrenFrom<T>]`, and the other standard projection annotations. See [Model-Bound Nested Objects](model-bound/nested).
 
@@ -133,7 +133,7 @@ projection Slice => SliceReadModel
     clear with CommandClearedForSlice
 ```
 
-<ChronicleClientTabs snippet="projections/nested-objects-design/recursive" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/nested-objects-design/recursive" />
 
 ### Nested within children
 

--- a/Documentation/projections/projection-declaration-language/adhoc-querying.mdx
+++ b/Documentation/projections/projection-declaration-language/adhoc-querying.mdx
@@ -18,7 +18,7 @@ Ad-hoc PDL querying with `IProjections.Query()` is currently C#-only. Kotlin's `
 
 Inject `IProjections` into your service, then call `Query()` with a PDL declaration string:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/basic" clients="csharp" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/basic" />
 
 `ReadModelEntries` is a `IReadOnlyList<string>` where each element is the JSON representation of one projected read model instance.
 
@@ -26,23 +26,23 @@ Inject `IProjections` into your service, then call `Query()` with a PDL declarat
 
 You can optionally specify a `=> ReadModelType` in your declaration. When you do, the server resolves the schema from the registered read model definition. When you omit it, the schema is **inferred** from the event properties.
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/inferred-vs-explicit" clients="csharp" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/inferred-vs-explicit" />
 
 When using an inferred schema with multiple `from` blocks, all events that contribute the same property name must use compatible types. The compiler reports an error at query time if there is a mismatch:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/type-mismatch" clients="csharp" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/type-mismatch" />
 
 ## Error Handling
 
 If the declaration contains syntax or type errors, `Query()` throws `UnableToQueryProjection`:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/error-handling" clients="csharp" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/error-handling" />
 
 ## Targeting a Different Event Sequence
 
 By default `Query()` reads from the `event-log` sequence. Pass a different sequence identifier as the second argument:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/custom-sequence" clients="csharp" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/adhoc-querying/custom-sequence" />
 
 ## Practical Use Cases
 

--- a/Documentation/projections/projection-declaration-language/auto-map.mdx
+++ b/Documentation/projections/projection-declaration-language/auto-map.mdx
@@ -96,11 +96,11 @@ AutoMap matches properties when:
 
 Example event:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/auto-map/event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/auto-map/event" />
 
 Example read model:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/auto-map/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/auto-map/read-model" />
 
 With default AutoMap, `Name`, `Email`, and `Age` are automatically copied. `IsActive` must be set explicitly.
 

--- a/Documentation/projections/projection-declaration-language/children.mdx
+++ b/Documentation/projections/projection-declaration-language/children.mdx
@@ -342,7 +342,7 @@ children members id userId
 
 The children block maps to a collection property on the read model:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/children/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/children/read-model" />
 
 ## Best Practices
 

--- a/Documentation/projections/projection-declaration-language/counters.mdx
+++ b/Documentation/projections/projection-declaration-language/counters.mdx
@@ -201,7 +201,7 @@ Attempting to use counters on non-numeric properties will result in a validation
 
 Counter properties should have an initial value:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/counters/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/counters/read-model" />
 
 ## Best Practices
 

--- a/Documentation/projections/projection-declaration-language/expressions.mdx
+++ b/Documentation/projections/projection-declaration-language/expressions.mdx
@@ -222,7 +222,7 @@ This transformation ensures compatibility with Chronicle's internal expression f
 
 Expressions must be compatible with the target property type:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/expressions/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/expressions/read-model" />
 
 **Valid:**
 

--- a/Documentation/projections/projection-declaration-language/nested.mdx
+++ b/Documentation/projections/projection-declaration-language/nested.mdx
@@ -143,7 +143,7 @@ children tasks id taskId
 
 The nested property maps to a nullable property on the parent read model:
 
-<ChronicleClientTabs snippet="projections/projection-declaration-language/nested/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="projections/projection-declaration-language/nested/read-model" />
 
 ## Examples
 

--- a/Documentation/projections/tagging-projections.mdx
+++ b/Documentation/projections/tagging-projections.mdx
@@ -16,31 +16,31 @@ You can tag projections in multiple ways:
 
 Apply a single tag to your projection:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/single-tag" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/single-tag" />
 
 ### Multiple Tags (Single Attribute)
 
 Use the params feature to specify multiple tags in a single attribute:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/multiple-tags-single-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/multiple-tags-single-attribute" />
 
 ### Multiple Tags (Multiple Attributes)
 
 Apply multiple `[Tag]` attributes:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/multiple-tags-multiple-attributes" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/multiple-tags-multiple-attributes" />
 
 ### Mixed Approach
 
 Combine both approaches:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/mixed-approach" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/mixed-approach" />
 
 ## Model-Bound Projections
 
 Tags also work with model-bound projections:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/model-bound" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/model-bound" />
 
 ## Best Practices
 
@@ -53,7 +53,7 @@ Tags also work with model-bound projections:
 
 Here are some common patterns for tagging projections:
 
-<ChronicleClientTabs snippet="projections/tagging-projections/tag-categories" clients="csharp" />
+<ChronicleClientTabs snippet="projections/tagging-projections/tag-categories" />
 
 ## Querying by Tag
 

--- a/Documentation/reactors/event-processing.mdx
+++ b/Documentation/reactors/event-processing.mdx
@@ -14,7 +14,7 @@ Event parameter types must be marked with `[EventType]`.
 
 ## Supported Signatures
 
-<ChronicleClientTabs snippet="reactors/event-processing/supported-signatures" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/event-processing/supported-signatures" />
 
 `TResult` can be an event type or `IEnumerable<TEvent>`. See [Returning Side Effects](side-effects) for the full list of supported return types and metadata resolution.
 
@@ -24,13 +24,13 @@ This overload table is specific to C#'s method-overload-based dispatch. Kotlin, 
 
 The optional `EventContext` parameter provides metadata about the event, including the event source ID, sequence number, timestamps, and correlation identifiers.
 
-<ChronicleClientTabs snippet="reactors/event-processing/event-context" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/event-processing/event-context" />
 
 ## Taking Dependencies
 
 Beyond the event and `EventContext`, a handler method can take additional parameters that Chronicle resolves when the method runs. Only the first parameter is fixed; it is the event that drives dispatch.
 
-<ChronicleClientTabs snippet="reactors/event-processing/dependencies" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/event-processing/dependencies" />
 
 This is currently a C#-only capability. Kotlin, Elixir, and TypeScript reactor handlers accept only the event and, optionally, the event context — there's no mechanism to have Chronicle resolve and inject further parameters (services or strongly-consistent read models) into the handler call.
 
@@ -44,7 +44,7 @@ Each parameter after the event resolves as follows:
 
 By default the read model is materialized using the `EventSourceId` from the event context. When the key differs, implement `ICanResolveReadModelKey` on the reactor to return the `ReadModelKey` to use:
 
-<ChronicleClientTabs snippet="reactors/event-processing/read-model-key" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/event-processing/read-model-key" />
 
 The resolved key applies to every read model parameter across all of the reactor's handler methods. This is also currently C#-only, since it exists to customize the read-model-parameter resolution described above.
 

--- a/Documentation/reactors/event-sequence.mdx
+++ b/Documentation/reactors/event-sequence.mdx
@@ -6,7 +6,7 @@ By default, reactors observe the default event log. You can override this by spe
 
 Apply `[EventSequence]` directly to your reactor class to pin it to a specific event sequence:
 
-<ChronicleClientTabs snippet="reactors/event-sequence/event-sequence-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/event-sequence/event-sequence-attribute" />
 
 TypeScript reaches the same result through the `reactor()` decorator's `eventSequenceId` parameter shown below rather than a separate attribute. Kotlin, Java, and Elixir don't currently support targeting a non-default event sequence at all.
 
@@ -14,7 +14,7 @@ TypeScript reaches the same result through the `reactor()` decorator's `eventSeq
 
 When you are already using the `[Reactor]` attribute to set a custom identifier or other options, use its `eventSequence` parameter instead of adding a separate `[EventSequence]` attribute:
 
-<ChronicleClientTabs snippet="reactors/event-sequence/reactor-attribute" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="reactors/event-sequence/reactor-attribute" />
 
 Both approaches produce the same result. Prefer `[Reactor(eventSequence: ...)]` when you are already customizing the reactor with other parameters on that attribute.
 
@@ -22,7 +22,7 @@ Both approaches produce the same result. Prefer `[Reactor(eventSequence: ...)]` 
 
 Use `[EventLog]` when you want to be explicit that the reactor reads from the default event log, even when event types in the assembly carry a `[EventStore]` attribute pointing elsewhere:
 
-<ChronicleClientTabs snippet="reactors/event-sequence/event-log-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/event-sequence/event-log-attribute" />
 
 This convenience is C#-only — it exists to disambiguate against C#'s `[EventStore]` attribute on event types, which the other clients don't have.
 

--- a/Documentation/reactors/external-event-store-subscriptions.mdx
+++ b/Documentation/reactors/external-event-store-subscriptions.mdx
@@ -13,7 +13,7 @@ When all event types handled by a reactor come from the same source event store,
 
 This works when the source is declared on event types (or assembly) using `[EventStore("...")]`, and no explicit event sequence is configured on the reactor.
 
-<ChronicleClientTabs snippet="reactors/external-event-store-subscriptions/automatic-routing" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/external-event-store-subscriptions/automatic-routing" />
 
 ## Observer-Level EventStore for Missing Event Metadata
 
@@ -21,7 +21,7 @@ When event contracts cannot carry `[EventStore]` metadata, apply `[EventStore]` 
 
 Chronicle resolves the reactor to the inbox for that source event store and implicitly creates or reuses the outbox-to-inbox subscription.
 
-<ChronicleClientTabs snippet="reactors/external-event-store-subscriptions/observer-level-event-store" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/external-event-store-subscriptions/observer-level-event-store" />
 
 ## Implicit Combined Event Type Filtering
 

--- a/Documentation/reactors/filtering.mdx
+++ b/Documentation/reactors/filtering.mdx
@@ -12,7 +12,7 @@ A reactor observes all events that match its handler method signatures by defaul
 
 These attributes correlate directly to the metadata you provide when appending an event:
 
-<ChronicleClientTabs snippet="reactors/filtering/metadata-example" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/metadata-example" />
 
 :::note[Client coverage]
 Observer-level filtering by tag, event source type, or event stream type is currently C#-only. Kotlin's `@Reactor`, Elixir's `use Chronicle.Reactors.Reactor`, and TypeScript's `reactor()` all register a reactor without a way to attach these filters.
@@ -22,7 +22,7 @@ Observer-level filtering by tag, event source type, or event stream type is curr
 
 Append an event with a tag and place `[FilterEventsByTag]` on the reactor to receive only tagged events.
 
-<ChronicleClientTabs snippet="reactors/filtering/by-tag" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/by-tag" />
 
 `PriorityOrderNotifier` receives the event because the append call includes the `priority` tag. Orders appended without that tag are not dispatched.
 
@@ -30,25 +30,25 @@ Append an event with a tag and place `[FilterEventsByTag]` on the reactor to rec
 
 Multiple `[FilterEventsByTag]` attributes widen the match. The reactor receives the event if the appended event has any of the configured tags:
 
-<ChronicleClientTabs snippet="reactors/filtering/multiple-tags" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/multiple-tags" />
 
 ## Filter by event source type
 
 Place `[EventSourceType]` on the reactor to receive only events appended with a matching `eventSourceType`:
 
-<ChronicleClientTabs snippet="reactors/filtering/by-event-source-type" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/by-event-source-type" />
 
 ## Filter by event stream type
 
 Place `[EventStreamType]` on the reactor to receive only events appended to a matching stream type:
 
-<ChronicleClientTabs snippet="reactors/filtering/by-event-stream-type" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/by-event-stream-type" />
 
 ## Combine multiple filters
 
 You can combine `[FilterEventsByTag]`, `[EventSourceType]`, and `[EventStreamType]` on the same reactor. Chronicle requires all filter categories to match:
 
-<ChronicleClientTabs snippet="reactors/filtering/combine-filters" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/combine-filters" />
 
 The reactor only receives events that match all three: the `express` tag, the `shipment` event source type, and the `logistics` stream type.
 
@@ -56,7 +56,7 @@ The reactor only receives events that match all three: the `express` tag, the `s
 
 `[Tag]` and `[Tags]` on a reactor class label the reactor itself for organization and discoverability. They do not filter incoming events:
 
-<ChronicleClientTabs snippet="reactors/filtering/tag-vs-filter" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/filtering/tag-vs-filter" />
 
 ## Detailed guides
 

--- a/Documentation/reactors/getting-started.mdx
+++ b/Documentation/reactors/getting-started.mdx
@@ -8,25 +8,25 @@ Reactors do not build queryable state. Use a [projection](/chronicle/projections
 
 A reactor handles one or more event types. The event is still a normal Chronicle event: an immutable fact with a stable event type identity.
 
-<ChronicleClientTabs snippet="reactors/getting-started/event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/getting-started/event" />
 
 ## Define the reactor
 
 The client SDK decides how a reactor is declared. The common shape is the same: mark a type or module as a reactor, add a handler for the event, and accept event context when the side effect needs metadata such as sequence number, occurrence time, event store, namespace, or correlation.
 
-<ChronicleClientTabs snippet="reactors/getting-started/reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/getting-started/reactor" />
 
 ## Register the reactor
 
 Registration is client-specific. Some clients discover reactor types and register them as part of event-store startup. Others register a reactor instance or include the reactor module in client startup options.
 
-<ChronicleClientTabs snippet="reactors/getting-started/register" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/getting-started/register" />
 
 ## Use a stable reactor ID
 
 By default, clients derive a reactor identifier from the type or module name. Set an explicit ID when the reactor's identity must survive a rename. Changing the ID makes Chronicle treat it as a different observer, with a different observation position.
 
-<ChronicleClientTabs snippet="reactors/getting-started/stable-id" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/getting-started/stable-id" />
 
 ## Design for replay
 

--- a/Documentation/reactors/index.mdx
+++ b/Documentation/reactors/index.mdx
@@ -27,7 +27,7 @@ Reactors are a good fit when you need to:
 
 ## Basic Example
 
-<ChronicleClientTabs snippet="reactors/index/basic-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reactors/index/basic-example" />
 
 ## Topics
 

--- a/Documentation/reactors/once-only.mdx
+++ b/Documentation/reactors/once-only.mdx
@@ -6,7 +6,7 @@ for instance during a replay.
 There are scenarios where you need side effects to occur only on the initial event processing,
 such as sending notifications, triggering external integrations, or performing non-idempotent operations.
 
-<ChronicleClientTabs snippet="reactors/once-only/basic" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/once-only/basic" />
 
 The `OnceOnly` attribute ensures that the marked method is executed exactly once,
 providing a clean way to separate one-time operations from normal reactor behavior.

--- a/Documentation/reactors/side-effects.mdx
+++ b/Documentation/reactors/side-effects.mdx
@@ -12,7 +12,7 @@ Auto-appending a reactor handler's return value is currently C#-only. Kotlin and
 
 Return a single event directly from a handler method — synchronously or as a `Task<T>`:
 
-<ChronicleClientTabs snippet="reactors/side-effects/basic" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/basic" />
 
 The returned event is appended to the event log using the `EventSourceId` from the incoming `EventContext`. No `IEventLog` injection required.
 
@@ -20,7 +20,7 @@ The returned event is appended to the event log using the `EventSourceId` from t
 
 Return `IEnumerable<TEvent>` to append several events in one handler call:
 
-<ChronicleClientTabs snippet="reactors/side-effects/multiple" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/multiple" />
 
 ## Targeting a Specific Event Source Id
 
@@ -28,27 +28,27 @@ Everything above lands the returned event on the *triggering* event's `EventSour
 
 Picture a library. A member reserves a book, and that reservation is a fact about the *book*:
 
-<ChronicleClientTabs snippet="reactors/side-effects/source-event" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/source-event" />
 
 When it happens you want to record activity on the *member* — a different event source altogether. Return an `EventForEventSourceId` and pick the target `EventSourceId` yourself:
 
-<ChronicleClientTabs snippet="reactors/side-effects/specific-event-source" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/specific-event-source" />
 
 `MemberActivityRecorded` is appended to `@event.MemberId`, **not** to the book that triggered the reactor — so it shows up on the member's stream, ready for a member-activity projection to pick up.
 
 A single reservation usually ripples to more than one entity: the member gains activity, and the book loses stock. Return `IEnumerable<EventForEventSourceId>` to fan out to several event source ids in one go — they are appended together as a single transaction:
 
-<ChronicleClientTabs snippet="reactors/side-effects/fan-out" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/fan-out" />
 
 Each `EventForEventSourceId` is self-describing: alongside the source id it carries the event stream type and id, source type, subject, occurred time, tags and causation. Set only the ones you need — the rest fall back to sensible defaults:
 
-<ChronicleClientTabs snippet="reactors/side-effects/explicit-metadata" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/explicit-metadata" />
 
 > **Two modes**: a **bare event** uses the reactor's resolved metadata — its `[EventStreamType]`/`[EventSourceType]` attributes and `ICanProvide*` interfaces. An **`EventForEventSourceId`** is the *explicit* mode: it is self-describing and uses only the values on it, so the reactor's metadata does **not** apply (an unset field takes the append default such as `EventStreamType.All`, and an omitted `Subject` is resolved from the event). Reach for a bare event when you want "use my reactor's config", and an `EventForEventSourceId` when you want "I'll specify exactly where and how".
 
 You can also **mix** the two in a single `IEnumerable<object>` return — each bare event uses the reactor's resolved metadata and the triggering event source id, while each `EventForEventSourceId` keeps its own. They are appended together as one transaction:
 
-<ChronicleClientTabs snippet="reactors/side-effects/mixed" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/mixed" />
 
 ## Reactor-Level Metadata Resolution
 
@@ -58,25 +58,25 @@ Set metadata once on the reactor type so every returned event inherits it automa
 
 Implement this interface to supply a custom `EventSourceId` for all side-effect events from this reactor:
 
-<ChronicleClientTabs snippet="reactors/side-effects/provide-event-source-id" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/provide-event-source-id" />
 
 ### `ICanProvideSubject`
 
 Implement this interface to attach a `Subject` (e.g. a user or principal) to appended events:
 
-<ChronicleClientTabs snippet="reactors/side-effects/provide-subject" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/provide-subject" />
 
 ### `ICanProvideEventStreamId`
 
 Implement this interface to specify a runtime `EventStreamId`:
 
-<ChronicleClientTabs snippet="reactors/side-effects/provide-event-stream-id" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/provide-event-stream-id" />
 
 ### `[EventStreamType]` and `[EventSourceType]` Attributes
 
 Apply these attributes to the reactor class for a compile-time stream or source type:
 
-<ChronicleClientTabs snippet="reactors/side-effects/stream-and-source-type" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/stream-and-source-type" />
 
 ### Priority Order
 
@@ -92,7 +92,7 @@ Apply these attributes to the reactor class for a compile-time stream or source 
 
 Extend the pipeline by registering a custom `IReactorSideEffectHandler`:
 
-<ChronicleClientTabs snippet="reactors/side-effects/custom-handler" clients="csharp" />
+<ChronicleClientTabs snippet="reactors/side-effects/custom-handler" />
 
 ## Supported Return Types
 

--- a/Documentation/read-models/getting-collection-instances.mdx
+++ b/Documentation/read-models/getting-collection-instances.mdx
@@ -11,7 +11,7 @@ This is a strong-consistency operation. It is also proportional to event history
 
 Use collection replay when the result set is small enough to fit comfortably in memory and the caller needs state that includes every event appended so far.
 
-<ChronicleClientTabs snippet="read-models/getting-collection-instances/basic" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-collection-instances/basic" />
 
 Kotlin currently exposes single-instance read-model lookup only, so collection replay is not shown for that client.
 
@@ -19,7 +19,7 @@ Kotlin currently exposes single-instance read-model lookup only, so collection r
 
 Replay returns every instance. Apply language-native filtering after the read, and keep that in-memory cost in mind.
 
-<ChronicleClientTabs snippet="read-models/getting-collection-instances/filtering" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-collection-instances/filtering" />
 
 For large result sets, query the materialized sink directly or use a product-specific query model instead of replaying everything and filtering afterward.
 
@@ -27,7 +27,7 @@ For large result sets, query the materialized sink directly or use a product-spe
 
 You can cap the number of events Chronicle processes. This can make diagnostics faster, but it can also return incomplete state if the cap cuts off events that matter.
 
-<ChronicleClientTabs snippet="read-models/getting-collection-instances/event-count" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-collection-instances/event-count" />
 
 Use an event-count cap for historical analysis, back-testing, or bounded diagnostics. Do not use it when the reader expects the current truth.
 

--- a/Documentation/read-models/getting-single-instance.mdx
+++ b/Documentation/read-models/getting-single-instance.mdx
@@ -17,7 +17,7 @@ This makes the read strongly consistent. The cost is replay: longer histories ta
 
 The read model type must already be registered by the client, either as a model-bound projection, a declarative projection, or the read model produced by a reducer.
 
-<ChronicleClientTabs snippet="read-models/getting-single-instance/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-single-instance/basic" />
 
 Each client names the operation in its own idiom, but the inputs are the same: the read model type and the read model key.
 

--- a/Documentation/read-models/getting-snapshots.mdx
+++ b/Documentation/read-models/getting-snapshots.mdx
@@ -24,7 +24,7 @@ Every snapshot includes:
 
 The read model type must be registered, and the key must identify the read model instance you want to inspect.
 
-<ChronicleClientTabs snippet="read-models/getting-snapshots/basic" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-snapshots/basic" />
 
 Kotlin currently exposes single-instance read-model lookup only, so snapshots are not shown for that client.
 
@@ -32,7 +32,7 @@ Kotlin currently exposes single-instance read-model lookup only, so snapshots ar
 
 Snapshot data is usually most useful when you print or inspect the correlation ID, event count, timestamp, and resulting state together.
 
-<ChronicleClientTabs snippet="read-models/getting-snapshots/analyze" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/getting-snapshots/analyze" />
 
 If you need to compare two states, materialize the snapshot list and compare neighboring entries. Chronicle gives you the timeline; your diagnostic tool decides which properties matter.
 

--- a/Documentation/read-models/materialized-pagination.mdx
+++ b/Documentation/read-models/materialized-pagination.mdx
@@ -35,7 +35,7 @@ For those needs, inject the sink's native client directly. If your sink is Mongo
 
 `IMaterializedReadModels` is exposed through `IReadModels.Materialized`:
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/accessing-api" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/accessing-api" />
 
 ## Getting Instances
 
@@ -43,13 +43,13 @@ For those needs, inject the sink's native client directly. If your sink is Mongo
 
 Retrieve the first page of stored instances using the defaults (skip: 0, take: 50):
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/basic-usage" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/basic-usage" />
 
 ### Pagination
 
 Both `skip` and `take` are optional with sensible defaults. Use them for page-based or offset-based navigation:
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/pagination" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/pagination" />
 
 ### Pagination Parameters
 
@@ -60,17 +60,17 @@ The parameters use strongly-typed concepts that convert implicitly from `int`:
 | `skip` | `InstanceCountToSkip?` | `0` | `InstanceCountToSkip.Zero` |
 | `take` | `InstanceCount?` | `50` | `InstanceCount.Default`, `InstanceCount.Unlimited` |
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/named-constants" clients="csharp" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/named-constants" />
 
 ### Building a Paged API Endpoint
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/paged-endpoint" clients="csharp" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/paged-endpoint" />
 
 ## Observing Changes
 
 `ObserveInstances` returns an `IObservable<IEnumerable<TReadModel>>` that emits a new page snapshot whenever the underlying stored data changes. This is useful for live-updating UIs, dashboards, and monitoring tools.
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/observing" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/observing" />
 
 Observation relies on the sink's change stream mechanism:
 
@@ -82,7 +82,7 @@ Observation relies on the sink's change stream mechanism:
 
 ### Observing in a Service
 
-<ChronicleClientTabs snippet="read-models/materialized-pagination/observing-in-service" clients="csharp" />
+<ChronicleClientTabs snippet="read-models/materialized-pagination/observing-in-service" />
 
 ## When to Use the Materialized API
 

--- a/Documentation/read-models/watching-read-models.mdx
+++ b/Documentation/read-models/watching-read-models.mdx
@@ -24,7 +24,7 @@ The change carries the current read model state, not the previous state. If you 
 
 The read model type must be registered before you subscribe.
 
-<ChronicleClientTabs snippet="read-models/watching-read-models/basic" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="read-models/watching-read-models/basic" />
 
 Dispose, cancel, or break out of the subscription when the caller no longer needs updates. Long-lived subscriptions should be owned by a service with an explicit lifetime.
 
@@ -32,7 +32,7 @@ Dispose, cancel, or break out of the subscription when the caller no longer need
 
 Filter as close to the subscription as the client allows. This keeps application code focused on the state changes it actually cares about.
 
-<ChronicleClientTabs snippet="read-models/watching-read-models/filtering" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="read-models/watching-read-models/filtering" />
 
 Filtering happens client-side. If the client subscribes to a busy read model, the server still sends matching change notifications for that read model type.
 

--- a/Documentation/reducers/event-processing.mdx
+++ b/Documentation/reducers/event-processing.mdx
@@ -16,7 +16,7 @@ Reducers use convention-based method discovery. Chronicle automatically finds an
 - Accept the current read model state (nullable) as the second parameter
 - Optionally accept `EventContext` as the third parameter
 
-<ChronicleClientTabs snippet="reducers/event-processing/method-discovery" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/method-discovery" />
 
 ### Event Source Isolation
 
@@ -40,29 +40,29 @@ Events are guaranteed to be processed in sequence order:
 
 The simplest pattern accepts the event and current state:
 
-<ChronicleClientTabs snippet="reducers/event-processing/basic-sync-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/basic-sync-pattern" />
 
 ### Pattern with Event Context
 
 Access event metadata by adding `EventContext` parameter:
 
-<ChronicleClientTabs snippet="reducers/event-processing/pattern-with-context" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/pattern-with-context" />
 
 ### Async Patterns
 
 Both patterns support async methods:
 
-<ChronicleClientTabs snippet="reducers/event-processing/async-patterns" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/async-patterns" />
 
 ## Event Context
 
 The `EventContext` provides metadata about the event:
 
-<ChronicleClientTabs snippet="reducers/event-processing/event-context-shape" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/event-context-shape" />
 
 ### Using Event Context
 
-<ChronicleClientTabs snippet="reducers/event-processing/using-event-context" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/using-event-context" />
 
 ## Current State Parameter
 
@@ -76,7 +76,7 @@ When processing the first event for an event source:
 - Initialize your read model with appropriate values
 - You can return `null` (declare the handler's return type as `TReadModel?`) to skip creating state for certain events
 
-<ChronicleClientTabs snippet="reducers/event-processing/first-event" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/first-event" />
 
 ### Subsequent Events
 
@@ -92,31 +92,31 @@ For subsequent events:
 
 Accumulate values across events:
 
-<ChronicleClientTabs snippet="reducers/event-processing/accumulation-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/accumulation-pattern" />
 
 ### Pattern 2: State Transitions
 
 Track state changes through events:
 
-<ChronicleClientTabs snippet="reducers/event-processing/state-transitions-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/state-transitions-pattern" />
 
 ### Pattern 3: Collection Building
 
 Build collections from events:
 
-<ChronicleClientTabs snippet="reducers/event-processing/collection-building-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/collection-building-pattern" />
 
 ### Pattern 4: Time-Based Aggregation
 
 Aggregate events within time windows:
 
-<ChronicleClientTabs snippet="reducers/event-processing/time-based-aggregation-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/time-based-aggregation-pattern" />
 
 ### Pattern 5: Conditional Processing
 
 Skip processing based on conditions:
 
-<ChronicleClientTabs snippet="reducers/event-processing/conditional-processing-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/conditional-processing-pattern" />
 
 ## Error Handling
 
@@ -124,7 +124,7 @@ Skip processing based on conditions:
 
 When there's no state to build on yet, return `null` from a nullable-returning handler (`TReadModel? Handle(...)`) to leave the read model unset:
 
-<ChronicleClientTabs snippet="reducers/event-processing/skip-invalid-state" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/skip-invalid-state" />
 
 Note the difference between **skipping** an event and **removing** a read model: returning `null` when `current` was already `null` is a no-op, but returning `null` when `current` holds real state deletes that read model. To ignore an event without discarding existing state, return `current` unchanged instead.
 
@@ -132,7 +132,7 @@ Note the difference between **skipping** an event and **removing** a read model:
 
 Include error information in your read model:
 
-<ChronicleClientTabs snippet="reducers/event-processing/recording-errors" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/recording-errors" />
 
 ## Performance Optimization
 
@@ -140,13 +140,13 @@ Include error information in your read model:
 
 Leverage record types with `with` expressions:
 
-<ChronicleClientTabs snippet="reducers/event-processing/minimize-object-creation" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/minimize-object-creation" />
 
 ### Reuse Collections
 
 Copy a collection before mutating it — a previously-returned state instance may still be held by a snapshot or another reader, so mutating it in place can corrupt state you don't own:
 
-<ChronicleClientTabs snippet="reducers/event-processing/reuse-collections" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-processing/reuse-collections" />
 
 ## Best Practices
 

--- a/Documentation/reducers/event-sequence.mdx
+++ b/Documentation/reducers/event-sequence.mdx
@@ -6,7 +6,7 @@ By default, reducers observe the default event log. You can override this by spe
 
 Apply `[EventSequence]` directly to your reducer class to pin it to a specific event sequence:
 
-<ChronicleClientTabs snippet="reducers/event-sequence/event-sequence-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-sequence/event-sequence-attribute" />
 
 TypeScript reaches the same result through the `reducer()` decorator's event-sequence parameter shown below rather than a separate attribute. Kotlin, Java, and Elixir don't currently support targeting a non-default event sequence for a reducer at all.
 
@@ -14,7 +14,7 @@ TypeScript reaches the same result through the `reducer()` decorator's event-seq
 
 When you are already using the `[Reducer]` attribute to set a custom identifier or other options, use its `eventSequence` parameter instead of adding a separate `[EventSequence]` attribute:
 
-<ChronicleClientTabs snippet="reducers/event-sequence/reducer-attribute" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="reducers/event-sequence/reducer-attribute" />
 
 Both approaches produce the same result. Prefer `[Reducer(eventSequence: ...)]` when you are already customizing the reducer with other parameters on that attribute.
 
@@ -22,7 +22,7 @@ Both approaches produce the same result. Prefer `[Reducer(eventSequence: ...)]` 
 
 Use `[EventLog]` when you want to be explicit that the reducer reads from the default event log, even when event types in the assembly carry a `[EventStore]` attribute pointing elsewhere:
 
-<ChronicleClientTabs snippet="reducers/event-sequence/event-log-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/event-sequence/event-log-attribute" />
 
 This convenience is C#-only — it exists to disambiguate against C#'s `[EventStore]` attribute on event types, which the other clients don't have.
 

--- a/Documentation/reducers/external-event-store-subscriptions.mdx
+++ b/Documentation/reducers/external-event-store-subscriptions.mdx
@@ -13,7 +13,7 @@ When all event types reduced by a reducer come from the same source event store,
 
 This works when the source is declared on event types (or assembly) using `[EventStore("...")]`, and no explicit event sequence is configured on the reducer.
 
-<ChronicleClientTabs snippet="reducers/external-event-store-subscriptions/automatic-routing" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/external-event-store-subscriptions/automatic-routing" />
 
 ## Observer-Level EventStore for Missing Event Metadata
 
@@ -21,7 +21,7 @@ When event contracts cannot carry `[EventStore]` metadata, apply `[EventStore]` 
 
 Chronicle resolves the reducer to the inbox for that source event store and implicitly creates or reuses the outbox-to-inbox subscription.
 
-<ChronicleClientTabs snippet="reducers/external-event-store-subscriptions/observer-level-event-store" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/external-event-store-subscriptions/observer-level-event-store" />
 
 ## Implicit Combined Event Type Filtering
 

--- a/Documentation/reducers/filtering.mdx
+++ b/Documentation/reducers/filtering.mdx
@@ -12,7 +12,7 @@ A reducer observes all events that match its handler method signatures by defaul
 
 These attributes correlate directly to the metadata you provide when appending an event:
 
-<ChronicleClientTabs snippet="reducers/filtering/metadata-example" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/metadata-example" />
 
 :::note[Client coverage]
 Observer-level filtering by tag, event source type, or event stream type is currently C#-only. Kotlin's `@Reducer`, Elixir's `use Chronicle.Reducers.Reducer`, and TypeScript's `reducer()` all register a reducer without a way to attach these filters.
@@ -22,7 +22,7 @@ Observer-level filtering by tag, event source type, or event stream type is curr
 
 Append an event with a tag and place `[FilterEventsByTag]` on the reducer to accumulate state only from tagged events.
 
-<ChronicleClientTabs snippet="reducers/filtering/by-tag" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/by-tag" />
 
 `PriorityOrderTotalsReducer` updates only when the appended event carries the `priority` tag. Orders without that tag do not affect this read model.
 
@@ -30,13 +30,13 @@ Append an event with a tag and place `[FilterEventsByTag]` on the reducer to acc
 
 Multiple `[FilterEventsByTag]` attributes widen the match. The reducer receives the event if the appended event has any of the configured tags:
 
-<ChronicleClientTabs snippet="reducers/filtering/multiple-tags" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/multiple-tags" />
 
 ## Filter by event source type
 
 Place `[EventSourceType]` on the reducer to accumulate state only from events appended with a matching `eventSourceType`:
 
-<ChronicleClientTabs snippet="reducers/filtering/by-event-source-type" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/by-event-source-type" />
 
 If the same event is appended with `eventSourceType: "supplier"`, this reducer does not receive it.
 
@@ -44,13 +44,13 @@ If the same event is appended with `eventSourceType: "supplier"`, this reducer d
 
 Place `[EventStreamType]` on the reducer to accumulate state only from events appended to a matching stream type:
 
-<ChronicleClientTabs snippet="reducers/filtering/by-event-stream-type" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/by-event-stream-type" />
 
 ## Combine multiple filters
 
 You can combine `[FilterEventsByTag]`, `[EventSourceType]`, and `[EventStreamType]` on the same reducer. Chronicle requires all filter categories to match:
 
-<ChronicleClientTabs snippet="reducers/filtering/combine-filters" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/combine-filters" />
 
 The reducer only receives events that match all three: the `premium` tag, the `order` event source type, and the `fulfillment` stream type.
 
@@ -58,7 +58,7 @@ The reducer only receives events that match all three: the `premium` tag, the `o
 
 `[Tag]` and `[Tags]` on a reducer class label the reducer itself for organization and discoverability. They do not filter incoming events:
 
-<ChronicleClientTabs snippet="reducers/filtering/tag-vs-filter" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/filtering/tag-vs-filter" />
 
 ## Detailed guides
 

--- a/Documentation/reducers/getting-started.mdx
+++ b/Documentation/reducers/getting-started.mdx
@@ -16,13 +16,13 @@ Before you begin, ensure you have:
 
 First, create a record representing the state you want to compute:
 
-<ChronicleClientTabs snippet="reducers/getting-started/read-model" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reducers/getting-started/read-model" />
 
 ### 2. Implement the Reducer
 
 Create a reducer by implementing `IReducerFor<TReadModel>` with methods for each event type:
 
-<ChronicleClientTabs snippet="reducers/getting-started/reducer-implementation" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reducers/getting-started/reducer-implementation" />
 
 Kotlin, Java, and TypeScript handler methods only receive the event and the current state — unlike C# and Elixir, they don't get an `EventContext` parameter, so they can't use an event's metadata (like `Occurred`) when computing the next state.
 
@@ -32,11 +32,11 @@ Reducer methods are discovered by convention and support the following signature
 
 ### Synchronous Methods
 
-<ChronicleClientTabs snippet="reducers/getting-started/sync-signatures" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/getting-started/sync-signatures" />
 
 ### Asynchronous Methods
 
-<ChronicleClientTabs snippet="reducers/getting-started/async-signatures" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/getting-started/async-signatures" />
 
 These overload tables are specific to C#'s method-overload-based dispatch. Kotlin, Java, and TypeScript each dispatch reducer handlers by matching the first parameter's event type against a fixed 2-parameter (event, current) shape — no context parameter. TypeScript's dispatch does `await` the handler, so an `async` handler works there; Kotlin and Java invoke the handler directly and cannot await it, so a suspend/async handler isn't supported in those two. Elixir dispatches through a single `reduce/3` callback per event, pattern-matched by struct type, which does receive a context map.
 
@@ -52,7 +52,7 @@ These overload tables are specific to C#'s method-overload-based dispatch. Kotli
 
 You can customize the reducer using the `[Reducer]` attribute:
 
-<ChronicleClientTabs snippet="reducers/getting-started/reducer-attribute" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reducers/getting-started/reducer-attribute" />
 
 **Attribute parameters:**
 
@@ -66,7 +66,7 @@ Kotlin, Java, and Elixir only support setting a custom `id` — none of them cur
 
 Once your reducer is set up, you can retrieve the computed state:
 
-<ChronicleClientTabs snippet="reducers/getting-started/retrieving-state" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reducers/getting-started/retrieving-state" />
 
 ## Event Processing
 

--- a/Documentation/reducers/index.mdx
+++ b/Documentation/reducers/index.mdx
@@ -22,7 +22,7 @@ Reducers are ideal when you need to:
 
 ## Basic Example
 
-<ChronicleClientTabs snippet="reducers/index/basic-example" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="reducers/index/basic-example" />
 
 ## Topics
 

--- a/Documentation/reducers/passive-reducers.mdx
+++ b/Documentation/reducers/passive-reducers.mdx
@@ -34,13 +34,13 @@ There are two ways to make a reducer passive:
 
 Set the `isActive` parameter to `false` on the reducer class:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/reducer-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/reducer-attribute" />
 
 ### Option 2: Using the Passive Attribute on the Read Model
 
 Mark the read model class with the `[Passive]` attribute:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/passive-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/passive-attribute" />
 
 **Note:** The `[Passive]` attribute on the read model automatically makes all reducers targeting that read model passive, regardless of individual reducer settings.
 
@@ -60,31 +60,31 @@ This means the `[Passive]` attribute on the read model takes precedence over the
 
 Generate reports only when requested, avoiding the overhead of continuous state maintenance:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/on-demand-reports" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/on-demand-reports" />
 
 ### 2. Temporary Analysis
 
 Perform exploratory data analysis without polluting your persistent storage:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/temporary-analysis" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/temporary-analysis" />
 
 ### 3. Historical Snapshots
 
 Compute read model state at specific points in time without maintaining continuous state:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/historical-snapshots" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/historical-snapshots" />
 
 ### 4. Development and Testing
 
 During development, you might want to register reducers without activating them:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/development-testing" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/development-testing" />
 
 ## Retrieving State from Passive Reducers
 
 Passive reducers compute state on-demand using the same API as active reducers:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/retrieving-state" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/retrieving-state" />
 
 ## Performance Considerations
 
@@ -116,7 +116,7 @@ Passive reducers compute state on-demand using the same API as active reducers:
 
 You can change a reducer from active to passive (or vice versa) by updating the attribute:
 
-<ChronicleClientTabs snippet="reducers/passive-reducers/switching-active-passive" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/passive-reducers/switching-active-passive" />
 
 When you change the `isActive` setting:
 

--- a/Documentation/reducers/tagging-reducers.mdx
+++ b/Documentation/reducers/tagging-reducers.mdx
@@ -16,25 +16,25 @@ You can tag reducers in multiple ways:
 
 Apply a single tag to your reducer:
 
-<ChronicleClientTabs snippet="reducers/tagging-reducers/single-tag" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/tagging-reducers/single-tag" />
 
 ### Multiple Tags (Single Attribute)
 
 Use the params feature to specify multiple tags in a single attribute:
 
-<ChronicleClientTabs snippet="reducers/tagging-reducers/multiple-tags-single-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/tagging-reducers/multiple-tags-single-attribute" />
 
 ### Multiple Tags (Multiple Attributes)
 
 Apply multiple `[Tag]` attributes:
 
-<ChronicleClientTabs snippet="reducers/tagging-reducers/multiple-tags-multiple-attributes" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/tagging-reducers/multiple-tags-multiple-attributes" />
 
 ### Mixed Approach
 
 Combine both approaches:
 
-<ChronicleClientTabs snippet="reducers/tagging-reducers/mixed-approach" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/tagging-reducers/mixed-approach" />
 
 ## Best Practices
 
@@ -47,7 +47,7 @@ Combine both approaches:
 
 Here are some common patterns for tagging reducers:
 
-<ChronicleClientTabs snippet="reducers/tagging-reducers/tag-categories" clients="csharp" />
+<ChronicleClientTabs snippet="reducers/tagging-reducers/tag-categories" />
 
 ## Querying by Tag
 

--- a/Documentation/scenarios/react-to-an-event.mdx
+++ b/Documentation/scenarios/react-to-an-event.mdx
@@ -9,7 +9,7 @@ description: Run a side effect — send a notification, call an external system,
 
 A reactor is a class implementing the marker interface `IReactor`. You don't implement a method from it — you write a method whose **first parameter is the event type** you want to handle, and Chronicle routes matching events to it:
 
-<ChronicleClientTabs snippet="scenarios/react-to-an-event/basic-reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="scenarios/react-to-an-event/basic-reactor" />
 
 Chronicle discovers it by convention — no registration.
 
@@ -25,7 +25,7 @@ Reach for the event first — it carries the truth of what happened, and `contex
 You *can* read state from a reactor — just mind the consistency level. The **materialized** read model (what the projection writes to the sink) is [eventually consistent](../read-models/consistency.md) and may not have caught up with the very event you're reacting to. `IReadModels.GetInstanceById` is **strongly consistent**: it rebuilds the instance from the event log on demand, so it includes the event in your hand.
 :::
 
-<ChronicleClientTabs snippet="scenarios/react-to-an-event/reading-state" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="scenarios/react-to-an-event/reading-state" />
 
 The full menu of read APIs — single, all, paged, observed — is in [Get read models](./real-time-query).
 
@@ -33,13 +33,13 @@ The full menu of read APIs — single, all, paged, observed — is in [Get read 
 
 The common "translation" pattern — react to one slice's event by recording a new fact. The simplest way is to **return the event**: Chronicle appends it to the event log for you, against the triggering event's `EventSourceId`:
 
-<ChronicleClientTabs snippet="scenarios/react-to-an-event/return-event" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/react-to-an-event/return-event" />
 
 `Task<StockDecreased>` and collections of events work too, and you can control the target event source — see [Returning side effects](../reactors/side-effects). Auto-appending a returned event is C#-only — every other client appends explicitly instead, shown next.
 
 When you want to inspect the outcome yourself, append explicitly and handle the `AppendResult` — and **throw if it failed**, so the partition pauses instead of the fact being silently lost:
 
-<ChronicleClientTabs snippet="scenarios/react-to-an-event/explicit-append" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="scenarios/react-to-an-event/explicit-append" />
 
 ## See also
 

--- a/Documentation/scenarios/real-time-query.mdx
+++ b/Documentation/scenarios/real-time-query.mdx
@@ -13,7 +13,7 @@ Getting a single strongly-consistent instance (below) is real in every client. K
 
 `GetInstanceById` replays the key's events through the projection or reducer on demand — strongly consistent, reflecting everything appended up to this moment:
 
-<ChronicleClientTabs snippet="scenarios/real-time-query/get-one" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="scenarios/real-time-query/get-one" />
 
 `ReadModelKey` converts implicitly from `string`, `Guid`, and `EventSourceId`, so you can pass the id you already have.
 
@@ -21,19 +21,19 @@ Getting a single strongly-consistent instance (below) is real in every client. K
 
 `GetInstances` rebuilds every instance by replaying the event log — strongly consistent, suited to reads where accuracy beats latency. The cost grows with history; filter the result with LINQ:
 
-<ChronicleClientTabs snippet="scenarios/real-time-query/get-all" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/real-time-query/get-all" />
 
 ## Page through materialized state
 
 For list views and grids, skip the replay: `Materialized` reads the instances the projection has already persisted to the sink — eventually consistent (typically milliseconds behind), fast regardless of history, and paged:
 
-<ChronicleClientTabs snippet="scenarios/real-time-query/materialized-page" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/real-time-query/materialized-page" />
 
 ## Watch every change
 
 `Watch<T>()` returns an `IObservable<ReadModelChangeset<T>>` that emits whenever **any** instance of that read model type changes — the changeset carries the key, the new state, and whether the instance was removed:
 
-<ChronicleClientTabs snippet="scenarios/real-time-query/watch-changes" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/real-time-query/watch-changes" />
 
 Dispose the subscription when you're done. If you need explicit lifecycle control — for example awaiting the watcher's `Subscribed` before producing events — use `GetWatcherFor<Book>()` instead.
 
@@ -41,7 +41,7 @@ Dispose the subscription when you're done. If you need explicit lifecycle contro
 
 `Materialized.ObserveInstances` pushes a fresh page snapshot whenever the stored data changes — a live dashboard or table with no polling:
 
-<ChronicleClientTabs snippet="scenarios/real-time-query/observe-page" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/real-time-query/observe-page" />
 
 When a command appends `BookBorrowed`, the projection updates the materialized `Book` and every subscriber receives the new page. The brief gap between append and push is the normal [eventual consistency](../read-models/consistency.md) window — usually imperceptible.
 

--- a/Documentation/scenarios/test-a-slice.mdx
+++ b/Documentation/scenarios/test-a-slice.mdx
@@ -23,11 +23,11 @@ The examples below use the [Cratis Specifications](/testing-with-cratis/) style 
 
 `EventScenario` exercises the appending side. Seed pre-existing history with `Given`, append through `EventLog` exactly like production code does, and assert on the `AppendResult`:
 
-<ChronicleClientTabs snippet="scenarios/test-a-slice/append-spec" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/test-a-slice/append-spec" />
 
 Constraints are discovered automatically, the same way the real client discovers them. So given a unique-ISBN constraint (like the one in [Enforce a unique value](./enforce-a-unique-value.md)), seeding a book and appending a duplicate proves the rule fires:
 
-<ChronicleClientTabs snippet="scenarios/test-a-slice/constraint-spec" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/test-a-slice/constraint-spec" />
 
 Beyond `ShouldBeSuccessful`/`ShouldBeFailed` and `ShouldHaveConstraintViolationFor`, there are assertions for concurrency violations and errors — the full family is in [Append result assertions](../testing/events/assertions). Create a fresh `EventScenario` per spec and dispose it; the in-memory log accumulates state across calls on the same instance.
 
@@ -35,7 +35,7 @@ Beyond `ShouldBeSuccessful`/`ShouldBeFailed` and `ShouldHaveConstraintViolationF
 
 `ReadModelScenario<TReadModel>` exercises the deriving side: feed a history of events through the **real projection or reducer engine** and assert on the resulting instance. It auto-detects how the read model is built — reducer, fluent projection, or model-bound attributes:
 
-<ChronicleClientTabs snippet="scenarios/test-a-slice/read-model-spec" clients="csharp" />
+<ChronicleClientTabs snippet="scenarios/test-a-slice/read-model-spec" />
 
 For a read model spec the event history **is** the act — `Given` supplies the input, `Instance` is the output. If the spec fails, your mapping (`[SetFrom<T>]`/`[SetValue<T>]` attributes or reducer logic) is wrong, because the engine applying it is the real one.
 

--- a/Documentation/sinks/index.mdx
+++ b/Documentation/sinks/index.mdx
@@ -32,7 +32,7 @@ This allows teams using SQL databases (SQL Server, PostgreSQL, SQLite) to take a
 
 Set `DefaultSinkTypeId` in `ChronicleOptions`:
 
-<ChronicleClientTabs snippet="sinks/index/enable-sql-sink" clients="csharp" />
+<ChronicleClientTabs snippet="sinks/index/enable-sql-sink" />
 
 Or in `appsettings.json`:
 
@@ -50,7 +50,7 @@ Or in `appsettings.json`:
 
 The SQL sink is provided by the `Cratis.Chronicle.Storage.Sql` NuGet package. Add it to your Kernel host project and register it in the `IChronicleBuilder`:
 
-<ChronicleClientTabs snippet="sinks/index/register-sql-storage" clients="csharp" />
+<ChronicleClientTabs snippet="sinks/index/register-sql-storage" />
 
 Refer to the hosting documentation for full server setup details.
 

--- a/Documentation/subscriptions/explicit-subscriptions.mdx
+++ b/Documentation/subscriptions/explicit-subscriptions.mdx
@@ -24,7 +24,7 @@ Explicit subscriptions are real in Elixir (`Chronicle.subscribe_to_event_store/3
 
 Use the `Subscriptions` property on `IEventStore` to subscribe:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/basic" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/basic" />
 
 The three arguments are:
 
@@ -40,29 +40,29 @@ The subscription ID must be unique within the target event store. It serves as t
 
 A typical naming convention:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/naming-convention" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/naming-convention" />
 
 ## Filtering Event Types
 
 Without a configuration callback, **all events** from the source outbox are forwarded. Use `WithEventType<T>()` to limit the subscription to specific types:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/filtering" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/filtering" />
 
 If you need to subscribe to all events without filtering, omit the configuration callback entirely:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/no-filter" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/no-filter" />
 
 ## Accessing Forwarded Events
 
 Events forwarded via an explicit subscription are placed into the inbox sequence for the source event store. Access inbox events through any observer (reactor, projection, reducer):
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/inbox-reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/inbox-reactor" />
 
 The kernel automatically routes incoming events to the appropriate `inbox-{sourceEventStore}` event sequence. You do not need to reference the subscription ID when observing the events.
 
 ## Removing a Subscription
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/unsubscribe" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/unsubscribe" />
 
 Calling `Unsubscribe` with the subscription ID:
 - Stops event forwarding from the source outbox
@@ -77,7 +77,7 @@ Subscriptions are identified by their subscription ID. Calling `Subscribe` with 
 
 This makes it safe to register all subscriptions at application startup without checking if they already exist:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/startup-registration" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/startup-registration" />
 
 If any of these subscriptions already exist on the kernel, they are left unchanged.
 
@@ -94,7 +94,7 @@ Explicit subscriptions are **kernel-managed** and **persistent**:
 
 A common pattern is to register all subscriptions once during application startup:
 
-<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/typical-pattern" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/explicit-subscriptions/typical-pattern" />
 
 ## When to Use Explicit Subscriptions
 

--- a/Documentation/subscriptions/implicit-subscriptions.mdx
+++ b/Documentation/subscriptions/implicit-subscriptions.mdx
@@ -23,7 +23,7 @@ When every event type handled by an observer shares the same `[EventStore]` attr
 
 Apply `[EventStore]` to any event type that originates from a foreign event store:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/event-store-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/event-store-attribute" />
 
 The string argument is the **name of the source event store** — the same name you would use if setting up an explicit subscription.
 
@@ -33,7 +33,7 @@ A common pattern is to publish your public event contracts as a NuGet package. C
 
 A typical public events package looks like this:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/nuget-package" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/nuget-package" />
 
 ## Assembly-Level Configuration with `[EventStore]`
 
@@ -123,7 +123,7 @@ MSBuild will emit `[assembly: Cratis.Chronicle.Events.EventStoreAttribute("fulfi
 
 Now your event types only need `[EventType]`:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/event-types-with-assembly-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/event-types-with-assembly-attribute" />
 
 All events in this assembly are automatically associated with the `fulfillment-service` event store.
 
@@ -141,7 +141,7 @@ All events in this assembly are automatically associated with the `fulfillment-s
 
 Example consumer setup:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/consumer-setup" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/consumer-setup" />
 
 ## Automatic Inbox Routing for Observers
 
@@ -152,7 +152,7 @@ Automatic inbox routing is documented per observer type:
 
 ### Projections
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/projection" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/projection" />
 
 ## Subscription Lifecycle
 
@@ -167,11 +167,11 @@ The kernel automatically manages the implicit subscription:
 
 An observer may only handle event types from a **single** event store. Mixing types annotated with different `[EventStore]` values on the same observer throws `MultipleEventStoresDefined` at startup:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/mixing-not-allowed" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/mixing-not-allowed" />
 
 To observe events from multiple sources, create a separate observer for each source event store:
 
-<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/separate-reactors" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/implicit-subscriptions/separate-reactors" />
 
 ## Schema Registration and Metadata
 

--- a/Documentation/subscriptions/outbox-inbox.mdx
+++ b/Documentation/subscriptions/outbox-inbox.mdx
@@ -12,7 +12,7 @@ The outbox exists by convention — you do not need to create it. Append events 
 
 When event store **A** subscribes to event store **B**, Chronicle automatically manages an **inbox** sequence on A for events forwarded from B. The well-known inbox sequence is `EventSequenceId.Inbox`, and the per-source inbox identifier is derived from the source event store name using `EventSequenceId.InboxPrefix`:
 
-<ChronicleClientTabs snippet="subscriptions/outbox-inbox/inbox-id" clients="csharp" />
+<ChronicleClientTabs snippet="subscriptions/outbox-inbox/inbox-id" />
 
 `EventSequenceId.InboxPrefix` is a small C#-only convenience constant — the other clients don't have a dedicated helper for it, since the inbox sequence id itself (`"inbox-<source-event-store>"`) is just a plain string wherever event sequence ids are used.
 
@@ -46,7 +46,7 @@ The `EventStoreSubscriptionObserverSubscriber` grain on the Kernel side observes
 
 Client-side observers (reactors, projections, reducers) can target `EventSequenceId.Inbox` to process all events arriving from subscribed sources. The client SDK automatically routes inbox-targeted observers to the correct per-source inbox sequence.
 
-<ChronicleClientTabs snippet="subscriptions/outbox-inbox/inbox-reactor" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="subscriptions/outbox-inbox/inbox-reactor" />
 
 ## See Also
 

--- a/Documentation/testing/event-append-collection.mdx
+++ b/Documentation/testing/event-append-collection.mdx
@@ -28,7 +28,7 @@ collection definition so every test class in the project shares one `ChronicleIn
 `Specification` convenience base that closes the generic `Specification<TChronicleFixture>` over
 your fixture type:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/scope-lifetime" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/scope-lifetime" />
 
 Every other example on this page builds on this same setup.
 
@@ -37,7 +37,7 @@ Every other example on this page builds on this same setup.
 Create a scope immediately before the operation under test so no earlier events are captured. Dispose
 it when the operation is done. The recommended pattern, on a `given` context class:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/scope-lifetime" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/scope-lifetime" />
 
 Disposal unsubscribes the collection immediately. Any appends that occur after disposal are not
 captured, which prevents tests sharing a fixture from interfering with each other.
@@ -81,13 +81,13 @@ full outcome of the operation:
 Pairing the `given` context above with a `Given<TSetup>`-derived spec class gives you access to the
 collected events through `Context`:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/single-event" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/single-event" />
 
 ### Multiple events
 
 When several events land in the same collection scope, use LINQ to locate the one you want:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/multiple-events" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/multiple-events" />
 
 ## Waiting for Asynchronous Appends
 
@@ -95,15 +95,15 @@ When a reactor appends events after handling an incoming event, those appends ha
 on the server. Use `WaitForCount()` to wait for the expected number of events to arrive before
 asserting. The events and reactor:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/shipment-events-and-reactor" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/shipment-events-and-reactor" />
 
 The shared `given` context:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/shipment-given-context" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/shipment-given-context" />
 
 The spec, waiting for both the original event and the reactor's follow-up to be captured:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/shipment-spec" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/shipment-spec" />
 
 `WaitForCount` accepts an optional `TimeSpan` timeout (default: 5 seconds) and throws
 `TimeoutException` if the expected count is not reached in time. `WaitTillActive()` ensures the
@@ -114,17 +114,17 @@ reactor is registered and listening on the server before the test appends the tr
 When a reactor appends directly and the append is rejected by a constraint, the violation is captured
 on the `AppendedEventWithResult.Result` instead of throwing. The events, constraint, and reactor:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/violation-events-and-reactor" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/violation-events-and-reactor" />
 
 The shared `given` context:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/violation-given-context" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/violation-given-context" />
 
 The spec appends the same unique value from two different event sources — the reactor's second
 follow-up violates the uniqueness constraint, so `HasConstraintViolations` is `true` and `IsSuccess`
 is `false` for that entry, while the append itself still completes and is captured in the collection:
 
-<ChronicleClientTabs snippet="testing/event-append-collection/violation-spec" clients="csharp" />
+<ChronicleClientTabs snippet="testing/event-append-collection/violation-spec" />
 
 ## Full Example
 

--- a/Documentation/testing/events/assertions.mdx
+++ b/Documentation/testing/events/assertions.mdx
@@ -24,29 +24,29 @@ All `Should*` methods throw `AppendResultAssertionException` on failure. The exc
 
 ## Happy path assertion
 
-<ChronicleClientTabs snippet="testing/events/assertions/happy-path" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/happy-path" />
 
 ## Failure assertions
 
-<ChronicleClientTabs snippet="testing/events/assertions/failure" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/failure" />
 
 ## Constraint violation assertions
 
 Assert that a specific named constraint fired:
 
-<ChronicleClientTabs snippet="testing/events/assertions/constraint-violation" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/constraint-violation" />
 
 Assert that no constraint violations occurred:
 
-<ChronicleClientTabs snippet="testing/events/assertions/no-constraint-violation" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/no-constraint-violation" />
 
 ## Concurrency violation assertions
 
-<ChronicleClientTabs snippet="testing/events/assertions/concurrency" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/concurrency" />
 
 ## Error assertions
 
-<ChronicleClientTabs snippet="testing/events/assertions/errors" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/errors" />
 
 For asserting on the event sequence itself (tail sequence number, event types, and event content), see [Event Sequence Assertions](event-sequence-assertions).
 
@@ -54,4 +54,4 @@ For asserting on the event sequence itself (tail sequence number, event types, a
 
 Pre-seed state with `Given`, act with `When`, then assert on the captured `scenario.AppendResult` — including constraints declared on `ConceptAs<T>` properties:
 
-<ChronicleClientTabs snippet="testing/events/assertions/constraint-e2e" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/assertions/constraint-e2e" />

--- a/Documentation/testing/events/event-sequence-assertions.mdx
+++ b/Documentation/testing/events/event-sequence-assertions.mdx
@@ -30,7 +30,7 @@ All methods are async and return `Task`. They throw `EventSequenceAssertionExcep
 
 The tail sequence number is the sequence number of the last event appended to the sequence. Use `ShouldHaveTailSequenceNumber` to verify the expected number of events were appended:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/tail-sequence-number" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/tail-sequence-number" />
 
 Sequence numbers are zero-based, so the first event has sequence number `0` and the second has `1`. The special value `EventSequenceNumber.Unavailable` indicates no events have been appended.
 
@@ -38,33 +38,33 @@ Sequence numbers are zero-based, so the first event has sequence number `0` and 
 
 Use `ShouldHaveAppendedEvent<TEvent>` without a sequence number to verify that at least one event of the expected type was appended anywhere in the sequence:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-by-type" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-by-type" />
 
 When you know the exact position, pass a sequence number to assert at a specific location:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-at-position" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-at-position" />
 
 ## Verifying event content
 
 Pass a validator action to inspect the event content. The assertion fails if the event is not of the expected type or if the validator throws:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/validator" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/validator" />
 
 Without a sequence number, the validator runs against the first event of the matching type:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/validator-no-sequence" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/validator-no-sequence" />
 
 ## Verifying with a predicate
 
 Pass a `Func<TEvent, bool>` predicate when you only need to check whether the event satisfies a condition. The assertion fails if no event of the expected type returns `true` from the predicate:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/predicate" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/predicate" />
 
 ## Verifying event content for a specific event source
 
 When events for multiple event sources exist in the same sequence, filter by event source to avoid ambiguity. All event source overloads support both `Action<TEvent>` validators and `Func<TEvent, bool>` predicates:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/by-event-source" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/by-event-source" />
 
 ## AppendedEventWithResult assertions
 
@@ -95,12 +95,12 @@ All [append result assertions](assertions) are available directly on `AppendedEv
 
 ### Example: asserting on a collected event
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-with-result" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/appended-event-with-result" />
 
 ## Full example
 
 The following test pre-seeds state, appends two events, and then verifies both the tail sequence number and individual event content:
 
-<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/full-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/event-sequence-assertions/full-example" />
 
 For asserting on the result of an individual append operation, see [Append Assertions](assertions).

--- a/Documentation/testing/events/scenario.mdx
+++ b/Documentation/testing/events/scenario.mdx
@@ -22,7 +22,7 @@ dotnet add package Cratis.Chronicle.Testing
 
 ## Basic usage
 
-<ChronicleClientTabs snippet="testing/events/scenario/basic" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/basic" />
 
 `EventLog` and `EventSequence` are backed by the same in-memory store. Use `EventLog` for domain tests (it maps to `EventSequenceId.Log`). Use `EventSequence` when you need a generic `IEventSequence` reference.
 
@@ -30,11 +30,11 @@ dotnet add package Cratis.Chronicle.Testing
 
 Use the fluent `Given` builder to put the in-memory event log into a known state **before** running the act phase:
 
-<ChronicleClientTabs snippet="testing/events/scenario/given" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/given" />
 
 Chain multiple `ForEventSource` calls to seed events for different event sources in the same scenario:
 
-<ChronicleClientTabs snippet="testing/events/scenario/given-multiple-sources" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/given-multiple-sources" />
 
 **Rules:**
 - Call `Given` before the act phase — seeded events get monotonically increasing sequence numbers.
@@ -44,7 +44,7 @@ Chain multiple `ForEventSource` calls to seed events for different event sources
 
 `When` mirrors `Given`: where `Given` seeds pre-existing state, `When` performs the act under test. It appends the event(s) through the same in-memory kernel grain and returns the resulting `AppendResult` — the same "the act returns its result" shape as `CommandScenario.Execute` — so a constraint or append spec reads with `Given` / `When` / `then` symmetry without binding the raw `Append` overload by hand:
 
-<ChronicleClientTabs snippet="testing/events/scenario/when-builder" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/when-builder" />
 
 The returned value is an `AppendResult`, so every [append assertion](assertions) is available on it. When you supply more than one event to a single `When`, each is appended in order and the result of the final append is returned.
 
@@ -52,7 +52,7 @@ The returned value is an `AppendResult`, so every [append assertion](assertions)
 
 `AppendMany` appends a collection of events in one call and returns an `AppendManyResult`:
 
-<ChronicleClientTabs snippet="testing/events/scenario/append-many" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/append-many" />
 
 ## Isolation
 
@@ -60,6 +60,6 @@ Create a **new `EventScenario` instance per test** to keep tests isolated. The i
 
 ## Example: full test
 
-<ChronicleClientTabs snippet="testing/events/scenario/full-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/events/scenario/full-example" />
 
 For information on asserting the result of an append operation, see [Assertions](assertions).

--- a/Documentation/testing/index.mdx
+++ b/Documentation/testing/index.mdx
@@ -30,7 +30,7 @@ Use `Cratis.Testing` instead of `Cratis.Chronicle.Testing` when the same spec al
 
 ## A specification-shaped example
 
-<ChronicleClientTabs snippet="testing/index/example-spec" clients="csharp" />
+<ChronicleClientTabs snippet="testing/index/example-spec" />
 
 The projection runs in-process, but the spec still reads like the domain: given the `AuthorRegistered` fact, the `Author` read model should contain the name the screen needs.
 

--- a/Documentation/testing/reactors/scenario.mdx
+++ b/Documentation/testing/reactors/scenario.mdx
@@ -24,7 +24,7 @@ dotnet add package Cratis.Chronicle.Testing
 
 ## Basic usage
 
-<ChronicleClientTabs snippet="testing/reactors/scenario/basic" clients="csharp" />
+<ChronicleClientTabs snippet="testing/reactors/scenario/basic" />
 
 `Given` is a fluent builder: call `ForEventSource(id)` to specify the event source, then `Events(...)` to route events through the reactor in order.
 
@@ -32,17 +32,17 @@ dotnet add package Cratis.Chronicle.Testing
 
 Pass an `IServiceProvider` to the constructor to supply mocks and stubs that the reactor depends on:
 
-<ChronicleClientTabs snippet="testing/reactors/scenario/injecting-dependencies" clients="csharp" />
+<ChronicleClientTabs snippet="testing/reactors/scenario/injecting-dependencies" />
 
 When no `IServiceProvider` is provided, `ReactorScenario<TReactor>` uses a `DefaultServiceProvider` that constructs the reactor via its default constructor.
 
 ## Example: email notification
 
-<ChronicleClientTabs snippet="testing/reactors/scenario/email-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/reactors/scenario/email-example" />
 
 ## Example: multiple events across event sources
 
-<ChronicleClientTabs snippet="testing/reactors/scenario/multiple-sources" clients="csharp" />
+<ChronicleClientTabs snippet="testing/reactors/scenario/multiple-sources" />
 
 ## Notes
 

--- a/Documentation/testing/read-models/scenario.mdx
+++ b/Documentation/testing/read-models/scenario.mdx
@@ -24,7 +24,7 @@ dotnet add package Cratis.Chronicle.Testing
 
 ## Basic usage
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/basic" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/basic" />
 
 `Given` is a fluent builder: call `ForEventSource(id)` to specify the event source, then `Events(...)` to feed events through the read model's projection or reducer in order. The result is stored in `Instance`.
 
@@ -32,13 +32,13 @@ dotnet add package Cratis.Chronicle.Testing
 
 Pass an initial state to the constructor when the read model starts from a non-default baseline:
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/initial-state" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/initial-state" />
 
 ## Injecting dependencies
 
 Pass an `IServiceProvider` to the constructor to supply mocks and stubs that the reducer or projection depends on:
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/injecting-dependencies" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/injecting-dependencies" />
 
 ## Pre-seeding read model instances
 
@@ -46,7 +46,7 @@ Use `Given.ForEventSourceId(id).ReadModel(instance)` to register a pre-built rea
 production code under test that calls `IReadModels.GetInstanceById`. This lets you test a service that
 fetches a read model by ID without replaying events through a full projection:
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/preseeding-instances" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/preseeding-instances" />
 
 `scenario.ReadModels` returns an `IReadModels` instance that intercepts `GetInstanceById` for registered
 instances and delegates everything else to the real read model implementation.
@@ -63,15 +63,15 @@ If none are found, `NoReadModelHandlerFound` is thrown.
 
 ## Example: reducer
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/reducer-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/reducer-example" />
 
 ## Example: fluent projection
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/fluent-projection-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/fluent-projection-example" />
 
 ## Example: model-bound projection
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/model-bound-example" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/model-bound-example" />
 
 ## Child collections
 
@@ -83,13 +83,13 @@ If none are found, `NoReadModelHandlerFound` is thrown.
 
 Both same-event-source children (parent and child events share one event source) and cross-stream children (child events on their own event source, linked with `parentKey`) are supported, and two events carrying the same child key merge into a single child — matching the real sink.
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/children" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/children" />
 
 ## Multiple instances (joins and cross-stream)
 
 `Instance` returns a single threaded result, which is ambiguous when events span more than one event source — for example a `[Join]`, whose join-source event materializes a second instance. For those specs, assert against a specific instance with `InstanceForEventSourceId`, which resolves the intended instance from the sink even when another source's event was seeded first:
 
-<ChronicleClientTabs snippet="testing/read-models/scenario/multiple-instances" clients="csharp" />
+<ChronicleClientTabs snippet="testing/read-models/scenario/multiple-instances" />
 
 `Instances` exposes every materialized instance keyed by its event source id. Both are populated for projections; reducers are single-instance and expose their result through `Instance`.
 

--- a/Documentation/tutorial/first-event.mdx
+++ b/Documentation/tutorial/first-event.mdx
@@ -11,7 +11,7 @@ Your instinct, coming from most databases, is probably to create a `Book` row an
 
 So let's name it. A `BookAdded` event, as a `record` marked with `[EventType]`:
 
-<ChronicleClientTabs snippet="tutorial/first-event/book-added" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/first-event/book-added" />
 
 A couple of things worth noticing here:
 
@@ -22,7 +22,7 @@ A couple of things worth noticing here:
 
 Every event is about *something* — here, a specific book. Chronicle calls that the **event source**, and the events that share a source form that book's own little stream of history. In C#, we'll identify a book with a strongly-typed id rather than a bare `Guid`, so the compiler stops us from ever mixing a book's id up with, say, a member's:
 
-<ChronicleClientTabs snippet="tutorial/first-event/book-id" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/first-event/book-id" />
 
 By inheriting from `EventSourceId<Guid>`, `BookId` becomes a specialized concept — a `ConceptAs<>` targeting `EventSourceId` — so it converts to and from the stream key automatically: you hand a `BookId` straight to Chronicle, no ceremony. And because the *type itself* says "I am an event source id", conventions elsewhere in the stack pick it up — [Arc](/arc/), for instance, recognizes an `EventSourceId`-derived parameter on a command and resolves which stream to write to without any wiring from you. One small record, and the whole stack knows what a book's identity is. The [event source concept](../concepts/event-source.md) goes deeper on how these per-thing streams of facts work.
 
@@ -32,7 +32,7 @@ Kotlin, Java, Elixir, and TypeScript don't currently have an equivalent typed-id
 
 Now the moment itself. With a `ChronicleClient` connected to your event store, append the event against the book's id (in C#, the strongly-typed `BookId`; in the other clients, a plain string you generate yourself):
 
-<ChronicleClientTabs snippet="tutorial/first-event/append" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/first-event/append" />
 
 Run it. Nothing dramatic appears on screen — and that's exactly right. Behind that one line, Chronicle validated the event against its registered schema, assigned it the next sequence number, and committed it to the **event log** — permanently, and in order. The fact is now part of your system's history; nothing will ever quietly overwrite it.
 

--- a/Documentation/tutorial/reacting.mdx
+++ b/Documentation/tutorial/reacting.mdx
@@ -18,7 +18,7 @@ tf 02 processor Library.WaitlistNotifier
 
 `IReactor` is a marker — there's no method to override. Instead you write a method whose **first parameter is the event you care about**, and Chronicle routes matching events to it. So "when a book is returned, notify the next person" reads almost exactly like that in code:
 
-<ChronicleClientTabs snippet="tutorial/reacting/waitlist-notifier" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/waitlist-notifier" />
 
 Chronicle discovers this by convention — no registration, no wiring. Drop the class in, and every `BookReturned` now flows to it.
 
@@ -28,7 +28,7 @@ Here's the rule that catches everyone once: **a reactor may run more than once f
 
 For side effects that genuinely must never repeat — a physical letter, a payment — Chronicle gives you `[OnceOnly]`. Put it on the reactor class, or on just one handler method, and that handler is **excluded from replay** entirely: redactions, revisions, and observer rewinds all skip it, so it runs only once per event.
 
-<ChronicleClientTabs snippet="tutorial/reacting/once-only" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/once-only" />
 
 Kotlin, Java, Elixir, and TypeScript don't currently have an equivalent to `[OnceOnly]` — replay/redaction exclusion for a specific handler is C#-only for now.
 
@@ -37,23 +37,23 @@ Use it deliberately, though — the same guarantee means a `[OnceOnly]` handler 
 :::tip[Two things you can do — keep these in mind]
 **Read state — at the right consistency level.** `BookReturned` carries no title, so a friendlier notification ("*The Pragmatic Programmer* is back!") needs the `Book` read model. Just know your [consistency levels](../concepts/consistency.md): the materialized collection you queried last chapter is *eventually* consistent — it may not have caught up with the very event you're handling. When a decision needs current state — and it usually does — go through the strongly consistent `IReadModels` interface instead, which [re-derives the instance from the event log on demand](../read-models/getting-single-instance):
 
-<ChronicleClientTabs snippet="tutorial/reacting/reading-state" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/reading-state" />
 
 Kotlin and Java reactor handlers can't currently await Chronicle's asynchronous read-model or append APIs from inside a handler method, and TypeScript reactors are always constructed without arguments, so there's no way to inject an event store reference into one — this pattern is C#/Elixir only for now.
 
 **Produce new facts.** Reacting often *is* a new fact — "we told the next member" deserves its own event:
 
-<ChronicleClientTabs snippet="tutorial/reacting/notification-sent-event" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/notification-sent-event" />
 
 You can append it yourself — but then **handle the result**, and throw if it failed, so the failure surfaces (and the partition pauses for a retry) instead of the fact silently going missing:
 
-<ChronicleClientTabs snippet="tutorial/reacting/explicit-append" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/explicit-append" />
 
 Same limitation as reading state above: Kotlin, Java, and TypeScript can't append from inside a reactor handler this way yet — Elixir can, since `Chronicle.append/2` doesn't need an injected reference.
 
 Or skip the plumbing with **side effects**: return the event from the handler, and Chronicle appends it to the event log for you — against the same book's stream:
 
-<ChronicleClientTabs snippet="tutorial/reacting/side-effect" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/reacting/side-effect" />
 
 Returning an event for Chronicle to auto-append is a C#-only convention — Kotlin, Elixir, and TypeScript reactors don't have an equivalent, so they append explicitly (as above) instead.
 

--- a/Documentation/tutorial/read-model.mdx
+++ b/Documentation/tutorial/read-model.mdx
@@ -20,7 +20,7 @@ tf 04 readmodel Library.Book ->> 01 ->> 02 ->> 03
 
 A book doesn't just arrive; it gets borrowed and brought back. Those are facts too, so they're events:
 
-<ChronicleClientTabs snippet="tutorial/read-model/a-events" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/read-model/a-events" />
 
 Notice `BookReturned` has no data at all — and that's fine. The fact that it *happened*, on a particular book's stream, at a particular time, is the whole story. Not every event needs a payload.
 
@@ -28,7 +28,7 @@ Notice `BookReturned` has no data at all — and that's fine. The fact that it *
 
 Here's the shift. In a database you'd write code to keep a `Books` table in sync — insert on add, update a flag on borrow, update it back on return. In Chronicle you instead **declare the shape you want** and tell it which events feed it. Chronicle does the keeping-in-sync for you. That declaration is a [projection](/chronicle/concepts/projection/):
 
-<ChronicleClientTabs snippet="tutorial/read-model/book" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/read-model/book" />
 
 Read the attributes as a sentence: a book is *made from* `BookAdded` — its `Title` and `Isbn` come straight off the event; `OnLoan` is `false` when the book is added, `true` when it's borrowed, and `false` again when it's returned; `BorrowedBy` is set to whoever borrowed it. You're *declaring* how each fact maps onto the view — not writing imperative updates, not worrying about ordering. Chronicle replays the events in order and applies your mapping.
 
@@ -46,7 +46,7 @@ Kotlin and Java's model-bound projections don't currently have an equivalent to 
 
 By default Chronicle **materializes** the projection into its configured **sink** storage — MongoDB unless you change it — so the `Book` read model is just a collection you query, exactly what you're used to:
 
-<ChronicleClientTabs snippet="tutorial/read-model/query" clients="csharp" />
+<ChronicleClientTabs snippet="tutorial/read-model/query" />
 
 Now exercise it. Append a `BookBorrowed` for your book and query again — `OnLoan` is `true`, and `BorrowedBy` has the member's name. Append a `BookReturned` and it flips back. You never wrote an `UPDATE`. The projection did it, by re-deriving the book from its events.
 
@@ -58,13 +58,13 @@ The read model updates *just after* the event is appended, not in the same insta
 
 The catalog answers "what books do we have?" — but the librarian's most common question at the desk is sharper: *what's out on loan right now?* You could filter `Book` on `OnLoan`, and we just did. But there's a more direct way to model it: a read model whose instances **exist only while the book is out**. A `BorrowedBook` appears when a book is borrowed, and disappears when it comes back:
 
-<ChronicleClientTabs snippet="tutorial/read-model/borrowed-book" clients="csharp,kotlin,java,elixir,typescript" />
+<ChronicleClientTabs snippet="tutorial/read-model/borrowed-book" />
 
 Kotlin and Java don't currently have an equivalent to `[RemovedWith<T>]` either, so this one is C#/Elixir/TypeScript only for now.
 
 And its own query, just as plain as the last one:
 
-<ChronicleClientTabs snippet="tutorial/read-model/borrowed-books-query" clients="csharp" />
+<ChronicleClientTabs snippet="tutorial/read-model/borrowed-books-query" />
 
 Two attributes carry the whole lifecycle. `[FromEvent<BookBorrowed>]` creates the instance when the borrow happens — `MemberName` mapped by convention, keyed by the book's id. `[RemovedWith<BookReturned>]` is the new move: when a `BookReturned` arrives on that same book's stream, Chronicle **deletes the instance from the sink**. No `IsActive` flag, no soft-delete column, no cleanup job — the collection *is* the answer to "what's out right now", because instances that no longer apply simply aren't in it.
 

--- a/Documentation/understanding-constraints.mdx
+++ b/Documentation/understanding-constraints.mdx
@@ -26,7 +26,7 @@ An append that would introduce a duplicate is *rejected at the source* — it ne
 
 The simplest way to declare a rule is right where the value lives — adorn the event property with `[Unique]`:
 
-<ChronicleClientTabs snippet="understanding-constraints/property-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="understanding-constraints/property-attribute" />
 
 That one attribute is the whole client-side story. When your application starts, Chronicle scans for `[Unique]`-adorned types, registers the constraint with the kernel, and the kernel builds the indexes it needs to enforce it on every subsequent append.
 
@@ -35,11 +35,11 @@ A few things make this practical:
 - **One rule can span several events.** Give the same `name` to `[Unique]` on `UserRegistered.Email` and `UserEmailChanged.NewEmail`, and a changed email is checked against registered ones too — the rule follows the *value*, not a single event type.
 - **Some events are one-of-a-kind.** Put `[Unique]` on the event *type* instead of a property, and only one event of that type can ever be appended per event source — registering the same user twice becomes impossible by declaration:
 
-<ChronicleClientTabs snippet="understanding-constraints/event-type-attribute" clients="csharp" />
+<ChronicleClientTabs snippet="understanding-constraints/event-type-attribute" />
 
 - **Values can be released.** When the thing that held the value goes away, mark that event with `[RemoveConstraint]` so the value can be claimed again:
 
-<ChronicleClientTabs snippet="understanding-constraints/remove-constraint" clients="csharp" />
+<ChronicleClientTabs snippet="understanding-constraints/remove-constraint" />
 
 The reference calls this attribute style [model-bound constraints](/chronicle/constraints/model-bound/) — every parameter and combination is documented there.
 
@@ -47,7 +47,7 @@ The reference calls this attribute style [model-bound constraints](/chronicle/co
 
 Attributes shine when the rule belongs to one event type. Some rules don't: the same logical value appears under *different property names* in different events, the comparison should ignore casing, or the violation message needs to be composed from context. For those, declare the rule in a dedicated class — implement `IConstraint` and describe it with the builder:
 
-<ChronicleClientTabs snippet="understanding-constraints/dedicated-class" clients="csharp,typescript" />
+<ChronicleClientTabs snippet="understanding-constraints/dedicated-class" />
 
 Read it top to bottom and it says exactly what the rule is: one named constraint, fed by two events with differently named properties, case-insensitive, released when the user is removed, with a friendly message when it fires. The one-of-a-kind variant has a builder form too — `builder.Unique<UserRegistered>()` enforces a single `UserRegistered` per event source.
 

--- a/Documentation/webhooks/index.mdx
+++ b/Documentation/webhooks/index.mdx
@@ -7,13 +7,13 @@ A webhook forwards events Chronicle observes to an external HTTP endpoint — us
 
 ## Register a webhook
 
-<ChronicleClientTabs snippet="webhooks/index/register" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="webhooks/index/register" />
 
 If no event types are configured, the webhook forwards every event type registered for the client.
 
 ## Query registered webhooks
 
-<ChronicleClientTabs snippet="webhooks/index/query" clients="csharp,elixir,typescript" />
+<ChronicleClientTabs snippet="webhooks/index/query" />
 
 Kotlin and Java don't currently have a webhooks API — there's no equivalent anywhere in the Kotlin client SDK yet.
 


### PR DESCRIPTION
# Summary

Companion change to [Cratis/Documentation#45](https://github.com/Cratis/Documentation/pull/45), which taught the docs-site sync to discover which clients apply to a `<ChronicleClientTabs />` example by checking each client repo's snippet root for a matching file, instead of reading a `clients="..."` attribute on the placeholder. This repo owns the shared page content, so the now-dead attribute needs to come out here.

## Changed

- Removed the `clients="..."` attribute from every `<ChronicleClientTabs />` placeholder in the shared docs — the tab set for each example is now determined purely by which client repos have a matching snippet file.
- Updated `Documentation/contributing/clients/index.mdx` to describe the new auto-discovery behavior instead of the old attribute.

## Notes for reviewers

- Purely mechanical for the 691 attribute removals: verified beforehand that removing `clients="..."` and letting auto-discovery resolve the tab set gives an identical result in all but nine placeholders. In those nine (`concepts/correlation-identity-causation.mdx`, `jobs/index.mdx`, `webhooks/index.mdx`), auto-discovery now correctly surfaces Java/Kotlin/TypeScript tabs that already had real snippet content (including honest "not supported yet" stubs) but were hidden behind a stale `clients=` list.
- Should land together with Cratis/Documentation#45 so the sync behavior and the shared docs stay in sync, but this repo's own CI doesn't depend on it (no `<ChronicleClientTabs>` expansion happens here).