### PR TITLE
Make SQL username and email lookups case-insensitive

### DIFF
--- a/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/given/a_user_storage.cs
+++ b/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/given/a_user_storage.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Cratis.Chronicle.Concepts.Security;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Chronicle.Storage.Sql.Cluster.Security.for_UserStorage.given;
+
+/// <summary>
+/// Sets up a SQL <see cref="UserStorage"/> backed by an in-memory SQLite cluster database that keeps
+/// a single connection open so every <see cref="IDatabase.Cluster"/> scope sees the same data. A user
+/// is seeded with a deliberately lower-cased username and email so the specs can prove case-insensitive
+/// lookups, matching the InMemory and MongoDB backends.
+/// </summary>
+public class a_user_storage : Specification
+{
+    protected SqliteConnection _connection;
+    protected IDatabase _database;
+    protected UserStorage _storage;
+    protected UserId _userId;
+    protected Username _storedUsername;
+    protected UserEmail _storedEmail;
+
+    void Establish()
+    {
+        _userId = Guid.NewGuid();
+        _storedUsername = "admin";
+        _storedEmail = "admin@cratis.io";
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var context = CreateContext())
+        {
+            context.Database.EnsureCreated();
+            context.Users.Add(new UserEntity
+            {
+                Id = _userId.Value,
+                Username = _storedUsername.Value,
+                Email = _storedEmail.Value,
+                IsActive = true,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            context.SaveChanges();
+        }
+
+        _database = Substitute.For<IDatabase>();
+        _database.Cluster().Returns(_ => Task.FromResult(new DbContextScope<ClusterDbContext>(CreateContext(), () => { })));
+
+        _storage = new UserStorage(_database);
+    }
+
+    void Destroy()
+    {
+        _storage.Dispose();
+        _connection.Dispose();
+    }
+
+    ClusterDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ClusterDbContext>()
+            .UseSqlite(_connection)
+            .AddConceptAsSupport()
+            .Options;
+
+        return new ClusterDbContext(options);
+    }
+}

--- a/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/when_getting_by_email/and_stored_casing_differs.cs
+++ b/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/when_getting_by_email/and_stored_casing_differs.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+
+namespace Cratis.Chronicle.Storage.Sql.Cluster.Security.for_UserStorage.when_getting_by_email;
+
+public class and_stored_casing_differs : given.a_user_storage
+{
+    User? _byUpperCase;
+    User? _byExactCase;
+    User? _byUnknownEmail;
+
+    async Task Because()
+    {
+        _byUpperCase = await _storage.GetByEmail("ADMIN@CRATIS.IO");
+        _byExactCase = await _storage.GetByEmail("admin@cratis.io");
+        _byUnknownEmail = await _storage.GetByEmail("nobody@cratis.io");
+    }
+
+    [Fact] void should_find_the_user_when_casing_differs() => _byUpperCase.ShouldNotBeNull();
+    [Fact] void should_return_the_stored_user_when_casing_differs() => _byUpperCase!.Id.ShouldEqual(_userId);
+    [Fact] void should_still_find_the_user_with_exact_casing() => _byExactCase.ShouldNotBeNull();
+    [Fact] void should_not_match_a_different_email() => _byUnknownEmail.ShouldBeNull();
+}

--- a/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/when_getting_by_username/and_stored_casing_differs.cs
+++ b/Source/Kernel/Storage.Sql.Specs/Cluster/Security/for_UserStorage/when_getting_by_username/and_stored_casing_differs.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+
+namespace Cratis.Chronicle.Storage.Sql.Cluster.Security.for_UserStorage.when_getting_by_username;
+
+public class and_stored_casing_differs : given.a_user_storage
+{
+    User? _byUpperCase;
+    User? _byExactCase;
+    User? _byUnknownUsername;
+
+    async Task Because()
+    {
+        _byUpperCase = await _storage.GetByUsername("ADMIN");
+        _byExactCase = await _storage.GetByUsername("admin");
+        _byUnknownUsername = await _storage.GetByUsername("someone-else");
+    }
+
+    [Fact] void should_find_the_user_when_casing_differs() => _byUpperCase.ShouldNotBeNull();
+    [Fact] void should_return_the_stored_user_when_casing_differs() => _byUpperCase!.Id.ShouldEqual(_userId);
+    [Fact] void should_still_find_the_user_with_exact_casing() => _byExactCase.ShouldNotBeNull();
+    [Fact] void should_not_match_a_different_username() => _byUnknownUsername.ShouldBeNull();
+}

--- a/Source/Kernel/Storage.Sql/Cluster/Security/UserStorage.cs
+++ b/Source/Kernel/Storage.Sql/Cluster/Security/UserStorage.cs
@@ -39,7 +39,19 @@ public class UserStorage(IDatabase database) : IUserStorage, IDisposable
     public async Task<User?> GetByUsername(Username username)
     {
         await using var scope = await database.Cluster();
-        var entity = await scope.DbContext.Users.FirstOrDefaultAsync(u => u.Username == username.Value);
+        var normalizedUsername = username.Value.ToLowerInvariant();
+
+        // Match usernames case-insensitively, consistent with the InMemory (OrdinalIgnoreCase) and
+        // MongoDB ("en" primary collation) backends. ToLower() (never ToLowerInvariant()) is used on
+        // the column because EF's SQLite provider only translates the parameterless string.ToLower()
+        // to the SQL LOWER() function, and Npgsql translates it too — so this is the single form that
+        // runs server-side on both providers we ship rather than client-evaluating the whole table.
+        // The comparison executes as SQL LOWER(), so no client culture is involved: CA1304/CA1311
+        // (culture-dependent in-memory ToLower) do not apply, and CA1862's suggested
+        // string.Equals(StringComparison.OrdinalIgnoreCase) is not translatable to SQL by EF.
+#pragma warning disable CA1304, CA1311, CA1862
+        var entity = await scope.DbContext.Users.FirstOrDefaultAsync(u => u.Username.ToLower() == normalizedUsername);
+#pragma warning restore CA1304, CA1311, CA1862
         return entity is null ? null : ToUser(entity);
     }
 
@@ -51,7 +63,13 @@ public class UserStorage(IDatabase database) : IUserStorage, IDisposable
             return null;
         }
         await using var scope = await database.Cluster();
-        var entity = await scope.DbContext.Users.FirstOrDefaultAsync(u => u.Email == email.Value);
+        var normalizedEmail = email.Value.ToLowerInvariant();
+
+        // Case-insensitive email match, consistent with the InMemory and MongoDB backends. See the
+        // note in GetByUsername for why the column uses ToLower() rather than ToLowerInvariant().
+#pragma warning disable CA1304, CA1311, CA1862
+        var entity = await scope.DbContext.Users.FirstOrDefaultAsync(u => u.Email != null && u.Email.ToLower() == normalizedEmail);
+#pragma warning restore CA1304, CA1311, CA1862
         return entity is null ? null : ToUser(entity);
     }
 


### PR DESCRIPTION
## Fixed

- Username and email lookups on the SQL backend are now case-insensitive, matching the in-memory and MongoDB backends. Previously SQL matched case-sensitively, so the same name in different casing could create duplicate accounts and cause login failures when the stored casing differed
