### PR TITLE
Regenerate stale Chronicle protobuf contracts

### DIFF
--- a/Source/Kernel/Protobuf/clients.proto
+++ b/Source/Kernel/Protobuf/clients.proto
@@ -6,6 +6,21 @@ message ConnectRequest {
    string ConnectionId = 1;
    string ClientVersion = 2;
    bool IsRunningWithDebugger = 3;
+   int32 ProcessId = 4;
+   string ProcessPath = 5;
+   string MachineName = 6;
+   string ClientType = 7;
+}
+message ConnectedClient {
+   string ConnectionId = 1;
+   string Version = 2;
+   SerializableDateTimeOffset LastSeen = 3;
+   bool IsRunningWithDebugger = 4;
+   string SiloAddress = 5;
+   int32 ProcessId = 6;
+   string ProcessPath = 7;
+   string MachineName = 8;
+   string ClientType = 9;
 }
 message ConnectionKeepAlive {
    string ConnectionId = 1;
@@ -13,8 +28,17 @@ message ConnectionKeepAlive {
 message DescriptorSetResponse {
    string SchemaDefinition = 1;
 }
+message IEnumerable_ConnectedClient {
+   repeated ConnectedClient items = 1;
+}
+// Represents a DateTimeOffset value as an ISO 8601 string (e.g., "2024-01-15T12:30:00.0000000+02:00").
+message SerializableDateTimeOffset {
+   string Value = 1;
+}
 service ConnectionService {
    rpc Connect (ConnectRequest) returns (stream .Cratis.Chronicle.Contracts.Clients.ConnectionKeepAlive);
    rpc ConnectionKeepAlive (.Cratis.Chronicle.Contracts.Clients.ConnectionKeepAlive) returns (.google.protobuf.Empty);
+   rpc GetConnectedClients (.google.protobuf.Empty) returns (IEnumerable_ConnectedClient);
    rpc GetDescriptorSet (.google.protobuf.Empty) returns (DescriptorSetResponse);
+   rpc ObserveConnectedClients (.google.protobuf.Empty) returns (stream IEnumerable_ConnectedClient);
 }

--- a/Source/Kernel/Protobuf/compliance.proto
+++ b/Source/Kernel/Protobuf/compliance.proto
@@ -1,6 +1,12 @@
 syntax = "proto3";
 package Cratis.Chronicle.Contracts.Compliance;
+import "google/protobuf/empty.proto";
 
+message DeleteEncryptionKeyRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string Identifier = 3;
+}
 message ReleaseRequest {
    string EventStore = 1;
    string Namespace = 2;
@@ -14,5 +20,6 @@ message ReleaseResponse {
    string Error = 3;
 }
 service Compliance {
+   rpc DeleteEncryptionKey (DeleteEncryptionKeyRequest) returns (.google.protobuf.Empty);
    rpc Release (ReleaseRequest) returns (ReleaseResponse);
 }

--- a/Source/Kernel/Protobuf/events_constraints.proto
+++ b/Source/Kernel/Protobuf/events_constraints.proto
@@ -19,6 +19,7 @@ enum ConstraintType {
    Unique = 1;
    UniqueEventType = 2;
    Schema = 3;
+   StreamClosed = 4;
 }
 message OneOf_UniqueConstraintDefinition_UniqueEventTypeConstraintDefinition {
    UniqueConstraintDefinition Value0 = 1;

--- a/Source/Kernel/Protobuf/eventsequences.proto
+++ b/Source/Kernel/Protobuf/eventsequences.proto
@@ -57,6 +57,22 @@ message Causation {
    string Type = 2;
    map<string,string> Properties = 3;
 }
+enum CompleteStreamError {
+   AlreadyCompleted = 0;
+   DefaultStreamCannotBeCompleted = 1;
+}
+message CompleteStreamRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string EventSequenceId = 3;
+   string EventStreamType = 4;
+   string EventStreamId = 5;
+}
+message CompleteStreamResponse {
+   bool IsSuccess = 1;
+   uint64 SequenceNumber = 2;
+   CompleteStreamError Error = 3;
+}
 message ConcurrencyScope {
    uint64 SequenceNumber = 1;
    bool EventSourceId = 2;
@@ -75,6 +91,7 @@ enum ConstraintType {
    Unique = 1;
    UniqueEventType = 2;
    Schema = 3;
+   StreamClosed = 4;
 }
 message ConstraintViolation {
    string EventTypeId = 1;
@@ -226,6 +243,7 @@ message SerializableDateTimeOffset {
 service EventSequences {
    rpc Append (AppendRequest) returns (AppendResponse);
    rpc AppendMany (AppendManyRequest) returns (AppendManyResponse);
+   rpc CompleteStream (CompleteStreamRequest) returns (CompleteStreamResponse);
    rpc GetEventsFromEventSequenceNumber (GetFromEventSequenceNumberRequest) returns (GetFromEventSequenceNumberResponse);
    rpc GetForEventSourceIdAndEventTypes (GetForEventSourceIdAndEventTypesRequest) returns (GetForEventSourceIdAndEventTypesResponse);
    rpc GetTailSequenceNumber (GetTailSequenceNumberRequest) returns (GetTailSequenceNumberResponse);

--- a/Source/Kernel/Protobuf/host.proto
+++ b/Source/Kernel/Protobuf/host.proto
@@ -9,4 +9,5 @@ message ServerVersionInfo {
 service Server {
    rpc GetVersionInfo (.google.protobuf.Empty) returns (ServerVersionInfo);
    rpc ReloadState (.google.protobuf.Empty) returns (.google.protobuf.Empty);
+   rpc ResetKernelState (.google.protobuf.Empty) returns (.google.protobuf.Empty);
 }

--- a/Source/Kernel/Protobuf/observation.proto
+++ b/Source/Kernel/Protobuf/observation.proto
@@ -7,6 +7,23 @@ message AllObserversRequest {
    string EventStore = 1;
    string Namespace = 2;
 }
+message ClearObserverQuarantine {
+   string EventStore = 1;
+   string Namespace = 2;
+   string ObserverId = 3;
+   string EventSequenceId = 4;
+}
+message ConnectedClient {
+   string ConnectionId = 1;
+   string Version = 2;
+   SerializableDateTimeOffset LastSeen = 3;
+   bool IsRunningWithDebugger = 4;
+   string SiloAddress = 5;
+   int32 ProcessId = 6;
+   string ProcessPath = 7;
+   string MachineName = 8;
+   string ClientType = 9;
+}
 message EventType {
    string Id = 1;
    uint32 Generation = 2;
@@ -24,6 +41,12 @@ message FailedPartitionAttempt {
    repeated string Messages = 3;
    string StackTrace = 4;
 }
+message GetConnectedClientsForObserverRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string ObserverId = 3;
+   string EventSequenceId = 4;
+}
 message GetFailedPartitionsRequest {
    string EventStore = 1;
    string Namespace = 2;
@@ -39,6 +62,9 @@ message GetReplayableObserversForEventTypesRequest {
    string EventStore = 1;
    string Namespace = 2;
    repeated EventType EventTypes = 3;
+}
+message IEnumerable_ConnectedClient {
+   repeated ConnectedClient items = 1;
 }
 message IEnumerable_FailedPartition {
    repeated FailedPartition items = 1;
@@ -86,18 +112,15 @@ message Replay {
    string ObserverId = 3;
    string EventSequenceId = 4;
 }
-message ClearObserverQuarantine {
-   string EventStore = 1;
-   string Namespace = 2;
-   string ObserverId = 3;
-   string EventSequenceId = 4;
-}
 message ReplayPartition {
    string EventStore = 1;
    string Namespace = 2;
    string ObserverId = 3;
    string EventSequenceId = 4;
    string Partition = 5;
+}
+message ReplayResponse {
+   string JobId = 1;
 }
 message RetryPartition {
    string EventStore = 1;
@@ -110,17 +133,29 @@ message RetryPartition {
 message SerializableDateTimeOffset {
    string Value = 1;
 }
+message WaitForObserverCompletionRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string EventSequenceId = 3;
+   uint64 TailEventSequenceNumber = 4;
+}
+message WaitForObserverCompletionResponse {
+   bool IsSuccess = 1;
+   repeated FailedPartition FailedPartitions = 2;
+}
 service FailedPartitions {
    rpc GetFailedPartitions (GetFailedPartitionsRequest) returns (IEnumerable_FailedPartition);
    rpc ObserveFailedPartitions (GetFailedPartitionsRequest) returns (stream IEnumerable_FailedPartition);
 }
 service Observers {
+   rpc ClearObserverQuarantine (.Cratis.Chronicle.Contracts.Observation.ClearObserverQuarantine) returns (.google.protobuf.Empty);
+   rpc GetConnectedClientsForObserver (GetConnectedClientsForObserverRequest) returns (IEnumerable_ConnectedClient);
    rpc GetObserverInformation (GetObserverInformationRequest) returns (ObserverInformation);
    rpc GetObservers (AllObserversRequest) returns (IEnumerable_ObserverInformation);
    rpc GetReplayableObserversForEventTypes (GetReplayableObserversForEventTypesRequest) returns (IEnumerable_ObserverInformation);
    rpc ObserveObservers (AllObserversRequest) returns (stream IEnumerable_ObserverInformation);
-   rpc Replay (.Cratis.Chronicle.Contracts.Observation.Replay) returns (.google.protobuf.Empty);
-   rpc ClearObserverQuarantine (.Cratis.Chronicle.Contracts.Observation.ClearObserverQuarantine) returns (.google.protobuf.Empty);
+   rpc Replay (.Cratis.Chronicle.Contracts.Observation.Replay) returns (ReplayResponse);
    rpc ReplayPartition (.Cratis.Chronicle.Contracts.Observation.ReplayPartition) returns (.google.protobuf.Empty);
    rpc RetryPartition (.Cratis.Chronicle.Contracts.Observation.RetryPartition) returns (.google.protobuf.Empty);
+   rpc WaitForCompletion (WaitForObserverCompletionRequest) returns (WaitForObserverCompletionResponse);
 }

--- a/Source/Kernel/Protobuf/observation_reactors.proto
+++ b/Source/Kernel/Protobuf/observation_reactors.proto
@@ -58,6 +58,7 @@ message EventTypeWithKeyExpression {
 message EventsToObserve {
    string Partition = 1;
    repeated AppendedEvent Events = 2;
+   ReplayState ReplayState = 3;
 }
 message HasReactorRequest {
    string EventStore = 1;
@@ -111,6 +112,13 @@ message RegisterReactor {
    string EventStore = 2;
    string Namespace = 3;
    ReactorDefinition Reactor = 4;
+}
+enum ReplayState {
+   REPLAY_STATE_None = 0;
+   BeginReplay = 1;
+   EndReplay = 2;
+   BeginReplayPartition = 3;
+   EndReplayPartition = 4;
 }
 // Represents a DateTimeOffset value as an ISO 8601 string (e.g., "2024-01-15T12:30:00.0000000+02:00").
 message SerializableDateTimeOffset {

--- a/Source/Kernel/Protobuf/observation_reducers.proto
+++ b/Source/Kernel/Protobuf/observation_reducers.proto
@@ -79,6 +79,7 @@ message ReduceOperationMessage {
    string Partition = 1;
    string InitialState = 2;
    repeated AppendedEvent Events = 3;
+   ReplayState ReplayState = 4;
 }
 message ReducerDefinition {
    string ReducerId = 1;
@@ -86,7 +87,6 @@ message ReducerDefinition {
    repeated EventTypeWithKeyExpression EventTypes = 3;
    string ReadModel = 4;
    bool IsActive = 5;
-   SinkDefinition Sink = 6;
    repeated string Tags = 7;
    ObserverFilters Filters = 8;
 }
@@ -107,13 +107,16 @@ message RegisterReducer {
    string Namespace = 3;
    ReducerDefinition Reducer = 4;
 }
+enum ReplayState {
+   REPLAY_STATE_None = 0;
+   BeginReplay = 1;
+   EndReplay = 2;
+   BeginReplayPartition = 3;
+   EndReplayPartition = 4;
+}
 // Represents a DateTimeOffset value as an ISO 8601 string (e.g., "2024-01-15T12:30:00.0000000+02:00").
 message SerializableDateTimeOffset {
    string Value = 1;
-}
-message SinkDefinition {
-   .bcl.Guid ConfigurationId = 1; // default value could not be applied: 00000000-0000-0000-0000-000000000000
-   string TypeId = 2;
 }
 service Reducers {
    rpc Observe (stream ReducerMessage) returns (stream ReduceOperationMessage);

--- a/Source/Kernel/Protobuf/projections.proto
+++ b/Source/Kernel/Protobuf/projections.proto
@@ -218,7 +218,7 @@ message SerializableDateTimeOffset {
 }
 message SinkDefinition {
    .bcl.Guid ConfigurationId = 1; // default value could not be applied: 00000000-0000-0000-0000-000000000000
-   .bcl.Guid TypeId = 2; // default value could not be applied: 00000000-0000-0000-0000-000000000000
+   string TypeId = 2;
 }
 service Projections {
    rpc GenerateDeclarativeCode (GenerateDeclarativeCodeRequest) returns (OneOf_GeneratedCode_ProjectionDeclarationParsingErrors);

--- a/Source/Kernel/Protobuf/readmodels.proto
+++ b/Source/Kernel/Protobuf/readmodels.proto
@@ -131,11 +131,26 @@ message Identity {
 message IndexDefinition {
    string PropertyPath = 1;
 }
+message ObserveInstancesRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string ReadModel = 3;
+   int32 Page = 4;
+   int32 PageSize = 5;
+   string Occurrence = 6;
+}
+message ObserveInstancesResponse {
+   repeated string Instances = 1;
+   int32 TotalCount = 2;
+   int32 Page = 3;
+   int32 PageSize = 4;
+}
 message ReadModelChangeset {
    string Namespace = 1;
    string ModelKey = 2;
    string ReadModel = 3;
    bool Removed = 4;
+   bool Subscribed = 5;
 }
 message ReadModelDefinition {
    ReadModelType Type = 1;
@@ -210,6 +225,10 @@ message WatchRequest {
    string Namespace = 2;
    string ReadModelIdentifier = 3;
    string EventSequenceId = 4;
+}
+service MaterializedReadModels {
+   rpc GetInstances (GetInstancesRequest) returns (GetInstancesResponse);
+   rpc ObserveInstances (ObserveInstancesRequest) returns (stream ObserveInstancesResponse);
 }
 service ReadModels {
    rpc DehydrateSession (DehydrateSessionRequest) returns (.google.protobuf.Empty);


### PR DESCRIPTION
## Fixed

- The .proto files under Source/Kernel/Protobuf were last regenerated before several C# contract changes landed (ConnectRequest's ProcessId/ProcessPath/MachineName/ClientType, ConnectedClient's matching fields, and other unrelated drift). None of the client SDKs that generate code from these files could see the new fields until this ran. Regenerated via generate-protos.sh with no manual edits.