### PR TITLE
Make hardcoded operational timeouts configurable

### DIFF
--- a/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_client_connects.cs
+++ b/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_client_connects.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Clients;
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients.for_ConnectedClients;
 
@@ -17,7 +19,8 @@ public class when_client_connects : Specification
     {
         _connectedClients = new ConnectedClients(
             Substitute.For<ILogger<ConnectedClients>>(),
-            Substitute.For<IMeter<ConnectedClients>>());
+            Substitute.For<IMeter<ConnectedClients>>(),
+            Options.Create(new ChronicleOptions()));
         _connectionId = ConnectionId.New();
     }
 

--- a/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_deactivating.cs
+++ b/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_deactivating.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients.for_ConnectedClients;
 
@@ -16,7 +18,8 @@ public class when_deactivating : Specification
     {
         _connectedClients = new ConnectedClients(
             Substitute.For<ILogger<ConnectedClients>>(),
-            Substitute.For<IMeter<ConnectedClients>>());
+            Substitute.For<IMeter<ConnectedClients>>(),
+            Options.Create(new ChronicleOptions()));
         _timer = Substitute.For<IGrainTimer>();
 
         typeof(ConnectedClients)

--- a/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_getting_connection_count.cs
+++ b/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_getting_connection_count.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Clients;
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients.for_ConnectedClients;
 
@@ -16,7 +18,8 @@ public class when_getting_connection_count : Specification
     {
         _connectedClients = new ConnectedClients(
             Substitute.For<ILogger<ConnectedClients>>(),
-            Substitute.For<IMeter<ConnectedClients>>());
+            Substitute.For<IMeter<ConnectedClients>>(),
+            Options.Create(new ChronicleOptions()));
     }
 
     async Task Because()

--- a/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_getting_connection_count_with_a_reservation_and_a_connected_client.cs
+++ b/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_getting_connection_count_with_a_reservation_and_a_connected_client.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Clients;
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients.for_ConnectedClients;
 
@@ -16,7 +18,8 @@ public class when_getting_connection_count_with_a_reservation_and_a_connected_cl
     {
         _connectedClients = new ConnectedClients(
             Substitute.For<ILogger<ConnectedClients>>(),
-            Substitute.For<IMeter<ConnectedClients>>());
+            Substitute.For<IMeter<ConnectedClients>>(),
+            Options.Create(new ChronicleOptions()));
     }
 
     async Task Because()

--- a/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_reserving_a_connection.cs
+++ b/Source/Kernel/Core.Specs/Clients/for_ConnectedClients/when_reserving_a_connection.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients.for_ConnectedClients;
 
@@ -15,7 +17,8 @@ public class when_reserving_a_connection : Specification
     {
         _connectedClients = new ConnectedClients(
             Substitute.For<ILogger<ConnectedClients>>(),
-            Substitute.For<IMeter<ConnectedClients>>());
+            Substitute.For<IMeter<ConnectedClients>>(),
+            Options.Create(new ChronicleOptions()));
     }
 
     async Task Because()

