### PR TITLE
Fix octal parse crash in coverage script on days 08 and 09

### DIFF
--- a/.github/scripts/collect-coverage.sh
+++ b/.github/scripts/collect-coverage.sh
@@ -67,7 +67,7 @@ current_date=$(date +%Y-%m-%d)
 year=$(date +%Y)
 month=$(date +%m)
 day=$(date +%d)
-week_of_month=$(( (day + 6) / 7 ))
+week_of_month=$(( (10#$day + 6) / 7 ))
 current_week="${year}-M${month}-W${week_of_month}"
 
 # Extract commit hash (first 7 chars)


### PR DESCRIPTION
## Fixed

- `collect-coverage.sh` crashed with `08: value too great for base` on the 8th and 9th of every month: `date +%d` zero-pads the day and bash `$(( ))` parsed `08`/`09` as octal, aborting the `coverage-merge-and-cache` job under `set -e`. Forced base-10 parsing with `10#$day`.