### PR TITLE
Fix root PII failing to decrypt beside a sibling PII read model

### DIFF
--- a/Source/Kernel/Concepts/Compliance/EncryptionKeyRevision.cs
+++ b/Source/Kernel/Concepts/Compliance/EncryptionKeyRevision.cs
@@ -15,6 +15,11 @@ public record EncryptionKeyRevision(uint Value) : ConceptAs<uint>(Value)
     public static readonly EncryptionKeyRevision Latest = uint.MaxValue;
 
     /// <summary>
+    /// Gets the first revision a subject's encryption key is provisioned under.
+    /// </summary>
+    public static readonly EncryptionKeyRevision Initial = 1u;
+
+    /// <summary>
     /// Implicitly convert from <see cref="uint"/> to <see cref="EncryptionKeyRevision"/>.
     /// </summary>
     /// <param name="value"><see cref="uint"/> to convert from.</param>

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_applying_and_key_does_not_exist.cs
@@ -13,6 +13,7 @@ public class when_applying_and_key_does_not_exist : given.a_property_handler
     JsonNode _input;
     JsonNode _result;
     EncryptionKey _generatedKey;
+    EncryptionKey _provisionedKey;
     byte[] _encryptedBytes;
 
     void Establish()
@@ -20,14 +21,21 @@ public class when_applying_and_key_does_not_exist : given.a_property_handler
         _keyStore.TryGetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier).Returns(Task.FromResult<EncryptionKey?>(null));
         _generatedKey = new EncryptionKey(Encoding.UTF8.GetBytes("NewPublic"), Encoding.UTF8.GetBytes("NewPrivate"));
         _encryption.GenerateKey().Returns(_generatedKey);
+
+        // Provisioning goes through the atomic get-or-create so concurrent callers converge on one key pair.
+        // The store echoes back the key that was actually persisted — here the freshly generated one.
+        _provisionedKey = _generatedKey;
+        _keyStore.GetOrAddFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, Arg.Any<EncryptionKey>()).Returns(Task.FromResult(_provisionedKey));
+
         _encryptedBytes = Encoding.UTF8.GetBytes("encrypted");
-        _encryption.Encrypt(Arg.Any<byte[]>(), _generatedKey).Returns(_encryptedBytes);
+        _encryption.Encrypt(Arg.Any<byte[]>(), _provisionedKey).Returns(_encryptedBytes);
         _input = JsonValue.Create("sensitive");
     }
 
     async Task Because() => _result = await _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
 
     [Fact] void should_generate_a_new_key() => _encryption.Received(1).GenerateKey();