--- a/Source/Kernel/Core.Specs/Configuration/for_ChronicleOptions/when_binding_configuration/and_all_values_are_configured.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ChronicleOptions/when_binding_configuration/and_all_values_are_configured.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Cratis.Chronicle.Configuration.for_ChronicleOptions.when_binding_configuration;
+
+public class and_all_values_are_configured : Specification
+{
+    ChronicleOptions _options;
+
+    void Establish()
+    {
+        _options = new ChronicleOptions();
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cratis:Chronicle:ConnectedClients:ReviseIntervalSeconds"] = "11",
+                ["Cratis:Chronicle:ConnectedClients:ReservationTtlSeconds"] = "42",
+                ["Cratis:Chronicle:ConnectedClients:StaleThresholdSeconds"] = "9",
+                ["Cratis:Chronicle:ConnectedClients:ObserveIntervalSeconds"] = "3",
+                ["Cratis:Chronicle:ConnectedClients:KeepAliveIntervalSeconds"] = "4",
+                ["Cratis:Chronicle:Webhooks:RetryDelaySeconds"] = "7",
+                ["Cratis:Chronicle:Webhooks:CircuitBreakerSamplingDurationSeconds"] = "45",
+                ["Cratis:Chronicle:Webhooks:CircuitBreakerBreakDurationSeconds"] = "20",
+                ["Cratis:Chronicle:Webhooks:RequestTimeoutSeconds"] = "90",
+                ["Cratis:Chronicle:Webhooks:TestTimeoutSeconds"] = "15",
+                ["Cratis:Chronicle:Sql:LiveQueryPollIntervalSeconds"] = "6",
+                ["Cratis:Chronicle:Observers:SubscriptionReadyTimeout"] = "8",
+                ["Cratis:Chronicle:Events:QueueDepletionWaitTimeoutMilliseconds"] = "750"
+            })
+            .Build()
+            .GetSection(ChronicleOptions.SectionPath)
+            .Bind(_options);
+    }
+
+    [Fact] void should_bind_the_revise_interval() => _options.ConnectedClients.ReviseIntervalSeconds.ShouldEqual(11);
+    [Fact] void should_bind_the_reservation_ttl() => _options.ConnectedClients.ReservationTtlSeconds.ShouldEqual(42);
+    [Fact] void should_bind_the_stale_threshold() => _options.ConnectedClients.StaleThresholdSeconds.ShouldEqual(9);
+    [Fact] void should_bind_the_observe_interval() => _options.ConnectedClients.ObserveIntervalSeconds.ShouldEqual(3);
+    [Fact] void should_bind_the_keep_alive_interval() => _options.ConnectedClients.KeepAliveIntervalSeconds.ShouldEqual(4);
+    [Fact] void should_bind_the_retry_delay() => _options.Webhooks.RetryDelaySeconds.ShouldEqual(7);
+    [Fact] void should_bind_the_circuit_breaker_sampling_duration() => _options.Webhooks.CircuitBreakerSamplingDurationSeconds.ShouldEqual(45);
+    [Fact] void should_bind_the_circuit_breaker_break_duration() => _options.Webhooks.CircuitBreakerBreakDurationSeconds.ShouldEqual(20);
+    [Fact] void should_bind_the_request_timeout() => _options.Webhooks.RequestTimeoutSeconds.ShouldEqual(90);
+    [Fact] void should_bind_the_webhook_test_timeout() => _options.Webhooks.TestTimeoutSeconds.ShouldEqual(15);
+    [Fact] void should_bind_the_live_query_poll_interval() => _options.Sql.LiveQueryPollIntervalSeconds.ShouldEqual(6);
+    [Fact] void should_bind_the_subscription_ready_timeout() => _options.Observers.SubscriptionReadyTimeout.ShouldEqual(8);
+    [Fact] void should_bind_the_queue_depletion_wait_timeout() => _options.Events.QueueDepletionWaitTimeoutMilliseconds.ShouldEqual(750);
+}

--- a/Source/Kernel/Core.Specs/Configuration/for_ChronicleOptions/when_binding_configuration/and_no_values_are_configured.cs
+++ b/Source/Kernel/Core.Specs/Configuration/for_ChronicleOptions/when_binding_configuration/and_no_values_are_configured.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Cratis.Chronicle.Configuration.for_ChronicleOptions.when_binding_configuration;
+
+public class and_no_values_are_configured : Specification
+{
+    ChronicleOptions _options;
+
+    void Establish()
+    {
+        _options = new ChronicleOptions();
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build()
+            .GetSection(ChronicleOptions.SectionPath)
+            .Bind(_options);
+    }
+
+    [Fact] void should_default_the_revise_interval() => _options.ConnectedClients.ReviseIntervalSeconds.ShouldEqual(2);
+    [Fact] void should_default_the_reservation_ttl() => _options.ConnectedClients.ReservationTtlSeconds.ShouldEqual(30);
+    [Fact] void should_default_the_stale_threshold() => _options.ConnectedClients.StaleThresholdSeconds.ShouldEqual(5);
+    [Fact] void should_default_the_observe_interval() => _options.ConnectedClients.ObserveIntervalSeconds.ShouldEqual(1);
+    [Fact] void should_default_the_keep_alive_interval() => _options.ConnectedClients.KeepAliveIntervalSeconds.ShouldEqual(1);
+    [Fact] void should_default_the_retry_delay() => _options.Webhooks.RetryDelaySeconds.ShouldEqual(2);
+    [Fact] void should_default_the_circuit_breaker_sampling_duration() => _options.Webhooks.CircuitBreakerSamplingDurationSeconds.ShouldEqual(30);
+    [Fact] void should_default_the_circuit_breaker_break_duration() => _options.Webhooks.CircuitBreakerBreakDurationSeconds.ShouldEqual(15);
+    [Fact] void should_default_the_request_timeout() => _options.Webhooks.RequestTimeoutSeconds.ShouldEqual(60);
+    [Fact] void should_default_the_webhook_test_timeout() => _options.Webhooks.TestTimeoutSeconds.ShouldEqual(10);
+    [Fact] void should_default_the_live_query_poll_interval() => _options.Sql.LiveQueryPollIntervalSeconds.ShouldEqual(2);
+    [Fact] void should_default_the_subscription_ready_timeout() => _options.Observers.SubscriptionReadyTimeout.ShouldEqual(5);
+    [Fact] void should_default_the_queue_depletion_wait_timeout() => _options.Events.QueueDepletionWaitTimeoutMilliseconds.ShouldEqual(500);
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/given/an_event_store_subscriptions_service.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptions/given/an_event_store_subscriptions_service.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptions.given;
 
@@ -15,6 +17,6 @@ public class an_event_store_subscriptions_service : Specification
     {
         _grainFactory = Substitute.For<IGrainFactory>();
         _storage = Substitute.For<IStorage>();
-        _service = new Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(_grainFactory, _storage);
+        _service = new Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(_grainFactory, _storage, Options.Create(new ChronicleOptions()));
     }
 }

