### PR TITLE
Fix PII active projections stalling on the SQL sink (#3463)

### DIFF
--- a/Integration/Client/ChronicleConfigurableFixture.cs
+++ b/Integration/Client/ChronicleConfigurableFixture.cs
@@ -338,6 +338,31 @@ public class ChronicleConfigurableFixture : XUnit.Integration.ChronicleFixture
         ? _outOfProcessKernelContainer.GetMappedPublicPort(35000)
         : throw new InvalidOperationException("KernelGrpcHostPort is only valid in OutOfProcess mode after the kernel container has been built.");
 
+    /// <summary>
+    /// Gets the captured stdout/stderr of the out-of-process kernel container, or a short
+    /// placeholder when running in-process. Used by specs to surface kernel-side diagnostics
+    /// (observer subscription, routing, projection traces) into the test output when an
+    /// eventual-consistency poll times out in CI, where the container logs are otherwise lost.
+    /// </summary>
+    /// <returns>The container logs, or a placeholder when no OOP kernel container exists.</returns>
+    public async Task<string> GetOutOfProcessKernelLogs()
+    {
+        if (_outOfProcessKernelContainer is null)
+        {
+            return "(no out-of-process kernel container; running in-process)";
+        }
+
+        try
+        {
+            var logs = await _outOfProcessKernelContainer.GetLogsAsync();
+            return $"===== OOP kernel STDOUT =====\n{logs.Stdout}\n===== OOP kernel STDERR =====\n{logs.Stderr}";
+        }
+        catch (Exception ex)
+        {
+            return $"(could not retrieve out-of-process kernel logs: {ex.Message})";
+        }
+    }
+
     string BuildAndStartMongoDB(INetwork network)
     {
         // Initiate the replica set using the docker-network hostname as the member name so

--- a/Integration/Client/for_ReadModels/when_a_subject_owns_a_pii_child_collection/and_reading_the_child_collection.cs
+++ b/Integration/Client/for_ReadModels/when_a_subject_owns_a_pii_child_collection/and_reading_the_child_collection.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using System.Text.Json;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_a_subject_owns_a_pii_child_collection.and_reading_the_child_collection.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_a_subject_owns_a_pii_child_collection;
+
+/// <summary>
+/// End-to-end regression for #3463. A subject owns two read models projected in the same run: a root-PII
+/// model (a simple fluent projection) and a sibling <b>non-passive, model-bound <c>[ChildrenFrom]</c></b>
+/// model whose children carry <c>[PII]</c>. Both are keyed by — and encrypt under — the same subject
+/// (the event source id). The child collection reliably fails to materialize in the out-of-process kernel
+/// (the poll on <c>Assessments.Count</c> times out) even though the parent document is returned and the
+/// simple sibling projection materializes fine in the exact same run.
+/// </summary>
+/// <param name="context">The test context.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_reading_the_child_collection(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        public EventSourceId ApplicantId { get; } = "applicant-1";
+        public ApplicantRegistered RegisteredEvent { get; private set; } = default!;
+        public IReadOnlyList<AssessmentRecorded> AssessmentEvents { get; private set; } = default!;
+
+        public ApplicantProfile SiblingModel { get; private set; } = default!;
+        public ApplicantDossier Dossier { get; private set; } = default!;
+
+        public override IEnumerable<Type> EventTypes => [typeof(ApplicantRegistered), typeof(AssessmentRecorded)];
+
+        public override IEnumerable<Type> Projections => [typeof(ApplicantProfileProjection)];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(ApplicantDossier)];
+
+        void Establish()
+        {
+            RegisteredEvent = new ApplicantRegistered("Ada Lovelace", "Prefers to be contacted by letter");
+            AssessmentEvents =
+            [
+                new AssessmentRecorded(Guid.Parse("8b95cb59-3a99-4bda-a11a-cd0000000201"), "communication", "Wrote a warm, detailed cover letter"),
+                new AssessmentRecorded(Guid.Parse("8b95cb59-3a99-4bda-a11a-cd0000000202"), "experience", "Ten years building analytical engines"),
+                new AssessmentRecorded(Guid.Parse("8b95cb59-3a99-4bda-a11a-cd0000000203"), "culture", "Would mentor juniors on her own time")
+            ];
+        }
+
+        async Task Because()
+        {
+            await EventStore.EventLog.Append(ApplicantId, RegisteredEvent);
+            foreach (var assessment in AssessmentEvents)
+            {
+                await EventStore.EventLog.Append(ApplicantId, assessment);
+            }
+
+            // The simple sibling projection is expected to materialize; wait for it first so the
+            // child-collection poll below is not gated on the subject's other read model.
+            SiblingModel = await PollUntil<ApplicantProfile>(_ => _.FullName == RegisteredEvent.FullName);
+            Dossier = await PollUntil<ApplicantDossier>(_ => _.Assessments is { Count: 3 });
+        }
+
+        async Task<TReadModel> PollUntil<TReadModel>(Func<TReadModel, bool> ready)
+            where TReadModel : class
+        {
+            using var cts = new CancellationTokenSource(TimeSpanFactory.DefaultTimeout());
+            TReadModel? last = null;
+            try
+            {
+                while (true)
+                {
+                    last = await EventStore.ReadModels.GetInstanceById<TReadModel>(ApplicantId.Value);
+                    if (last is not null && ready(last))
+                    {
+                        return last;
+                    }
+
+                    await Task.Delay(200, cts.Token);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Surface kernel-side diagnostics into the CI job log — the container logs (at Debug level
+                // for Cratis) carry the observer subscription / routing traces that explain why the child
+                // collection never materialized. Without this a CI-only timeout is opaque.
+                var lastJson = last is null ? "null" : JsonSerializer.Serialize(last);
+                var kernelLogs = ChronicleFixture is ChronicleConfigurableFixture configurable
+                    ? await configurable.GetOutOfProcessKernelLogs()
+                    : "(fixture is not configurable; no kernel logs)";
+                throw new TimeoutException(
+                    $"'{typeof(TReadModel).Name}' never satisfied the readiness condition for '{ApplicantId.Value}' within the poll timeout.\n" +
+                    $"Last read model instance: {lastJson}\n\n{kernelLogs}");
+            }
+        }
+    }
+
+    [Fact] void should_materialize_the_sibling_model() => Context.SiblingModel.ShouldNotBeNull();
+    [Fact] void should_return_the_dossier() => Context.Dossier.ShouldNotBeNull();
+    [Fact] void should_have_three_assessments() => Context.Dossier.Assessments.Count.ShouldEqual(3);
+    [Fact] void should_keep_each_assessment_identifier() => Context.Dossier.Assessments.Select(_ => _.AssessmentId).Order().ShouldEqual(Context.AssessmentEvents.Select(_ => _.AssessmentId).Order());
+    [Fact] void should_release_child_pii_to_plaintext() => Context.Dossier.Assessments.Select(_ => _.Note).Order().ShouldEqual(Context.AssessmentEvents.Select(_ => _.Note).Order());
+}
+
+[EventType]
+public record ApplicantRegistered(string FullName, [property: PII] string PersonalNote);
+
+[EventType]
+public record AssessmentRecorded(Guid AssessmentId, string Criterion, [property: PII] string Note);
+
+public record ApplicantProfile(string FullName, [property: PII] string PersonalNote);
+
+[FromEvent<ApplicantRegistered>]
+public record ApplicantDossier(
+    string FullName,
+    [ChildrenFrom<AssessmentRecorded>(key: nameof(AssessmentRecorded.AssessmentId), identifiedBy: nameof(DossierAssessment.AssessmentId))]
+    IReadOnlyList<DossierAssessment> Assessments);
+
+[FromEvent<AssessmentRecorded>]
+public record DossierAssessment(
+    [Key] Guid AssessmentId,
+    string Criterion,
+    [property: PII] string Note);
+
+public class ApplicantProfileProjection : IProjectionFor<ApplicantProfile>
+{
+    public ProjectionId Identifier => "pii-child-collection-applicant-profile";
+
+    public void Define(IProjectionBuilderFor<ApplicantProfile> builder) => builder
+        .From<ApplicantRegistered>(e => e
+            .Set(m => m.FullName).To(e => e.FullName)
+            .Set(m => m.PersonalNote).To(e => e.PersonalNote));
+}
+
+#pragma warning restore SA1402

--- a/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
+++ b/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
@@ -38,7 +38,23 @@ public class ReadModelsCompliance(
         var json = expandoObjectConverter.ToJsonObject(instance, schema);
         var applied = await complianceManager.Apply(eventStore, eventStoreNamespace, schema, identifier, json);
         var result = expandoObjectConverter.ToExpandoObject(applied, schema);
-        ((IDictionary<string, object?>)result)[WellKnownProperties.Subject] = identifier;
+        var resultAsDictionary = (IDictionary<string, object?>)result;
+
+        // Encryption must only change the PII members; it must not drop the rest of the document. The
+        // schema round-trip above only carries schema-declared properties, so document identity and
+        // bookkeeping fields that live outside the read model schema — the sink's primary key column and
+        // similar — are lost. Downstream difference computation would then see them as removed and emit a
+        // spurious "property -> null" change; for the SQL sink that nulls the read model's primary key and
+        // the save fails on every attempt. Carry any such non-schema property through unchanged.
+        foreach (var (propertyName, propertyValue) in (IDictionary<string, object?>)instance)
+        {
+            if (!resultAsDictionary.ContainsKey(propertyName))
+            {
+                resultAsDictionary[propertyName] = propertyValue;
+            }
+        }
+
+        resultAsDictionary[WellKnownProperties.Subject] = identifier;
         return result;
     }
 

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ProjectedColumns.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/ReadModels/ProjectedColumns.cs
@@ -73,6 +73,22 @@ public static class ProjectedColumns
             IsArray: false,
             IsNullable: true));
 
