### PR TITLE
Add CHR0034-CHR0037 analyzers and backfill string-keyed join in ReadModelScenario

### DIFF
--- a/Documentation/client-snippets/code-analysis/chr0034/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0034/violation.md
@@ -1,0 +1,15 @@
+```csharp
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+
+// Error CHR0034: 'CustomerId' is typed as 'CustomerId' (derives from EventSourceId<T>);
+// [PII] cannot be applied to an event source id — Chronicle throws
+// PIINotSupportedOnEventSourceId at runtime. Remove [PII].
+[EventType]
+public record CustomerRegistered([PII] Chr0034CustomerId CustomerId, string Name);
+
+public record Chr0034CustomerId(Guid Value) : EventSourceId<Guid>(Value)
+{
+    public static implicit operator Chr0034CustomerId(Guid value) => new(value);
+}
+```

--- a/Documentation/client-snippets/code-analysis/chr0035/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0035/violation.md
@@ -1,0 +1,8 @@
+```csharp
+using Cratis.Arc.Queries.ModelBound;
+
+// Error CHR0035: Read model 'Customer' declares a property named '_subject', which
+// Chronicle reserves as an internal MongoDB field. Rename it.
+[ReadModel]
+public record Customer(Guid Id, string Name, string _subject);
+```

--- a/Documentation/client-snippets/code-analysis/chr0036/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0036/violation.md
@@ -1,0 +1,22 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+// Warning CHR0036: Reducer 'Chr0036BalanceReducer' declares mutable state '_runningTotal'.
+// Reducers must be stateless for deterministic replay.
+public class Chr0036BalanceReducer : IReducerFor<Chr0036Balance>
+{
+    decimal _runningTotal;
+
+    public Chr0036Balance Reduce(Chr0036AmountDeposited @event, Chr0036Balance? current)
+    {
+        _runningTotal += @event.Amount;
+        return new(_runningTotal);
+    }
+}
+
+[EventType]
+public record Chr0036AmountDeposited(decimal Amount);
+
+public record Chr0036Balance(decimal Total);
+```

--- a/Documentation/client-snippets/code-analysis/chr0037/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0037/violation.md
@@ -1,0 +1,20 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+// Warning CHR0037: Event type generations 'CustomerRegisteredV2' and 'CustomerRegisteredV1'
+// referenced by migration 'CustomerRegisteredMigration' must share one explicit [EventType]
+// id and differ only by generation.
+[EventType("Customer.Registered", generation: 1)]
+public record CustomerRegisteredV1(string Name);
+
+[EventType("Customer.Renamed", generation: 2)]
+public record CustomerRegisteredV2(string FirstName, string LastName);
+
+public class CustomerRegisteredMigration
+    : EventTypeMigration<CustomerRegisteredV2, CustomerRegisteredV1>
+{
+    public override void Upcast(IEventMigrationBuilder<CustomerRegisteredV2, CustomerRegisteredV1> builder) { }
+    public override void Downcast(IEventMigrationBuilder<CustomerRegisteredV1, CustomerRegisteredV2> builder) { }
+}
+```

--- a/Documentation/code-analysis/CHR0034.mdx
+++ b/Documentation/code-analysis/CHR0034.mdx
@@ -1,0 +1,28 @@
+# CHR0034: [PII] cannot be applied to an EventSourceId&lt;T&gt;
+
+## Rule Description
+
+A property or record parameter whose type derives from `EventSourceId<T>` is marked with `[PII]`. The event source id is the identity Chronicle uses to look up the encryption key for a subject, so it cannot itself be encrypted. Applying `[PII]` to it throws `PIINotSupportedOnEventSourceId` at runtime.
+
+Remove the `[PII]` attribute. The id is already the compliance subject.
+
+## Severity
+
+Error
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0034/violation" />
+
+## Why This Rule Exists
+
+Chronicle encrypts `[PII]` values per subject, and the subject is resolved from the event source id. That makes the id the key-lookup identity for every other encrypted value on the event. If the id itself were encrypted, there would be nothing left to resolve the key by — a circular dependency Chronicle cannot satisfy, so it throws `PIINotSupportedOnEventSourceId`.
+
+This analyzer turns that runtime failure into a compile-time error, caught the moment you write the attribute rather than the first time the event is appended.
+
+If the identifier itself is sensitive, do not try to encrypt the id. Instead use a random `Guid`-backed surrogate as the event source id and store the sensitive value in a separate `[PII]` property, which Chronicle can encrypt under the surrogate subject.
+
+## Related Rules
+
+- [CHR0026: [Key] or [Subject] on an EventSourceId&lt;T&gt; is redundant](CHR0026) — the id is already the key and the compliance subject.
+- [Subject](/chronicle/concepts/subject/) — how the compliance subject is resolved.

--- a/Documentation/code-analysis/CHR0035.mdx
+++ b/Documentation/code-analysis/CHR0035.mdx
@@ -1,0 +1,28 @@
+# CHR0035: Read model declares a reserved '_subject' property
+
+## Rule Description
+
+A read model — a record or class marked with `[ReadModel]` — declares a property or record parameter named exactly `_subject`. Chronicle reserves the `_subject` field in the MongoDB document backing a read model for internal compliance-subject tracking, so a same-named property silently collides with it.
+
+Rename the property.
+
+## Severity
+
+Error
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0035/violation" />
+
+## Why This Rule Exists
+
+Every managed read-model document carries an internal `_subject` field that Chronicle uses to track the compliance subject the document belongs to — the identity its `[PII]` values are encrypted under and erased by. That field is infrastructure, not part of your model.
+
+A read-model property named `_subject` maps to the same document field, so your value and Chronicle's internal tracking value fight over one slot. The projected value can overwrite the tracking value or read back as Chronicle's, and after a right-to-erasure key deletion the behavior is undefined. Because the collision is by name in the persisted document, nothing surfaces at compile time without this rule — it just misbehaves at runtime.
+
+Rename the property to anything else (for example `Subject`, without the leading underscore, if you genuinely need to expose the subject).
+
+## Related Rules
+
+- [Subject](/chronicle/concepts/subject/) — how the compliance subject is resolved and tracked.
+- [CHR0034: [PII] cannot be applied to an EventSourceId&lt;T&gt;](CHR0034) — the id is the compliance subject.

