### PR TITLE
Add the ability to rename an identity

### DIFF
--- a/Source/Clients/Testing/EventSequences/InMemoryIdentityStorage.cs
+++ b/Source/Clients/Testing/EventSequences/InMemoryIdentityStorage.cs
@@ -47,6 +47,9 @@ internal sealed class InMemoryIdentityStorage : IIdentityStorage
         Task.FromResult(KernelIdentities::Identity.System);
 
     /// <inheritdoc/>
+    public Task Rename(string subject, string name) => Task.CompletedTask;
+
+    /// <inheritdoc/>
     public Task<IEnumerable<KernelIdentities::Identity>> GetAll() =>
         Task.FromResult(Enumerable.Empty<KernelIdentities::Identity>());
 

--- a/Source/Kernel/Contracts/Identities/IIdentities.cs
+++ b/Source/Kernel/Contracts/Identities/IIdentities.cs
@@ -26,4 +26,13 @@ public interface IIdentities
     /// <returns>An observable of a collection of <see cref="Identity"/>.</returns>
     [Operation]
     IObservable<IEnumerable<Identity>> ObserveIdentities(GetIdentitiesRequest request, CallContext context = default);
+
+    /// <summary>
+    /// Rename the display name of an identity based on its subject.
+    /// </summary>
+    /// <param name="request">The <see cref="RenameIdentityRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns>Awaitable task.</returns>
+    [Operation]
+    Task RenameIdentity(RenameIdentityRequest request, CallContext context = default);
 }

--- a/Source/Kernel/Contracts/Identities/RenameIdentityRequest.cs
+++ b/Source/Kernel/Contracts/Identities/RenameIdentityRequest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Identities;
+
+/// <summary>
+/// Represents the request for renaming the display name of an identity.
+/// </summary>
+[ProtoContract]
+public class RenameIdentityRequest
+{
+    /// <summary>
+    /// Gets or sets the event store to rename the identity in.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the namespace to rename the identity in.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subject that identifies the identity to rename.
+    /// </summary>
+    [ProtoMember(3)]
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the new name to set on the identity.
+    /// </summary>
+    [ProtoMember(4)]
+    public string Name { get; set; } = string.Empty;
+}

--- a/Source/Kernel/Core/Services/Identities/Identities.cs
+++ b/Source/Kernel/Core/Services/Identities/Identities.cs
@@ -30,4 +30,11 @@ internal sealed class Identities(IStorage storage) : IIdentities
             .ObserveAll()
             .CompletedBy(context.CancellationToken)
             .Select(_ => _.ToContract());
+
+    /// <inheritdoc/>
+    public Task RenameIdentity(RenameIdentityRequest request, CallContext context = default) =>
+        storage
+            .GetEventStore(request.EventStore)
+            .GetNamespace(request.Namespace).Identities
+            .Rename(request.Subject, request.Name);
 }

--- a/Source/Kernel/Protobuf/identities.proto
+++ b/Source/Kernel/Protobuf/identities.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package Cratis.Chronicle.Contracts.Identities;
+import "google/protobuf/empty.proto";
 
 message GetIdentitiesRequest {
    string EventStore = 1;
@@ -14,7 +15,14 @@ message Identity {
    string UserName = 3;
    Identity OnBehalfOf = 4;
 }
+message RenameIdentityRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string Subject = 3;
+   string Name = 4;
+}
 service Identities {
    rpc GetIdentities (GetIdentitiesRequest) returns (IEnumerable_Identity);
    rpc ObserveIdentities (GetIdentitiesRequest) returns (stream IEnumerable_Identity);
+   rpc RenameIdentity (RenameIdentityRequest) returns (.google.protobuf.Empty);
 }

--- a/Source/Kernel/Storage.InMemory/Identities/IdentityStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Identities/IdentityStorage.cs
@@ -45,6 +45,9 @@ public class IdentityStorage : IIdentityStorage
         Task.FromResult(Identity.System);
 
     /// <inheritdoc/>
