### PR TITLE
Fix [Join] backfill for an AutoMap-keyed join onto a pre-existing source

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/AutoMappedJoinOrderSummary.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/AutoMappedJoinOrderSummary.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model that enriches an order with the customer's name through a <c>[Join]</c>, where the join key
+/// (<see cref="CustomerId"/>) is populated by AutoMap — it name-matches <see cref="JoinOrderPlaced.CustomerId"/>
+/// and carries NO <c>[SetFrom]</c>. This is the reproduction shape for the row-creation-time join backfill:
+/// the join key never appears in the explicit From mappings, only in the AutoMap-merged From properties.
+/// </summary>
+/// <param name="Id">The order identifier.</param>
+/// <param name="CustomerId">The customer the order is for (the AutoMapped join key — no <c>[SetFrom]</c>).</param>
+/// <param name="Amount">The order amount.</param>
+/// <param name="CustomerName">The customer name, joined in from <see cref="JoinCustomerRegistered"/>.</param>
+[Passive]
+[FromEvent<JoinOrderPlaced>]
+public record AutoMappedJoinOrderSummary(
+    [Key] Guid Id,
+
+    JoinCustomerId CustomerId,
+
+    [SetFrom<JoinOrderPlaced>]
+    decimal Amount,
+
+    [Join<JoinCustomerRegistered>(on: nameof(CustomerId), eventPropertyName: nameof(JoinCustomerRegistered.Name))]
+    string CustomerName);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_an_automapped_join_key.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_an_automapped_join_key.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario;
+
+/// <summary>
+/// Regression for CHR-14: a <c>[Join]</c> whose <c>on</c> column is populated by AutoMap (a name-matched
+/// foreign key with NO <c>[SetFrom]</c>) must be backfilled at row-creation time (Path B / ResolveJoin)
+/// against the joining row's OWN join-source event — even when the join-source events already exist because
+/// they were seeded BEFORE the row-creating from-events (the common production order).
+/// <para>
+/// Two distinct customers are seeded first, then two orders — one per customer. Before the fix, the
+/// row-creation-time backfill is only wired when the join key appears in the explicit From mappings, so an
+/// AutoMapped join key never resolves its own source at row creation: each order surfaces whatever customer
+/// name the harness carried over from the last-processed join source (here, the OTHER customer), not its
+/// own. Asserting each order shows ITS OWN customer's name therefore fails without the fix and passes with it.
+/// </para>
+/// </summary>
+public class when_projecting_with_an_automapped_join_key : Specification
+{
+    ReadModelScenario<AutoMappedJoinOrderSummary> _scenario;
+    Guid _xavierGuid;
+    Guid _yolandaGuid;
+    EventSourceId _orderForXavierId;
+    EventSourceId _orderForYolandaId;
+    Guid _orderForXavierGuid;
+    Guid _orderForYolandaGuid;
+    AutoMappedJoinOrderSummary? _orderForXavier;
+    AutoMappedJoinOrderSummary? _orderForYolanda;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<AutoMappedJoinOrderSummary>();
+        _xavierGuid = Guid.NewGuid();
+        _yolandaGuid = Guid.NewGuid();
+        _orderForXavierGuid = Guid.NewGuid();
+        _orderForYolandaGuid = Guid.NewGuid();
+        _orderForXavierId = new EventSourceId(_orderForXavierGuid);
+        _orderForYolandaId = new EventSourceId(_orderForYolandaGuid);
+    }
+
+    async Task Because()
+    {
+        // Seed both JOIN SOURCES (customers) first — the common production order where the join sources
+        // already exist when the order rows are created. Each order's AutoMapped join key must resolve its
+        // OWN customer, not the last one processed.
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(_xavierGuid))
+            .Events(new JoinCustomerRegistered("Xavier"));
+
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(_yolandaGuid))
+            .Events(new JoinCustomerRegistered("Yolanda"));
+
+        await _scenario.Given
+            .ForEventSource(_orderForXavierId)
+            .Events(new JoinOrderPlaced(new JoinCustomerId(_xavierGuid), 100m));
+
+        await _scenario.Given
+            .ForEventSource(_orderForYolandaId)
+            .Events(new JoinOrderPlaced(new JoinCustomerId(_yolandaGuid), 200m));
+
+        _orderForXavier = _scenario.InstanceForEventSourceId(_orderForXavierId);
+        _orderForYolanda = _scenario.InstanceForEventSourceId(_orderForYolandaId);
+    }
+
+    [Fact] void should_resolve_the_order_for_xavier() => _orderForXavier.ShouldNotBeNull();
+    [Fact] void should_resolve_the_order_for_yolanda() => _orderForYolanda.ShouldNotBeNull();
+    [Fact] void should_key_each_order_by_its_own_id() => (_orderForXavier!.Id, _orderForYolanda!.Id).ShouldEqual((_orderForXavierGuid, _orderForYolandaGuid));
+    [Fact] void should_have_each_amount() => (_orderForXavier!.Amount, _orderForYolanda!.Amount).ShouldEqual((100m, 200m));
+    [Fact] void should_join_xaviers_name_onto_his_order() => _orderForXavier!.CustomerName.ShouldEqual("Xavier");
+    [Fact] void should_join_yolandas_name_onto_her_order() => _orderForYolanda!.CustomerName.ShouldEqual("Yolanda");
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/given/all_dependencies.cs
@@ -14,8 +14,17 @@ public class all_dependencies : Specification
     {
         _taskFactory = Substitute.For<ITaskFactory>();
         _grainFactory = Substitute.For<IGrainFactory>();
+
+        // The real ITaskFactory.Run offloads the queue handler to a background thread. Running it inline
+        // on the caller here deadlocks the spec under constrained parallelism (e.g. CI's 2-core agents):
+        // the handler's continuations and the test's AwaitQueueDepletion timers contend for the same
+        // starved thread pool and never make progress. Offload to a dedicated thread to mirror production.
         _taskFactory
             .When(_ => _.Run(Arg.Any<Func<Task>>()))
-            .Do(callInfo => callInfo.Arg<Func<Task>>()());
+            .Do(callInfo => Task.Factory.StartNew(
+                callInfo.Arg<Func<Task>>(),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default));
     }
 }