--- a/Source/Kernel/Core.Specs/Observation/Webhooks/for_Webhooks/given/a_webhooks_service_grain.cs
+++ b/Source/Kernel/Core.Specs/Observation/Webhooks/for_Webhooks/given/a_webhooks_service_grain.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Security;
 using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Observation.Webhooks.for_Webhooks.given;
 
@@ -24,6 +26,6 @@ public class a_webhooks_service_grain : Specification
         _encryption = Substitute.For<IEncryption>();
         _oauthClient = Substitute.For<IOAuthClient>();
         _webhookMediator = Substitute.For<IWebhookMediator>();
-        _webhooksService = new Services.Observation.Webhooks.Webhooks(_grainFactory, _storage, _webhookDefinitionComparer, _encryption, _oauthClient, _webhookMediator);
+        _webhooksService = new Services.Observation.Webhooks.Webhooks(_grainFactory, _storage, _webhookDefinitionComparer, _encryption, _oauthClient, _webhookMediator, Options.Create(new ChronicleOptions()));
     }
 }

--- a/Source/Kernel/Core/Clients/ConnectedClients.cs
+++ b/Source/Kernel/Core/Clients/ConnectedClients.cs
@@ -4,9 +4,11 @@
 using System.Diagnostics;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Clients;
+using Cratis.Chronicle.Configuration;
 using Cratis.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Clients;
 
@@ -15,14 +17,17 @@ namespace Cratis.Chronicle.Clients;
 /// </summary>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
 /// <param name="meter"><see cref="IMeter{ConnectedClients}"/> for metrics.</param>