+        // Sink-owned compliance column. A read model with PII encrypts under a per-subject key and stamps
+        // the resolved compliance subject into the document. The subject must be persisted so that PII
+        // releases on read, and so that a subsequent event's initial state is decrypted before being
+        // re-encrypted — without it the initial state stays encrypted and the next write double-encrypts it.
+        // MongoDB keeps __subject as a free document field; the SQL table needs an explicit column.
+        if (schema.HasComplianceMetadata())
+        {
+            columns.Add(new ProjectedColumn(
+                WellKnownProperties.Subject,
+                typeof(string),
+                IsKey: false,
+                IsJson: false,
+                IsArray: false,
+                IsNullable: true));
+        }
+
         return columns;
     }
 

--- a/Source/Kernel/Storage.Sql/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.Sql/Sinks/Sink.cs
@@ -832,7 +832,19 @@ public class Sink : ISink
         }
 
         var json = (JsonObject)JsonSerializer.SerializeToNode(dict, ReadModelDbContext.JsonSerializerOptions)!;
-        return _expandoObjectConverter.ToExpandoObject(json, _schema);
+        var result = _expandoObjectConverter.ToExpandoObject(json, _schema);
+
+        // The schema-aware conversion only carries schema-declared properties. The compliance subject is a
+        // sink-owned column that lives outside the read model schema, so re-attach it onto the materialized
+        // instance — both the read path (releasing PII on read) and the projection pipeline (decrypting the
+        // initial state before re-encrypting) key their release off this subject; without it PII stays
+        // encrypted on read and the next event double-encrypts the already-encrypted carry-over state.
+        if (entity.TryGetValue(WellKnownProperties.Subject, out var subject) && subject is string subjectValue)
+        {
+            ((IDictionary<string, object?>)result)[WellKnownProperties.Subject] = subjectValue;
+        }
+
+        return result;
     }
 
     void SeedDefaults(DynamicReadModelEntity entity)


### PR DESCRIPTION
## Fixed

- Active (non-passive) read models with `[PII]` persisted to a SQL sink (PostgreSQL, SQL Server, SQLite) stalled and never materialized out of process — the query returned `null` indefinitely with no error or observer quarantine, and PII could fail to decrypt on read. MongoDB-backed read models were unaffected. (#3463)