+    public Task Rename(string subject, string name) => Task.CompletedTask;
+
+    /// <inheritdoc/>
     public Task<IEnumerable<Identity>> GetAll() =>
         Task.FromResult(Enumerable.Empty<Identity>());
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Identities/for_MongoDBIdentityStorage/when_renaming_an_identity/and_the_identity_exists.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Identities/for_MongoDBIdentityStorage/when_renaming_an_identity/and_the_identity_exists.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Identities;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Identities.for_MongoDBIdentityStorage.when_renaming_an_identity;
+
+public class and_the_identity_exists : given.two_identities_registered
+{
+    const string NewName = "Renamed name";
+    Identity _renamed;
+    Identity _other;
+
+    async Task Establish() => await store.Populate();
+
+    async Task Because()
+    {
+        await store.Rename(first_identity_from_database.Subject, NewName);
+        _renamed = await store.GetSingleFor(first_identity_from_database.Id);
+        _other = await store.GetSingleFor(second_identity_from_database.Id);
+    }
+
+    [Fact] void should_change_the_name() => _renamed.Name.ShouldEqual(NewName);
+    [Fact] void should_preserve_the_subject_so_the_encryption_key_is_unaffected() => _renamed.Subject.ShouldEqual(first_identity_from_database.Subject);
+    [Fact] void should_preserve_the_user_name() => _renamed.UserName.ShouldEqual(first_identity_from_database.UserName);
+    [Fact] void should_not_affect_other_identities() => _other.Name.ShouldEqual(second_identity_from_database.Name);
+    [Fact] void should_update_the_stored_document() => _collection.Received(1).UpdateOneAsync(Arg.Any<FilterDefinition<MongoDBIdentity>>(), Arg.Any<UpdateDefinition<MongoDBIdentity>>(), Arg.Any<UpdateOptions>(), Arg.Any<CancellationToken>());
+}

--- a/Source/Kernel/Storage.MongoDB/Identities/IdentityStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Identities/IdentityStorage.cs
@@ -125,6 +125,19 @@ public class IdentityStorage(
     }
 
     /// <inheritdoc/>
+    public async Task Rename(string subject, string name)
+    {
+        var update = Builders<MongoDBIdentity>.Update.Set(_ => _.Name, name);
+        await GetCollection().UpdateOneAsync(_ => _.Subject == subject, update).ConfigureAwait(false);
+
+        if (_identityIdsBySubject.TryGetValue(subject, out var identityId) &&
+            _identitiesByIdentityId.TryGetValue(identityId, out var existing))
+        {
+            _identitiesByIdentityId[identityId] = existing with { Name = name };
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<Identity>> GetAll()
     {
         using var result = await GetCollection().FindAsync(_ => true);

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Identities/IdentityStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Identities/IdentityStorage.cs
@@ -105,6 +105,24 @@ public class IdentityStorage(EventStoreName eventStore, EventStoreNamespaceName 
     }
 
     /// <inheritdoc/>
+    public async Task Rename(string subject, string name)
+    {
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var entity = await scope.DbContext.Identities.FirstOrDefaultAsync(_ => _.Subject == subject);
+        if (entity is not null)
+        {
+            entity.Name = name;
+            await scope.DbContext.SaveChangesAsync();
+        }
+
+        if (_identityIdsBySubject.TryGetValue(subject, out var identityId) &&
+            _identitiesByIdentityId.TryGetValue(identityId, out var existing))
+        {
+            _identitiesByIdentityId[identityId] = existing with { Name = name };
+        }
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<Concepts.Identities.Identity>> GetAll()
     {
         await using var scope = await database.Namespace(eventStore, @namespace);

--- a/Source/Kernel/Storage/Identities/IIdentityStorage.cs
+++ b/Source/Kernel/Storage/Identities/IIdentityStorage.cs
@@ -57,6 +57,19 @@ public interface IIdentityStorage
     Task<Identity> GetSingleFor(IdentityId identityId);
 
     /// <summary>
+    /// Rename the display name of the <see cref="Identity"/> identified by the given subject.
+    /// </summary>
+    /// <param name="subject">The subject that uniquely identifies the <see cref="Identity"/> to rename.</param>
+    /// <param name="name">The new name to set.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// Only the display name is changed — the subject, username and on-behalf-of chain are preserved.
+    /// Chronicle keys PII encryption on the compliance subject, never on the display name, so renaming
+    /// an identity does not affect any encryption-key lookup.
+    /// </remarks>
+    Task Rename(string subject, string name);
+
+    /// <summary>
     /// Get all identities.
     /// </summary>
     /// <returns>Collection of <see cref="Identity"/>.</returns>


### PR DESCRIPTION
## Added

- The ability to rename an identity's display name, from the kernel storage layer through the gRPC `IIdentities` contract to the client SDK. The rename is keyed by subject and preserves the subject, username and on-behalf-of chain — so it never affects the PII encryption key, which is derived from the subject (#1684)
