### PR TITLE
Skip TLS validation in the out-of-process kernel reset client

### DIFF
--- a/Integration/Client/ChronicleConfigurableFixture.cs
+++ b/Integration/Client/ChronicleConfigurableFixture.cs
@@ -481,7 +481,8 @@ public class ChronicleConfigurableFixture : XUnit.Integration.ChronicleFixture
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     async Task ResetOutOfProcessKernelState()
     {
-        var connectionString = new ChronicleConnectionString($"chronicle://localhost:{KernelGrpcHostPort}/");
+        // skipTlsValidation because the container serves a self-signed development certificate.
+        var connectionString = new ChronicleConnectionString($"chronicle://localhost:{KernelGrpcHostPort}/?skipTlsValidation=true");
         var options = new ChronicleClientOptions
         {
             ConnectionString = connectionString,


### PR DESCRIPTION
# Summary

The always-TLS client change (#3470) made certificate validation the default, but the integration fixture's out-of-process kernel reset client was missed - it dials the kernel container directly over gRPC without `skipTlsValidation=true`. The container serves a self-signed development certificate, so the reset client rejected it, retried for two minutes and failed the test-class cleanup. This failed out-of-process client integration jobs on every PR even when all their tests passed, for example the `for_PIIManager` suite on #3474.

## Fixed

- Out-of-process client integration jobs no longer fail at test-class cleanup with "The remote certificate was rejected by the provided RemoteCertificateValidationCallback"
