### PR TITLE
Fix crash releasing an erased subject's PII collection

### DIFF
--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_compliant_list_and_the_key_has_been_deleted.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_compliant_list_and_the_key_has_been_deleted.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+public class when_releasing_a_compliant_list_and_the_key_has_been_deleted : given.a_value_handler_and_a_type_with_a_compliant_list
+{
+    const string Identifier = "9ae5067b-2920-4c97-a263-efe35bec2b43";
+    JsonObject _result;
+
+    void Establish()
+    {
+        // After the subject's encryption key has been crypto-shredded (GDPR right-to-erasure), the handler
+        // surfaces the erased value as an empty string. The manager must round-trip that into an empty array
+        // for a coarse [PII] collection instead of throwing while re-parsing the empty released value.
+        _valueHandler.Release(string.Empty, string.Empty, Identifier, Arg.Any<JsonNode>())
+            .Returns(Task.FromResult<JsonNode>(JsonValue.Create(string.Empty)));
+    }
+
+    async Task Because() => _result = await _manager.Release(string.Empty, string.Empty, _schema, Identifier, _input);
+
+    [Fact] void should_release_the_list_as_an_array() => (_result[ListPropertyName] is JsonArray).ShouldBeTrue();
+    [Fact] void should_release_an_empty_array() => _result[ListPropertyName]!.AsArray().Count.ShouldEqual(0);
+}

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -58,6 +58,14 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
             released is JsonValue releasedValue &&
             releasedValue.TryGetValue<string>(out var releasedText))
         {
+            // When the subject's encryption key has been crypto-shredded (GDPR right-to-erasure), the handler
+            // surfaces the erased value as an empty string. An erased collection reads as empty, so return an
+            // empty array rather than letting JsonNode.Parse(string.Empty) throw and poison the release path.
+            if (string.IsNullOrWhiteSpace(releasedText))
+            {
+                return new JsonArray();
+            }
+
             return JsonNode.Parse(releasedText) ?? released;
         }
 


### PR DESCRIPTION
## Fixed

- Releasing a coarse `[PII]` collection for a subject whose encryption key has been erased (right-to-erasure) no longer throws — it now reads as an empty collection. Previously the empty released value crashed re-parsing on the read side, and on the observer path failed the partition on every retry, which could quarantine the observer after an erasure.
