### PR TITLE
Fix premature observer completion and leaked read cursors

### DIFF
--- a/Source/Kernel/Core.Specs/Services/EventSequences/for_EventSequences/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/EventSequences/for_EventSequences/given/all_dependencies.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Services.EventSequences.for_EventSequences.given;
+
+public class all_dependencies : Specification
+{
+    protected IGrainFactory _grainFactory;
+    protected IStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IEventCompliance _eventCompliance;
+    protected Contracts.EventSequences.IEventSequences _eventSequences;
+
+    void Establish()
+    {
+        _grainFactory = Substitute.For<IGrainFactory>();
+        _storage = Substitute.For<IStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _eventCompliance = Substitute.For<IEventCompliance>();
+
+        _storage.GetEventStore(Arg.Any<Concepts.EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<Concepts.EventStoreNamespaceName>()).Returns(_namespaceStorage);
+
+        _eventSequences = new EventSequences(_grainFactory, _storage, _eventCompliance, new JsonSerializerOptions());
+    }
+}

--- a/Source/Kernel/Core.Specs/Services/EventSequences/for_EventSequences/when_getting_events_from_event_sequence_number/and_the_event_cursor_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/EventSequences/for_EventSequences/when_getting_events_from_event_sequence_number/and_the_event_cursor_fails.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.EventSequences;
+using Cratis.Chronicle.Storage.EventSequences;
+
+namespace Cratis.Chronicle.Services.EventSequences.for_EventSequences.when_getting_events_from_event_sequence_number;
+
+public class and_the_event_cursor_fails : given.all_dependencies
+{
+    IEventCursor _cursor = null!;
+    Exception _error = null!;
+
+    void Establish()
+    {
+        var eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+        _namespaceStorage.GetEventSequence(Arg.Any<Concepts.EventSequences.EventSequenceId>()).Returns(eventSequenceStorage);
+
+        _cursor = Substitute.For<IEventCursor>();
+        _cursor.When(_ => _.MoveNext()).Do(_ => throw new Exception("cursor failure"));
+        eventSequenceStorage.GetFromSequenceNumber(
+            Arg.Any<EventSequenceNumber>(),
+            Arg.Any<EventSourceId?>(),
+            Arg.Any<EventStreamType?>(),
+            Arg.Any<EventStreamId?>(),
+            Arg.Any<IEnumerable<EventType>?>())
+            .Returns(_cursor);
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequences.GetEventsFromEventSequenceNumber(new GetFromEventSequenceNumberRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = "event-log",
+        FromEventSequenceNumber = 0UL
+    }));
+
+    [Fact] void should_propagate_the_failure() => _error.ShouldNotBeNull();
+    [Fact] void should_dispose_the_cursor() => _cursor.Received().Dispose();
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_waiting_for_completion/and_an_affected_observer_has_handled_beyond_the_tail.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_waiting_for_completion/and_an_affected_observer_has_handled_beyond_the_tail.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_waiting_for_completion;
+
+public class and_an_affected_observer_has_handled_beyond_the_tail : given.all_dependencies
+{
+    WaitForObserverCompletionResponse _result;
+
+    void Establish()
+    {
+        var observer = Substitute.For<IObserver>();
+        observer.IsSubscribed().Returns(true);
+
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = 100UL,
+            RunningState = Concepts.Observation.ObserverRunningState.Active,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(new Concepts.Observation.FailedPartitions());
+        _grainFactory.GetGrain<IObserver>(Arg.Any<string>()).Returns(observer);
+    }
+
+    async Task Because() => _result = await _observers.WaitForCompletion(new WaitForObserverCompletionRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        TailEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_have_failed_partitions() => _result.FailedPartitions.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_waiting_for_completion/and_an_affected_observer_has_never_handled_events.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_waiting_for_completion/and_an_affected_observer_has_never_handled_events.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_waiting_for_completion;
+
+public class and_an_affected_observer_has_never_handled_events : given.all_dependencies
+{
+    WaitForObserverCompletionResponse _result;
+
+    void Establish()
+    {
+        var observer = Substitute.For<IObserver>();
+        observer.IsSubscribed().Returns(true);
+
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+
+        // A registered-but-never-run observer carries EventSequenceNumber.Unavailable
+        // (ulong.MaxValue) as its last handled sequence number.
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = Concepts.Events.EventSequenceNumber.Unavailable,
+            RunningState = Concepts.Observation.ObserverRunningState.Active,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+
+        // First poll has no failed partitions - a never-handled observer must NOT be
+        // reported as caught up here (it would prematurely succeed before the fix).
+        // The second poll surfaces the observer's failed partition so the loop terminates.
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(
+            new Concepts.Observation.FailedPartitions(),
+            new Concepts.Observation.FailedPartitions
+            {
+                Partitions =
+                [
+                    new()
+                    {
+                        ObserverId = "observer-1",
+                        Partition = "partition-1"
+                    }
+                ]
+            });
+        _grainFactory.GetGrain<IObserver>(Arg.Any<string>()).Returns(observer);
+    }
+
+    async Task Because() => _result = await _observers.WaitForCompletion(new WaitForObserverCompletionRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        TailEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_not_report_completion_before_the_observer_has_handled_events() =>
+        _failedPartitionsStorage.Received(2).GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>());
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_all_instances/and_the_event_cursor_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_all_instances/and_the_event_cursor_fails.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.ReadModels;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_all_instances;
+
+public class and_the_event_cursor_fails : given.all_dependencies
+{
+    IEventCursor _cursor = null!;
+    Exception _error = null!;
+
+    void Establish()
+    {
+        var readModelDefinitionsStorage = Substitute.For<IReadModelDefinitionsStorage>();
+        _eventStoreStorage.ReadModels.Returns(readModelDefinitionsStorage);
+        readModelDefinitionsStorage.Get(_readModelDefinition.Identifier).Returns(_readModelDefinition);
+
+        var eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+        _namespaceStorage.GetEventSequence("event-log").Returns(eventSequenceStorage);
+
+        var projection = Substitute.For<IProjection>();
+        projection.GetEventTypes().Returns([]);
+        _grainFactory.GetGrain<IProjection>(Arg.Any<string>()).Returns(projection);
+
+        _cursor = Substitute.For<IEventCursor>();
+        _cursor.When(_ => _.MoveNext()).Do(_ => throw new Exception("cursor failure"));
+        eventSequenceStorage.GetFromSequenceNumber(EventSequenceNumber.First, eventSourceId: null, eventTypes: Arg.Any<IEnumerable<EventType>>())
+            .Returns(_cursor);
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _service.GetAllInstances(new()
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModelIdentifier = _readModelDefinition.Identifier,
+        EventSequenceId = "event-log",
+        EventCount = ulong.MaxValue
+    }));
+
+    [Fact] void should_propagate_the_failure() => _error.ShouldNotBeNull();
+    [Fact] void should_dispose_the_cursor() => _cursor.Received().Dispose();
+}

--- a/Source/Kernel/Core/Services/EventSequences/EventSequences.cs
+++ b/Source/Kernel/Core/Services/EventSequences/EventSequences.cs
@@ -148,25 +148,18 @@ internal sealed class EventSequences(
     {
         var eventSequence = GetEventSequenceStorage(request);
 
-        IEventCursor cursor;
-
-        if (request.ToEventSequenceNumber is not null)
-        {
-            cursor = await eventSequence.GetRange(
+        using var cursor = request.ToEventSequenceNumber is not null
+            ? await eventSequence.GetRange(
                 request.FromEventSequenceNumber,
                 request.ToEventSequenceNumber,
                 string.IsNullOrWhiteSpace(request.EventSourceId) ? (EventSourceId)null! : request.EventSourceId,
-                request.EventTypes.ToChronicle());
-        }
-        else
-        {
-            cursor = await eventSequence.GetFromSequenceNumber(
+                request.EventTypes.ToChronicle())
+            : await eventSequence.GetFromSequenceNumber(
                 request.FromEventSequenceNumber,
                 string.IsNullOrWhiteSpace(request.EventSourceId) ? (EventSourceId)null! : request.EventSourceId,
                 EventStreamType.All,
                 EventStreamId.Default,
                 request.EventTypes.ToChronicle());
-        }
 
         var appendedEvents = new List<AppendedEvent>();
         while (await cursor.MoveNext())
@@ -174,7 +167,6 @@ internal sealed class EventSequences(
             appendedEvents.AddRange(cursor.Current);
         }
 
-        cursor.Dispose();
         var eventTypeSchemas = await storage.GetEventStore(request.EventStore).EventTypes.GetFor(appendedEvents.Select(_ => _.Context.EventType).Distinct());
         var schemasByEventType = eventTypeSchemas.ToDictionary(_ => _.Type);
         var events = await ToContracts(appendedEvents, schemasByEventType);

--- a/Source/Kernel/Core/Services/Observation/Observers.cs
+++ b/Source/Kernel/Core/Services/Observation/Observers.cs
@@ -69,7 +69,8 @@ internal sealed class Observers(IGrainFactory grainFactory, IStorage storage) : 
                 .GetFor(observerIds);
             var failedObserverIds = failedPartitions.Partitions.Select(_ => _.ObserverId.Value).ToHashSet(StringComparer.Ordinal);
             if (observers.All(_ =>
-                _.LastHandledEventSequenceNumber >= request.TailEventSequenceNumber ||
+                (((EventSequenceNumber)_.LastHandledEventSequenceNumber).IsActualValue &&
+                 _.LastHandledEventSequenceNumber >= request.TailEventSequenceNumber) ||
                 failedObserverIds.Contains(_.Id)))
             {
                 return new WaitForObserverCompletionResponse

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -413,7 +413,7 @@ internal sealed class ReadModels(
         if (request.EventCount == ulong.MaxValue)
         {
             // Get all events
-            var cursor = await eventSequenceStorage.GetFromSequenceNumber(EventSequenceNumber.First, eventSourceId: null, eventTypes: eventTypes);
+            using var cursor = await eventSequenceStorage.GetFromSequenceNumber(EventSequenceNumber.First, eventSourceId: null, eventTypes: eventTypes);
             while (await cursor.MoveNext())
             {
                 if (!cursor.Current.Any())
@@ -422,7 +422,6 @@ internal sealed class ReadModels(
                 }
                 events.AddRange(cursor.Current);
             }
-            cursor.Dispose();
         }
         else
         {


### PR DESCRIPTION
## Fixed

- Waiting for observers to catch up no longer reports success against an observer that has never handled any events, so a caller waiting for an append to be processed no longer proceeds against a stale or empty read model on the first run
- Event and read-model read cursors are now disposed when an enumeration error occurs, instead of leaking the underlying database cursor
