### PR TITLE
Fix read-model live queries freezing after a reconnect

### DIFF
--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelWatcher/when_client_reconnects.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelWatcher/when_client_reconnects.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelWatcher;
+
+public class when_client_reconnects : given.a_watcher
+{
+    IObservable<ReadModelChangeset> _observable;
+    IDisposable _firstSubscription;
+    IDisposable _secondSubscription;
+
+    void Establish()
+    {
+        _observable = Substitute.For<IObservable<ReadModelChangeset>>();
+        _firstSubscription = Substitute.For<IDisposable>();
+        _secondSubscription = Substitute.For<IDisposable>();
+        _observable.Subscribe(Arg.Any<IObserver<ReadModelChangeset>>()).Returns(_firstSubscription, _secondSubscription);
+        _readModelsService.Watch(Arg.Any<WatchRequest>()).Returns(_observable);
+        _watcher.Start();
+    }
+
+    void Because()
+    {
+        _connection.Lifecycle.OnDisconnected += Raise.Event<Disconnected>();
+        _connection.Lifecycle.OnConnected += Raise.Event<Connected>();
+    }
+
+    [Fact] void should_re_establish_the_watch_stream() => _readModelsService.Received(2).Watch(Arg.Any<WatchRequest>());
+    [Fact] void should_dispose_the_previous_subscription() => _firstSubscription.Received(1).Dispose();
+}

--- a/Source/Clients/DotNET/ReadModels/ReadModelWatcher.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelWatcher.cs
@@ -21,6 +21,7 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
     TaskCompletionSource _subscribedTcs;
     Action? _stopped;
     IObservable<ContractReadModels.ReadModelChangeset>? _serverObservable;
+    IDisposable? _serverSubscription;
     bool _started;
 
     /// <summary>
@@ -38,6 +39,7 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
         _stopped = stopped;
         _jsonSerializerOptions = jsonSerializerOptions;
         _eventStore.Connection.Lifecycle.OnConnected += ClientConnected;
+        _eventStore.Connection.Lifecycle.OnDisconnected += ClientDisconnected;
     }
 
     /// <inheritdoc/>
@@ -50,6 +52,9 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
     public void Dispose()
     {
         _eventStore.Connection.Lifecycle.OnConnected -= ClientConnected;
+        _eventStore.Connection.Lifecycle.OnDisconnected -= ClientDisconnected;
+        _serverSubscription?.Dispose();
+        _serverSubscription = null;
         _stopped?.Invoke();
         _stopped = null;
         _observable.Dispose();
@@ -69,6 +74,10 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
             _subscribedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
+        // Dispose any prior subscription before opening a new server stream so a reconnect
+        // never leaks the subscription established for the previous connection.
+        _serverSubscription?.Dispose();
+
         var request = new ContractReadModels.WatchRequest
         {
             EventStore = _eventStore.Name,
@@ -77,21 +86,24 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
             EventSequenceId = EventSequences.EventSequenceId.Log
         };
         _serverObservable = _servicesAccessor.Services.ReadModels.Watch(request);
-        _serverObservable.Subscribe(changeset =>
-        {
-            if (changeset.Subscribed)
+        _serverSubscription = _serverObservable.Subscribe(
+            changeset =>
             {
-                _subscribedTcs.TrySetResult();
-                return;
-            }
+                if (changeset.Subscribed)
+                {
+                    _subscribedTcs.TrySetResult();
+                    return;
+                }
 
-            var readModel = JsonSerializer.Deserialize<TReadModel>(changeset.ReadModel, _jsonSerializerOptions);
-            _observable.OnNext(new ReadModelChangeset<TReadModel>(
-                changeset.Namespace,
-                changeset.ModelKey,
-                readModel,
-                changeset.Removed));
-        });
+                var readModel = JsonSerializer.Deserialize<TReadModel>(changeset.ReadModel, _jsonSerializerOptions);
+                _observable.OnNext(new ReadModelChangeset<TReadModel>(
+                    changeset.Namespace,
+                    changeset.ModelKey,
+                    readModel,
+                    changeset.Removed));
+            },
+            _ => ResetForReconnect(),
+            ResetForReconnect);
     }
 
     /// <inheritdoc/>
@@ -106,5 +118,21 @@ public class ReadModelWatcher<TReadModel> : IReadModelWatcher<TReadModel>, IDisp
     {
         Start();
         return Task.CompletedTask;
+    }
+
+    Task ClientDisconnected()
+    {
+        ResetForReconnect();
+        return Task.CompletedTask;
+    }
+
+    void ResetForReconnect()
+    {
+        // Tear down the current server stream and clear the started latch so the next
+        // OnConnected re-subscribes. Reached both on disconnect and on a stream fault or
+        // completion, so a dropped stream is never left silently non-emitting.
+        _serverSubscription?.Dispose();
+        _serverSubscription = null;
+        _started = false;
     }
 }


### PR DESCRIPTION
## Fixed

- Projection-backed observable read-model queries now keep emitting after a connection drop — previously the watch stream was never re-established after the first reconnect, so live queries silently froze on stale data