+/// <param name="options"><see cref="IOptions{ChronicleOptions}"/> for configuration.</param>
 [KeepAlive]
 [ConnectedClientsPlacement]
 public class ConnectedClients(
     ILogger<ConnectedClients> logger,
-    [FromKeyedServices(WellKnown.MeterName)] IMeter<ConnectedClients> meter) : Grain, IConnectedClients
+    [FromKeyedServices(WellKnown.MeterName)] IMeter<ConnectedClients> meter,
+    IOptions<ChronicleOptions> options) : Grain, IConnectedClients
 {
-    static readonly TimeSpan _reviseConnectedClientsPeriod = TimeSpan.FromSeconds(2);
-    static readonly TimeSpan _reservationTtl = TimeSpan.FromSeconds(30);
+    readonly TimeSpan _reviseConnectedClientsPeriod = TimeSpan.FromSeconds(options.Value.ConnectedClients.ReviseIntervalSeconds);
+    readonly TimeSpan _reservationTtl = TimeSpan.FromSeconds(options.Value.ConnectedClients.ReservationTtlSeconds);
+    readonly int _staleThresholdSeconds = options.Value.ConnectedClients.StaleThresholdSeconds;
     readonly List<ConnectedClient> _clients = [];
     readonly List<DateTimeOffset> _reservations = [];
     IGrainTimer? _reviseConnectedClientsTimer;
@@ -148,9 +153,9 @@ public class ConnectedClients(
         {
             if (connectedClient.IsRunningWithDebugger) continue;
 
-            if (connectedClient.LastSeen < DateTimeOffset.UtcNow.AddSeconds(-5))
+            if (connectedClient.LastSeen < DateTimeOffset.UtcNow.AddSeconds(-_staleThresholdSeconds))
             {
-                await OnClientDisconnected(connectedClient.ConnectionId, "Last seen was more than 5 seconds ago");
+                await OnClientDisconnected(connectedClient.ConnectionId, $"Last seen was more than {_staleThresholdSeconds} seconds ago");
             }
         }
     }

--- a/Source/Kernel/Core/Configuration/ChronicleOptions.cs
+++ b/Source/Kernel/Core/Configuration/ChronicleOptions.cs
@@ -62,6 +62,11 @@ public class ChronicleOptions
     public Storage Storage { get; init; } = new Storage();
 
     /// <summary>
+    /// Gets or inits the SQL storage backend configuration.
+    /// </summary>
+    public Sql Sql { get; init; } = new Sql();
+
+    /// <summary>
     /// Gets or inits the compliance configuration.
     /// When <see cref="Encryption.Storage"/> is not set, the general <see cref="Storage"/> is used for compliance data.
     /// </summary>
@@ -71,6 +76,16 @@ public class ChronicleOptions
     /// Gets the observers configuration.
     /// </summary>
     public Observers Observers { get; init; } = new Observers();
+
+    /// <summary>
+    /// Gets the connected clients configuration.
+    /// </summary>
+    public Clients ConnectedClients { get; init; } = new Clients();
+
+    /// <summary>
+    /// Gets the webhooks configuration.
+    /// </summary>
+    public Webhooks Webhooks { get; init; } = new Webhooks();
 
     /// <summary>
     /// Gets the clustering configuration.

--- a/Source/Kernel/Core/Configuration/Clients.cs
+++ b/Source/Kernel/Core/Configuration/Clients.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents the configuration for connected clients.
+/// </summary>
+public class Clients
+{
+    /// <summary>
+    /// Gets the interval in seconds between revisions of the connected clients state.
+    /// </summary>
+    /// <remarks>
+    /// The revision loop prunes stale clients and removes expired connection reservations.
+    /// </remarks>
+    public int ReviseIntervalSeconds { get; init; } = 2;
+
+    /// <summary>
+    /// Gets the number of seconds a connection reservation is kept before it expires.
+    /// </summary>
+    /// <remarks>
+    /// A reservation holds a slot for a client that is in the process of connecting, so the
+    /// connection count reflects the client before its real connection has been registered.
+    /// </remarks>
+    public int ReservationTtlSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Gets the number of seconds a client can go unseen before it is considered disconnected.
+    /// </summary>
+    /// <remarks>
+    /// The revision loop disconnects any client whose last-seen time is older than this threshold.
+    /// </remarks>
+    public int StaleThresholdSeconds { get; init; } = 5;
+
+    /// <summary>
+    /// Gets the interval in seconds between observations of the connected clients for observers.
+    /// </summary>
+    public int ObserveIntervalSeconds { get; init; } = 1;
+
+    /// <summary>
+    /// Gets the interval in seconds between keep-alive messages sent to a connected client.
+    /// </summary>
+    public int KeepAliveIntervalSeconds { get; init; } = 1;
+}

--- a/Source/Kernel/Core/Configuration/Events.cs
+++ b/Source/Kernel/Core/Configuration/Events.cs
@@ -28,4 +28,13 @@ public class Events
     /// A value of 0 means unbounded (no backpressure). Defaults to 2000 batches.
     /// </remarks>
     public int QueueBoundedCapacity { get; init; } = 2000;
+
+    /// <summary>
+    /// Timeout in milliseconds for the final wait on the appended-events queue to become empty when awaiting depletion.
+    /// </summary>
+    /// <remarks>
+    /// Bounds the wait for the queue-empty signal so awaiting depletion cannot hang indefinitely
+    /// when running outside a debugger.
+    /// </remarks>
+    public int QueueDepletionWaitTimeoutMilliseconds { get; init; } = 500;
 }

--- a/Source/Kernel/Core/Configuration/Observers.cs
+++ b/Source/Kernel/Core/Configuration/Observers.cs
@@ -19,6 +19,15 @@ public class Observers
     public int SubscriberTimeout { get; init; } = 5;
 
     /// <summary>
+    /// Gets the timeout in seconds to wait for an event store subscription to become ready before returning to the client.
+    /// </summary>
+    /// <remarks>
+    /// Waiting ensures events are not lost if the client immediately starts publishing. When the timeout
+    /// elapses, the subscription may still activate asynchronously and the client is not blocked further.
+    /// </remarks>
+    public int SubscriptionReadyTimeout { get; init; } = 5;
+
+    /// <summary>
     /// Gets the maximum number of retries that can be attempted on a failed observer partition.
     /// </summary>
     /// <remarks>

--- a/Source/Kernel/Core/Configuration/Sql.cs
+++ b/Source/Kernel/Core/Configuration/Sql.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents the configuration for the SQL storage backends.
+/// </summary>
+public class Sql
+{
+    /// <summary>
+    /// Gets the interval in seconds between polls of the database for live, database-watching queries.
+    /// </summary>
+    /// <remarks>
+    /// The SQL backends cannot use push-based change streams the way MongoDB does, so live queries
+    /// poll the database on this interval and re-emit only when the result actually changes.
+    /// </remarks>
+    public int LiveQueryPollIntervalSeconds { get; init; } = 2;
+}

