### PR TITLE
Ignore unsubscribed events in ReadModelScenario projection harness

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/ModuleAudited.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/ModuleAudited.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test audit/marker event that coexists on a module's event stream but is not subscribed to by
+/// <see cref="SimpleModule"/> — used to verify the harness ignores unsubscribed events the way the
+/// production projection engine does.
+/// </summary>
+[EventType]
+public record ModuleAudited;

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_projecting_a_children_from_collection.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_projecting_a_children_from_collection.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_a_stream_that_carries_an_unsubscribed_event;
+
+/// <summary>
+/// Seeds a <c>[ChildrenFrom]</c> projection's event source with the root event, its child events, and an
+/// unsubscribed audit/marker event. This guards that the skip predicate (<c>HasKeyResolverFor</c>) still treats
+/// child event types as subscribed — so the child collection materializes — while ignoring only the truly
+/// unsubscribed event, leaving previously-working hierarchical scenarios unaffected.
+/// </summary>
+public class and_projecting_a_children_from_collection : Specification
+{
+    ReadModelScenario<Sheet> _scenario;
+    SheetId _sheetId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<Sheet>();
+        _sheetId = SheetId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_sheetId)
+            .Events(
+                new SheetStarted(2026),
+                new DayWorked(new DateOnly(2026, 6, 1), 7.5m),
+                new ModuleAudited(),
+                new DayWorked(new DateOnly(2026, 6, 2), 8m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_map_the_root_year() => _scenario.Instance!.Year.ShouldEqual(2026);
+    [Fact] void should_have_two_day_entries() => _scenario.Instance!.Days.Count().ShouldEqual(2);
+    [Fact] void should_map_first_day() => _scenario.Instance!.Days.First().Day.ShouldEqual(new DateOnly(2026, 6, 1));
+    [Fact] void should_map_second_day() => _scenario.Instance!.Days.Last().Day.ShouldEqual(new DateOnly(2026, 6, 2));
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_projecting_a_flat_read_model.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_projecting_a_flat_read_model.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_a_stream_that_carries_an_unsubscribed_event;
+
+/// <summary>
+/// Seeds a flat projection's event source with a subscribed event and a coexisting audit/marker event the
+/// projection does not subscribe to. The production projection engine filters the stream to subscribed event
+/// types, so the harness must ignore the unsubscribed event rather than throwing MissingKeyResolverForEventType.
+/// </summary>
+public class and_projecting_a_flat_read_model : Specification
+{
+    ReadModelScenario<SimpleModule> _scenario;
+    EventSourceId _moduleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SimpleModule>();
+        _moduleId = EventSourceId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_moduleId)
+            .Events(new ModuleCreated("My Module"), new ModuleAudited());
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_map_name_from_the_subscribed_event() => _scenario.Instance!.Name.ShouldEqual("My Module");
+    [Fact] void should_resolve_the_instance_for_the_event_source() => _scenario.InstanceForEventSourceId(_moduleId).ShouldNotBeNull();
+    [Fact] void should_materialize_exactly_one_instance() => _scenario.Instances.Count.ShouldEqual(1);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_the_unsubscribed_event_is_seeded_first.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_a_stream_that_carries_an_unsubscribed_event/and_the_unsubscribed_event_is_seeded_first.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_a_stream_that_carries_an_unsubscribed_event;
+
+/// <summary>
+/// Seeds the unsubscribed audit/marker event before the subscribed event, verifying the skip is order-independent:
+/// the projection still resolves its key and materializes the read model from the subscribed event regardless of
+/// where the ignored event falls in the stream.
+/// </summary>
+public class and_the_unsubscribed_event_is_seeded_first : Specification
+{
+    ReadModelScenario<SimpleModule> _scenario;
+    EventSourceId _moduleId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SimpleModule>();
+        _moduleId = EventSourceId.New();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_moduleId)
+            .Events(new ModuleAudited(), new ModuleCreated("My Module"));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_map_name_from_the_subscribed_event() => _scenario.Instance!.Name.ShouldEqual("My Module");
+    [Fact] void should_materialize_exactly_one_instance() => _scenario.Instances.Count.ShouldEqual(1);
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -411,6 +411,18 @@ internal static class ProjectionReadModelProcessor
         ExpandoObject state,
         Queue<KernelAppendedEvent> deferredEvents)
     {
+        // The production projection engine filters the event stream to the types the projection
+        // subscribes to, so an event a projection does not handle never reaches it. A seeded stream
+        // may legitimately carry such unrelated events (e.g. an audit/marker event); skip them here
+        // rather than letting GetKeyResolverFor throw MissingKeyResolverForEventType. HasKeyResolverFor
+        // is the exact predicate for "would GetKeyResolverFor succeed" (same resolver map), and the
+        // root projection's map includes child ([ChildrenFrom]) event types, so this is a faithful
+        // no-op filter for nested/join scenarios too.
+        if (!projection.HasKeyResolverFor(@event.Context.EventType))
+        {
+            return (state, null, false);
+        }
+
         var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
         var keyResult = await projection.GetKeyResolverFor(@event.Context.EventType)(eventSequenceStorage, sink, @event);
 


### PR DESCRIPTION
# Summary

`ReadModelScenario<T>` now mirrors the production projection engine when a seeded event source carries an event the projection does not subscribe to. Previously, seeding a projection with a legitimately-coexisting event (for example an audit/marker event on the same stream) threw `MissingKeyResolverForEventType`, forcing spec authors to omit those events and diverge from the real stream. The harness now ignores unsubscribed events just as the runtime filters the stream to the subscribed event types.

## Fixed

- `ReadModelScenario<T>` no longer throws `MissingKeyResolverForEventType` when a projection's event source is seeded with an event the projection does not subscribe to; such events are ignored, matching the production projection engine's subscribed-type filtering.