-    [Fact] async Task should_save_the_generated_key_for_the_identifier() => await _keyStore.Received(1).SaveFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _generatedKey);
-    [Fact] void should_return_encrypted_value() => _result.ToString().ShouldEqual(Convert.ToBase64String(_encryptedBytes));
+    [Fact] async Task should_provision_the_key_through_get_or_add() => await _keyStore.Received(1).GetOrAddFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _generatedKey);
+    [Fact] async Task should_not_mint_a_separate_revision_with_save() => await _keyStore.DidNotReceive().SaveFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, Arg.Any<EncryptionKey>());
+    [Fact] void should_return_value_encrypted_with_the_provisioned_key() => _result.ToString().ShouldEqual(Convert.ToBase64String(_encryptedBytes));
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/and_a_provisioning_read_is_stale.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/and_a_provisioning_read_is_stale.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.when_provisioning_a_key_concurrently;
+
+/// <summary>
+/// REPRO of the residual GDPR-PII defect: a subject owns two read models (a root-PII model A and a
+/// sibling child-collection-PII model B) that both encrypt under the same subject. When the second
+/// provisioner's existence check reads state that does not yet reflect the first save — a MongoDB
+/// secondary lagging the primary, or a second silo — check-then-act provisioning saves a SECOND key.
+/// Because a save mints a new revision and reads return the latest, the value model A already encrypted
+/// under the first key can no longer be decrypted: "rsa routines::padding check failed". Provisioning
+/// must converge to exactly one key pair per subject so the earlier value still releases.
+/// </summary>
+public class and_a_provisioning_read_is_stale : given.a_key_store_with_read_after_write_lag
+{
+    readonly string _subject = Guid.NewGuid().ToString();
+    const string ModelARootValue = "Jane Doe";
+    const string ModelBChildValue = "A sensitive evaluation note";
+
+    PIICompliancePropertyValueHandler _handler;
+    JsonNode _modelACiphertext;
+    Exception _releaseError;
+    string _modelAReleased;
+    int _revisionCount;
+
+    void Establish() => _handler = new(_keyStore, new Encryption());
+
+    async Task Because()
+    {
+        // Model A encrypts its root PII under the subject — provisions the first key.
+        _modelACiphertext = await _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _subject, JsonValue.Create(ModelARootValue));
+
+        // Model B's projection encrypts a child-collection PII under the same subject, but its existence
+        // check still reads the stale secondary and does not see model A's key — so it provisions again.
+        await _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _subject, JsonValue.Create(ModelBChildValue));
+
+        await _keyStore.Replicate();
+
+        _releaseError = await Catch.Exception(async () =>
+        {
+            var released = await _handler.Release(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _subject, _modelACiphertext);
+            _modelAReleased = released.ToString();
+        });
+
+        _revisionCount = await _keyStore.RevisionCountOnPrimary(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _subject);
+    }
+
+    [Fact] void should_release_model_a_root_pii_without_a_padding_failure() => _releaseError.ShouldBeNull();
+    [Fact] void should_release_model_a_root_pii_back_to_plaintext() => _modelAReleased.ShouldEqual(ModelARootValue);
+    [Fact] void should_provision_exactly_one_key_pair_for_the_subject() => _revisionCount.ShouldEqual(1);
+}

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/for_the_same_subject.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/for_the_same_subject.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.when_provisioning_a_key_concurrently;
+
+/// <summary>
+/// REPRO: a subject receives many PII values encrypted concurrently (a batch append + sibling
+/// projections encrypt every PII field under the same subject at once, via Task.WhenAll). The
+/// real key-provisioning path must yield exactly one key and every ciphertext must release back
+/// to plaintext. A padding failure on release means the key changed between encrypt and read.
+/// </summary>
+public class for_the_same_subject : Specification
+{
+    const string Identifier = "39b34712-ad8e-4cde-b879-2719c995aa49";
+    const int Count = 64;
+
+    InMemoryEncryptionKeyStorage _keyStore;
+    PIICompliancePropertyValueHandler _handler;
+    string[] _plaintexts;
+    JsonNode[] _ciphertexts;
+    Exception _releaseError;
+    string[] _released;
+    int _revisionCount;
+
+    void Establish()
+    {
+        _keyStore = new InMemoryEncryptionKeyStorage();
+        _handler = new(_keyStore, new Encryption());
+        _plaintexts = Enumerable.Range(0, Count).Select(i => $"secret-{i}").ToArray();
+    }
+
+    async Task Because()
+    {
+        var applyTasks = _plaintexts.Select(p =>
+            _handler.Apply(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, JsonValue.Create(p)));
+        _ciphertexts = await Task.WhenAll(applyTasks);
+
+        _releaseError = await Catch.Exception(async () =>
+        {
+            var releaseTasks = _ciphertexts.Select(c =>
+                _handler.Release(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, c));
+            var results = await Task.WhenAll(releaseTasks);
+            _released = results.Select(r => r.ToString()).ToArray();
+        });
+
+        _revisionCount = await CountRevisions();
+    }
+
+    async Task<int> CountRevisions()
+    {
+        var count = 0;
+        for (var revision = 1u; revision <= Count + 1; revision++)
+        {
+            if (await _keyStore.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, new EncryptionKeyRevision(revision)))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    [Fact] void should_release_every_value_without_a_padding_failure() => _releaseError.ShouldBeNull();
+    [Fact] void should_round_trip_every_value() => _released.ShouldContainOnly(_plaintexts);
+    [Fact] void should_provision_exactly_one_key_revision() => _revisionCount.ShouldEqual(1);
+}

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/given/a_key_store_with_read_after_write_lag.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_provisioning_a_key_concurrently/given/a_key_store_with_read_after_write_lag.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.when_provisioning_a_key_concurrently.given;
+
+/// <summary>
+/// An <see cref="IEncryptionKeyStorage"/> that models a MongoDB replica set (or a second silo) where a
+/// read can observe state older than the latest write: writes land on a "primary" but reads are served
+/// from a "secondary" that only catches up when <see cref="LaggingReadKeyStorage.Replicate"/> is called. This is enough to
+/// defeat the check-then-act provisioning in <c>EnsureKeyFor</c> — two provisioners for one subject can
+/// both observe "no key" and each save a key, and the store then returns whichever was written last.
+/// It delegates to a real <see cref="InMemoryEncryptionKeyStorage"/> for the actual revisioned behavior.
+/// </summary>
+public class a_key_store_with_read_after_write_lag : Specification
+{
+    protected LaggingReadKeyStorage _keyStore;
+
+    void Establish() => _keyStore = new LaggingReadKeyStorage();
+
+    /// <summary>
+    /// An <see cref="IEncryptionKeyStorage"/> whose reads lag behind its writes until <see cref="Replicate"/>.
+    /// </summary>
+    public sealed class LaggingReadKeyStorage : IEncryptionKeyStorage
+    {
+        readonly InMemoryEncryptionKeyStorage _primary = new();
+        readonly InMemoryEncryptionKeyStorage _secondary = new();
+        readonly List<(EventStoreName EventStore, EventStoreNamespaceName Namespace, EncryptionKeyIdentifier Identifier, EncryptionKey Key, EncryptionKeyRevision? Revision)> _pending = [];
+
+        public async Task SaveFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key, EncryptionKeyRevision? revision = null)
+        {
+            await _primary.SaveFor(eventStore, eventStoreNamespace, identifier, key, revision);
+            _pending.Add((eventStore, eventStoreNamespace, identifier, key, revision));
+        }
+
+        public async Task<EncryptionKey> GetOrAddFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key)
+        {
+            // Writes (and the atomic get-or-create) land on the primary — the ordering point — even though
+            // reads are served from a lagging secondary. This models MongoDB, where the insert-if-absent is
+            // executed against the primary regardless of read preference.
+            var result = await _primary.GetOrAddFor(eventStore, eventStoreNamespace, identifier, key);
+            _pending.Add((eventStore, eventStoreNamespace, identifier, result, EncryptionKeyRevision.Initial));
+            return result;
+        }
+
+        public Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+            _secondary.HasFor(eventStore, eventStoreNamespace, identifier, revision);
+
+        public Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+            _secondary.TryGetFor(eventStore, eventStoreNamespace, identifier, revision);
+
+        public Task<EncryptionKey> GetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+            _secondary.GetFor(eventStore, eventStoreNamespace, identifier, revision);
+
+        public Task DeleteFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null) =>
+            Task.WhenAll(
+                _primary.DeleteFor(eventStore, eventStoreNamespace, identifier, revision),
+                _secondary.DeleteFor(eventStore, eventStoreNamespace, identifier, revision));
+
+        /// <summary>Catches the secondary up to the primary, making prior writes visible to reads.</summary>
+        /// <returns>Awaitable task.</returns>
+        public async Task Replicate()
+        {
+            foreach (var (eventStore, eventStoreNamespace, identifier, key, revision) in _pending)
+            {
+                await _secondary.SaveFor(eventStore, eventStoreNamespace, identifier, key, revision);
+            }
+
+            _pending.Clear();
+        }
+
+        /// <summary>Counts how many distinct revisions exist on the primary for a subject.</summary>
+        /// <param name="eventStore">The event store.</param>
+        /// <param name="eventStoreNamespace">The namespace.</param>
+        /// <param name="identifier">The subject identifier.</param>
+        /// <returns>The number of persisted revisions.</returns>
+        public async Task<int> RevisionCountOnPrimary(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier)
+        {
+            var count = 0;
+            for (var revision = 1u; revision <= 16; revision++)
+            {
+                if (await _primary.HasFor(eventStore, eventStoreNamespace, identifier, new EncryptionKeyRevision(revision)))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_event_has_explicit_subject.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_event_has_explicit_subject.cs
@@ -36,8 +36,7 @@ public class and_event_has_explicit_subject : Specification
 
         _encryptionKeyStorage = Substitute.For<IEncryptionKeyStorage>();
         _encryptionKeyStorage.HasFor("Lobby", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(false);
-        _encryptionKeyStorage.HasFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(true);
-        _encryptionKeyStorage.GetFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(new EncryptionKey([], []));
+        _encryptionKeyStorage.TryGetFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(new EncryptionKey([], []));
         _silo.AddService(_encryptionKeyStorage);
 
         _inboxSequence = Substitute.For<IEventSequence>();
@@ -109,7 +108,7 @@ public class and_event_has_explicit_subject : Specification
 
     [Fact]
     Task should_copy_encryption_key_to_target_event_store() =>
-        _encryptionKeyStorage.Received(1).SaveFor(
+        _encryptionKeyStorage.Received(1).GetOrAddFor(
             "Lobby",
             EventStoreNamespaceName.Default,
             Arg.Is<EncryptionKeyIdentifier>(identifier => identifier.Value == _explicitSubject.Value),

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_multiple_events_share_subject.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_multiple_events_share_subject.cs
@@ -36,8 +36,7 @@ public class and_multiple_events_share_subject : Specification
 
         _encryptionKeyStorage = Substitute.For<IEncryptionKeyStorage>();
         _encryptionKeyStorage.HasFor("Lobby", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(false);
-        _encryptionKeyStorage.HasFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(true);
-        _encryptionKeyStorage.GetFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(new EncryptionKey([], []));
+        _encryptionKeyStorage.TryGetFor("Admin", EventStoreNamespaceName.Default, Arg.Any<EncryptionKeyIdentifier>()).Returns(new EncryptionKey([], []));
         _silo.AddService(_encryptionKeyStorage);
 
         _inboxSequence = Substitute.For<IEventSequence>();
@@ -106,7 +105,7 @@ public class and_multiple_events_share_subject : Specification
 
     [Fact]
     Task should_only_copy_encryption_key_once() =>
-        _encryptionKeyStorage.Received(1).SaveFor(
+        _encryptionKeyStorage.Received(1).GetOrAddFor(
             "Lobby",
             EventStoreNamespaceName.Default,
             Arg.Is<EncryptionKeyIdentifier>(identifier => identifier.Value == _explicitSubject.Value),

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_target_store_already_has_encryption_key.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionObserverSubscriber/when_forwarding_events/and_target_store_already_has_encryption_key.cs
@@ -90,7 +90,7 @@ public class and_target_store_already_has_encryption_key : Specification
 
     [Fact]
     Task should_not_copy_encryption_key_to_target_event_store() =>
-        _encryptionKeyStorage.DidNotReceive().SaveFor(
+        _encryptionKeyStorage.DidNotReceive().GetOrAddFor(
             Arg.Any<EventStoreName>(),
             Arg.Any<EventStoreNamespaceName>(),
             Arg.Any<EncryptionKeyIdentifier>(),

--- a/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
@@ -64,22 +64,18 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
             return existing;
         }
 
-        // Serialize key creation per subject. Appending a batch encrypts all events concurrently
-        // (Task.WhenAll), so multiple events for the same subject can otherwise each generate and
-        // save a key, with the last write overwriting the rest — orphaning the data encrypted with
-        // the losing keys. The gate ensures only the first caller creates the key; the rest reuse it.
+        // A subject's key must be provisioned exactly once: a batch append and the sibling projections that
+        // observe it all encrypt PII under the same subject concurrently (Task.WhenAll), and the same subject
+        // may be provisioned from more than one silo. If two provisioners each generate and save a key, the
+        // store mints a second revision and the value encrypted under the first key can no longer be decrypted
+        // ("padding check failed"). The in-process gate serializes provisioning within this process to avoid
+        // generating throwaway keys; GetOrAddFor is the atomic get-or-create that makes every provisioner
+        // converge on a single persisted key pair even across processes / stale reads.
         var gate = _keyCreationGates.GetOrAdd($"{eventStore.Value}+{eventStoreNamespace.Value}+{identifier.Value}", _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync();
         try
         {
-            if (await _encryptionKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existingAfterGate)
-            {
-                return existingAfterGate;
-            }
-
-            var key = _encryption.GenerateKey();
-            await _encryptionKeyStore.SaveFor(eventStore, eventStoreNamespace, identifier, key);
-            return key;
+            return await _encryptionKeyStore.GetOrAddFor(eventStore, eventStoreNamespace, identifier, _encryption.GenerateKey());
         }
         finally
         {

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionObserverSubscriber.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionObserverSubscriber.cs
@@ -109,13 +109,15 @@ public class EventStoreSubscriptionObserverSubscriber(
             return;
         }
 
-        var sourceHasKey = await encryptionKeyStorage.HasFor(_key.EventStore, _key.Namespace, identifier);
-        if (!sourceHasKey)
+        var sourceKey = await encryptionKeyStorage.TryGetFor(_key.EventStore, _key.Namespace, identifier);
+        if (sourceKey is null)
         {
             return;
         }
 
-        var sourceKey = await encryptionKeyStorage.GetFor(_key.EventStore, _key.Namespace, identifier);
-        await encryptionKeyStorage.SaveFor(targetEventStore, _key.Namespace, identifier, sourceKey);
+        // Idempotently place the source key in the target store. GetOrAddFor keeps any key the target already
+        // has and otherwise persists the source key as the initial revision, so concurrent forwarded events for
+        // the same subject — or a replay — converge on a single revision instead of minting duplicate revisions.
+        await encryptionKeyStorage.GetOrAddFor(targetEventStore, _key.Namespace, identifier, sourceKey);
     }
 }

--- a/Source/Kernel/Storage.MongoDB/Encryption/EncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Encryption/EncryptionKeyStorage.cs
@@ -39,6 +39,35 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
     }
 
     /// <inheritdoc/>
+    public async Task<EncryptionKey> GetOrAddFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        EncryptionKey key)
+    {
+        var collection = GetCollection(eventStore, eventStoreNamespace);
+        if (await TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existing)
+        {
+            return existing;
+        }
+
+        var id = new EncryptionKeyId(identifier, EncryptionKeyRevision.Initial);
+        try
+        {
+            await collection.InsertOneAsync(new EncryptionKeyForIdentifier(id, key.Public, key.Private));
+            return key;
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Another provisioner created the initial key concurrently. Converge on the persisted key so
+            // every writer encrypts under the same one — the insert on the primary is the ordering point,
+            // so this is race-safe even when the pre-check above read a stale replica.
+            var winner = await collection.Find(_ => _.Id == id).FirstOrDefaultAsync();
+            return winner is null ? key : new(winner.PublicKey, winner.PrivateKey);
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> HasFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,

--- a/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/and_a_key_already_exists.cs
+++ b/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/and_a_key_already_exists.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.Compliance.for_InMemoryEncryptionKeyStorage.when_getting_or_adding_a_key;
+
+public class and_a_key_already_exists : given.an_in_memory_key_store
+{
+    EncryptionKey _existing;
+    EncryptionKey _candidate;
+    EncryptionKey _result;
+    int _revisionCount;
+
+    async Task Establish()
+    {
+        _existing = KeyNamed("existing");
+        _candidate = KeyNamed("candidate");
+        await _store.GetOrAddFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _identifier, _existing);
+    }
+
+    async Task Because()
+    {
+        _result = await _store.GetOrAddFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _identifier, _candidate);
+        _revisionCount = await RevisionCount();
+    }
+
+    [Fact] void should_return_the_existing_key() => _result.ShouldEqual(_existing);
+    [Fact] void should_ignore_the_candidate_key() => _result.ShouldNotEqual(_candidate);
+    [Fact] void should_not_mint_an_additional_revision() => _revisionCount.ShouldEqual(1);
+}

--- a/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/and_no_key_exists_yet.cs
+++ b/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/and_no_key_exists_yet.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.Compliance.for_InMemoryEncryptionKeyStorage.when_getting_or_adding_a_key;
+
+public class and_no_key_exists_yet : given.an_in_memory_key_store
+{
+    EncryptionKey _candidate;
+    EncryptionKey _result;
+    EncryptionKey _stored;
+    int _revisionCount;
+
+    void Establish() => _candidate = KeyNamed("candidate");
+
+    async Task Because()
+    {
+        _result = await _store.GetOrAddFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _identifier, _candidate);
+        _stored = (await _store.TryGetFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _identifier))!;
+        _revisionCount = await RevisionCount();
+    }
+
+    [Fact] void should_return_the_candidate_key() => _result.ShouldEqual(_candidate);
+    [Fact] void should_persist_the_candidate_key() => _stored.ShouldEqual(_candidate);
+    [Fact] void should_provision_exactly_one_revision() => _revisionCount.ShouldEqual(1);
+}

--- a/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/given/an_in_memory_key_store.cs
+++ b/Source/Kernel/Storage.Specs/Compliance/for_InMemoryEncryptionKeyStorage/when_getting_or_adding_a_key/given/an_in_memory_key_store.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.Compliance.for_InMemoryEncryptionKeyStorage.when_getting_or_adding_a_key.given;
+
+public class an_in_memory_key_store : Specification
+{
+    protected InMemoryEncryptionKeyStorage _store;
+    protected EncryptionKeyIdentifier _identifier;
+
+    void Establish()
+    {
+        _store = new InMemoryEncryptionKeyStorage();
+        _identifier = new EncryptionKeyIdentifier(Guid.NewGuid().ToString());
+    }
+
+    protected static EncryptionKey KeyNamed(string name) =>
+        new(Encoding.UTF8.GetBytes($"{name}-public"), Encoding.UTF8.GetBytes($"{name}-private"));
+
+    protected async Task<int> RevisionCount()
+    {
+        var count = 0;
+        for (var revision = 1u; revision <= 8; revision++)
+        {
+            if (await _store.HasFor(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, _identifier, new EncryptionKeyRevision(revision)))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Encryption/EncryptionKeyStorage.cs
@@ -40,6 +40,40 @@ public class EncryptionKeyStorage(IDatabase database) : IEncryptionKeyStorage
     }
 
     /// <inheritdoc/>
+    public async Task<StoredEncryptionKey> GetOrAddFor(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        EncryptionKeyIdentifier identifier,
+        StoredEncryptionKey key)
+    {
+        if (await TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existing)
+        {
+            return existing;
+        }
+
+        await using var scope = await database.Namespace(eventStore, eventStoreNamespace);
+        try
+        {
+            scope.DbContext.EncryptionKeys.Add(new EncryptionKey
+            {
+                Identifier = identifier.Value,
+                Revision = EncryptionKeyRevision.Initial.Value,
+                PublicKey = key.Public,
+                PrivateKey = key.Private
+            });
+            await scope.DbContext.SaveChangesAsync();
+            return key;
+        }
+        catch (DbUpdateException)
+        {
+            // Another provisioner inserted the initial revision first (primary key violation on
+            // Identifier + Revision). Converge on the persisted key so every writer encrypts under the same one.
+            var winner = await TryGetFor(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Initial);
+            return winner ?? key;
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> HasFor(
         EventStoreName eventStore,
         EventStoreNamespaceName eventStoreNamespace,

--- a/Source/Kernel/Storage/Compliance/CacheEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/CacheEncryptionKeyStorage.cs
@@ -16,27 +16,52 @@ namespace Cratis.Chronicle.Storage.Compliance;
 public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : IEncryptionKeyStorage
 {
     readonly Dictionary<Key, EncryptionKey> _keys = [];
+    readonly Lock _lock = new();
 
     /// <inheritdoc/>
     public async Task DeleteFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
-        if (IsLatest(revision))
+        lock (_lock)
         {
-            var keysToRemove = _keys.Keys
-                .Where(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier)
-                .ToList();
-            foreach (var key in keysToRemove)
+            if (IsLatest(revision))
             {
-                _keys.Remove(key);
+                var keysToRemove = _keys.Keys
+                    .Where(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier)
+                    .ToList();
+                foreach (var key in keysToRemove)
+                {
+                    _keys.Remove(key);
+                }
             }
-        }
-        else
-        {
-            _keys.Remove(new(eventStore, eventStoreNamespace, identifier, revision!));
-            _keys.Remove(new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest));
+            else
+            {
+                _keys.Remove(new(eventStore, eventStoreNamespace, identifier, revision!));
+                _keys.Remove(new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest));
+            }
         }
 
         await actualKeyStore.DeleteFor(eventStore, eventStoreNamespace, identifier, revision);
+    }
+
+    /// <inheritdoc/>
+    public async Task<EncryptionKey> GetOrAddFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key)
+    {
+        var cacheKey = new Key(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest);
+        lock (_lock)
+        {
+            if (_keys.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+        }
+
+        var provisioned = await actualKeyStore.GetOrAddFor(eventStore, eventStoreNamespace, identifier, key);
+        lock (_lock)
+        {
+            _keys[cacheKey] = provisioned;
+        }
+
+        return provisioned;
     }
 
     /// <inheritdoc/>
@@ -45,15 +70,21 @@ public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : I
         var cacheRevision = revision ?? EncryptionKeyRevision.Latest;
         var cacheKey = new Key(eventStore, eventStoreNamespace, identifier, cacheRevision);
 
-        if (_keys.TryGetValue(cacheKey, out var encryptionKey))
+        lock (_lock)
         {
-            return encryptionKey;
+            if (_keys.TryGetValue(cacheKey, out var encryptionKey))
+            {
+                return encryptionKey;
+            }
         }
 
         var key = await actualKeyStore.TryGetFor(eventStore, eventStoreNamespace, identifier, revision);
         if (key is not null)
         {
-            _keys[cacheKey] = key;
+            lock (_lock)
+            {
+                _keys[cacheKey] = key;
+            }
         }
 
         return key;
@@ -68,9 +99,12 @@ public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : I
     {
         var cacheRevision = revision ?? EncryptionKeyRevision.Latest;
 
-        if (_keys.ContainsKey(new(eventStore, eventStoreNamespace, identifier, cacheRevision)))
+        lock (_lock)
         {
-            return true;
+            if (_keys.ContainsKey(new(eventStore, eventStoreNamespace, identifier, cacheRevision)))
+            {
+                return true;
+            }
         }
 
         return await actualKeyStore.HasFor(eventStore, eventStoreNamespace, identifier, revision);
@@ -79,14 +113,18 @@ public class CacheEncryptionKeyStorage(IEncryptionKeyStorage actualKeyStore) : I
     /// <inheritdoc/>
     public async Task SaveFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key, EncryptionKeyRevision? revision = null)
     {
-        _keys.Remove(new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest));
-
-        if (revision is not null && revision != EncryptionKeyRevision.Latest)
+        lock (_lock)
         {
-            _keys[new(eventStore, eventStoreNamespace, identifier, revision)] = key;
+            _keys.Remove(new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest));
+
+            if (revision is not null && revision != EncryptionKeyRevision.Latest)
+            {
+                _keys[new(eventStore, eventStoreNamespace, identifier, revision)] = key;
+            }
+
+            _keys[new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest)] = key;
         }
 
-        _keys[new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Latest)] = key;
         await actualKeyStore.SaveFor(eventStore, eventStoreNamespace, identifier, key, revision);
     }
 

--- a/Source/Kernel/Storage/Compliance/CompositeEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/CompositeEncryptionKeyStorage.cs
@@ -47,6 +47,25 @@ public class CompositeEncryptionKeyStorage(params IEncryptionKeyStorage[] inner)
         await TryGetFor(eventStore, eventStoreNamespace, identifier, revision) ?? throw new MissingEncryptionKey(identifier);
 
     /// <inheritdoc/>
+    public async Task<EncryptionKey> GetOrAddFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key)
+    {
+        if (inner.Length == 0)
+        {
+            return key;
+        }
+
+        // Provision atomically on the first store, then mirror the winning key to the rest so every store
+        // converges on the same key pair. Using GetOrAddFor on the mirrors keeps them idempotent.
+        var provisioned = await inner[0].GetOrAddFor(eventStore, eventStoreNamespace, identifier, key);
+        foreach (var store in inner.Skip(1))
+        {
+            await store.GetOrAddFor(eventStore, eventStoreNamespace, identifier, provisioned);
+        }
+
+        return provisioned;
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
         foreach (var innerStore in inner)

--- a/Source/Kernel/Storage/Compliance/IEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/IEncryptionKeyStorage.cs
@@ -23,6 +23,35 @@ public interface IEncryptionKeyStorage
     Task SaveFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key, EncryptionKeyRevision? revision = null);
 
     /// <summary>
+    /// Atomically get the existing <see cref="EncryptionKey"/> for an <see cref="EncryptionKeyIdentifier"/>,
+    /// or persist and return the provided key when none exists yet.
+    /// </summary>
+    /// <param name="eventStore"><see cref="EventStoreName"/> the key belongs to.</param>
+    /// <param name="eventStoreNamespace"><see cref="EventStoreNamespaceName"/> the key belongs to.</param>
+    /// <param name="identifier"><see cref="EncryptionKeyIdentifier"/> to provision for.</param>
+    /// <param name="key">The <see cref="EncryptionKey"/> to persist when none exists yet.</param>
+    /// <returns>The existing key, or the provided key when it was the one persisted.</returns>
+    /// <remarks>
+    /// This is the get-or-create primitive for subject key provisioning. Concurrent or repeated callers for the
+    /// same identifier — across a batch append, sibling projections, multiple silos, or a stale read that does not
+    /// yet see a just-written key — must converge on a <b>single</b> persisted key pair, so that a value encrypted
+    /// under the returned key can always be decrypted later. Unlike <see cref="SaveFor"/>, this never mints an
+    /// additional revision when a key already exists; it reuses the initial revision. The default implementation is
+    /// best-effort for stores without a native atomic insert-if-absent; stores that support one override this to be
+    /// fully race-safe.
+    /// </remarks>
+    async Task<EncryptionKey> GetOrAddFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key)
+    {
+        if (await TryGetFor(eventStore, eventStoreNamespace, identifier) is { } existing)
+        {
+            return existing;
+        }
+
+        await SaveFor(eventStore, eventStoreNamespace, identifier, key, EncryptionKeyRevision.Initial);
+        return await TryGetFor(eventStore, eventStoreNamespace, identifier) ?? key;
+    }
+
+    /// <summary>
     /// Check if there is an <see cref="EncryptionKey"/> for a specific <see cref="EncryptionKeyIdentifier"/>.
     /// </summary>
     /// <param name="eventStore"><see cref="EventStoreName"/> the key belongs to.</param>

--- a/Source/Kernel/Storage/Compliance/InMemoryEncryptionKeyStorage.cs
+++ b/Source/Kernel/Storage/Compliance/InMemoryEncryptionKeyStorage.cs
@@ -14,40 +14,61 @@ namespace Cratis.Chronicle.Storage.Compliance;
 public class InMemoryEncryptionKeyStorage : IEncryptionKeyStorage
 {
     readonly Dictionary<Key, EncryptionKey> _keys = [];
+    readonly Lock _lock = new();
 
     /// <inheritdoc/>
     public Task SaveFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key, EncryptionKeyRevision? revision = null)
     {
-        var actualRevision = IsLatest(revision) ? GetNextRevision(eventStore, eventStoreNamespace, identifier) : revision!;
-        _keys[new(eventStore, eventStoreNamespace, identifier, actualRevision)] = key;
+        lock (_lock)
+        {
+            var actualRevision = IsLatest(revision) ? GetNextRevision(eventStore, eventStoreNamespace, identifier) : revision!;
+            _keys[new(eventStore, eventStoreNamespace, identifier, actualRevision)] = key;
+        }
+
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<EncryptionKey> GetOrAddFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKey key)
+    {
+        lock (_lock)
+        {
+            if (TryGetLatest(eventStore, eventStoreNamespace, identifier) is { } existing)
+            {
+                return Task.FromResult(existing);
+            }
+
+            _keys[new(eventStore, eventStoreNamespace, identifier, EncryptionKeyRevision.Initial)] = key;
+            return Task.FromResult(key);
+        }
     }
 
     /// <inheritdoc/>
     public Task<bool> HasFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
-        if (IsLatest(revision))
+        lock (_lock)
         {
-            return Task.FromResult(_keys.Keys.Any(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier));
-        }
+            if (IsLatest(revision))
+            {
+                return Task.FromResult(_keys.Keys.Any(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier));
+            }
 
-        return Task.FromResult(_keys.ContainsKey(new(eventStore, eventStoreNamespace, identifier, revision!)));
+            return Task.FromResult(_keys.ContainsKey(new(eventStore, eventStoreNamespace, identifier, revision!)));
+        }
     }
 
     /// <inheritdoc/>
     public Task<EncryptionKey?> TryGetFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