--- a/Source/Kernel/Core/Configuration/Webhooks.cs
+++ b/Source/Kernel/Core/Configuration/Webhooks.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents the configuration for webhook observers.
+/// </summary>
+public class Webhooks
+{
+    /// <summary>
+    /// Gets the delay in seconds used as the base for the exponential backoff between webhook delivery retries.
+    /// </summary>
+    public int RetryDelaySeconds { get; init; } = 2;
+
+    /// <summary>
+    /// Gets the duration in seconds over which failures are sampled by the webhook delivery circuit breaker.
+    /// </summary>
+    public int CircuitBreakerSamplingDurationSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Gets the duration in seconds the webhook delivery circuit breaker stays open after it trips.
+    /// </summary>
+    public int CircuitBreakerBreakDurationSeconds { get; init; } = 15;
+
+    /// <summary>
+    /// Gets the timeout in seconds applied to each individual webhook delivery request.
+    /// </summary>
+    public int RequestTimeoutSeconds { get; init; } = 60;
+
+    /// <summary>
+    /// Gets the timeout in seconds applied when testing a webhook endpoint.
+    /// </summary>
+    public int TestTimeoutSeconds { get; init; } = 10;
+}

--- a/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
+++ b/Source/Kernel/Core/EventSequences/AppendedEventsQueue.cs
@@ -31,6 +31,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
     readonly IActivitySource<AppendedEventsQueue> _activitySource;
     readonly ILogger<AppendedEventsQueue> _logger;
     readonly Channel<IReadOnlyList<AppendedEvent>> _channel;
+    readonly int _queueDepletionWaitTimeoutMs;
     readonly AsyncManualResetEvent _queueEmptyEvent = new();
     readonly Lock _subscriptionsLock = new();
     readonly List<AppendedEventsQueueObserverSubscription> _subscriptions = [];
@@ -64,6 +65,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
         _logger = logger;
 
         var eventsConfig = options.Value.Events;
+        _queueDepletionWaitTimeoutMs = eventsConfig.QueueDepletionWaitTimeoutMilliseconds;
         var capacity = eventsConfig.QueueBoundedCapacity;
         _channel = capacity > 0
             ? Channel.CreateBounded<IReadOnlyList<AppendedEvent>>(new BoundedChannelOptions(capacity)
@@ -205,7 +207,7 @@ public class AppendedEventsQueue : Grain, IAppendedEventsQueue, IDisposable
                     }
                 }
 
-                await _queueEmptyEvent.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(500));
+                await _queueEmptyEvent.WaitAsync().WaitAsync(TimeSpan.FromMilliseconds(_queueDepletionWaitTimeoutMs));
             }
         });
     }

--- a/Source/Kernel/Core/Services/Clients/ConnectionService.cs
+++ b/Source/Kernel/Core/Services/Clients/ConnectionService.cs
@@ -4,9 +4,11 @@
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Cratis.Chronicle.Clients;
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Contracts.Clients;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ProtoBuf.Grpc;
 using ProtoBuf.Grpc.Reflection;
 using ProtoBuf.Meta;
@@ -19,13 +21,16 @@ namespace Cratis.Chronicle.Services.Clients;
 /// <param name="grainFactory"><see cref="IGrainFactory"/> to get grains with.</param>
 /// <param name="localSiloDetails"><see cref="ILocalSiloDetails"/> for the silo terminating the client connections.</param>
 /// <param name="logger"><see cref="ILogger"/> for logging.</param>
