### PR TITLE
Fix event-type generation handling in Mongo and SQL storage

### DIFF
--- a/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Events.EventTypes.for_EventTypesStorage.given;
+
+public class an_event_types_storage : Specification
+{
+    protected static readonly EventTypeId _eventTypeId = new("event-type-with-first-generation");
+    protected static readonly EventTypeGeneration _firstGeneration = EventTypeGeneration.First;
+    protected static readonly EventTypeGeneration _secondGeneration = new(2);
+
+    protected IEventStoreDatabase _database;
+    protected IMongoCollection<EventType> _collection;
+    protected List<EventType> _eventTypesInDatabase;
+    protected EventTypesStorage _storage;
+
+    void Establish()
+    {
+        _database = Substitute.For<IEventStoreDatabase>();
+        _collection = Substitute.For<IMongoCollection<EventType>>();
+        _database.GetCollection<EventType>(WellKnownCollectionNames.EventTypes).Returns(_collection);
+
+        _eventTypesInDatabase = [];
+
+        _collection
+            .FindAsync<EventType>(Arg.Any<FilterDefinition<EventType>>(), null, default)
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<EventType>>();
+                cursor.MoveNextAsync(default).Returns(true, false);
+                cursor.Current.Returns(_ => [.. _eventTypesInDatabase]);
+                return Task.FromResult(cursor);
+            });
+
+        _storage = new EventTypesStorage(EventStoreName.NotSet, _database, Substitute.For<ILogger<EventTypesStorage>>());
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_checking_has_for/and_event_type_has_only_the_first_generation.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_checking_has_for/and_event_type_has_only_the_first_generation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using MongoDB.Bson;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Events.EventTypes.for_EventTypesStorage.when_checking_has_for;
+
+public class and_event_type_has_only_the_first_generation : given.an_event_types_storage
+{
+    bool _hasFirstGeneration;
+    bool _hasSecondGeneration;
+
+    void Establish() =>
+        _eventTypesInDatabase.Add(new EventType(
+            _eventTypeId,
+            EventTypeOwner.Client,
+            EventTypeSource.Code,
+            false,
+            new Dictionary<string, BsonDocument>
+            {
+                { _firstGeneration.ToString(), new BsonDocument("type", "object") }
+            }));
+
+    async Task Because()
+    {
+        _hasFirstGeneration = await _storage.HasFor(_eventTypeId, _firstGeneration);
+        _hasSecondGeneration = await _storage.HasFor(_eventTypeId, _secondGeneration);
+    }
+
+    [Fact] void should_have_the_first_generation() => _hasFirstGeneration.ShouldBeTrue();
+    [Fact] void should_not_have_the_second_generation() => _hasSecondGeneration.ShouldBeFalse();
+}

--- a/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
@@ -132,10 +132,13 @@ public class EventTypesStorage(
     /// <inheritdoc/>
     public async Task<bool> HasFor(EventTypeId type, EventTypeGeneration? generation = default)
     {
+        generation ??= EventTypeGeneration.First;
+
         var filter = GetFilterForSpecificEventType(type);
         using var result = await GetCollection().FindAsync(filter).ConfigureAwait(false);
-        var schemas = await result.ToListAsync();
-        return schemas.Count == 1;
+        var eventTypes = await result.ToListAsync();
+
+        return eventTypes.Count > 0 && eventTypes[0].Schemas.ContainsKey(generation.ToString());
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.EventTypes.for_EventTypesStorage.given;
+
+/// <summary>
+/// Sets up an <see cref="EventTypesStorage"/> backed by a shared in-memory SQLite database with an
+/// event type that has two generations. The storage is never populated, so its cache stays cold and
+/// resolving a schema for a generation falls back to the database.
+/// </summary>
+public class an_event_types_storage : Specification, IDisposable
+{
+    protected static readonly EventTypeId _eventTypeId = new("event-type-with-two-generations");
+    protected static readonly EventTypeGeneration _firstGeneration = EventTypeGeneration.First;
+    protected static readonly EventTypeGeneration _secondGeneration = new(2);
+
+    protected const string FirstGenerationProperty = "firstGenerationValue";
+    protected const string SecondGenerationProperty = "secondGenerationValue";
+
+    protected SqliteConnection _connection;
+    protected IDatabase _database;
+    protected EventTypesStorage _storage;
+
+    void Establish()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var schemaContext = CreateContext())
+        {
+            schemaContext.Database.EnsureCreated();
+            schemaContext.EventTypes.Add(new EventType
+            {
+                Id = _eventTypeId,
+                Schemas = new Dictionary<uint, string>
+                {
+                    { _firstGeneration, SchemaFor(FirstGenerationProperty) },
+                    { _secondGeneration, SchemaFor(SecondGenerationProperty) }
+                }
+            });
+            schemaContext.SaveChanges();
+        }
+
+        _database = Substitute.For<IDatabase>();
+        _database.EventStore(Arg.Any<EventStoreName>())
+            .Returns(_ => Task.FromResult(new DbContextScope<EventStoreDbContext>(CreateContext(), () => { })));
+
+        // Deliberately not populated — the cache stays cold so GetFor hits the database fallback path.
+        _storage = new EventTypesStorage(EventStoreName.NotSet, _database);
+    }
+
+    protected static string SchemaFor(string propertyName) =>
+        $$"""
+        {
+            "type": "object",
+            "properties": {
+                "{{propertyName}}": { "type": "string" }
+            }
+        }
+        """;
+
+    protected EventStoreDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<EventStoreDbContext>()
+            .UseSqlite(_connection)
+            .AddConceptAsSupport()
+            .Options;
+
+        return new EventStoreDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/EventTypes/for_EventTypesStorage/when_resolving_schema_for_a_generation/with_a_cold_cache.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/EventTypes/for_EventTypesStorage/when_resolving_schema_for_a_generation/with_a_cold_cache.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventTypes;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.EventTypes.for_EventTypesStorage.when_resolving_schema_for_a_generation;
+
+public class with_a_cold_cache : given.an_event_types_storage
+{
+    EventTypeSchema _result;
+
+    async Task Because() => _result = await _storage.GetFor(_eventTypeId, _secondGeneration);
+
+    [Fact] void should_return_the_requested_generation() => _result.Type.Generation.ShouldEqual(_secondGeneration);
+    [Fact] void should_return_the_schema_for_the_requested_generation() => _result.Schema.ToJson().Contains(SecondGenerationProperty).ShouldBeTrue();
+    [Fact] void should_not_return_the_schema_for_another_generation() => _result.Schema.ToJson().Contains(FirstGenerationProperty).ShouldBeFalse();
+}

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypesStorage.cs
@@ -159,7 +159,7 @@ public class EventTypesStorage(EventStoreName eventStore, IDatabase database) : 
                 generation);
         }
 
-        return eventType.ToKernel();
+        return eventType.ToKernel(generation);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Fixed

- Adding a new generation to an existing event type now works on the MongoDB backend. The storage's "does this generation exist" check ignored the generation and reported any existing type as already having every generation, so legitimate event-type migrations were rejected as an unexpected schema change
- Resolving an event type by a specific generation from the SQL database on a cold cache now returns that generation's schema instead of always the first generation's
