### PR TITLE
Update Cratis.Fundamentals to 7.16.5 for resilient type discovery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <!-- Aspire -->
     <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.4" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.4" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.5" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.5" />
     <PackageVersion Include="Cratis.Arc" Version="20.54.3" />
     <PackageVersion Include="Cratis.Arc.Core" Version="20.54.3" />
     <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.54.3" />


### PR DESCRIPTION
# Summary

Updates Cratis.Fundamentals and Cratis.Metrics.Roslyn to 7.16.5, which makes type discovery resilient to types that cannot be loaded (Cratis/Fundamentals#1086). This stops the server from crashing at startup during type discovery when a referenced assembly resolves to a version that no longer contains a type another assembly references — the flaky failure that was breaking the integration jobs.