+/// <param name="options"><see cref="IOptions{ChronicleOptions}"/> for configuration.</param>
 internal sealed class ConnectionService(
     IGrainFactory grainFactory,
     ILocalSiloDetails localSiloDetails,
-    ILogger<ConnectionService> logger) : IConnectionService
+    ILogger<ConnectionService> logger,
+    IOptions<ChronicleOptions> options) : IConnectionService
 {
     static readonly Lazy<string> _schemaDefinition = new(GenerateSchema);
-    static readonly TimeSpan _observeConnectedClientsInterval = TimeSpan.FromSeconds(1);
+    readonly TimeSpan _observeConnectedClientsInterval = TimeSpan.FromSeconds(options.Value.ConnectedClients.ObserveIntervalSeconds);
+    readonly TimeSpan _keepAliveInterval = TimeSpan.FromSeconds(options.Value.ConnectedClients.KeepAliveIntervalSeconds);
 
     /// <inheritdoc/>
     public IObservable<ConnectionKeepAlive> Connect(
@@ -51,7 +56,7 @@ internal sealed class ConnectionService(
                 {
                     while (!context.CancellationToken.IsCancellationRequested)
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                        await Task.Delay(_keepAliveInterval).ConfigureAwait(false);
 
                         if (context.CancellationToken.IsCancellationRequested)
                         {

--- a/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
+++ b/Source/Kernel/Core/Services/Observation/EventStoreSubscriptions/EventStoreSubscriptions.cs
@@ -4,10 +4,12 @@
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Options;
 using ProtoBuf.Grpc;
 using ConceptsEventStoreSubscriptionDefinition = Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition;
 using ContractEventStoreSubscriptionDefinition = Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions.EventStoreSubscriptionDefinition;
@@ -20,9 +22,11 @@ namespace Cratis.Chronicle.Services.Observation.EventStoreSubscriptions;
 /// </summary>
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="storage"><see cref="IStorage"/> for accessing subscription definitions.</param>
+/// <param name="options"><see cref="IOptions{ChronicleOptions}"/> for configuration.</param>
 internal sealed class EventStoreSubscriptions(
     IGrainFactory grainFactory,
-    IStorage storage) : ContractIEventStoreSubscriptions
+    IStorage storage,
+    IOptions<ChronicleOptions> options) : ContractIEventStoreSubscriptions
 {
     /// <inheritdoc/>
     public async Task Add(AddEventStoreSubscriptions request, CallContext context = default)
@@ -61,7 +65,7 @@ internal sealed class EventStoreSubscriptions(
             {
                 await subscriptionsManager.WaitUntilSubscribed(
                     new EventStoreSubscriptionId(subscription.Identifier),
-                    TimeSpan.FromSeconds(5));
+                    TimeSpan.FromSeconds(options.Value.Observers.SubscriptionReadyTimeout));
             }
             catch (TimeoutException)
             {

--- a/Source/Kernel/Core/Services/Observation/Webhooks/Webhooks.cs
+++ b/Source/Kernel/Core/Services/Observation/Webhooks/Webhooks.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation.Webhooks;
 using Cratis.Chronicle.Concepts.Security;
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Contracts.Observation.Webhooks;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Observation.Webhooks;
@@ -12,6 +13,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Security;
 using Cratis.Chronicle.Storage;
 using Cratis.Reactive;
+using Microsoft.Extensions.Options;
 using ProtoBuf.Grpc;
 using ContractIWebhooks = Cratis.Chronicle.Contracts.Observation.Webhooks.IWebhooks;
 using WebhookDefinition = Cratis.Chronicle.Contracts.Observation.Webhooks.WebhookDefinition;
@@ -27,16 +29,18 @@ namespace Cratis.Chronicle.Services.Observation.Webhooks;
 /// <param name="encryption"><see cref="IEncryption"/> for encrypting sensitive data.</param>
 /// <param name="oauthClient"><see cref="IOAuthClient"/> for testing OAuth authorization.</param>
 /// <param name="webhookMediator"><see cref="IWebhookMediator"/> for testing webhook endpoints.</param>
+/// <param name="options"><see cref="IOptions{ChronicleOptions}"/> for configuration.</param>
 internal sealed class Webhooks(
     IGrainFactory grainFactory,
     IStorage storage,
     IWebhookDefinitionComparer webhookDefinitionComparer,
     IEncryption encryption,
     IOAuthClient oauthClient,
-    IWebhookMediator webhookMediator) : ContractIWebhooks
+    IWebhookMediator webhookMediator,
+    IOptions<ChronicleOptions> options) : ContractIWebhooks
 {
     const string WebhookTestPartitionKey = "test";
-    static readonly TimeSpan _webhookTestTimeout = TimeSpan.FromSeconds(10);
+    readonly TimeSpan _webhookTestTimeout = TimeSpan.FromSeconds(options.Value.Webhooks.TestTimeoutSeconds);
 
     /// <inheritdoc/>
     public async Task Add(AddWebhooks request, CallContext context = default)

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -33,6 +33,7 @@ using Cratis.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Hosting;
 
@@ -139,8 +140,8 @@ public static class ChronicleServerSiloBuilderExtensions
                     sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Observation.Reactors.Reactors>>()),
                 new Cratis.Chronicle.Services.Observation.Reducers.Reducers(grainFactory, sp.GetRequiredService<IReducerMediator>(), expandoObjectConverter, jsonSerializerOptions, sp.GetRequiredKeyedService<Cratis.Traces.IActivitySource<Cratis.Chronicle.Services.Observation.Reducers.Reducers>>(Cratis.Chronicle.Concepts.WellKnown.MeterName), sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Observation.Reducers.Reducers>>()),
                 projections,
-                new Cratis.Chronicle.Services.Observation.Webhooks.Webhooks(grainFactory, storage, sp.GetRequiredService<IWebhookDefinitionComparer>(), sp.GetRequiredService<Cratis.Chronicle.Security.IEncryption>(), sp.GetRequiredService<IOAuthClient>(), sp.GetRequiredService<IWebhookMediator>()),
-                new Cratis.Chronicle.Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(grainFactory, storage),
+                new Cratis.Chronicle.Services.Observation.Webhooks.Webhooks(grainFactory, storage, sp.GetRequiredService<IWebhookDefinitionComparer>(), sp.GetRequiredService<Cratis.Chronicle.Security.IEncryption>(), sp.GetRequiredService<IOAuthClient>(), sp.GetRequiredService<IWebhookMediator>(), sp.GetRequiredService<IOptions<ChronicleOptions>>()),
+                new Cratis.Chronicle.Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(grainFactory, storage, sp.GetRequiredService<IOptions<ChronicleOptions>>()),
                 new Cratis.Chronicle.Services.ReadModels.ReadModels(grainFactory, storage, expandoObjectConverter, sp.GetRequiredService<IReducerMediator>(), sp.GetRequiredService<IReadModelsCompliance>(), sp.GetRequiredService<IEventCompliance>(), jsonSerializerOptions),
                 new Cratis.Chronicle.Services.ReadModels.MaterializedReadModels(grainFactory, storage, sp.GetRequiredService<IReadModelsCompliance>()),
                 new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage),
@@ -156,7 +157,8 @@ public static class ChronicleServerSiloBuilderExtensions
                 new Cratis.Chronicle.Services.Clients.ConnectionService(
                     grainFactory,
                     sp.GetRequiredService<ILocalSiloDetails>(),
-                    sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Clients.ConnectionService>>()));
+                    sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Clients.ConnectionService>>(),
+                    sp.GetRequiredService<IOptions<ChronicleOptions>>()));
         });
 
         return builder;

