### PR TITLE
Fix AppendMany livelock and sequence gaps on storage failure

### DIFF
--- a/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/given/SimulatedStorageError.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/given/SimulatedStorageError.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.given;
+
+/// <summary>
+/// The exception that is thrown by a substituted storage to simulate a non-duplicate (transient/aborted) failure
+/// while appending a batch of events.
+/// </summary>
+public class SimulatedStorageError() : Exception("Simulated non-duplicate storage error");

--- a/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/given/an_event_sequence.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/given/an_event_sequence.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.EventSequences.Migrations;
+using Cratis.Chronicle.Namespaces;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.EventTypes;
+using Cratis.Chronicle.Storage.Identities;
+using Cratis.Metrics;
+using Cratis.Traces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Core;
+using Orleans.TestKit;
+using IChronicleStorage = Cratis.Chronicle.Storage.IStorage;
+using JsonExpandoObjectConverter = Cratis.Chronicle.Json.IExpandoObjectConverter;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.given;
+
+public class an_event_sequence : Specification
+{
+    protected TestKitSilo _silo;
+    protected EventSequence _grain;
+    protected IEventSequenceStorage _eventSequenceStorage;
+    protected IStorage<EventSequenceState> _stateStorage;
+    protected EventSequenceKey _key;
+
+    async Task Establish()
+    {
+        _silo = new();
+        _key = new EventSequenceKey(EventSequenceId.Log, "TestStore", "TestNamespace");
+
+        var storage = Substitute.For<IChronicleStorage>();
+        var eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        var namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+
+        storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(eventStoreStorage);
+        eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(namespaceStorage);
+        eventStoreStorage.EventTypes.Returns(Substitute.For<IEventTypesStorage>());
+        namespaceStorage.GetEventSequence(Arg.Any<EventSequenceId>()).Returns(_eventSequenceStorage);
+        namespaceStorage.Identities.Returns(Substitute.For<IIdentityStorage>());
+
+        var constraintValidationFactory = Substitute.For<IConstraintValidationFactory>();
+        constraintValidationFactory.Create(Arg.Any<EventSequenceKey>()).Returns(Substitute.For<IConstraintValidation>());
+
+        var eventHashCalculator = Substitute.For<IEventHashCalculator>();
+        eventHashCalculator.Calculate(Arg.Any<EventTypeId>(), Arg.Any<EventSourceId>(), Arg.Any<ExpandoObject>()).Returns(EventHash.NotSet);
+
+        _silo.AddService(storage);
+        _silo.AddService(constraintValidationFactory);
+        _silo.AddService(Substitute.For<IEventTypeMigrations>());
+        _silo.AddService(Substitute.For<IJsonComplianceManager>());
+        _silo.AddService(Substitute.For<JsonExpandoObjectConverter>());
+        _silo.AddService(Substitute.For<IEventSerializer>());
+        _silo.AddService(eventHashCalculator);
+        _silo.AddService(NullLogger<EventSequence>.Instance);
+        _silo.AddKeyedService<IMeter<EventSequence>>(WellKnown.MeterName, Substitute.For<IMeter<EventSequence>>());
+        _silo.AddKeyedService<IActivitySource<EventSequence>>(WellKnown.MeterName, new ActivitySource<EventSequence>());
+
+        _silo.AddProbe(_ => Substitute.For<INamespaces>());
+        _silo.AddProbe(_ => Substitute.For<IAppendedEventsQueues>());
+
+        _stateStorage = _silo.StorageManager.GetStorage<EventSequenceState>(typeof(EventSequence).FullName!);
+        _stateStorage.State = new EventSequenceState();
+
+        _grain = await _silo.CreateGrainAsync<EventSequence>(_key.ToString());
+    }
+
+    /// <summary>
+    /// Build a single already validated and compliant event ready to be appended to storage, bypassing the
+    /// schema/compliance/constraint pipeline so specs can exercise the batch append and sequence-number logic directly.
+    /// </summary>
+    /// <returns>A validated event tuple in the shape expected by <see cref="EventSequence.AppendManyToStorage"/>.</returns>
+    protected static (EventToAppend Event, ExpandoObject CompliantEvent, ConstraintValidationContext ConstraintContext) ValidatedEvent()
+    {
+        var eventSourceId = EventSourceId.New();
+        var eventType = new EventType("BatchEvent", EventTypeGeneration.First);
+        var content = new ExpandoObject();
+        var eventToAppend = new EventToAppend(
+            EventSourceType.Default,
+            eventSourceId,
+            EventStreamType.All,
+            new EventStreamId(EventStreamId.Default),
+            eventType,
+            [],
+            new JsonObject());
+        var constraintContext = new ConstraintValidationContext([], eventSourceId, eventType.Id, content);
+        return (eventToAppend, content, constraintContext);
+    }
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/when_appending_many_and_storage_reports_duplicate_sequence_numbers.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/when_appending_many_and_storage_reports_duplicate_sequence_numbers.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence;
+
+public class when_appending_many_and_storage_reports_duplicate_sequence_numbers : given.an_event_sequence
+{
+    const int SafetyCap = 20;
+    static readonly EventSequenceNumber _staleSequenceNumber = 5UL;
+    static readonly EventSequenceNumber _nextAvailableSequenceNumber = 10UL;
+    readonly HashSet<ulong> _usedSequenceNumbers = [5, 6, 7, 8, 9];
+
+    int _callCount;
+    bool _safetyCapReached;
+    IReadOnlyList<ulong> _lastSubmittedSequenceNumbers = [];
+    AppendManyResult _result;
+
+    void Establish()
+    {
+        // The grain reactivated with a stale sequence number (its advanced state never got persisted before a
+        // crash), so the first submission collides with numbers already present in storage.
+        _stateStorage.State.SequenceNumber = _staleSequenceNumber;
+
+        _eventSequenceStorage
+            .AppendMany(Arg.Any<IEnumerable<EventToAppendToStorage>>())
+            .Returns(callInfo =>
+            {
+                _callCount++;
+                _lastSubmittedSequenceNumbers = callInfo.Arg<IEnumerable<EventToAppendToStorage>>()
+                    .Select(_ => _.SequenceNumber.Value)
+                    .ToArray();
+
+                // Safety valve: without the re-numbering fix the same colliding numbers are resubmitted forever;
+                // this bounds that regression to a failed assertion instead of an infinite loop / hung test.
+                if (_callCount >= SafetyCap)
+                {
+                    _safetyCapReached = true;
+                    return Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>.Success([]);
+                }
+
+                return _lastSubmittedSequenceNumbers.Any(_usedSequenceNumbers.Contains)
+                    ? (Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>)new DuplicateEventSequenceNumber(_nextAvailableSequenceNumber)
+                    : Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>.Success([]);
+            });
+    }
+
+    async Task Because() => _result = await _grain.AppendManyToStorage(
+        [ValidatedEvent(), ValidatedEvent()],
+        Cratis.Execution.CorrelationId.New(),
+        [],
+        []);
+
+    [Fact] void should_terminate_before_the_safety_cap() => _safetyCapReached.ShouldBeFalse();
+    [Fact] void should_resubmit_with_non_colliding_sequence_numbers() => _lastSubmittedSequenceNumbers.Any(_usedSequenceNumbers.Contains).ShouldBeFalse();
+    [Fact] void should_have_succeeded() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] async Task should_advance_next_sequence_number_past_the_renumbered_batch() =>
+        (await _grain.GetNextSequenceNumber()).ShouldEqual((EventSequenceNumber)12UL);
+}