--- a/Documentation/code-analysis/CHR0036.mdx
+++ b/Documentation/code-analysis/CHR0036.mdx
@@ -1,0 +1,30 @@
+# CHR0036: Reducer must not have mutable state
+
+## Rule Description
+
+A class implementing `IReducerFor<T>` declares mutable instance state — a non-`readonly` field or a settable (non-`init`) property — or injects a storage primitive such as `IMongoCollection<T>` through its constructor. Reducers fold events into read-model state and Chronicle re-creates and replays them, so they must be stateless and deterministic.
+
+Keep the reducer stateless: express dependencies as `readonly`, primary-constructor-injected fields, read keyed state through an injected read model or `IReadModels.GetInstanceById`, and derive everything else from the current state and the event.
+
+## Severity
+
+Warning
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0036/violation" />
+
+## Why This Rule Exists
+
+A reducer is a pure function of `(current state, event) → next state`. Chronicle drives that function by replaying the event stream — during initial projection, after a rewind, on recovery, or when rebuilding a read model — and a single event source may be folded more than once.
+
+Mutable instance state breaks that contract. A running total accumulated in a field is wrong the moment the stream replays, and a value can bleed from one event source into the next when the instance is reused. Everything the next state depends on is already available: the `current` state parameter (the fold's accumulator, which Chronicle persists between events) and the event being handled. Anything derived should be computed from those inputs each time, not stored on the instance.
+
+Injecting a storage primitive like `IMongoCollection<T>` is the same failure from the other side: it lets the reducer read or write the sink directly, outside the deterministic fold, coupling it to where state is persisted. Read state through the read-model abstraction instead.
+
+This rule mirrors [CHR0031](CHR0031) and [CHR0032](CHR0032) for reactors — reducers carry the identical statelessness requirement.
+
+## Related Rules
+
+- [CHR0031: Reactor must not have mutable state](CHR0031) — the same requirement for reactors.
+- [CHR0032: Reactor must not access storage directly](CHR0032) — read state through a read model, not a sink.

--- a/Documentation/code-analysis/CHR0037.mdx
+++ b/Documentation/code-analysis/CHR0037.mdx
@@ -1,0 +1,35 @@
+# CHR0037: Event type migration generations must share one explicit [EventType] id
+
+## Rule Description
+
+A class deriving from `EventTypeMigration<TUpgrade, TPrevious>` references two event type generations whose `[EventType]` ids are absent or differ. Chronicle keys generations of the same event by their explicit `[EventType]` id, so both generations must carry the same id and differ only by their generation number.
+
+Give both event types the same explicit id, and set a distinct `generation:` on each.
+
+## Severity
+
+Warning
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0037/violation" />
+
+## Why This Rule Exists
+
+When an event's schema changes after events of the old shape are already stored, you add a new generation of the same event type and an `EventTypeMigration<TUpgrade, TPrevious>` that upcasts the stored events into the new shape. Chronicle recognizes the two records as generations of *one* event type by their shared `[EventType]` id — not by their C# type names.
+
+If the ids differ, or one generation has no explicit id (so it defaults to the type name), Chronicle sees two unrelated event types. The migration then never applies: stored events of the previous generation are never upcast, and consumers read the old shape. Because both records compile and the migration is discovered by convention, nothing surfaces the mistake without this rule.
+
+The correct shape is one id, two generations:
+
+```csharp
+[EventType("Customer.Registered", generation: 1)]
+public record CustomerRegisteredV1(string Name);
+
+[EventType("Customer.Registered", generation: 2)]
+public record CustomerRegisteredV2(string FirstName, string LastName);
+```
+
+## Related Rules
+
+- [CHR0021: Event types should be record types](CHR0021) — event types are immutable records.

--- a/Documentation/code-analysis/index.md
+++ b/Documentation/code-analysis/index.md
@@ -2,7 +2,7 @@
 
 This section documents the code analysis rules provided by the Chronicle Code Analyzer for the .NET client.
 
-All rules follow the identifier format `CHR####` where the numbers are sequential without gaps.
+All rules follow the identifier format `CHR####`. Numbers are assigned sequentially; an occasional id is reserved for a rule still in progress, so a gap in the published set is expected.
 
 ## Rules Overview
 
@@ -36,6 +36,10 @@ All rules follow the identifier format `CHR####` where the numbers are sequentia
 | [CHR0030](CHR0030) | [ChildrenFrom] child collection property auto-maps to nothing | Warning | A [ChildrenFrom] child collection property matching no event property and with no explicit mapping always projects empty; rename it or bridge with `[SetFrom<T>]` |
 | [CHR0031](CHR0031) | Reactor must not have mutable state | Warning | Reactors are re-created and replayed, so mutable instance state is unreliable; use readonly, primary-constructor-injected dependencies |
 | [CHR0032](CHR0032) | Reactor must not access storage directly | Warning | Injecting a storage primitive like `IMongoCollection<T>` couples the reactor to a sink; read state via a read model or IReadModels.GetInstanceById |
+| [CHR0034](CHR0034) | [PII] cannot be applied to an `EventSourceId<T>` | Error | The event source id is the encryption-key lookup identity, so it cannot be encrypted; [PII] on it throws PIINotSupportedOnEventSourceId at runtime |
+| [CHR0035](CHR0035) | Read model declares a reserved '_subject' property | Error | Chronicle reserves the `_subject` field in a read model's document for internal compliance-subject tracking; a same-named property collides with it |
+| [CHR0036](CHR0036) | Reducer must not have mutable state | Warning | Reducers are re-created and replayed, so mutable instance state or direct storage injection makes the fold non-deterministic; keep them stateless |
+| [CHR0037](CHR0037) | Event type migration generations must share one explicit [EventType] id | Warning | The two generations referenced by an EventTypeMigration must carry the same explicit [EventType] id and differ only by generation, or the migration never applies |
 
 ## Quick Fixes
 

--- a/Documentation/code-analysis/toc.yml
+++ b/Documentation/code-analysis/toc.yml
@@ -56,3 +56,11 @@
   href: CHR0031.mdx
 - name: CHR0032 - Reactor must not access storage directly
   href: CHR0032.mdx
+- name: CHR0034 - [PII] cannot be applied to an EventSourceId
+  href: CHR0034.mdx
+- name: CHR0035 - Read model declares a reserved '_subject' property
+  href: CHR0035.mdx
+- name: CHR0036 - Reducer must not have mutable state
+  href: CHR0036.mdx
+- name: CHR0037 - Event type migration generations must share one explicit [EventType] id
+  href: CHR0037.mdx

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/given/a_migration_generation_event_type_id_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/given/a_migration_generation_event_type_id_analyzer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_MigrationGenerationEventTypeIdAnalyzer.given;
+
+public class a_migration_generation_event_type_id_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Events;",
+            "using Cratis.Chronicle.Events.Migrations;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Events",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class EventTypeAttribute : Attribute",
+            "    {",
+            "        public EventTypeAttribute(string id = \"\", uint generation = 1) { }",
+            "    }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Events.Migrations",
+            "{",
+            "    public abstract class EventTypeMigration<TUpgrade, TPrevious> { }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_a_generation_has_no_explicit_id.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_a_generation_has_no_explicit_id.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_MigrationGenerationEventTypeIdAnalyzer.when_analyzing_migration;
+
+public class and_a_generation_has_no_explicit_id : given.a_migration_generation_event_type_id_analyzer
+{
+    const string Usage = """
+    [EventType(generation: 1)]
+    public record CustomerRegisteredV1(string Name);
+
+    [EventType(generation: 2)]
+    public record CustomerRegisteredV2(string FirstName, string LastName);
+
+    public class {|#0:CustomerRegisteredMigration|}
+        : Cratis.Chronicle.Events.Migrations.EventTypeMigration<CustomerRegisteredV2, CustomerRegisteredV1>;
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.MigrationGenerationEventTypeIdAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.MigrationGenerationEventTypeId, DiagnosticSeverity.Warning, "CustomerRegisteredMigration"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_generations_have_different_ids.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_generations_have_different_ids.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_MigrationGenerationEventTypeIdAnalyzer.when_analyzing_migration;
+
+public class and_generations_have_different_ids : given.a_migration_generation_event_type_id_analyzer
+{
+    const string Usage = """
+    [EventType("Customer.Registered", generation: 1)]
+    public record CustomerRegisteredV1(string Name);
+
+    [EventType("Customer.Renamed", generation: 2)]
+    public record CustomerRegisteredV2(string FirstName, string LastName);
+
+    public class {|#0:CustomerRegisteredMigration|}
+        : Cratis.Chronicle.Events.Migrations.EventTypeMigration<CustomerRegisteredV2, CustomerRegisteredV1>;
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.MigrationGenerationEventTypeIdAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.MigrationGenerationEventTypeId, DiagnosticSeverity.Warning, "CustomerRegisteredV2", "CustomerRegisteredV1", "CustomerRegisteredMigration"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_generations_share_explicit_id.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_analyzing_migration/and_generations_share_explicit_id.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_MigrationGenerationEventTypeIdAnalyzer.when_analyzing_migration;
+
+public class and_generations_share_explicit_id : given.a_migration_generation_event_type_id_analyzer
+{
+    const string Usage = """
+    [EventType("Customer.Registered", generation: 1)]
+    public record CustomerRegisteredV1(string Name);
+
+    [EventType("Customer.Registered", generation: 2)]
+    public record CustomerRegisteredV2(string FirstName, string LastName);
+
+    public class CustomerRegisteredMigration
+        : Cratis.Chronicle.Events.Migrations.EventTypeMigration<CustomerRegisteredV2, CustomerRegisteredV1>;
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.MigrationGenerationEventTypeIdAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_MigrationGenerationEventTypeIdAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_MigrationGenerationEventTypeIdAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.MigrationGenerationEventTypeIdAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.MigrationGenerationEventTypeIdAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0037_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.MigrationGenerationEventTypeId).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/given/a_pii_on_event_source_id_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/given/a_pii_on_event_source_id_analyzer.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer.given;
+
+public class a_pii_on_event_source_id_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Events;",
+            "using Cratis.Chronicle.Compliance.GDPR;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Compliance.GDPR",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter)]",
+            "    public sealed class PIIAttribute : Attribute { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Events",
+            "{",
+            "    public record EventSourceId<T>(T Value);",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_event_source_id_without_pii.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_event_source_id_without_pii.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer.when_analyzing_members;
+
+public class and_event_source_id_without_pii : given.a_pii_on_event_source_id_analyzer
+{
+    const string Usage = """
+    public record CustomerId(Guid Value) : EventSourceId<Guid>(Value);
+
+    public record CustomerRegistered(
+        CustomerId CustomerId,
+        [PII] string Name);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_a_non_event_source_id_value.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_a_non_event_source_id_value.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer.when_analyzing_members;
+
+public class and_pii_on_a_non_event_source_id_value : given.a_pii_on_event_source_id_analyzer
+{
+    const string Usage = """
+    public record CustomerRegistered(
+        [PII] string SocialSecurityNumber,
+        string Name);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_event_source_id_parameter.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_event_source_id_parameter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer.when_analyzing_members;
+
+public class and_pii_on_event_source_id_parameter : given.a_pii_on_event_source_id_analyzer
+{
+    const string Usage = """
+    public record CustomerId(Guid Value) : EventSourceId<Guid>(Value);
+
+    public record CustomerRegistered(
+        {|#0:[PII]|} CustomerId CustomerId,
+        string Name);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.PiiOnEventSourceId, DiagnosticSeverity.Error, "CustomerId"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_event_source_id_property.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_analyzing_members/and_pii_on_event_source_id_property.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer.when_analyzing_members;
+
+public class and_pii_on_event_source_id_property : given.a_pii_on_event_source_id_analyzer
+{
+    const string Usage = """
+    public record CustomerId(Guid Value) : EventSourceId<Guid>(Value);
+
+    public class Customer
+    {
+        {|#0:[PII]|}
+        public CustomerId Id { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.PiiOnEventSourceId, DiagnosticSeverity.Error, "Id", "CustomerId"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_PiiOnEventSourceIdAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_PiiOnEventSourceIdAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.PiiOnEventSourceIdAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0034_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.PiiOnEventSourceId).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/given/a_reducer_must_not_have_mutable_state_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/given/a_reducer_must_not_have_mutable_state_analyzer.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerMustNotHaveMutableStateAnalyzer.given;
+
+public class a_reducer_must_not_have_mutable_state_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using System.Threading.Tasks;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Reducers",
+            "{",
+            "    public interface IReducer { }",
+            "    public interface IReducerFor<TReadModel> : IReducer { }",
+            "}",
+            "",
+            "namespace MongoDB.Driver",
+            "{",
+            "    public interface IMongoCollection<T> { }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_has_mutable_field.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_has_mutable_field.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerMustNotHaveMutableStateAnalyzer.when_analyzing_reducer;
+
+public class and_reducer_has_mutable_field : given.a_reducer_must_not_have_mutable_state_analyzer
+{
+    const string Usage = """
+    public class Balance
+    {
+    }
+
+    public class BalanceReducer : Cratis.Chronicle.Reducers.IReducerFor<Balance>
+    {
+        {|#0:int _count|};
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerMustNotHaveMutableStateAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReducerMustNotHaveMutableState, DiagnosticSeverity.Warning, "BalanceReducer", "_count"));
+
+    [Fact] Task should_report_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_injects_mongo_collection.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_injects_mongo_collection.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerMustNotHaveMutableStateAnalyzer.when_analyzing_reducer;
+
+public class and_reducer_injects_mongo_collection : given.a_reducer_must_not_have_mutable_state_analyzer
+{
+    const string Usage = """
+    public class Balance
+    {
+    }
+
+    public class BalanceReducer : Cratis.Chronicle.Reducers.IReducerFor<Balance>
+    {
+        public BalanceReducer({|#0:MongoDB.Driver.IMongoCollection<Balance> collection|})
+        {
+        }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerMustNotHaveMutableStateAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReducerMustNotHaveMutableState, DiagnosticSeverity.Warning, "BalanceReducer", "collection"));
+
+    [Fact] Task should_report_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_is_stateless.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_analyzing_reducer/and_reducer_is_stateless.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerMustNotHaveMutableStateAnalyzer.when_analyzing_reducer;
+
+public class and_reducer_is_stateless : given.a_reducer_must_not_have_mutable_state_analyzer
+{
+    const string Usage = """
+    public interface IDependency
+    {
+    }
+
+    public class Balance
+    {
+    }
+
+    public class BalanceReducer(IDependency dependency) : Cratis.Chronicle.Reducers.IReducerFor<Balance>
+    {
+        readonly IDependency _dependency = dependency;
+
+        public string Name { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerMustNotHaveMutableStateAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerMustNotHaveMutableStateAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerMustNotHaveMutableStateAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.ReducerMustNotHaveMutableStateAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.ReducerMustNotHaveMutableStateAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0036_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.ReducerMustNotHaveMutableState).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/given/a_reserved_subject_property_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/given/a_reserved_subject_property_analyzer.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer.given;
+
+public class a_reserved_subject_property_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Arc.Queries.ModelBound;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Arc.Queries.ModelBound",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class ReadModelAttribute : Attribute { }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_has_reserved_subject_parameter.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_has_reserved_subject_parameter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer.when_analyzing_read_model;
+
+public class and_read_model_has_reserved_subject_parameter : given.a_reserved_subject_property_analyzer
+{
+    const string Usage = """
+    [ReadModel]
+    public record Customer(
+        Guid Id,
+        {|#0:string _subject|});
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReservedSubjectProperty, DiagnosticSeverity.Error, "Customer"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_has_reserved_subject_property.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_has_reserved_subject_property.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer.when_analyzing_read_model;
+
+public class and_read_model_has_reserved_subject_property : given.a_reserved_subject_property_analyzer
+{
+    const string Usage = """
+    [ReadModel]
+    public class Customer
+    {
+        public Guid Id { get; init; }
+
+        public string {|#0:_subject|} { get; init; }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReservedSubjectProperty, DiagnosticSeverity.Error, "Customer"));
+
+    [Fact] Task should_report_the_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_without_reserved_property.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_read_model_without_reserved_property.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer.when_analyzing_read_model;
+
+public class and_read_model_without_reserved_property : given.a_reserved_subject_property_analyzer
+{
+    const string Usage = """
+    [ReadModel]
+    public record Customer(
+        Guid Id,
+        string Subject);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_type_without_read_model_attribute.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_analyzing_read_model/and_type_without_read_model_attribute.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer.when_analyzing_read_model;
+
+public class and_type_without_read_model_attribute : given.a_reserved_subject_property_analyzer
+{
+    const string Usage = """
+    public record Customer(
+        Guid Id,
+        string _subject);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReservedSubjectPropertyAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReservedSubjectPropertyAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.ReservedSubjectPropertyAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0035_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.ReservedSubjectProperty).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/MigrationGenerationEventTypeIdAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/MigrationGenerationEventTypeIdAnalyzer.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports when the two event type generations referenced by an
+/// <c>EventTypeMigration&lt;TUpgrade, TPrevious&gt;</c> do not share one explicit <c>[EventType]</c> id.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class MigrationGenerationEventTypeIdAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.MigrationGenerationEventTypeId,
+        title: "Event type migration generations must share one explicit [EventType] id",
+        messageFormat: "Event type generations '{0}' and '{1}' referenced by migration '{2}' must share one explicit [EventType] id and differ only by generation",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An EventTypeMigration<TUpgrade, TPrevious> upcasts stored events of the previous generation into the newer generation. Chronicle keys generations by the [EventType] id, so both generations must carry the same explicit id and differ only by their generation number. If the id is absent (defaulting to the type name) or the two ids differ, Chronicle treats them as unrelated event types and the migration never applies.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        var migrationBase = WellKnownTypes.GetEventTypeMigrationBase(typeSymbol);
+        if (migrationBase is null || migrationBase.TypeArguments.Length != 2)
+        {
+            return;
+        }
+
+        var upgrade = migrationBase.TypeArguments[0];
+        var previous = migrationBase.TypeArguments[1];
+
+        var upgradeAttribute = WellKnownTypes.GetEventTypeAttributeData(upgrade);
+        var previousAttribute = WellKnownTypes.GetEventTypeAttributeData(previous);
+        if (upgradeAttribute is null || previousAttribute is null)
+        {
+            return;
+        }
+
+        var upgradeId = WellKnownTypes.GetEventTypeExplicitId(upgradeAttribute);
+        var previousId = WellKnownTypes.GetEventTypeExplicitId(previousAttribute);
+
+        if (upgradeId is null || previousId is null || upgradeId != previousId)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Rule,
+                typeSymbol.Locations.FirstOrDefault(),
+                upgrade.Name,
+                previous.Name,
+                typeSymbol.Name));
+        }
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/PiiOnEventSourceIdAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/PiiOnEventSourceIdAnalyzer.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports a <c>[PII]</c> attribute placed on a property or record positional parameter
+/// whose type derives from <c>EventSourceId&lt;T&gt;</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class PiiOnEventSourceIdAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.PiiOnEventSourceId,
+        title: "[PII] cannot be applied to an EventSourceId<T>",
+        messageFormat: "'{0}' is typed as '{1}' (derives from EventSourceId<T>); [PII] cannot be applied to an event source id — Chronicle throws PIINotSupportedOnEventSourceId at runtime. Remove [PII].",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "An EventSourceId<T> is the encryption-key lookup identity, so Chronicle cannot itself encrypt it; marking it [PII] throws PIINotSupportedOnEventSourceId at runtime. The id is already the compliance subject. If the identifier itself is sensitive, use a random Guid-backed surrogate as the event source id and store the sensitive value in a separate [PII] property.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>().Where(property => !property.IsStatic))
+        {
+            ReportForMember(context, property, property.Type);
+        }
+
+        // For a positional record, [PII] without an explicit target lands on the constructor
+        // parameter rather than the generated property, so the parameters must be inspected too.
+        var primaryConstructor = typeSymbol.InstanceConstructors
+            .OrderByDescending(constructor => constructor.Parameters.Length)
+            .FirstOrDefault();
+
+        if (primaryConstructor is not null)
+        {
+            foreach (var parameter in primaryConstructor.Parameters)
+            {
+                ReportForMember(context, parameter, parameter.Type);
+            }
+        }
+    }
+
+    static void ReportForMember(SymbolAnalysisContext context, ISymbol member, ITypeSymbol memberType)
+    {
+        if (!WellKnownTypes.DerivesFromEventSourceId(memberType))
+        {
+            return;
+        }
+
+        var attribute = member.GetAttributes()
+            .FirstOrDefault(attribute => attribute.AttributeClass?.ToDisplayString() == WellKnownTypes.PiiAttributeName);
+
+        if (attribute is null)
+        {
+            return;
+        }
+
+        var location = attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+            ?? member.Locations.FirstOrDefault();
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            location,
+            member.Name,
+            memberType.Name));
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerMustNotHaveMutableStateAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerMustNotHaveMutableStateAnalyzer.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that checks that a class implementing IReducer does not declare mutable instance state
+/// or inject a storage primitive such as IMongoCollection&lt;T&gt; directly.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReducerMustNotHaveMutableStateAnalyzer : DiagnosticAnalyzer
+{
+    const string MongoCollectionOpenGenericDisplay = "MongoDB.Driver.IMongoCollection<T>";
+
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.ReducerMustNotHaveMutableState,
+        title: "Reducer must not have mutable state",
+        messageFormat: "Reducer '{0}' declares mutable state '{1}'. Reducers must be stateless for deterministic replay.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Reducers build read-model state by folding events; Chronicle re-creates and replays them, so any mutable instance state or direct storage access makes the result depend on which events happened to run through a particular instance. Keep reducers stateless and deterministic: express dependencies as readonly, primary-constructor-injected fields, read keyed state through an injected read model or IReadModels.GetInstanceById instead of a storage primitive, and derive everything else from the current state and the event.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!WellKnownTypes.ImplementsIReducer(namedTypeSymbol, context.Compilation))
+        {
+            return;
+        }
+
+        foreach (var member in namedTypeSymbol.GetMembers().Where(IsMutableState))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Rule,
+                member.Locations.FirstOrDefault(),
+                namedTypeSymbol.Name,
+                member.Name));
+        }
+
+        foreach (var constructor in namedTypeSymbol.Constructors.Where(constructor => !constructor.IsImplicitlyDeclared))
+        {
+            foreach (var parameter in constructor.Parameters.Where(parameter => IsStoragePrimitive(parameter.Type, context.Compilation)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule,
+                    parameter.Locations.FirstOrDefault(),
+                    namedTypeSymbol.Name,
+                    parameter.Name));
+            }
+        }
+    }
+
+    static bool IsMutableState(ISymbol member) => member switch
+    {
+        IFieldSymbol field => IsMutableField(field),
+        IPropertySymbol property => IsMutableProperty(property),
+        _ => false
+    };
+
+    static bool IsMutableField(IFieldSymbol field) =>
+        !field.IsStatic &&
+        !field.IsConst &&
+        !field.IsReadOnly &&
+        !field.IsImplicitlyDeclared;
+
+    static bool IsMutableProperty(IPropertySymbol property) =>
+        !property.IsStatic &&
+        property.SetMethod is { IsInitOnly: false };
+
+    static bool IsStoragePrimitive(ITypeSymbol parameterType, Compilation compilation)
+    {
+        if (parameterType is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        var mongoCollection = compilation.GetTypeByMetadataName(WellKnownTypes.IMongoCollectionName);
+        if (mongoCollection is not null &&
+            SymbolEqualityComparer.Default.Equals(named.OriginalDefinition, mongoCollection))
+        {
+            return true;
+        }
+
+        return named.OriginalDefinition.ToDisplayString() == MongoCollectionOpenGenericDisplay;
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReservedSubjectPropertyAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReservedSubjectPropertyAnalyzer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports a read model declaring a property named <c>_subject</c>, which Chronicle reserves
+/// as an internal MongoDB field.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReservedSubjectPropertyAnalyzer : DiagnosticAnalyzer
+{
+    const string ReservedName = "_subject";
+
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.ReservedSubjectProperty,
+        title: "Read model declares a reserved '_subject' property",
+        messageFormat: "Read model '{0}' declares a property named '_subject', which Chronicle reserves as an internal MongoDB field. Rename it.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Chronicle reserves the '_subject' field in the MongoDB document backing a read model for internal compliance-subject tracking. A read-model property with the same name silently collides with that internal field. Rename the property to something else.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        if (!WellKnownTypes.HasAttribute(typeSymbol, WellKnownTypes.ReadModelAttributeName))
+        {
+            return;
+        }
+
+        var reservedProperty = typeSymbol.GetMembers().OfType<IPropertySymbol>()
+            .FirstOrDefault(property => !property.IsStatic && property.Name == ReservedName);
+
+        if (reservedProperty is not null)
+        {
+            // For a positional record the generated property's location points at the parameter, so
+            // reporting on the property alone covers both the property and the positional parameter.
+            Report(context, typeSymbol, reservedProperty.Locations.FirstOrDefault());
+            return;
+        }
+
+        // A primary-constructor parameter without a generated property (a class-based read model)
+        // still collides with the reserved field.
+        var reservedParameter = typeSymbol.InstanceConstructors
+            .OrderByDescending(constructor => constructor.Parameters.Length)
+            .FirstOrDefault()?.Parameters
+            .FirstOrDefault(parameter => parameter.Name == ReservedName);
+
+        if (reservedParameter is not null)
+        {
+            Report(context, typeSymbol, reservedParameter.Locations.FirstOrDefault());
+        }
+    }
+
+    static void Report(SymbolAnalysisContext context, INamedTypeSymbol typeSymbol, Location? location) =>
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, typeSymbol.Name));
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -170,4 +170,24 @@ public static class DiagnosticIds
     /// A reactor injects a storage primitive (e.g. IMongoCollection&lt;T&gt;) directly.
     /// </summary>
     public const string ReactorMustNotAccessStorageDirectly = "CHR0032";
+
+    /// <summary>
+    /// A [PII] attribute is placed on a property or parameter whose type derives from EventSourceId&lt;T&gt;.
+    /// </summary>
+    public const string PiiOnEventSourceId = "CHR0034";
+
+    /// <summary>
+    /// A read model declares a property named '_subject', which Chronicle reserves as an internal field.
+    /// </summary>
+    public const string ReservedSubjectProperty = "CHR0035";
+
+    /// <summary>
+    /// A reducer declares mutable instance state or injects a storage primitive directly.
+    /// </summary>
+    public const string ReducerMustNotHaveMutableState = "CHR0036";
+
+    /// <summary>
+    /// The event type generations referenced by an event type migration must share one explicit [EventType] id.
+    /// </summary>
+    public const string MigrationGenerationEventTypeId = "CHR0037";
 }

--- a/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
@@ -117,6 +117,24 @@ public static class WellKnownTypes
     public const string NoAutoMapAttributeName = "Cratis.Chronicle.Projections.NoAutoMapAttribute";
 
     /// <summary>
+    /// The full name of the PII attribute.
+    /// </summary>
+    public const string PiiAttributeName = "Cratis.Chronicle.Compliance.GDPR.PIIAttribute";
+
+    /// <summary>
+    /// The full name of the Arc model-bound ReadModel attribute.
+    /// </summary>
+    /// <remarks>
+    /// Matched by full-name string so the analyzer does not need a reference to the Arc assembly.
+    /// </remarks>
+    public const string ReadModelAttributeName = "Cratis.Arc.Queries.ModelBound.ReadModelAttribute";
+
+    /// <summary>
+    /// The open-generic display string of the EventTypeMigration&lt;TUpgrade, TPrevious&gt; base class.
+    /// </summary>
+    public const string EventTypeMigrationGenericDisplay = "Cratis.Chronicle.Events.Migrations.EventTypeMigration<TUpgrade, TPrevious>";
+
+    /// <summary>
     /// The full name of the EventStreamId attribute.
     /// </summary>
     public const string EventStreamIdAttributeName = "Cratis.Chronicle.Events.EventStreamIdAttribute";
@@ -162,6 +180,63 @@ public static class WellKnownTypes
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Check whether a symbol carries an attribute with the given full name.
+    /// </summary>
+    /// <param name="symbol">The symbol to inspect.</param>
+    /// <param name="attributeFullName">The full display name of the attribute type.</param>
+    /// <returns>True if the symbol carries the attribute, false otherwise.</returns>
+    public static bool HasAttribute(ISymbol symbol, string attributeFullName) =>
+        symbol.GetAttributes().Any(attribute => attribute.AttributeClass?.ToDisplayString() == attributeFullName);
+
+    /// <summary>
+    /// Find the <c>EventTypeMigration&lt;TUpgrade, TPrevious&gt;</c> base type of a type, if any.
+    /// </summary>
+    /// <param name="type">The type symbol to check.</param>
+    /// <returns>The constructed <c>EventTypeMigration&lt;TUpgrade, TPrevious&gt;</c> base, or <see langword="null"/> when the type does not derive from it.</returns>
+    public static INamedTypeSymbol? GetEventTypeMigrationBase(ITypeSymbol? type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current is INamedTypeSymbol { IsGenericType: true } named &&
+                named.OriginalDefinition.ToDisplayString() == EventTypeMigrationGenericDisplay)
+            {
+                return named;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Get the <c>[EventType]</c> attribute data from a type, whether the client or kernel attribute.
+    /// </summary>
+    /// <param name="type">The type symbol to inspect.</param>
+    /// <returns>The <see cref="AttributeData"/> for the <c>[EventType]</c> attribute, or <see langword="null"/> when the type has none.</returns>
+    public static AttributeData? GetEventTypeAttributeData(ITypeSymbol type) =>
+        type.GetAttributes().FirstOrDefault(attribute =>
+        {
+            var attributeName = attribute.AttributeClass?.ToDisplayString();
+            return attributeName == KernelEventTypeAttributeName ||
+                   attributeName == ClientEventTypeAttributeName;
+        });
+
+    /// <summary>
+    /// Get the explicit id argument from an <c>[EventType]</c> attribute, or <see langword="null"/> when no explicit id was supplied.
+    /// </summary>
+    /// <param name="attributeData">The <c>[EventType]</c> attribute data.</param>
+    /// <returns>The explicit id string, or <see langword="null"/> when the id is absent or empty.</returns>
+    public static string? GetEventTypeExplicitId(AttributeData attributeData)
+    {
+        if (attributeData.ConstructorArguments.Length == 0)
+        {
+            return null;
+        }
+
+        var id = attributeData.ConstructorArguments[0].Value as string;
+        return string.IsNullOrEmpty(id) ? null : id;
     }
 
     /// <summary>

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_joining_a_string_concept_keyed_source.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_joining_a_string_concept_keyed_source.cs
@@ -7,17 +7,10 @@ namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
 
 /// <summary>
 /// A read model carrying a <c>[Join]</c> whose source event is keyed by a string concept (an organization
-/// number) is spec-able: seeding the string-keyed source no longer force-converts the join key to the
-/// read model's Guid identifier and crashes the whole scenario. The read model materializes and its own
-/// properties can be asserted.
+/// number) both materializes and enriches: seeding the string-keyed source no longer force-converts the join
+/// key to the read model's Guid identifier and crashes the whole scenario, and the joined value is backfilled
+/// onto the root document — parity with a Guid-keyed join.
 /// </summary>
-/// <remarks>
-/// The joined value itself (<c>CustomerName</c>) is not asserted here: <c>ReadModelScenario</c> does not
-/// materialize root-level join enrichment (a pre-existing harness limitation that applies to Guid-keyed
-/// joins too — the real engine enriches via its join read-back, covered by the out-of-process integration
-/// specs). The point of this spec is that a string-concept-keyed join source no longer makes the read model
-/// entirely un-spec-able.
-/// </remarks>
 public class when_joining_a_string_concept_keyed_source : Specification
 {
     ReadModelScenario<EngagementSummary> _scenario;
@@ -39,4 +32,5 @@ public class when_joining_a_string_concept_keyed_source : Specification
 
     [Fact] void should_materialize_the_read_model() => _scenario.InstanceForEventSourceId(_engagementId).ShouldNotBeNull();
     [Fact] void should_keep_the_string_org_number() => _scenario.InstanceForEventSourceId(_engagementId)!.CustomerOrgNumber.Value.ShouldEqual("999888777");
+    [Fact] void should_backfill_the_joined_customer_name() => _scenario.InstanceForEventSourceId(_engagementId)!.CustomerName.ShouldEqual("Acme Corp");
 }

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -195,7 +195,7 @@ internal static class ProjectionReadModelProcessor
         var deferredEvents = new Queue<KernelAppendedEvent>();
         foreach (var @event in appendedEvents)
         {
-            var (newState, eventKey, eventRemoved) = await ProcessSingleEvent(engineProjection, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents, strictEventSubscription);
+            var (newState, eventKey, eventRemoved) = await ProcessSingleEvent(engineProjection, kernelProjectionDefinition, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents, strictEventSubscription);
             state = newState;
             rootKey ??= eventKey;
             removed = eventRemoved;
@@ -412,6 +412,7 @@ internal static class ProjectionReadModelProcessor
 
     static async Task<(ExpandoObject State, KernelKey? Key, bool Removed)> ProcessSingleEvent(
         KernelProjectionEngine::IProjection projection,
+        KernelConceptsNs::Projections.Definitions.ProjectionDefinition kernelProjectionDefinition,
         InMemoryEventSequenceStorage eventSequenceStorage,
         InMemorySink sink,
         KernelAppendedEvent @event,
@@ -446,13 +447,19 @@ internal static class ProjectionReadModelProcessor
         }
         catch (FormatException) when (projection.GetOperationTypeFor(@event.Context.EventType).HasFlag(KernelProjectionEngine::ProjectionOperationType.Join))
         {
-            // A [Join] source event keyed by a string concept (e.g. an organization number) cannot be routed
-            // by a differently typed (e.g. Guid) read model identifier in this in-process harness. The real
-            // engine enriches such a join through its own join pipeline (verified out-of-process); this harness
-            // does not materialize root-level join enrichment (a pre-existing limitation shared with Guid-keyed
-            // joins), so skip the event rather than crashing the whole scenario — the read model still
-            // materializes from its own events and stays spec-able.
-            return (state, null, false);
+            // A root-level [Join] whose join-source event is keyed by a string concept (e.g. an organization
+            // number) throws here because the engine key resolver force-converts the join key to the read
+            // model's own identifier type (e.g. a Guid) and fails on the string value. Resolve the root
+            // document ourselves — mirroring the engine's root ForJoin branch — so the enrichment still runs,
+            // matching the parity a Guid-keyed join already has. A nested join, or a root with no matching
+            // document, falls back to the previous skip behavior so the scenario never crashes.
+            var resolvedRootKey = await TryResolveStringKeyedRootJoin(projection, kernelProjectionDefinition, sink, @event);
+            if (resolvedRootKey is null)
+            {
+                return (state, null, false);
+            }
+
+            keyResult = resolvedRootKey;
         }
 
         if (keyResult is KernelProjectionEngine::DeferredKey)
@@ -477,6 +484,45 @@ internal static class ProjectionReadModelProcessor
         var updatedState = removed ? new ExpandoObject() : ApplyActualChanges(key, changeset.Changes, state);
         await sink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
         return (updatedState, key, removed);
+    }
+
+    /// <summary>
+    /// Resolve the root read-model key for a root-level <c>[Join]</c> whose join-source event is keyed by a
+    /// string concept, by matching the join-on property against the join event's event source id.
+    /// </summary>
+    /// <param name="projection">The <see cref="KernelProjectionEngine::IProjection"/> being processed.</param>
+    /// <param name="kernelProjectionDefinition">The kernel projection definition carrying the join metadata.</param>
+    /// <param name="sink">The in-memory sink holding the materialized root documents.</param>
+    /// <param name="event">The join-source event being processed.</param>
+    /// <returns>A resolved <see cref="KernelProjectionEngine::KeyResolverResult"/> for the root document, or <see langword="null"/> when there is no root join or no matching document.</returns>
+    /// <remarks>
+    /// The engine's own <c>ForJoin</c> key resolver would do this lookup, but it throws before reaching it
+    /// because it force-converts the join key to the read model's identifier type. This replicates only the
+    /// root branch of that resolver (<c>sink.TryFindRootKeyByChildValue</c>) using the raw string value, so
+    /// no engine behavior changes — a nested join returns <see langword="null"/> and falls back to skipping.
+    /// </remarks>
+    static async Task<KernelProjectionEngine::KeyResolverResult?> TryResolveStringKeyedRootJoin(
+        KernelProjectionEngine::IProjection projection,
+        KernelConceptsNs::Projections.Definitions.ProjectionDefinition kernelProjectionDefinition,
+        InMemorySink sink,
+        KernelAppendedEvent @event)
+    {
+        if (projection.HasParent)
+        {
+            return null;
+        }
+
+        var joinDefinition = kernelProjectionDefinition.Join
+            .FirstOrDefault(join => join.Key.Id == @event.Context.EventType.Id).Value;
+        if (joinDefinition is null)
+        {
+            return null;
+        }
+
+        var rootKeyResult = await sink.TryFindRootKeyByChildValue(joinDefinition.On, @event.Context.EventSourceId.Value);
+        return rootKeyResult.TryGetValue(out var rootKey)
+            ? KernelProjectionEngine::KeyResolverResult.Resolved(rootKey)
+            : null;
     }
 
     static KernelReadModels::ReadModelDefinition BuildKernelReadModelDefinition(Type readModelType, JsonSchema schema)


### PR DESCRIPTION
## Added

- `CHR0034` — error when `[PII]` is applied to a property or record parameter whose type derives from `EventSourceId<T>`. The event source id is the encryption-key lookup identity, so Chronicle throws `PIINotSupportedOnEventSourceId` at runtime; the analyzer turns that into a compile-time error.
- `CHR0035` — error when a `[ReadModel]` declares a property or record parameter named `_subject`, which Chronicle reserves as an internal MongoDB field for compliance-subject tracking.
- `CHR0036` — warning when a reducer declares mutable instance state or injects a storage primitive such as `IMongoCollection<T>`. Reducers must be stateless for deterministic replay; this mirrors `CHR0031`/`CHR0032` for reactors. (#958)
- `CHR0037` — warning when the two generations referenced by an `EventTypeMigration<TUpgrade, TPrevious>` do not share one explicit `[EventType]` id. Chronicle keys generations by that id, so absent or differing ids mean the migration silently never applies.

## Fixed

- `ReadModelScenario<T>` now backfills the joined value for a root-level `[Join]` whose join-source event is keyed by a string concept, matching the parity a `Guid`-keyed join already had.
