### PR TITLE
Fix token revocation no-op and pruning of valid tokens

### DIFF
--- a/Chronicle.slnx
+++ b/Chronicle.slnx
@@ -22,6 +22,7 @@
         <Project Path="Source/Kernel/Core/Core.csproj" />
         <Project Path="Source/Kernel/Core.Specs/Core.Specs.csproj" />
         <Project Path="Source/Kernel/Server/Server.csproj" />
+        <Project Path="Source/Kernel/Server.Specs/Server.Specs.csproj" />
         <Project Path="Source/Kernel/Storage/Storage.csproj" />
         <Project Path="Source/Kernel/Storage.InMemory/Storage.InMemory.csproj" />
         <Project Path="Source/Kernel/Storage.InMemory.Specs/Storage.InMemory.Specs.csproj" />

--- a/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/given/a_token_store.cs
+++ b/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/given/a_token_store.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.InMemory.Security;
+
+namespace Cratis.Chronicle.Server.Authentication.OpenIddict.for_TokenStore.given;
+
+public class a_token_store : Specification
+{
+    protected TokenStorage _storage;
+    protected TokenStore _store;
+
+    void Establish()
+    {
+        _storage = new();
+        _store = new(_storage);
+    }
+}

--- a/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_application_id.cs
+++ b/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_application_id.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+using OpenIddict.Abstractions;
+
+namespace Cratis.Chronicle.Server.Authentication.OpenIddict.for_TokenStore;
+
+public class when_revoking_by_application_id : given.a_token_store
+{
+    long _count;
+
+    async Task Establish()
+    {
+        await _storage.Create(new Token { Id = "first", ApplicationId = "app", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "second", ApplicationId = "app", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "other", ApplicationId = "other-app", Status = OpenIddictConstants.Statuses.Valid });
+    }
+
+    async Task Because() => _count = await _store.RevokeByApplicationIdAsync("app", CancellationToken.None);
+
+    [Fact] void should_report_two_tokens_revoked() => _count.ShouldEqual(2L);
+    [Fact] async Task should_revoke_the_first_matching_token() => (await _storage.GetById("first"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_revoke_the_second_matching_token() => (await _storage.GetById("second"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_leave_the_token_for_another_application_untouched() => (await _storage.GetById("other"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Valid);
+}

--- a/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_authorization_id.cs
+++ b/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_authorization_id.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+using OpenIddict.Abstractions;
+
+namespace Cratis.Chronicle.Server.Authentication.OpenIddict.for_TokenStore;
+
+public class when_revoking_by_authorization_id : given.a_token_store
+{
+    long _count;
+
+    async Task Establish()
+    {
+        await _storage.Create(new Token { Id = "first", AuthorizationId = "auth", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "second", AuthorizationId = "auth", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "other", AuthorizationId = "other-auth", Status = OpenIddictConstants.Statuses.Valid });
+    }
+
+    async Task Because() => _count = await _store.RevokeByAuthorizationIdAsync("auth", CancellationToken.None);
+
+    [Fact] void should_report_two_tokens_revoked() => _count.ShouldEqual(2L);
+    [Fact] async Task should_revoke_the_first_matching_token() => (await _storage.GetById("first"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_revoke_the_second_matching_token() => (await _storage.GetById("second"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_leave_the_token_for_another_authorization_untouched() => (await _storage.GetById("other"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Valid);
+}

--- a/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_client_and_type.cs
+++ b/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_client_and_type.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+using OpenIddict.Abstractions;
+
+namespace Cratis.Chronicle.Server.Authentication.OpenIddict.for_TokenStore;
+
+public class when_revoking_by_client_and_type : given.a_token_store
+{
+    long _count;
+
+    async Task Establish()
+    {
+        await _storage.Create(new Token { Id = "access", ApplicationId = "app", Type = OpenIddictConstants.TokenTypeHints.AccessToken, Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "refresh", ApplicationId = "app", Type = OpenIddictConstants.TokenTypeHints.RefreshToken, Status = OpenIddictConstants.Statuses.Valid });
+    }
+
+    async Task Because() => _count = await _store.RevokeAsync(null, "app", null, OpenIddictConstants.TokenTypeHints.AccessToken, CancellationToken.None);
+
+    [Fact] void should_report_one_token_revoked() => _count.ShouldEqual(1L);
+    [Fact] async Task should_revoke_the_matching_access_token() => (await _storage.GetById("access"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_leave_the_token_of_another_type_untouched() => (await _storage.GetById("refresh"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Valid);
+}

--- a/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_subject.cs
+++ b/Source/Kernel/Server.Specs/Authentication/OpenIddict/for_TokenStore/when_revoking_by_subject.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+using OpenIddict.Abstractions;
+
+namespace Cratis.Chronicle.Server.Authentication.OpenIddict.for_TokenStore;
+
+public class when_revoking_by_subject : given.a_token_store
+{
+    long _count;
+
+    async Task Establish()
+    {
+        await _storage.Create(new Token { Id = "first", Subject = "user", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "second", Subject = "user", Status = OpenIddictConstants.Statuses.Valid });
+        await _storage.Create(new Token { Id = "other", Subject = "other-user", Status = OpenIddictConstants.Statuses.Valid });
+    }
+
+    async Task Because() => _count = await _store.RevokeBySubjectAsync("user", CancellationToken.None);
+
+    [Fact] void should_report_two_tokens_revoked() => _count.ShouldEqual(2L);
+    [Fact] async Task should_revoke_the_first_matching_token() => (await _storage.GetById("first"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_revoke_the_second_matching_token() => (await _storage.GetById("second"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Revoked);
+    [Fact] async Task should_leave_the_token_for_another_subject_untouched() => (await _storage.GetById("other"))!.Status.ShouldEqual(OpenIddictConstants.Statuses.Valid);
+}

--- a/Source/Kernel/Server.Specs/Server.Specs.csproj
+++ b/Source/Kernel/Server.Specs/Server.Specs.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Chronicle.Server.Specs</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Server</RootNamespace>
+        <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../Server/Server.csproj" />
+        <ProjectReference Include="../Storage.InMemory/Storage.InMemory.csproj" />
+        <ProjectReference Include="../Storage/Storage.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/Kernel/Server/Authentication/OpenIddict/TokenStore.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/TokenStore.cs
@@ -165,16 +165,50 @@ public class TokenStore(ITokenStorage tokenStorage) : IOpenIddictTokenStore<Toke
     public async ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken) => await tokenStorage.Prune(threshold);
 
     /// <inheritdoc/>
-    public ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken) => new(0L);
+    public async ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken)
+    {
+        IEnumerable<Token> tokens;
+
+        if (!string.IsNullOrEmpty(client) && !string.IsNullOrEmpty(subject) && !string.IsNullOrEmpty(status))
+        {
+            tokens = await tokenStorage.FindByApplicationIdSubjectAndStatus(client, subject, status);
+        }
+        else if (!string.IsNullOrEmpty(client) && !string.IsNullOrEmpty(subject))
+        {
+            tokens = await tokenStorage.FindByApplicationIdAndSubject(client, subject);
+        }
+        else if (!string.IsNullOrEmpty(client))
+        {
+            tokens = await tokenStorage.FindByApplicationId(client);
+        }
+        else if (!string.IsNullOrEmpty(subject))
+        {
+            tokens = await tokenStorage.FindBySubject(subject);
+        }
+        else
+        {
+            return 0;
+        }
+
+        if (!string.IsNullOrEmpty(type))
+        {
+            tokens = tokens.Where(t => t.Type == type);
+        }
+
+        return await Revoke(tokens);
+    }
 
     /// <inheritdoc/>
-    public ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken = default) => new(0L);
+    public async ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken = default) =>
+        await Revoke(await tokenStorage.FindByApplicationId(identifier));
 
     /// <inheritdoc/>
-    public ValueTask<long> RevokeByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken) => new(0L);
+    public async ValueTask<long> RevokeByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken) =>
+        await Revoke(await tokenStorage.FindByAuthorizationId(identifier));
 
     /// <inheritdoc/>
-    public ValueTask<long> RevokeBySubjectAsync(string subject, CancellationToken cancellationToken = default) => new(0L);
+    public async ValueTask<long> RevokeBySubjectAsync(string subject, CancellationToken cancellationToken = default) =>
+        await Revoke(await tokenStorage.FindBySubject(subject));
 
     /// <inheritdoc/>
     public ValueTask SetApplicationIdAsync(Token token, string? identifier, CancellationToken cancellationToken)
@@ -255,4 +289,16 @@ public class TokenStore(ITokenStorage tokenStorage) : IOpenIddictTokenStore<Toke
 
     /// <inheritdoc/>
     public async ValueTask UpdateAsync(Token token, CancellationToken cancellationToken) => await tokenStorage.Update(token);
+
+    async Task<long> Revoke(IEnumerable<Token> tokens)
+    {
+        var count = 0L;
+        foreach (var token in tokens)
+        {
+            await tokenStorage.Update(token with { Status = OpenIddictConstants.Statuses.Revoked });
+            count++;
+        }
+
+        return count;
+    }
 }

--- a/Source/Kernel/Storage.InMemory.Specs/Security/for_TokenStorage/when_pruning_with_valid_expired_and_inactive_tokens.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Security/for_TokenStorage/when_pruning_with_valid_expired_and_inactive_tokens.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.Security;
+
+namespace Cratis.Chronicle.Storage.InMemory.Security.for_TokenStorage;
+
+public class when_pruning_with_valid_expired_and_inactive_tokens : given.a_token_storage
+{
+    long _removed;
+
+    async Task Establish()
+    {
+        await _storage.Create(new Token { Id = "valid", CreationDate = DateTimeOffset.UtcNow.AddDays(-2), Status = TokenStatuses.Valid, ExpirationDate = DateTimeOffset.UtcNow.AddDays(28) });
+        await _storage.Create(new Token { Id = "expired", CreationDate = DateTimeOffset.UtcNow.AddDays(-2), Status = TokenStatuses.Valid, ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1) });
+        await _storage.Create(new Token { Id = "inactive", CreationDate = DateTimeOffset.UtcNow.AddDays(-2), Status = "revoked" });
+    }
+
+    async Task Because() => _removed = await _storage.Prune(DateTimeOffset.UtcNow.AddDays(-1));
+
+    [Fact] void should_report_two_tokens_removed() => _removed.ShouldEqual(2L);
+    [Fact] async Task should_keep_the_still_valid_token() => (await _storage.GetById("valid")).ShouldNotBeNull();
+    [Fact] async Task should_remove_the_expired_token() => (await _storage.GetById("expired")).ShouldBeNull();
+    [Fact] async Task should_remove_the_inactive_token() => (await _storage.GetById("inactive")).ShouldBeNull();
+}

--- a/Source/Kernel/Storage.InMemory/Security/TokenStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Security/TokenStorage.cs
@@ -86,12 +86,16 @@ public sealed class TokenStorage : ITokenStorage
     /// <inheritdoc/>
     public Task<long> Prune(DateTimeOffset threshold, CancellationToken cancellationToken = default)
     {
-        var expired = _tokens.Values.Where(_ => _.CreationDate is { } createdAt && createdAt < threshold).ToList();
-        foreach (var token in expired)
+        var now = DateTimeOffset.UtcNow;
+        var prunable = _tokens.Values
+            .Where(_ => _.CreationDate is { } createdAt && createdAt < threshold &&
+                        (_.Status != TokenStatuses.Valid || (_.ExpirationDate is { } expiresAt && expiresAt < now)))
+            .ToList();
+        foreach (var token in prunable)
         {
             _tokens.TryRemove(token.Id, out _);
         }
 
-        return Task.FromResult<long>(expired.Count);
+        return Task.FromResult<long>(prunable.Count);
     }
 }

--- a/Source/Kernel/Storage.MongoDB/Security/TokenStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Security/TokenStorage.cs
@@ -96,8 +96,10 @@ public class TokenStorage(IMongoDatabase database) : ITokenStorage
     /// <inheritdoc/>
     public async Task<long> Prune(DateTimeOffset threshold, CancellationToken cancellationToken = default)
     {
+        var now = DateTimeOffset.UtcNow;
         var result = await _collection.DeleteManyAsync(
-            _ => _.CreationDate != null && _.CreationDate < threshold,
+            _ => _.CreationDate != null && _.CreationDate < threshold &&
+                 (_.Status != TokenStatuses.Valid || (_.ExpirationDate != null && _.ExpirationDate < now)),
             cancellationToken);
 
         return result.DeletedCount;

--- a/Source/Kernel/Storage.Sql/Cluster/Security/SqlTokenStorage.cs
+++ b/Source/Kernel/Storage.Sql/Cluster/Security/SqlTokenStorage.cs
@@ -132,10 +132,14 @@ public class SqlTokenStorage(IDatabase database, JsonSerializerOptions jsonSeria
     public async Task<long> Prune(DateTimeOffset threshold, CancellationToken cancellationToken = default)
     {
         await using var scope = await database.Cluster();
-        var expired = await scope.DbContext.Tokens.Where(t => t.CreationDate != null && t.CreationDate < threshold).ToListAsync(cancellationToken);
-        scope.DbContext.Tokens.RemoveRange(expired);
+        var now = DateTimeOffset.UtcNow;
+        var prunable = await scope.DbContext.Tokens
+            .Where(t => t.CreationDate != null && t.CreationDate < threshold &&
+                        (t.Status != TokenStatuses.Valid || (t.ExpirationDate != null && t.ExpirationDate < now)))
+            .ToListAsync(cancellationToken);
+        scope.DbContext.Tokens.RemoveRange(prunable);
         await scope.DbContext.SaveChangesAsync(cancellationToken);
-        return expired.Count;
+        return prunable.Count;
     }
 
     static TokenEntity ToEntity(Token token) => new()

--- a/Source/Kernel/Storage/Security/TokenStatuses.cs
+++ b/Source/Kernel/Storage/Security/TokenStatuses.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.Security;
+
+/// <summary>
+/// Holds the well-known values for <see cref="Token.Status"/>.
+/// </summary>
+/// <remarks>
+/// The values mirror OpenIddict's <c>OpenIddictConstants.Statuses</c> so the storage layer can reason
+/// about a token's lifecycle (for example when pruning) without taking a dependency on OpenIddict.
+/// </remarks>
+public static class TokenStatuses
+{
+    /// <summary>
+    /// The status for a token that is still valid.
+    /// </summary>
+    public const string Valid = "valid";
+}


### PR DESCRIPTION
## Fixed

- Token pruning no longer deletes still-valid tokens — it now removes only inactive or expired tokens created before the pruning threshold, so long-lived valid sessions/refresh tokens are no longer force-signed-out

## Security

- Token revocation now actually revokes. Previously every bulk revocation operation (by application, by subject, by authorization, and by client/status/type) reported success without revoking anything, so rotating a leaked client secret, removing an application, or signing a user out everywhere left already-issued tokens valid until their natural expiry