--- a/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/when_appending_many_and_storage_throws_a_non_duplicate_error.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/for_EventSequence/when_appending_many_and_storage_throws_a_non_duplicate_error.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence;
+
+public class when_appending_many_and_storage_throws_a_non_duplicate_error : given.an_event_sequence
+{
+    static readonly EventSequenceNumber _nextSequenceNumber = 5UL;
+    static readonly EventSequenceNumber _existingTail = 4UL;
+    Exception _exception;
+
+    void Establish()
+    {
+        _stateStorage.State.SequenceNumber = _nextSequenceNumber;
+        _eventSequenceStorage
+            .AppendMany(Arg.Any<IEnumerable<EventToAppendToStorage>>())
+            .ThrowsAsync(new given.SimulatedStorageError());
+    }
+
+    async Task Because() => _exception = await Catch.Exception(() => _grain.AppendManyToStorage(
+        [ValidatedEvent()],
+        Cratis.Execution.CorrelationId.New(),
+        [],
+        []));
+
+    [Fact] void should_fail_with_the_storage_error() => _exception.ShouldBeOfExactType<given.SimulatedStorageError>();
+    [Fact] async Task should_not_advance_the_next_sequence_number() =>
+        (await _grain.GetNextSequenceNumber()).ShouldEqual(_nextSequenceNumber);
+    [Fact] async Task should_not_advance_the_tail_sequence_number() =>
+        (await _grain.GetTailSequenceNumber()).ShouldEqual(_existingTail);
+}