--- a/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
@@ -575,6 +575,7 @@ public class ProjectionFactory(
                 projection,
                 currentReadModelSchema,
                 fromDefinition,
+                eventType,
                 isChild,
                 eventTypeSchemas);
         }
@@ -619,6 +620,7 @@ public class ProjectionFactory(
                         projection,
                         currentReadModelSchema,
                         fromDerivativesDefinition.From,
+                        eventType,
                         isChild,
                         eventTypeSchemas);
                 }
@@ -690,15 +692,22 @@ public class ProjectionFactory(
         Projection projection,
         JsonSchema currentReadModelSchema,
         FromDefinition fromDefinition,
+        EventType eventType,
         bool hasParent,
         IEnumerable<EventTypeSchema> eventTypeSchemas)
     {
         // Notes: The purpose of this method is to hook up on every From definition that matches the eventType of the Join definition
         // and the join definition matching the property its joining on to then add actions for resolving a join post a projection of
         // the "from".
+        // A join's `on` column can be populated by AutoMap (a name-matched foreign key) rather than an explicit From
+        // mapping, so match against the AutoMap-merged From properties — the same set SetupFromDefinition projects with —
+        // not the raw fromDefinition.Properties. Otherwise a join on an AutoMapped column never gets its row-creation-time
+        // backfill (ResolveJoin) wired, and only backfills when the join-source event arrives later — leaving the joined
+        // values empty whenever the join source already exists at the time the row is created (the common production order).
+        var mergedFromProperties = GetMergedFromProperties(fromDefinition, currentReadModelSchema, eventTypeSchemas.FirstOrDefault(ets => ets.Type == eventType)?.Schema, projection.AutoMap, projection.NoAutoMapProperties);
         var joinExpressions = hasParent
             ? projectionDefinition.Join.Where(join => join.Value.On == actualIdentifiedByProperty).ToArray()
-            : projectionDefinition.Join.Where(join => fromDefinition.Properties.Any(from => join.Value.On == from.Key)).ToArray();
+            : projectionDefinition.Join.Where(join => mergedFromProperties.Exists(from => join.Value.On == from.Key)).ToArray();
 
         // Include join expressions that join on the id property
         var keyPropertyName = currentReadModelSchema.HasKeyProperty() ? currentReadModelSchema.GetKeyProperty().Name : currentReadModelSchema.GetLikelyKeyPropertyName();


### PR DESCRIPTION
# Summary

A cross-stream `[Join]` whose join key is populated by **AutoMap** (a name-matched foreign key, no explicit `[SetFrom]`) did not backfill its joined value when the row was created *after* the join-source event already existed — the common production ordering, where a slowly-changing dimension is activated before the higher-frequency fact that references it.

`SetupJoinsForFromDefinition` wired the row-creation-time backfill (`ResolveJoin`) only when the join's `on` column appeared in the raw `fromDefinition.Properties` — i.e. an explicit `[SetFrom]` mapping. An AutoMapped join key is absent from that set, so the backfill was never wired and the value only resolved when the join source arrived *after* the row. The fix gates the wiring on the AutoMap-merged From properties (`GetMergedFromProperties`, the same set `SetupFromDefinition` projects with) and threads the from-event's `EventType` through so that set can be computed.

## Fixed

- A model-bound `[Join]` whose key is an AutoMapped foreign key now resolves its joined value when the read-model row is created after the join-source event already exists. Previously these columns were left empty whenever the join source (e.g. an activated engagement) preceded the row-creating fact (e.g. an approved timesheet) — the common production ordering.