-        if (IsLatest(revision))
+        lock (_lock)
         {
-            var entry = _keys
-                .Where(kv => kv.Key.EventStore == eventStore && kv.Key.EventStoreNamespace == eventStoreNamespace && kv.Key.Identifier == identifier)
-                .OrderByDescending(kv => kv.Key.Revision.Value)
-                .Select(kv => (EncryptionKey?)kv.Value)
-                .FirstOrDefault();
-            return Task.FromResult(entry);
-        }
+            if (IsLatest(revision))
+            {
+                return Task.FromResult(TryGetLatest(eventStore, eventStoreNamespace, identifier));
+            }
 
-        return Task.FromResult(_keys.TryGetValue(new(eventStore, eventStoreNamespace, identifier, revision!), out var key) ? key : null);
+            return Task.FromResult(_keys.TryGetValue(new(eventStore, eventStoreNamespace, identifier, revision!), out var key) ? key : null);
+        }
     }
 
     /// <inheritdoc/>
@@ -57,25 +78,35 @@ public class InMemoryEncryptionKeyStorage : IEncryptionKeyStorage
     /// <inheritdoc/>
     public Task DeleteFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier, EncryptionKeyRevision? revision = null)
     {
-        if (IsLatest(revision))
+        lock (_lock)
         {
-            var keysToRemove = _keys.Keys
-                .Where(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier)
-                .ToList();
-            foreach (var key in keysToRemove)
+            if (IsLatest(revision))
             {
-                _keys.Remove(key);
+                var keysToRemove = _keys.Keys
+                    .Where(k => k.EventStore == eventStore && k.EventStoreNamespace == eventStoreNamespace && k.Identifier == identifier)
+                    .ToList();
+                foreach (var key in keysToRemove)
+                {
+                    _keys.Remove(key);
+                }
             }
-        }
-        else
-        {
-            _keys.Remove(new(eventStore, eventStoreNamespace, identifier, revision!));
+            else
+            {
+                _keys.Remove(new(eventStore, eventStoreNamespace, identifier, revision!));
+            }
         }
 
         return Task.CompletedTask;
     }
 
     static bool IsLatest(EncryptionKeyRevision? revision) => revision is null || revision == EncryptionKeyRevision.Latest;
+
+    EncryptionKey? TryGetLatest(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier) =>
+        _keys
+            .Where(kv => kv.Key.EventStore == eventStore && kv.Key.EventStoreNamespace == eventStoreNamespace && kv.Key.Identifier == identifier)
+            .OrderByDescending(kv => kv.Key.Revision.Value)
+            .Select(kv => (EncryptionKey?)kv.Value)
+            .FirstOrDefault();
 
     EncryptionKeyRevision GetNextRevision(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier)
     {


### PR DESCRIPTION
# Summary

A read model's `[PII]` property could intermittently fail to decrypt — coming back as raw ciphertext or throwing `rsa routines::padding check failed` — when its subject also owned another read model that encrypted PII (for example a sibling read model with a `[ChildrenFrom]` child collection). Subject encryption keys are now provisioned exactly once per subject, so previously-encrypted PII always decrypts.

## Fixed

- Fixed a read model's `[PII]` property intermittently failing to decrypt (`rsa routines::padding check failed`, or rendering as ciphertext) when the same subject also carried PII in a sibling read model. Subject encryption keys are now provisioned atomically and exactly once, even under concurrent appends, multiple silos, or a replica that has not yet caught up.