--- a/Source/Kernel/Core/Setup/WebhookHttpClientExtensions.cs
+++ b/Source/Kernel/Core/Setup/WebhookHttpClientExtensions.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Observation.Webhooks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
 using Polly;
 
 namespace Orleans.Hosting;
@@ -21,13 +23,15 @@ public static class WebhookHttpClientExtensions
     public static ISiloBuilder AddWebhookObserverHttpClient(this ISiloBuilder builder)
     {
         builder.Services.AddHttpClient(WebhookHttpClientFactory.HttpClientName)
-            .AddResilienceHandler($"{WebhookHttpClientFactory.HttpClientName}-pipeline", pipeline =>
+            .AddResilienceHandler($"{WebhookHttpClientFactory.HttpClientName}-pipeline", (pipeline, context) =>
             {
+                var webhooks = context.ServiceProvider.GetRequiredService<IOptions<ChronicleOptions>>().Value.Webhooks;
+
                 // Retry with exponential backoff
                 pipeline.AddRetry(new HttpRetryStrategyOptions
                 {
                     MaxRetryAttempts = 3,
-                    Delay = TimeSpan.FromSeconds(2),
+                    Delay = TimeSpan.FromSeconds(webhooks.RetryDelaySeconds),
                     BackoffType = DelayBackoffType.Exponential,
                     ShouldHandle = retryArguments => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(retryArguments.Outcome))
                 });
@@ -35,14 +39,14 @@ public static class WebhookHttpClientExtensions
                 // Circuit breaker
                 pipeline.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
                 {
-                    SamplingDuration = TimeSpan.FromSeconds(30),
+                    SamplingDuration = TimeSpan.FromSeconds(webhooks.CircuitBreakerSamplingDurationSeconds),
                     FailureRatio = 0.5, // trip if 50% fail
                     MinimumThroughput = 10,
-                    BreakDuration = TimeSpan.FromSeconds(15)
+                    BreakDuration = TimeSpan.FromSeconds(webhooks.CircuitBreakerBreakDurationSeconds)
                 });
 
                 // Timeout per request
-                pipeline.AddTimeout(TimeSpan.FromSeconds(60));
+                pipeline.AddTimeout(TimeSpan.FromSeconds(webhooks.RequestTimeoutSeconds));
             });
         return builder;
     }

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/Observers/for_ObserverStateStorage/given/an_observer_state_storage.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/Observers/for_ObserverStateStorage/given/an_observer_state_storage.cs
@@ -42,6 +42,7 @@ public class an_observer_state_storage : Specification, IDisposable
         _load.SetResult();
 
         _database = Substitute.For<IDatabase>();
