### PR TITLE
Restore the ability to run Chronicle without TLS

### DIFF
--- a/Documentation/configuration/tls.mdx
+++ b/Documentation/configuration/tls.mdx
@@ -1,6 +1,6 @@
 # TLS Configuration (Client)
 
-Chronicle .NET clients communicate with Chronicle Server over TLS. The server always serves its single port over TLS — in development it generates a self-signed certificate automatically — so the client connects over TLS by default.
+Chronicle .NET clients communicate with Chronicle Server over TLS by default. With TLS enabled, the server serves its single port over TLS — in development it generates a self-signed certificate automatically — so the client connects over TLS with no extra setup. When the server runs with TLS disabled (for example behind a load balancer that terminates TLS), the client must disable TLS too — see [Connection string option](#connection-string-option).
 
 For server-side TLS configuration, see [TLS Configuration (Server)](../hosting/configuration/tls.md).
 
@@ -30,11 +30,11 @@ For server-side TLS configuration, see [TLS Configuration (Server)](../hosting/c
 | --- | --- | --- | --- |
 | CertificatePath | string | null | Path to the client certificate (PFX format) if mutual TLS is used |
 | CertificatePassword | string | null | Password for the certificate file |
-| IsDisabled | boolean (read-only) | computed | `true` when no certificate path/password is set. Use `?disableTls=true` in the connection string only to reach a genuinely non-TLS endpoint (a standard Chronicle server always serves TLS) |
+| IsDisabled | boolean (read-only) | computed | `true` when no certificate path/password is set. Use `?disableTls=true` in the connection string to reach a server running in cleartext (TLS disabled, or TLS terminated upstream) |
 
 ## Connection string option
 
-For the rare case of a non-TLS endpoint, TLS can be turned off through the connection string:
+When the server runs with TLS disabled — for example when a load balancer, ingress or service mesh terminates TLS upstream — turn TLS off on the client through the connection string:
 
 <ChronicleClientTabs snippet="configuration/tls/connection-string-disable" />
 

--- a/Documentation/hosting/configuration/port-reference.md
+++ b/Documentation/hosting/configuration/port-reference.md
@@ -16,5 +16,23 @@ Chronicle Server exposes the following ports:
 | 30000 | Orleans Gateway | Client connections to Orleans cluster |
 | 35000 | Chronicle | gRPC (HTTP/2) and Workbench, REST API, OAuth and health (HTTP/1.1), multiplexed over TLS |
 
-The port requires TLS. In development, when no certificate is configured, Chronicle generates a self-signed certificate automatically so the port works out of the box.
+With TLS enabled (the default), the port requires a certificate. In development, when no certificate is configured, Chronicle generates a self-signed certificate automatically so the port works out of the box.
 
+## Running without TLS
+
+When TLS is disabled (`tls.enabled` set to `false`), cleartext cannot multiplex both protocols on one port, so they split across two ports:
+
+| Port | Service | Description |
+| --- | --- | --- |
+| 35000 (`port`) | gRPC | Cleartext gRPC over h2c (HTTP/2 with prior knowledge) |
+| 8080 (`managementPort`) | Workbench, API, OAuth, health | Plain HTTP/1.1 |
+
+See [TLS Configuration](tls.md) for the full disable-TLS behavior.
+
+## Dedicated health port (optional)
+
+Set `healthPort` to serve only the health-check endpoint on a separate plaintext port, independent of TLS on the main port. It is disabled by default. Use it for orchestrator or load-balancer probes that cannot speak TLS while keeping the data plane on TLS.
+
+| Port | Service | Description |
+| --- | --- | --- |
+| `healthPort` | Health | Plain HTTP/1.1, serves `/health` only |

--- a/Documentation/hosting/configuration/tls.md
+++ b/Documentation/hosting/configuration/tls.md
@@ -1,6 +1,8 @@
 # TLS Configuration (Server)
 
-The Chronicle port serves gRPC (HTTP/2) and the Workbench, REST API, OAuth and health endpoints (HTTP/1.1) on a single port. Kestrel can only multiplex the two protocols on one port over TLS, where ALPN negotiates the protocol per connection — so **the port always uses TLS and requires a certificate**.
+With TLS enabled (the default), the Chronicle port serves gRPC (HTTP/2) and the Workbench, REST API, OAuth and health endpoints (HTTP/1.1) on a single port. Kestrel can only multiplex the two protocols on one port over TLS, where ALPN negotiates the protocol per connection — so with TLS on, **the port requires a certificate**.
+
+TLS can be **disabled** to run in cleartext — for example when TLS is terminated upstream by a load balancer, ingress or service mesh, or for local development. Because cleartext cannot multiplex both protocols on one port, disabling TLS splits them across two ports (see [TLS behavior](#tls-behavior) below).
 
 For client-side TLS configuration, see [TLS Configuration (Client)](../../configuration/tls).
 
@@ -26,20 +28,63 @@ Cratis__Chronicle__Tls__CertificatePassword=your-password
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
+| enabled | bool | true | Whether TLS is enabled. Set to `false` to serve cleartext across two ports |
 | certificatePath | string | null | Path to the TLS certificate file (PFX format) |
 | certificatePassword | string | null | Password for the certificate file |
 
 ## TLS behavior
 
-- **A certificate is provided** (`certificatePath` set): Chronicle serves the port with that certificate.
-- **No certificate is provided, development**: Chronicle generates an in-memory self-signed certificate so the port works out of the box. Clients accept it automatically in development, and browsers show a certificate warning you can bypass.
-- **No certificate is provided, production**: the server fails to start — a certificate is required.
+**TLS enabled (default), a certificate is provided** (`certificatePath` set): Chronicle serves the single multiplexed port with that certificate.
 
-When TLS is terminated upstream by an ingress or reverse proxy, re-encrypt the connection to Chronicle (the backend port is always TLS) and provide a certificate for it.
+**TLS enabled, no certificate, development**: Chronicle generates an in-memory self-signed certificate so the port works out of the box. Clients accept it automatically in development, and browsers show a certificate warning you can bypass.
+
+**TLS enabled, no certificate, production**: the server fails to start — a certificate is required.
+
+**TLS disabled** (`enabled` set to `false`): no certificate is used or required. Since cleartext cannot multiplex HTTP/1.1 and HTTP/2 on one port, the two protocols split across two cleartext ports:
+
+- `port` (35000 by default) serves cleartext gRPC over h2c (HTTP/2 with prior knowledge).
+- `managementPort` (8080 by default) serves plain HTTP/1.1 — the Workbench, REST API, OAuth and health endpoints.
+
+```json
+{
+  "tls": { "enabled": false },
+  "port": 35000,
+  "managementPort": 8080
+}
+```
+
+This mirrors the pre-16.0 topology and is the setup to use when a load balancer or ingress terminates TLS and forwards cleartext to Chronicle. Clients connect with TLS disabled — see [connection string with TLS disabled](../../configuration/tls).
+
+## Load balancer and health-check probes
+
+A **plain-HTTP health check against a TLS port fails at the TLS record layer** with `"Wrong version number"` — the port speaks TLS, not cleartext HTTP. Choose a probe that matches how the port is configured:
+
+- **TLS on the main port** — probe with a **TCP-connect** check on the port, or an **HTTPS** probe that trusts the certificate's CA (or skips verification) against a host listed in the certificate's SAN.
+- **TLS terminated upstream** (`enabled` set to `false`) — probe `/health` over plain HTTP on the `managementPort`.
+- **Either topology** — expose a dedicated plaintext health port (see below) and probe `/health` over plain HTTP there, while the data plane stays on TLS.
+
+There is no separate always-plaintext management port bound by default; when TLS is enabled everything is served on the single TLS `port`.
+
+### Dedicated plaintext health port
+
+Set `healthPort` to expose only the health-check endpoint on a separate cleartext port, independent of TLS on the main port. It is disabled by default (`0`). Bind it to the internal or cluster network only — it is a tiny, anonymous, health-only surface.
+
+```json
+{
+  "healthPort": 8090
+}
+```
+
+```bash
+Cratis__Chronicle__HealthPort=8090
+```
+
+An orchestrator or load balancer can then probe `http://<host>:8090/health` with no TLS, ALPN, CA trust or SAN matching, while gRPC, the API and OAuth remain fully on TLS.
 
 ## Related TLS and certificate pages
 
 - [Identity Provider Certificate Configuration](identity-provider-certificate.md) for internal OAuth authority certificates.
+- [Port Reference](port-reference.md) for the full list of ports Chronicle exposes.
 
 ## Certificate requirements
 
@@ -67,4 +112,8 @@ services:
 
 **Error**: "No TLS certificate is configured. The Chronicle port ... requires a certificate."
 
-**Solution**: Provide `certificatePath` and `certificatePassword` in the top-level `tls` configuration. In development the server generates a self-signed certificate automatically, so this error only occurs in production.
+**Solution**: Provide `certificatePath` and `certificatePassword` in the top-level `tls` configuration, or set `tls.enabled` to `false` to run in cleartext. In development the server generates a self-signed certificate automatically, so this error only occurs in production with TLS enabled.
+
+### Health check reports "Wrong version number"
+
+The probe is speaking plain HTTP to a TLS port. Use a TCP-connect or HTTPS probe on the TLS port, probe the `managementPort` when TLS is terminated upstream, or expose a dedicated plaintext `healthPort`. See [Load balancer and health-check probes](#load-balancer-and-health-check-probes).

--- a/Documentation/hosting/production.md
+++ b/Documentation/hosting/production.md
@@ -32,7 +32,7 @@ Chronicle exposes the following ports:
 | 30000 | Orleans Gateway   | Client connections to Orleans cluster    |
 | 35000 | Main Service      | gRPC (HTTP/2) plus REST API, Workbench, OAuth, and health checks (HTTP/1.1), multiplexed over one TLS port |
 
-> **Note**: Port 35000 serves both HTTP/2 (gRPC) and HTTP/1.1 over TLS, so it **requires** a certificate. In production you must supply one via `Tls:CertificatePath` (and `Tls:CertificatePassword` if the certificate is protected). See [TLS Configuration](configuration/tls.md).
+> **Note**: With TLS enabled (the default), port 35000 serves both HTTP/2 (gRPC) and HTTP/1.1 over TLS, so it **requires** a certificate. In production you must supply one via `Tls:CertificatePath` (and `Tls:CertificatePassword` if the certificate is protected). To run in cleartext instead — for example when TLS is terminated upstream by a load balancer or ingress — set `Tls:Enabled` to `false`; gRPC then moves to h2c on port 35000 and the HTTP/1.1 surface to the `ManagementPort` (8080 by default). See [TLS Configuration](configuration/tls.md).
 
 ## Docker Deployment
 
@@ -94,6 +94,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -fk https://localhost:35000/health || exit 1
 ```
 
+> **Warning**: A **plain-HTTP** health check against the TLS port fails at the TLS record layer with `"Wrong version number"` — the port speaks TLS, not cleartext HTTP. Probe the TLS port over HTTPS (as above, `-k` skips CA verification) or with a TCP-connect check. When TLS is terminated upstream (`Tls:Enabled=false`), probe `/health` over plain HTTP on the `ManagementPort` instead. To keep the data plane on TLS while still offering a cleartext probe, set `HealthPort` to expose `/health` on a dedicated plaintext port. See [TLS Configuration](configuration/tls.md#load-balancer-and-health-check-probes).
+>
 > **Note**: The health check endpoint path is configurable. See [Root Properties](configuration/root-properties.md#health-check-endpoint) for details.
 
 ## Security Considerations

--- a/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_a_health_port_is_configured.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_a_health_port_is_configured.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration.for_ServerEndpointResolver;
+
+public class when_a_health_port_is_configured : Specification
+{
+    ChronicleOptions _options;
+    IReadOnlyList<ServerEndpoint> _result;
+
+    void Establish() => _options = new ChronicleOptions
+    {
+        Port = 35000,
+        HealthPort = 8081,
+        Tls = new Tls { Enabled = true }
+    };
+
+    void Because() => _result = ServerEndpointResolver.Resolve(_options);
+
+    [Fact] void should_keep_the_main_tls_port() =>
+        _result.Any(_ => _.Port == 35000 && _.UseTls).ShouldBeTrue();
+    [Fact] void should_add_a_dedicated_plaintext_health_endpoint() =>
+        _result.Any(_ => _.Port == 8081 && _.Protocols == EndpointProtocols.Http1 && !_.UseTls).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_the_health_port_matches_the_main_port.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_the_health_port_matches_the_main_port.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration.for_ServerEndpointResolver;
+
+public class when_the_health_port_matches_the_main_port : Specification
+{
+    ChronicleOptions _options;
+    IReadOnlyList<ServerEndpoint> _result;
+
+    void Establish() => _options = new ChronicleOptions
+    {
+        Port = 35000,
+        HealthPort = 35000,
+        Tls = new Tls { Enabled = true }
+    };
+
+    void Because() => _result = ServerEndpointResolver.Resolve(_options);
+
+    [Fact] void should_not_bind_a_duplicate_endpoint() => _result.Count.ShouldEqual(1);
+}

--- a/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_tls_is_disabled.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_tls_is_disabled.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration.for_ServerEndpointResolver;
+
+public class when_tls_is_disabled : Specification
+{
+    ChronicleOptions _options;
+    IReadOnlyList<ServerEndpoint> _result;
+
+    void Establish() => _options = new ChronicleOptions
+    {
+        Port = 35000,
+        ManagementPort = 8080,
+        Tls = new Tls { Enabled = false }
+    };
+
+    void Because() => _result = ServerEndpointResolver.Resolve(_options);
+
+    [Fact] void should_bind_two_endpoints() => _result.Count.ShouldEqual(2);
+    [Fact] void should_serve_cleartext_grpc_on_the_main_port() =>
+        _result.Any(_ => _.Port == 35000 && _.Protocols == EndpointProtocols.Http2 && !_.UseTls).ShouldBeTrue();
+    [Fact] void should_serve_cleartext_http1_on_the_management_port() =>
+        _result.Any(_ => _.Port == 8080 && _.Protocols == EndpointProtocols.Http1 && !_.UseTls).ShouldBeTrue();
+    [Fact] void should_not_use_tls_on_any_endpoint() => _result.Any(_ => _.UseTls).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_tls_is_enabled.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ServerEndpointResolver/when_tls_is_enabled.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration.for_ServerEndpointResolver;
+
+public class when_tls_is_enabled : Specification
+{
+    ChronicleOptions _options;
+    IReadOnlyList<ServerEndpoint> _result;
+
+    void Establish() => _options = new ChronicleOptions
+    {
+        Port = 35000,
+        Tls = new Tls { Enabled = true }
+    };
+
+    void Because() => _result = ServerEndpointResolver.Resolve(_options);
+
+    [Fact] void should_bind_a_single_endpoint() => _result.Count.ShouldEqual(1);
+    [Fact] void should_bind_the_main_port() => _result[0].Port.ShouldEqual(35000);
+    [Fact] void should_multiplex_http1_and_http2() => _result[0].Protocols.ShouldEqual(EndpointProtocols.Http1AndHttp2);
+    [Fact] void should_use_tls() => _result[0].UseTls.ShouldBeTrue();
+}

--- a/Source/Kernel/Core/Configuration/ChronicleOptions.cs
+++ b/Source/Kernel/Core/Configuration/ChronicleOptions.cs
@@ -22,9 +22,27 @@ public class ChronicleOptions
     public static readonly string SectionPath = ConfigurationPath.Combine(SectionPaths);
 
     /// <summary>
-    /// Port to listen on for all Chronicle traffic — gRPC (HTTP/2) and the Workbench, API and OAuth flows (HTTP/1.1).
+    /// Port to listen on for Chronicle traffic. With TLS enabled (the default) this single port multiplexes
+    /// gRPC (HTTP/2) and the Workbench, API and OAuth flows (HTTP/1.1). When TLS is disabled it serves cleartext
+    /// gRPC (h2c) only, and the HTTP/1.1 surface moves to <see cref="ManagementPort"/>.
     /// </summary>
     public int Port { get; init; } = 35000;
+
+    /// <summary>
+    /// Port for the plaintext HTTP/1.1 surface (Workbench, API, OAuth and health) used only when TLS is disabled
+    /// (<see cref="Tls"/>.<see cref="Tls.Enabled"/> is <see langword="false"/>). Cleartext HTTP/1.1 and HTTP/2 cannot share a
+    /// single port — ALPN negotiation requires TLS — so the two protocols split across <see cref="Port"/> (h2c gRPC)
+    /// and this port (HTTP/1.1). With TLS enabled everything is served on <see cref="Port"/> and this is ignored.
+    /// </summary>
+    public int ManagementPort { get; init; } = 8080;
+
+    /// <summary>
+    /// Optional dedicated plaintext port that serves only the <see cref="HealthCheckEndpoint"/>, for orchestrator and
+    /// load-balancer probes that cannot speak TLS. When <c>0</c> (the default) it is disabled. It is independent of
+    /// TLS on <see cref="Port"/> — the data plane can stay on TLS while health checks answer over cleartext here.
+    /// Bind it to the internal or cluster network only.
+    /// </summary>
+    public int HealthPort { get; init; }
 
     /// <summary>
     /// Gets the health check endpoint.

--- a/Source/Kernel/Core/Configuration/EndpointProtocols.cs
+++ b/Source/Kernel/Core/Configuration/EndpointProtocols.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents the HTTP protocols a server endpoint serves.
+/// </summary>
+public enum EndpointProtocols
+{
+    /// <summary>
+    /// HTTP/1.1 only — the Workbench, REST API, OAuth and health surface.
+    /// </summary>
+    Http1 = 0,
+
+    /// <summary>
+    /// HTTP/2 only — cleartext gRPC (h2c) with prior knowledge.
+    /// </summary>
+    Http2 = 1,
+
+    /// <summary>
+    /// HTTP/1.1 and HTTP/2 multiplexed on one port, negotiated per connection through ALPN (requires TLS).
+    /// </summary>
+    Http1AndHttp2 = 2
+}

--- a/Source/Kernel/Core/Configuration/ServerEndpoint.cs
+++ b/Source/Kernel/Core/Configuration/ServerEndpoint.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents a single network endpoint the Chronicle server binds.
+/// </summary>
+/// <param name="Port">The TCP port to listen on.</param>
+/// <param name="Protocols">The <see cref="EndpointProtocols"/> served on the endpoint.</param>
+/// <param name="UseTls">Whether the endpoint terminates TLS and therefore requires a certificate.</param>
+public record ServerEndpoint(int Port, EndpointProtocols Protocols, bool UseTls);

--- a/Source/Kernel/Core/Configuration/ServerEndpointResolver.cs
+++ b/Source/Kernel/Core/Configuration/ServerEndpointResolver.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Resolves the set of <see cref="ServerEndpoint"/> the Chronicle server should bind from the configured
+/// <see cref="ChronicleOptions"/>.
+/// </summary>
+/// <remarks>
+/// Kestrel can only multiplex HTTP/1.1 and HTTP/2 on a single port over TLS, where ALPN negotiates the protocol
+/// per connection. With TLS enabled (the default) a single multiplexed TLS port therefore serves everything.
+/// With TLS disabled the two protocols must split across two cleartext ports — h2c gRPC on <see cref="ChronicleOptions.Port"/>
+/// and plain HTTP/1.1 (Workbench, API, OAuth and health) on <see cref="ChronicleOptions.ManagementPort"/> — mirroring the
+/// pre-16.0 topology.
+/// </remarks>
+public static class ServerEndpointResolver
+{
+    /// <summary>
+    /// Resolves the endpoints to bind for the given options.
+    /// </summary>
+    /// <param name="options">The <see cref="ChronicleOptions"/> to resolve endpoints from.</param>
+    /// <returns>The ordered set of <see cref="ServerEndpoint"/> to bind.</returns>
+    public static IReadOnlyList<ServerEndpoint> Resolve(ChronicleOptions options)
+    {
+        var endpoints = new List<ServerEndpoint>();
+
+        if (options.Tls.Enabled)
+        {
+            // Single multiplexed TLS port: gRPC (HTTP/2) and the Workbench, API and OAuth flows (HTTP/1.1),
+            // negotiated per connection through ALPN.
+            endpoints.Add(new ServerEndpoint(options.Port, EndpointProtocols.Http1AndHttp2, UseTls: true));
+        }
+        else
+        {
+            // Cleartext cannot multiplex on a single port, so split the protocols across two ports:
+            // h2c gRPC on the main port and plain HTTP/1.1 on the management port.
+            endpoints.Add(new ServerEndpoint(options.Port, EndpointProtocols.Http2, UseTls: false));
+            endpoints.Add(new ServerEndpoint(options.ManagementPort, EndpointProtocols.Http1, UseTls: false));
+        }
+
+        if (options.HealthPort > 0 && endpoints.TrueForAll(endpoint => endpoint.Port != options.HealthPort))
+        {
+            // Optional dedicated plaintext health-probe port, independent of TLS on the main port.
+            endpoints.Add(new ServerEndpoint(options.HealthPort, EndpointProtocols.Http1, UseTls: false));
+        }
+
+        return endpoints;
+    }
+}

--- a/Source/Kernel/Core/Configuration/Tls.cs
+++ b/Source/Kernel/Core/Configuration/Tls.cs
@@ -9,8 +9,11 @@ namespace Cratis.Chronicle.Configuration;
 public class Tls
 {
     /// <summary>
-    /// Gets or inits whether TLS is enabled. Defaults to true.
-    /// Can be set to false when TLS is terminated upstream by an ingress/reverse proxy.
+    /// Gets or inits whether TLS is enabled. Defaults to <see langword="true"/>, serving gRPC and the Workbench, API and OAuth
+    /// flows on a single multiplexed TLS <see cref="ChronicleOptions.Port"/>.
+    /// Set to <see langword="false"/> to run in cleartext — for example when TLS is terminated upstream by an ingress or reverse
+    /// proxy, or for local development — in which case gRPC (h2c) is served on <see cref="ChronicleOptions.Port"/> and
+    /// the HTTP/1.1 surface on <see cref="ChronicleOptions.ManagementPort"/>. No certificate is required when disabled.
     /// </summary>
     public bool Enabled { get; init; } = true;
 

--- a/Source/Kernel/Server/KernelLogMessages.cs
+++ b/Source/Kernel/Server/KernelLogMessages.cs
@@ -17,13 +17,19 @@ internal static partial class KernelLogMessages
     [LoggerMessage(LogLevel.Error, "No TLS certificate is configured. The Chronicle port requires a certificate to serve gRPC and HTTP on a single port")]
     internal static partial void TlsCertificateMissingProduction(this ILogger<Kernel> logger);
 
-    [LoggerMessage(LogLevel.Debug, "Configuring server to listen on port {Port} for gRPC (HTTP/2) and Workbench, API and OAuth (HTTP/1.1)")]
+    [LoggerMessage(LogLevel.Warning, "TLS is disabled - serving cleartext gRPC (h2c) on port {GrpcPort} and Workbench, API, OAuth and health (HTTP/1.1) on port {ManagementPort}")]
+    internal static partial void TlsDisabled(this ILogger<Kernel> logger, int grpcPort, int managementPort);
+
+    [LoggerMessage(LogLevel.Information, "Serving the health check endpoint on dedicated plaintext port {HealthPort}")]
+    internal static partial void HealthPortEnabled(this ILogger<Kernel> logger, int healthPort);
+
+    [LoggerMessage(LogLevel.Debug, "Configuring server to listen on port {Port}")]
     internal static partial void ServerListening(this ILogger<Kernel> logger, int port);
 
     [LoggerMessage(LogLevel.Debug, "Cratis Chronicle Server configured successfully - starting services")]
     internal static partial void ServerConfigured(this ILogger<Kernel> logger);
 
-    [LoggerMessage(LogLevel.Information, "Cratis Chronicle Server started successfully - ready and listening on port {Port} for gRPC (HTTP/2) and Workbench, API and OAuth (HTTP/1.1)")]
+    [LoggerMessage(LogLevel.Information, "Cratis Chronicle Server started successfully - ready and listening on port {Port}")]
     internal static partial void ServerStarted(this ILogger<Kernel> logger, int port);
 
     [LoggerMessage(LogLevel.Information, "Shutdown signal received. Chronicle Server is shutting down...")]

--- a/Source/Kernel/Server/NoTlsCertificateConfigured.cs
+++ b/Source/Kernel/Server/NoTlsCertificateConfigured.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Server;
+
+/// <summary>
+/// The exception that is thrown when TLS is enabled but no certificate is configured in a production build.
+/// </summary>
+public class NoTlsCertificateConfigured()
+    : Exception(
+        "No TLS certificate is configured. The Chronicle port serves gRPC (HTTP/2) and the Workbench, " +
+        "API and OAuth flows (HTTP/1.1) on a single TLS port, which requires a certificate. " +
+        "Provide one through Tls:CertificatePath (and Tls:CertificatePassword) in configuration. " +
+        "To run in cleartext instead — for example when TLS is terminated upstream by an ingress/reverse " +
+        "proxy — set Tls:Enabled to false.");

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Api;
 using Cratis.Chronicle.Configuration;
@@ -52,44 +53,63 @@ if (chronicleOptions.Features.Api)
     builder.Services.AddCratisChronicleApi(useGrpc: false);
 }
 
-// The Chronicle port multiplexes gRPC (HTTP/2) and the Workbench, API and OAuth flows (HTTP/1.1)
-// on a single port. Kestrel can only serve both protocols on one port over TLS, where ALPN
-// negotiates the protocol per connection — cleartext HTTP/2 (h2c) cannot share a port with HTTP/1.1.
-// A configured certificate is therefore required; in development one is generated automatically.
-var certificate = CertificateLoader.LoadCertificate(chronicleOptions);
-if (certificate is not null)
+// With TLS enabled (the default) the Chronicle port multiplexes gRPC (HTTP/2) and the Workbench, API and
+// OAuth flows (HTTP/1.1) on a single port — Kestrel can only serve both protocols on one port over TLS, where
+// ALPN negotiates the protocol per connection. A certificate is therefore required; in development one is
+// generated automatically. When TLS is disabled the two protocols fall back to separate cleartext ports and no
+// certificate is needed. ServerEndpointResolver computes the resulting listener topology from configuration.
+X509Certificate2? certificate = null;
+if (chronicleOptions.Tls.Enabled)
 {
-    logger.TlsCertificateLoaded();
+    certificate = CertificateLoader.LoadCertificate(chronicleOptions);
+    if (certificate is not null)
+    {
+        logger.TlsCertificateLoaded();
+    }
+    else
+    {
+#if DEVELOPMENT
+        // The certificate must live for the lifetime of the process; Kestrel uses it for every TLS handshake.
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        certificate = DevelopmentCertificate.Create();
+#pragma warning restore CA2000
+        logger.DevelopmentCertificateGenerated();
+#else
+        logger.TlsCertificateMissingProduction();
+        throw new NoTlsCertificateConfigured();
+#endif
+    }
 }
 else
 {
-#if DEVELOPMENT
-    // The certificate must live for the lifetime of the process; Kestrel uses it for every TLS handshake.
-#pragma warning disable CA2000 // Dispose objects before losing scope
-    certificate = DevelopmentCertificate.Create();
-#pragma warning restore CA2000
-    logger.DevelopmentCertificateGenerated();
-#else
-    logger.TlsCertificateMissingProduction();
-    throw new InvalidOperationException(
-        "No TLS certificate is configured. The Chronicle port serves gRPC (HTTP/2) and the Workbench, " +
-        "API and OAuth flows (HTTP/1.1) on a single TLS port, which requires a certificate. " +
-        "Provide one through Tls:CertificatePath (and Tls:CertificatePassword) in configuration. " +
-        "When TLS is terminated upstream by an ingress/reverse proxy, re-encrypt the connection to Chronicle.");
-#endif
+    logger.TlsDisabled(chronicleOptions.Port, chronicleOptions.ManagementPort);
 }
 
-logger.ServerListening(chronicleOptions.Port);
+var endpoints = ServerEndpointResolver.Resolve(chronicleOptions);
+foreach (var endpoint in endpoints)
+{
+    logger.ServerListening(endpoint.Port);
+}
 
 builder.WebHost.UseKestrel(options =>
 {
-    // A single TLS port for both gRPC (HTTP/2) and the Workbench, API and OAuth flows (HTTP/1.1),
-    // multiplexed per connection through ALPN.
-    options.ListenAnyIP(chronicleOptions.Port, listenOptions =>
+    foreach (var endpoint in endpoints)
     {
-        listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-        listenOptions.UseHttps(certificate);
-    });
+        options.ListenAnyIP(endpoint.Port, listenOptions =>
+        {
+            listenOptions.Protocols = endpoint.Protocols switch
+            {
+                EndpointProtocols.Http1 => HttpProtocols.Http1,
+                EndpointProtocols.Http2 => HttpProtocols.Http2,
+                _ => HttpProtocols.Http1AndHttp2
+            };
+
+            if (endpoint.UseTls)
+            {
+                listenOptions.UseHttps(certificate!);
+            }
+        });
+    }
 
     options.Limits.Http2.MaxStreamsPerConnection = 100;
 });
@@ -179,6 +199,15 @@ var app = builder.Build();
 
 logger = app.Services.GetRequiredService<ILogger<Kernel>>();
 logger.ServerConfigured();
+
+// A dedicated plaintext health-only port for orchestrator/load-balancer probes that cannot speak TLS.
+// The port-filtered middleware short-circuits health requests on that port before any routing, authentication
+// or gRPC middleware, keeping it a tiny anonymous surface. The main health endpoint is still mapped below.
+if (chronicleOptions.HealthPort > 0)
+{
+    logger.HealthPortEnabled(chronicleOptions.HealthPort);
+    app.UseHealthChecks(chronicleOptions.HealthCheckEndpoint, chronicleOptions.HealthPort);
+}
 
 app.UseRouting();
 


### PR DESCRIPTION
# Summary

Restores the pre-16.0 ability to run Chronicle without TLS. Since 16.0.0 the main port has been TLS-only, so `Tls:Enabled=false` — documented for deployments that terminate TLS upstream — crashed on startup instead of serving plaintext, and development could no longer run without a certificate. TLS on a single multiplexed port remains the default.

## Added

- `Tls:Enabled=false` runs Chronicle in cleartext: h2c gRPC on the main port and the Workbench, REST API, OAuth and health surface on `ManagementPort` (8080 by default). Use it when TLS is terminated upstream by a load balancer/ingress, or for local development with no certificate.
- Optional `HealthPort` exposes the `/health` endpoint on a dedicated plaintext port for orchestrator and load-balancer probes, while gRPC, the API and OAuth stay on TLS on the main port.

## Changed

- The startup error for a missing production certificate now states that TLS can be disabled with `Tls:Enabled=false`, rather than only that a certificate is required.

## Fixed

- `Tls:Enabled=false` no longer crashes the server on startup — it now produces a working plaintext server, matching the property's documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
