### PR TITLE
Fix SQL append livelock on a stale duplicate sequence number

### DIFF
--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/given/an_event_sequence_storage.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/given/an_event_sequence_storage.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.Identities;
+using Cratis.Monads;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.for_EventSequenceStorage.given;
+
+/// <summary>
+/// Sets up an <see cref="EventSequenceStorage"/> backed by a shared in-memory SQLite database.
+/// A single open connection is shared across every <see cref="IDatabase.EventSequenceTable"/> scope
+/// so seeded rows survive between the storage's individual unit-of-work scopes — the append path
+/// opens a fresh <see cref="EventSequenceDbContext"/> per call.
+/// </summary>
+public class an_event_sequence_storage : Specification, IDisposable
+{
+    protected static readonly string _tableName = "event-sequence";
+    protected static readonly EventStoreName _eventStore = "test-store";
+    protected static readonly EventStoreNamespaceName _namespace = "test-namespace";
+    protected static readonly EventSequenceId _eventSequenceId = EventSequenceId.Log;
+    protected static readonly EventType _eventType = new("some-event-type", EventTypeGeneration.First);
+    protected SqliteConnection _connection;
+    protected IDatabase _database;
+    protected IIdentityStorage _identityStorage;
+    protected EventSequenceStorage _storage;
+
+    void Establish()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var schemaContext = CreateContext())
+        {
+            schemaContext.Database.EnsureCreated();
+        }
+
+        _database = Substitute.For<IDatabase>();
+        _database.EventSequenceTable(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<string>())
+            .Returns(_ => CreateScope());
+
+        _identityStorage = Substitute.For<IIdentityStorage>();
+        _identityStorage.GetFor(Arg.Any<IEnumerable<IdentityId>>()).Returns(Identity.System);
+
+        _storage = new EventSequenceStorage(
+            _eventStore,
+            _namespace,
+            _eventSequenceId,
+            _database,
+            _identityStorage,
+            Substitute.For<ILogger<EventSequenceStorage>>());
+    }
+
+    protected EventSequenceDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<EventSequenceDbContext>()
+            .UseSqlite(_connection)
+            .AddConceptAsSupport()
+            .Options;
+
+        return new EventSequenceDbContext(options, _tableName, Substitute.For<IEventSequenceMigrator>());
+    }
+
+    protected void SeedEvent(EventSequenceNumber sequenceNumber)
+    {
+        using var context = CreateContext();
+        context.Events.Add(new EventEntry { SequenceNumber = sequenceNumber.Value });
+        context.SaveChanges();
+    }
+
+    protected Task<Result<AppendedEvent, DuplicateEventSequenceNumber>> Append(EventSequenceNumber sequenceNumber) =>
+        _storage.Append(
+            sequenceNumber,
+            EventSourceType.Default,
+            EventSourceId.New(),
+            EventStreamType.All,
+            EventStreamId.Default,
+            _eventType,
+            CorrelationId.New(),
+            [],
+            [],
+            [],
+            DateTimeOffset.UtcNow,
+            new Dictionary<EventTypeGeneration, ExpandoObject> { { EventTypeGeneration.First, new ExpandoObject() } },
+            new Dictionary<EventTypeGeneration, EventHash>());
+
+    protected Task<Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber>> AppendMany(params EventSequenceNumber[] sequenceNumbers) =>
+        _storage.AppendMany(sequenceNumbers.Select(number => new EventToAppendToStorage(
+            number,
+            EventSourceType.Default,
+            EventSourceId.New(),
+            EventStreamType.All,
+            EventStreamId.Default,
+            _eventType,
+            CorrelationId.New(),
+            [],
+            [],
+            [],
+            DateTimeOffset.UtcNow,
+            new ExpandoObject(),
+            EventHash.NotSet)));
+
+    Task<DbContextScope<EventSequenceDbContext>> CreateScope() =>
+        Task.FromResult(new DbContextScope<EventSequenceDbContext>(CreateContext(), () => { }));
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending/and_sequence_number_is_a_stale_duplicate.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending/and_sequence_number_is_a_stale_duplicate.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.for_EventSequenceStorage.when_appending;
+
+/// <summary>
+/// The stored tail is at sequence number 2, but the caller (an append grain whose persisted
+/// <c>State.SequenceNumber</c> lags the real tail) attempts to append at an already-occupied
+/// number. The recovery contract requires the returned <see cref="DuplicateEventSequenceNumber"/>
+/// to carry the true next-available slot (3) so the grain jumps forward — returning the occupied
+/// number would livelock the sequence. Before the fix the SQL backend returned the occupied number.
+/// </summary>
+public class and_sequence_number_is_a_stale_duplicate : given.an_event_sequence_storage
+{
+    static readonly EventSequenceNumber _tailSequenceNumber = new(2);
+    static readonly EventSequenceNumber _staleSequenceNumber = new(1);
+    Result<AppendedEvent, DuplicateEventSequenceNumber> _result;
+
+    void Establish()
+    {
+        SeedEvent(EventSequenceNumber.First);
+        SeedEvent(_staleSequenceNumber);
+        SeedEvent(_tailSequenceNumber);
+    }
+
+    async Task Because() => _result = await Append(_staleSequenceNumber);
+
+    [Fact] void should_fail() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_next_available_after_the_tail() => _result.AsT1.NextAvailableSequenceNumber.ShouldEqual(_tailSequenceNumber.Next());
+    [Fact] void should_not_report_the_occupied_sequence_number() => _result.AsT1.NextAvailableSequenceNumber.Value.ShouldBeGreaterThan(_staleSequenceNumber.Value);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending/and_sequence_number_is_the_next_available.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending/and_sequence_number_is_the_next_available.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.for_EventSequenceStorage.when_appending;
+
+/// <summary>
+/// A fresh append at the correct next-available sequence number (one past the stored tail) succeeds.
+/// </summary>
+public class and_sequence_number_is_the_next_available : given.an_event_sequence_storage
+{
+    static readonly EventSequenceNumber _tailSequenceNumber = new(2);
+    Result<AppendedEvent, DuplicateEventSequenceNumber> _result;
+
+    void Establish()
+    {
+        SeedEvent(EventSequenceNumber.First);
+        SeedEvent(new EventSequenceNumber(1));
+        SeedEvent(_tailSequenceNumber);
+    }
+
+    async Task Because() => _result = await Append(_tailSequenceNumber.Next());
+
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_append_at_the_next_available_sequence_number() => _result.AsT0.Context.SequenceNumber.ShouldEqual(_tailSequenceNumber.Next());
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending_many/and_a_sequence_number_is_a_stale_duplicate.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending_many/and_a_sequence_number_is_a_stale_duplicate.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.for_EventSequenceStorage.when_appending_many;
+
+/// <summary>
+/// Same stale-tail livelock as the single append, exercised through the batch path: the stored tail
+/// is 2 but the batch starts at an already-occupied number. The returned
+/// <see cref="DuplicateEventSequenceNumber"/> must carry the true next-available slot (3), not the
+/// occupied number the batch attempted. Before the fix the SQL backend returned the occupied number.
+/// </summary>
+public class and_a_sequence_number_is_a_stale_duplicate : given.an_event_sequence_storage
+{
+    static readonly EventSequenceNumber _tailSequenceNumber = new(2);
+    static readonly EventSequenceNumber _staleSequenceNumber = new(1);
+    Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber> _result;
+
+    void Establish()
+    {
+        SeedEvent(EventSequenceNumber.First);
+        SeedEvent(_staleSequenceNumber);
+        SeedEvent(_tailSequenceNumber);
+    }
+
+    async Task Because() => _result = await AppendMany(_staleSequenceNumber);
+
+    [Fact] void should_fail() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_next_available_after_the_tail() => _result.AsT1.NextAvailableSequenceNumber.ShouldEqual(_tailSequenceNumber.Next());
+    [Fact] void should_not_report_the_occupied_sequence_number() => _result.AsT1.NextAvailableSequenceNumber.Value.ShouldBeGreaterThan(_staleSequenceNumber.Value);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending_many/and_sequence_numbers_are_the_next_available.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventSequenceStorage/when_appending_many/and_sequence_numbers_are_the_next_available.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.for_EventSequenceStorage.when_appending_many;
+
+/// <summary>
+/// A fresh batch starting at the correct next-available sequence number (one past the stored tail)
+/// succeeds and appends every event in the batch.
+/// </summary>
+public class and_sequence_numbers_are_the_next_available : given.an_event_sequence_storage
+{
+    static readonly EventSequenceNumber _tailSequenceNumber = new(2);
+    Result<IEnumerable<AppendedEvent>, DuplicateEventSequenceNumber> _result;
+
+    void Establish()
+    {
+        SeedEvent(EventSequenceNumber.First);
+        SeedEvent(new EventSequenceNumber(1));
+        SeedEvent(_tailSequenceNumber);
+    }
+
+    async Task Because() => _result = await AppendMany(_tailSequenceNumber.Next(), new EventSequenceNumber(4));
+
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_append_every_event_in_the_batch() => _result.AsT0.Count().ShouldEqual(2);
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/EventSequenceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/EventSequenceStorage.cs
@@ -135,7 +135,7 @@ public class EventSequenceStorage(
 
             if (existingEvent is not null)
             {
-                return new DuplicateEventSequenceNumber(sequenceNumber);
+                return new DuplicateEventSequenceNumber(await GetNextAvailableSequenceNumber(scope));
             }
 
             var eventEntry = EventEntryConverter.ToEventEntry(
@@ -253,7 +253,7 @@ public class EventSequenceStorage(
 
                 if (existingEvent is not null)
                 {
-                    return new DuplicateEventSequenceNumber(eventToAppend.SequenceNumber);
+                    return new DuplicateEventSequenceNumber(await GetNextAvailableSequenceNumber(scope));
                 }
 
                 var eventEntry = EventEntryConverter.ToEventEntry(
@@ -751,6 +751,30 @@ public class EventSequenceStorage(
         query = query.Take(limit);
 
         return new EventCursor(query, scope, eventStore, @namespace, identityStorage, 100, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves the next-available sequence number for the duplicate-append recovery path.
+    /// </summary>
+    /// <param name="scope">The <see cref="DbContextScope{EventSequenceDbContext}"/> for the event sequence table.</param>
+    /// <returns>The next FREE <see cref="EventSequenceNumber"/> the append grain should jump to.</returns>
+    /// <remarks>
+    /// The <see cref="DuplicateEventSequenceNumber"/> contract is that this value is the next FREE
+    /// slot the append grain jumps to (<c>State.SequenceNumber = nextAvailable</c>) before it
+    /// retries. Returning the occupied number that was just attempted would make the grain retry the
+    /// same number, whose pre-read finds the same existing row again, returning the same number
+    /// forever — an infinite livelock that permanently stalls the event sequence when the grain's
+    /// persisted <c>State.SequenceNumber</c> lags the real tail (silo restart, reset grain state, or
+    /// a replayed append). Mirror the MongoDB and in-memory backends: the true next-available is the
+    /// current stored tail plus one. A duplicate guarantees at least one row exists, but the empty
+    /// case is guarded anyway.
+    /// </remarks>
+    static async Task<EventSequenceNumber> GetNextAvailableSequenceNumber(DbContextScope<EventSequenceDbContext> scope)
+    {
+        var highestSequenceNumber = await scope.DbContext.Events.MaxAsync(e => (ulong?)e.SequenceNumber);
+        return highestSequenceNumber.HasValue
+            ? new EventSequenceNumber(highestSequenceNumber.Value).Next()
+            : EventSequenceNumber.First;
     }
 
     async Task<AppendedEvent> BuildAppendedEventFromRedactionEntry(EventEntry redactionEntry)


### PR DESCRIPTION
## Fixed

- The SQL event-store backend no longer risks an infinite retry loop when appending at a sequence number that is already taken (for example after a silo restart leaves the grain's counter behind the stored tail). Storage now reports the true next-available sequence number so the append recovers, matching the MongoDB and in-memory backends