+        _database.LiveQueryPollingInterval.Returns(TimeSpan.FromSeconds(2));
         _database.Namespace(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>())
             .Returns(_ => CreateScopeWhenLoaded());
 

--- a/Source/Kernel/Storage.Sql/Database.cs
+++ b/Source/Kernel/Storage.Sql/Database.cs
@@ -81,6 +81,9 @@ public class Database(IServiceProvider serviceProvider, IOptions<ChronicleOption
     readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _ensuredDatabaseKeys = new();
 
     /// <inheritdoc/>
+    public TimeSpan LiveQueryPollingInterval { get; } = TimeSpan.FromSeconds(options.Value.Sql.LiveQueryPollIntervalSeconds);
+
+    /// <inheritdoc/>
     public async Task<DbContextScope<ClusterDbContext>> Cluster()
     {
         var connectionString = options.Value.Storage.ConnectionDetails;

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
@@ -106,7 +106,7 @@ public class EventTypesStorage(EventStoreName eventStore, IDatabase database) : 
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() => LiveQuery.Observe(GetLatestForAllEventTypes);
+    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() => LiveQuery.Observe(GetLatestForAllEventTypes, database.LiveQueryPollingInterval);
 
     /// <inheritdoc/>
     public async Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds)

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceStorage.cs
@@ -51,5 +51,5 @@ public class NamespaceStorage(EventStoreName eventStore, IDatabase database) : I
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<NamespaceState>> ObserveAll() => LiveQuery.Observe(GetAll);
+    public ISubject<IEnumerable<NamespaceState>> ObserveAll() => LiveQuery.Observe(GetAll, database.LiveQueryPollingInterval);
 }

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Observers/ObserverStateStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Observers/ObserverStateStorage.cs
@@ -26,7 +26,7 @@ public class ObserverStateStorage(EventStoreName eventStore, EventStoreNamespace
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<Observation.ObserverState>> ObserveAll() => LiveQuery.Observe(GetAll);
+    public ISubject<IEnumerable<Observation.ObserverState>> ObserveAll() => LiveQuery.Observe(GetAll, database.LiveQueryPollingInterval);
 
     /// <inheritdoc/>
     public async Task<Observation.ObserverState> Get(ObserverId observerId)

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Recommendations/RecommendationStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Recommendations/RecommendationStorage.cs
@@ -56,7 +56,7 @@ public class RecommendationStorage(EventStoreName eventStore, EventStoreNamespac
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<RecommendationState>> ObserveRecommendations() => LiveQuery.Observe(GetAllInternal);
+    public ISubject<IEnumerable<RecommendationState>> ObserveRecommendations() => LiveQuery.Observe(GetAllInternal, database.LiveQueryPollingInterval);
 
     async Task<IEnumerable<RecommendationState>> GetAllInternal()
     {

--- a/Source/Kernel/Storage.Sql/EventStores/Webhooks/WebhookDefinitionsStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Webhooks/WebhookDefinitionsStorage.cs
@@ -25,7 +25,7 @@ public class WebhookDefinitionsStorage(EventStoreName eventStore, IDatabase data
     }
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<Concepts.Observation.Webhooks.WebhookDefinition>> ObserveAll() => LiveQuery.Observe(GetAll);
+    public ISubject<IEnumerable<Concepts.Observation.Webhooks.WebhookDefinition>> ObserveAll() => LiveQuery.Observe(GetAll, database.LiveQueryPollingInterval);
 
     /// <inheritdoc/>
     public async Task<bool> Has(WebhookId id)

--- a/Source/Kernel/Storage.Sql/IDatabase.cs
+++ b/Source/Kernel/Storage.Sql/IDatabase.cs
@@ -16,6 +16,11 @@ namespace Cratis.Chronicle.Storage.Sql;
 public interface IDatabase
 {
     /// <summary>
+    /// Gets the interval between polls of the database for live, database-watching queries.
+    /// </summary>
+    TimeSpan LiveQueryPollingInterval { get; }
+
+    /// <summary>
     /// Gets a database context scope for the cluster.
     /// </summary>
     /// <returns>A <see cref="DbContextScope{ClusterDbContext}"/> for the cluster.</returns>


### PR DESCRIPTION
## Added

- Configuration options for operational timeouts that were previously hardcoded — connected-client revise/reservation-TTL/observe/keep-alive/stale-threshold intervals, the webhook HTTP resilience pipeline (retry delay, circuit-breaker sampling/break durations, request timeout, test timeout), the SQL live-query polling interval, the event-queue depletion wait, and the subscription-ready timeout — each defaulting to its current value (#1417)
