### PR TITLE
Fix event seeding losing events on a transient failure

### DIFF
--- a/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/given/a_global_event_seeding_grain.cs
+++ b/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/given/a_global_event_seeding_grain.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Seeding;
+
+namespace Cratis.Chronicle.Seeding.for_EventSeeding.given;
+
+public class a_global_event_seeding_grain : an_event_seeding_grain
+{
+    void Establish()
+    {
+        _key = EventSeedingKey.ForGlobal("TestEventStore");
+
+        var keyField = typeof(EventSeeding).GetField("_key", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        keyField.SetValue(_grain, _key);
+    }
+}

--- a/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/given/an_event_seeding_grain.cs
+++ b/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/given/an_event_seeding_grain.cs
@@ -14,6 +14,7 @@ public class an_event_seeding_grain : Specification
     protected EventSeeding _grain;
     protected IPersistentState<EventSeeds> _state;
     protected IEventSequence _eventSequence;
+    protected IGrainFactory _grainFactory;
     protected EventSeedingKey _key;
     protected ILogger<EventSeeding> _logger;
 
@@ -22,13 +23,14 @@ public class an_event_seeding_grain : Specification
         _key = new EventSeedingKey("TestEventStore", "TestNamespace");
         _state = Substitute.For<IPersistentState<EventSeeds>>();
         _eventSequence = Substitute.For<IEventSequence>();
+        _grainFactory = Substitute.For<IGrainFactory>();
         _logger = Substitute.For<ILogger<EventSeeding>>();
 
         _state.State.Returns(new EventSeeds(
             new Dictionary<EventTypeId, IEnumerable<SeededEventEntry>>(),
             new Dictionary<EventSourceId, IEnumerable<SeededEventEntry>>()));
 
-        _grain = new EventSeeding(_state, _logger);
+        _grain = new EventSeeding(_state, _grainFactory, _logger);
 
         // Simulate OnActivateAsync by setting internal fields via reflection
         var keyField = typeof(EventSeeding).GetField("_key", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);

--- a/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/when_seeding_again_after_a_failed_append.cs
+++ b/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/when_seeding_again_after_a_failed_append.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Seeding.for_EventSeeding;
+
+public class when_seeding_again_after_a_failed_append : given.an_event_seeding_grain
+{
+    IEnumerable<SeedingEntry> _entries;
+    Exception _firstError;
+    int _appendCount;
+
+    void Establish()
+    {
+        _entries = [
+            new SeedingEntry("event-source-1", "test-event-type", /*lang=json,strict*/ "{\"value\":\"test1\"}", null),
+            new SeedingEntry("event-source-2", "test-event-type", /*lang=json,strict*/ "{\"value\":\"test2\"}", null)
+        ];
+
+        // Fail the first append to simulate a transient failure, then succeed on the retry.
+        _eventSequence
+            .When(x => x.AppendMany(
+                Arg.Any<IEnumerable<EventToAppend>>(),
+                Arg.Any<CorrelationId>(),
+                Arg.Any<IEnumerable<Concepts.Auditing.Causation>>(),
+                Arg.Any<Concepts.Identities.Identity>(),
+                Arg.Any<Concepts.EventSequences.Concurrency.ConcurrencyScopes>()))
+            .Do(_ =>
+            {
+                _appendCount++;
+                if (_appendCount == 1)
+                {
+                    throw new Exception("Simulated transient append failure");
+                }
+            });
+    }
+
+    async Task Because()
+    {
+        _firstError = await Catch.Exception(() => _grain.Seed(_entries));
+        await _grain.Seed(_entries);
+    }
+
+    [Fact] void should_fail_the_first_attempt() => _firstError.ShouldNotBeNull();
+
+    [Fact]
+    void should_retry_the_append_on_the_second_attempt() => _eventSequence.Received(2).AppendMany(
+        Arg.Is<IEnumerable<EventToAppend>>(e => e.Count() == 2),
+        Arg.Any<CorrelationId>(),
+        Arg.Any<IEnumerable<Concepts.Auditing.Causation>>(),
+        Arg.Any<Concepts.Identities.Identity>(),
+        Arg.Any<Concepts.EventSequences.Concurrency.ConcurrencyScopes>());
+
+    [Fact] void should_write_state_after_the_successful_retry() => _state.Received(1).WriteStateAsync();
+}

--- a/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/when_seeding_globally_again_after_a_failed_namespace_dispatch.cs
+++ b/Source/Kernel/Core.Specs/Seeding/for_EventSeeding/when_seeding_globally_again_after_a_failed_namespace_dispatch.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Seeding;
+using Cratis.Chronicle.Namespaces;
+
+namespace Cratis.Chronicle.Seeding.for_EventSeeding;
+
+public class when_seeding_globally_again_after_a_failed_namespace_dispatch : given.a_global_event_seeding_grain
+{
+    IEnumerable<SeedingEntry> _entries;
+    INamespaces _namespaces;
+    IEventSeeding _firstNamespaceGrain;
+    IEventSeeding _secondNamespaceGrain;
+    EventStoreNamespaceName _firstNamespace;
+    EventStoreNamespaceName _secondNamespace;
+    Exception _firstError;
+    int _firstNamespaceDispatchCount;
+
+    void Establish()
+    {
+        _firstNamespace = "namespace-1";
+        _secondNamespace = "namespace-2";
+
+        _entries = [
+            new SeedingEntry("event-source-1", "test-event-type", /*lang=json,strict*/ "{\"value\":\"test1\"}", null)
+        ];
+
+        _namespaces = Substitute.For<INamespaces>();
+        _namespaces.GetAll().Returns(Task.FromResult<IEnumerable<EventStoreNamespaceName>>([_firstNamespace, _secondNamespace]));
+        _grainFactory.GetGrain<INamespaces>(Arg.Any<string>()).Returns(_namespaces);
+
+        _firstNamespaceGrain = Substitute.For<IEventSeeding>();
+        _secondNamespaceGrain = Substitute.For<IEventSeeding>();
+
+        _grainFactory.GetGrain<IEventSeeding>(EventSeedingKey.ForNamespace("TestEventStore", _firstNamespace).ToString()).Returns(_firstNamespaceGrain);
+        _grainFactory.GetGrain<IEventSeeding>(EventSeedingKey.ForNamespace("TestEventStore", _secondNamespace).ToString()).Returns(_secondNamespaceGrain);
+
+        // Fail the first namespace dispatch to simulate a transient failure, then succeed on the retry.
+        _firstNamespaceGrain
+            .When(x => x.Seed(Arg.Any<IEnumerable<SeedingEntry>>()))
+            .Do(_ =>
+            {
+                _firstNamespaceDispatchCount++;
+                if (_firstNamespaceDispatchCount == 1)
+                {
+                    throw new Exception("Simulated transient namespace dispatch failure");
+                }
+            });
+    }
+
+    async Task Because()
+    {
+        _firstError = await Catch.Exception(() => _grain.Seed(_entries));
+        await _grain.Seed(_entries);
+    }
+
+    [Fact] void should_fail_the_first_attempt() => _firstError.ShouldNotBeNull();
+    [Fact] void should_redispatch_to_the_failed_namespace_on_retry() => _firstNamespaceGrain.Received(2).Seed(Arg.Any<IEnumerable<SeedingEntry>>());
+    [Fact] void should_dispatch_to_the_remaining_namespace_on_retry() => _secondNamespaceGrain.Received(1).Seed(Arg.Any<IEnumerable<SeedingEntry>>());
+    [Fact] void should_commit_the_global_tracking_only_after_the_successful_retry() => _state.Received(1).WriteStateAsync();
+}

--- a/Source/Kernel/Core/Seeding/EventSeeding.cs
+++ b/Source/Kernel/Core/Seeding/EventSeeding.cs
@@ -21,11 +21,13 @@ namespace Cratis.Chronicle.Seeding;
 /// Represents an implementation of <see cref="IEventSeeding"/>.
 /// </summary>
 /// <param name="state">The <see cref="IPersistentState{T}"/> for the seeding data.</param>
+/// <param name="grainFactory">The <see cref="IGrainFactory"/> for resolving namespace grains.</param>
 /// <param name="logger">The <see cref="ILogger"/> for logging.</param>
 [StorageProvider(ProviderName = WellKnownGrainStorageProviders.EventSeeding)]
 public class EventSeeding(
     [PersistentState(nameof(EventSeeds), WellKnownGrainStorageProviders.EventSeeding)]
     IPersistentState<EventSeeds> state,
+    IGrainFactory grainFactory,
     ILogger<EventSeeding> logger) : Grain, IEventSeeding
 {
     /// <summary>
@@ -72,30 +74,44 @@ public class EventSeeding(
         // For global grains, store the entries and apply to all existing namespaces
         if (_key.IsGlobal)
         {
-            var newEntries = new List<SeedingEntry>();
+            var newEntries = new List<(SeedingEntry Entry, SeededEventEntry Seeded)>();
             foreach (var entry in entriesList)
             {
                 var tags = entry.Tags?.Select(t => t.Value) ?? [];
                 var seededEntry = new SeededEventEntry(entry.EventSourceId, entry.EventTypeId, entry.Content, tags);
                 if (!IsAlreadySeeded(seededEntry))
                 {
-                    TrackSeededEvent(seededEntry);
-                    newEntries.Add(entry);
+                    newEntries.Add((entry, seededEntry));
                 }
             }
-            await state.WriteStateAsync();
 
             if (newEntries.Count > 0)
             {
-                var namespacesGrain = GrainFactory.GetGrain<INamespaces>(_key.EventStore.Value);
+                // Dispatch to every namespace grain BEFORE committing the global tracking. Each namespace
+                // grain applies its own idempotency guard, so re-dispatching after a transient failure is
+                // append-idempotent. Committing the tracking first would permanently lose events: a grain
+                // that throws mid-loop would never be retried - on retry IsAlreadySeeded would report the
+                // entries as seeded, the dispatch would be skipped, and the remaining namespaces would
+                // never receive the events.
+                var entriesToSeed = newEntries.ConvertAll(_ => _.Entry);
+                var namespacesGrain = grainFactory.GetGrain<INamespaces>(_key.EventStore.Value);
                 var namespaces = await namespacesGrain.GetAll();
                 foreach (var ns in namespaces)
                 {
                     logger.ApplyingSeedsToNamespace(ns.Value);
                     var namespaceKey = EventSeedingKey.ForNamespace(_key.EventStore, ns);
-                    var nsGrain = GrainFactory.GetGrain<IEventSeeding>(namespaceKey.ToString());
-                    await nsGrain.Seed(newEntries);
+                    var nsGrain = grainFactory.GetGrain<IEventSeeding>(namespaceKey.ToString());
+                    await nsGrain.Seed(entriesToSeed);
                 }
+
+                // Only now, after every namespace has been seeded, commit the global tracking so a retry
+                // re-dispatches when a namespace dispatch throws.
+                foreach (var (_, seededEntry) in newEntries)
+                {
+                    TrackSeededEvent(seededEntry);
+                }
+
+                await state.WriteStateAsync();
             }
         }
         else
@@ -107,21 +123,30 @@ public class EventSeeding(
                 throw new InvalidOperationException("Event sequence should be initialized for namespace-specific grains");
             }
 
-            var eventsToAppend = GetEventsToSeed(entriesList);
-            if (eventsToAppend.Count > 0)
+            var seedableEvents = GetEventsToSeed(entriesList);
+            if (seedableEvents.Count > 0)
             {
-                logger.AppendingSeededEvents(eventsToAppend.Count);
+                logger.AppendingSeededEvents(seedableEvents.Count);
                 var causation = new Causation[] { new(DateTimeOffset.UtcNow, "event-seeding", new Dictionary<string, string>()) };
 
-                // Append in batches to avoid overwhelming the event sequence grain with too many events at once
-                foreach (var batch in eventsToAppend.Chunk(SeedingBatchSize))
+                // Append in batches to avoid overwhelming the event sequence grain with too many events at once.
+                // Mark each entry as seeded only AFTER its batch has been appended - never before. Tracking an
+                // entry before the append succeeds would dirty the in-memory seeded set; a transient append
+                // failure would then leave it claiming an event was seeded that was not, silently skipping the
+                // event on a same-activation retry until the grain deactivates and reloads clean state.
+                foreach (var batch in seedableEvents.Chunk(SeedingBatchSize))
                 {
                     await _eventSequence.AppendMany(
-                        batch,
+                        batch.Select(_ => _.ToAppend),
                         CorrelationId.New(),
                         causation,
                         Identity.System,
                         new ConcurrencyScopes(new Dictionary<EventSourceId, ConcurrencyScope>()));
+
+                    foreach (var seedable in batch)
+                    {
+                        TrackSeededEvent(seedable.Seeded);
+                    }
                 }
 
                 await state.WriteStateAsync();
@@ -143,37 +168,37 @@ public class EventSeeding(
         return Task.FromResult(state.State);
     }
 
-    List<EventToAppend> GetEventsToSeed(List<SeedingEntry> entriesList)
+    List<SeedableEvent> GetEventsToSeed(List<SeedingEntry> entriesList)
     {
-        var eventsToAppend = new List<EventToAppend>();
+        var seedableEvents = new List<SeedableEvent>();
 
         foreach (var entry in entriesList)
         {
             var tags = entry.Tags?.Select(t => t.Value) ?? [];
             var seededEntry = new SeededEventEntry(entry.EventSourceId, entry.EventTypeId, entry.Content, tags);
 
-            // Check if this exact event has already been seeded
+            // Determine whether this exact event still needs seeding WITHOUT marking it seeded here -
+            // the caller marks each entry as seeded only after its append has succeeded.
             var alreadySeeded = IsAlreadySeeded(seededEntry);
 
             if (!alreadySeeded)
             {
-                // Add to storage tracking
-                TrackSeededEvent(seededEntry);
-
                 // Prepare for appending
                 var content = JsonSerializer.Deserialize<JsonObject>(entry.Content)!;
-                eventsToAppend.Add(new EventToAppend(
-                    EventSourceType.Default,
-                    entry.EventSourceId,
-                    EventStreamType.All,
-                    EventStreamId.Default,
-                    new EventType(entry.EventTypeId, EventTypeGeneration.First),
-                    entry.Tags ?? [],
-                    content));
+                seedableEvents.Add(new SeedableEvent(
+                    seededEntry,
+                    new EventToAppend(
+                        EventSourceType.Default,
+                        entry.EventSourceId,
+                        EventStreamType.All,
+                        EventStreamId.Default,
+                        new EventType(entry.EventTypeId, EventTypeGeneration.First),
+                        entry.Tags ?? [],
+                        content)));
             }
         }
 
-        return eventsToAppend;
+        return seedableEvents;
     }
 
     bool IsAlreadySeeded(SeededEventEntry entry)
@@ -222,4 +247,12 @@ public class EventSeeding(
         state.State.ByEventSource[entry.EventSourceId] = [.. state.State.ByEventSource[entry.EventSourceId], .. new SeededEventEntry[] { entry }];
 #pragma warning restore CA1854 // Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
     }
+
+    /// <summary>
+    /// Represents an event that still needs seeding, pairing the entry to append with the entry to
+    /// record as seeded once the append has succeeded.
+    /// </summary>
+    /// <param name="Seeded">The <see cref="SeededEventEntry"/> to record once the event has been appended.</param>
+    /// <param name="ToAppend">The <see cref="EventToAppend"/> to append to the event sequence.</param>
+    record SeedableEvent(SeededEventEntry Seeded, EventToAppend ToAppend);
 }


### PR DESCRIPTION
## Fixed

- Seeding no longer permanently loses events when applying them to an event store's namespaces fails partway through — the global seed record is now committed only after every namespace has been seeded, so a transient failure is retried instead of leaving some namespaces without the events
- Seeding a namespace no longer silently skips events when the append fails — events are marked seeded only after they have been appended, so a retry re-attempts the append instead of treating them as already done