--- a/Source/Kernel/Core/EventSequences/EventSequence.cs
+++ b/Source/Kernel/Core/EventSequences/EventSequence.cs
@@ -319,73 +319,13 @@ public class EventSequence(
             }
 
             var identity = await IdentityStorage.GetFor(causedBy.WithoutDuplicates());
-            var eventsToAppend = new List<EventToAppendToStorage>();
-            var constraintContexts = new List<ConstraintValidationContext>();
-
-            foreach (var (eventToAppend, validAndCompliantEvent) in getValidAndCompliantEvents)
+            var validatedEvents = getValidAndCompliantEvents.ConvertAll(eventAndResult =>
             {
-                var (compliantEvent, constraintContext) = validAndCompliantEvent.AsT0;
-                constraintContexts.Add(constraintContext);
-                var eventHash = eventHashCalculator.Calculate(eventToAppend.EventType.Id, eventToAppend.EventSourceId, compliantEvent);
+                var (compliantEvent, constraintContext) = eventAndResult.Result.AsT0;
+                return (eventAndResult.Event, CompliantEvent: compliantEvent, ConstraintContext: constraintContext);
+            });
 
-                eventsToAppend.Add(new EventToAppendToStorage(
-                    State.SequenceNumber,
-                    eventToAppend.EventSourceType,
-                    eventToAppend.EventSourceId,
-                    eventToAppend.eventStreamType,
-                    eventToAppend.eventStreamId,
-                    eventToAppend.EventType,
-                    correlationId,
-                    causation,
-                    identity,
-                    eventToAppend.Tags,
-                    eventToAppend.Occurred ?? DateTimeOffset.UtcNow,
-                    compliantEvent,
-                    eventHash,
-                    eventToAppend.Subject));
-
-                State.SequenceNumber = State.SequenceNumber.Next();
-            }
-
-            Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>? appendResult = null;
-            do
-            {
-                await HandleFailedAppendManyResult(appendResult, eventsToAppend);
-                logger.AppendManyCallingStorage(_eventSequenceKey.EventStore, _eventSequenceKey.Namespace, _eventSequenceId, eventsToAppend.Count);
-                appendResult = await EventSequenceStorage.AppendMany(eventsToAppend);
-            }
-            while (!appendResult.IsSuccess);
-
-            List<AppendedEvent> appendedEventsList = new();
-            await appendResult.Match(
-                success =>
-                {
-                    appendedEventsList = success.ToList();
-                    return Task.CompletedTask;
-                },
-                _ => Task.CompletedTask);
-
-            var appendedCount = appendedEventsList?.Count ?? 0;
-            logger.AppendManyReceived(_eventSequenceKey.EventStore, _eventSequenceKey.Namespace, _eventSequenceId, appendedCount);
-
-            appendedEventsList ??= [];
-            var sequenceNumbers = appendedEventsList.Select(e => e.Context.SequenceNumber).ToImmutableList();
-
-            foreach (var appendedEvent in appendedEventsList)
-            {
-                State.TailSequenceNumberPerEventType[appendedEvent.Context.EventType.Id] = appendedEvent.Context.SequenceNumber;
-                _metrics?.AppendedEvent(appendedEvent.Context.EventSourceId, appendedEvent.Context.EventType.Id);
-            }
-
-            await WriteStateAsync();
-            await (_appendedEventsQueues?.Enqueue(appendedEventsList.ToList()) ?? Task.CompletedTask);
-
-            foreach (var constraintContext in constraintContexts)
-            {
-                await constraintContext.Update(State.SequenceNumber);
-            }
-
-            return AppendManyResult.Success(correlationId, sequenceNumbers);
+            return await AppendManyToStorage(validatedEvents, correlationId, causation, identity);
         }
         catch (Exception ex)
         {
@@ -521,6 +461,108 @@ public class EventSequence(
     /// <inheritdoc/>
     public Task<bool> IsStreamCompleted(EventStreamType eventStreamType, EventStreamId eventStreamId) =>
         ClosedStreamsStorage.IsStreamClosed(eventStreamType, eventStreamId);
+
+    /// <summary>
+    /// Append a set of already validated and compliant events to storage — numbering the batch,
+    /// recovering from duplicate sequence numbers by re-numbering and resubmitting, and advancing
+    /// <see cref="EventSequenceState.SequenceNumber"/> only after the batch has been durably appended.
+    /// </summary>
+    /// <param name="validatedEvents">The validated and compliant events to append, each with its <see cref="ConstraintValidationContext"/>.</param>
+    /// <param name="correlationId">The <see cref="CorrelationId"/> for the append.</param>
+    /// <param name="causation">The <see cref="Causation"/> chain for the append.</param>
+    /// <param name="causedByChain">The chain of <see cref="IdentityId"/> that caused the append.</param>
+    /// <returns>The <see cref="AppendManyResult"/> describing the outcome.</returns>
+    /// <remarks>
+    /// The sequence numbers are computed against a local running value and only committed to
+    /// <see cref="EventSequenceState.SequenceNumber"/> after a successful storage append — mirroring the
+    /// single-event path, which advances the state after append. This means a thrown (non-duplicate)
+    /// storage error leaves the in-memory sequence number untouched, avoiding a permanent gap and a tail
+    /// that points at an event which was never persisted. On a <see cref="DuplicateEventSequenceNumber"/>
+    /// the whole batch is re-numbered from the reported next-available number before resubmission, so the
+    /// retry can make progress instead of resubmitting the same colliding numbers forever.
+    /// </remarks>
+    internal async Task<AppendManyResult> AppendManyToStorage(
+        IReadOnlyList<(EventToAppend Event, ExpandoObject CompliantEvent, ConstraintValidationContext ConstraintContext)> validatedEvents,
+        CorrelationId correlationId,
+        IEnumerable<Causation> causation,
+        IEnumerable<IdentityId> causedByChain)
+    {
+        var eventsToAppend = new List<EventToAppendToStorage>();
+        var constraintContexts = new List<ConstraintValidationContext>();
+
+        var nextSequenceNumber = State.SequenceNumber;
+        foreach (var (eventToAppend, compliantEvent, constraintContext) in validatedEvents)
+        {
+            constraintContexts.Add(constraintContext);
+            var eventHash = eventHashCalculator.Calculate(eventToAppend.EventType.Id, eventToAppend.EventSourceId, compliantEvent);
+
+            eventsToAppend.Add(new EventToAppendToStorage(
+                nextSequenceNumber,
+                eventToAppend.EventSourceType,
+                eventToAppend.EventSourceId,
+                eventToAppend.eventStreamType,
+                eventToAppend.eventStreamId,
+                eventToAppend.EventType,
+                correlationId,
+                causation,
+                causedByChain,
+                eventToAppend.Tags,
+                eventToAppend.Occurred ?? DateTimeOffset.UtcNow,
+                compliantEvent,
+                eventHash,
+                eventToAppend.Subject));
+
+            nextSequenceNumber = nextSequenceNumber.Next();
+        }
+
+        Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>? appendResult = null;
+        do
+        {
+            HandleFailedAppendManyResult(appendResult, eventsToAppend);
+            logger.AppendManyCallingStorage(_eventSequenceKey.EventStore, _eventSequenceKey.Namespace, _eventSequenceId, eventsToAppend.Count);
+            appendResult = await EventSequenceStorage.AppendMany(eventsToAppend);
+        }
+        while (!appendResult.IsSuccess);
+
+        // Commit the advanced sequence number only after the batch has been durably appended, so a thrown
+        // storage error (handled by the caller's catch) cannot leave State.SequenceNumber advanced past
+        // events that were never persisted.
+        if (eventsToAppend.Count > 0)
+        {
+            State.SequenceNumber = eventsToAppend[^1].SequenceNumber.Next();
+        }
+
+        List<AppendedEvent> appendedEventsList = new();
+        await appendResult.Match(
+            success =>
+            {
+                appendedEventsList = success.ToList();
+                return Task.CompletedTask;
+            },
+            _ => Task.CompletedTask);
+
+        var appendedCount = appendedEventsList?.Count ?? 0;
+        logger.AppendManyReceived(_eventSequenceKey.EventStore, _eventSequenceKey.Namespace, _eventSequenceId, appendedCount);
+
+        appendedEventsList ??= [];
+        var sequenceNumbers = appendedEventsList.Select(e => e.Context.SequenceNumber).ToImmutableList();
+
+        foreach (var appendedEvent in appendedEventsList)
+        {
+            State.TailSequenceNumberPerEventType[appendedEvent.Context.EventType.Id] = appendedEvent.Context.SequenceNumber;
+            _metrics?.AppendedEvent(appendedEvent.Context.EventSourceId, appendedEvent.Context.EventType.Id);
+        }
+
+        await WriteStateAsync();
+        await (_appendedEventsQueues?.Enqueue(appendedEventsList.ToList()) ?? Task.CompletedTask);
+
+        foreach (var constraintContext in constraintContexts)
+        {
+            await constraintContext.Update(State.SequenceNumber);
+        }
+
+        return AppendManyResult.Success(correlationId, sequenceNumbers);
+    }
 
     async Task<AppendResult> AppendValidAndCompliantEvent(
         EventSourceType eventSourceType,
@@ -761,35 +803,43 @@ public class EventSequence(
         await WriteStateAsync();
     }
 
-    async Task HandleFailedAppendManyResult(
+    void HandleFailedAppendManyResult(
         Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>? appendResult,
-        IEnumerable<EventToAppendToStorage> eventsToAppend)
+        List<EventToAppendToStorage> eventsToAppend)
     {
         if (appendResult is null)
         {
             return;
         }
 
-        await appendResult.Match(
-            _ => Task.CompletedTask,
-            errorType => HandleAppendedDuplicateEventForMany(eventsToAppend, errorType.NextAvailableSequenceNumber));
+        if (appendResult.TryGetError(out var duplicateError))
+        {
+            HandleAppendedDuplicateEventForMany(eventsToAppend, duplicateError.NextAvailableSequenceNumber);
+        }
     }
 
-    async Task HandleAppendedDuplicateEventForMany(IEnumerable<EventToAppendToStorage> eventsToAppend, EventSequenceNumber nextAvailableSequenceNumber)
+    void HandleAppendedDuplicateEventForMany(List<EventToAppendToStorage> eventsToAppend, EventSequenceNumber nextAvailableSequenceNumber)
     {
         logger.DuplicateEventInMany(
             _eventSequenceKey.EventStore,
             _eventSequenceKey.Namespace,
             _eventSequenceId,
-            State.SequenceNumber);
+            nextAvailableSequenceNumber);
 
         foreach (var eventToAppend in eventsToAppend)
         {
             _metrics?.DuplicateEventSequenceNumber(eventToAppend.EventSourceId, eventToAppend.EventType.Id.Value);
         }
 
-        State.SequenceNumber = nextAvailableSequenceNumber;
-        await WriteStateAsync();
+        // Re-number the whole batch from the next available sequence number so the resubmission no longer
+        // collides with the numbers already in storage. Without this the same colliding numbers would be
+        // resubmitted every retry and the single-threaded grain would wedge on DuplicateEventSequenceNumber.
+        var sequenceNumber = nextAvailableSequenceNumber;
+        for (var index = 0; index < eventsToAppend.Count; index++)
+        {
+            eventsToAppend[index] = eventsToAppend[index] with { SequenceNumber = sequenceNumber };
+            sequenceNumber = sequenceNumber.Next();
+        }
     }
 
     async Task OnConstraintsChanged(ConstraintsChanged payload)


### PR DESCRIPTION
## Fixed

- Appending a batch of events (`AppendMany`) no longer risks an infinite retry loop that permanently wedges an event sequence when storage reports a duplicate sequence number (for example after a crash between a storage commit and state persistence) — the batch is now re-numbered from the next available sequence number before each retry
- Appending a batch of events no longer leaves a permanent sequence-number gap and a tail pointing at an event that was never persisted when the storage append throws — the sequence number now advances only after a successful append
