### PR TITLE
Surface jobs storage failures instead of returning empty

### DIFF
--- a/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/given/RecordingLogger.cs
+++ b/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/given/RecordingLogger.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Services.Jobs.for_Jobs.given;
+
+/// <summary>
+/// A recording <see cref="ILogger{TCategoryName}"/> test double that captures the levels it was asked to log at.
+/// </summary>
+/// <typeparam name="T">The category type the logger is for.</typeparam>
+/// <remarks>
+/// Used because <c>ILogger&lt;Jobs&gt;</c> cannot be proxied by NSubstitute (the <c>Jobs</c> type is internal in a
+/// strong-named assembly), so a hand-written double is needed to verify that a failure gets logged.
+/// </remarks>
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    readonly List<LogLevel> _entries = [];
+
+    /// <summary>
+    /// Gets the log levels captured, in the order they were logged.
+    /// </summary>
+    public IReadOnlyList<LogLevel> Entries => _entries;
+
+    /// <inheritdoc/>
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc/>
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc/>
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+        _entries.Add(logLevel);
+}

--- a/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/given/all_dependencies.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Reactive.Subjects;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Jobs;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Services.Jobs.for_Jobs.given;
+
+/// <summary>
+/// Base context that wires up the dependencies of the Jobs gRPC service with a failing jobs storage.
+/// </summary>
+public class all_dependencies : Specification
+{
+    protected IGrainFactory _grainFactory;
+    protected IStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IJobStorage _jobStorage;
+    protected IJobStepStorage _jobStepStorage;
+    internal RecordingLogger<Jobs> _logger;
+    protected Exception _exception;
+    protected Contracts.Jobs.IJobs _service;
+
+    void Establish()
+    {
+        _grainFactory = Substitute.For<IGrainFactory>();
+        _storage = Substitute.For<IStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _jobStorage = Substitute.For<IJobStorage>();
+        _jobStepStorage = Substitute.For<IJobStepStorage>();
+        _logger = new RecordingLogger<Jobs>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_namespaceStorage);
+        _namespaceStorage.Jobs.Returns(_jobStorage);
+        _namespaceStorage.JobSteps.Returns(_jobStepStorage);
+
+        _exception = new InvalidOperationException("Jobs storage is unavailable");
+
+        Catch<ISubject<IEnumerable<JobState>>> failedObserve = _exception;
+        _jobStorage.ObserveJobs(Arg.Any<JobStatus[]>()).Returns(failedObserve);
+
+        Catch<IImmutableList<JobStepState>> failedSteps = _exception;
+        _jobStepStorage.GetForJob(Arg.Any<JobId>(), Arg.Any<JobStepStatus[]>()).Returns(Task.FromResult(failedSteps));
+
+        _service = new Jobs(_grainFactory, _storage, _logger);
+    }
+}

--- a/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/when_getting_job_steps/and_storage_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/when_getting_job_steps/and_storage_fails.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Services.Jobs.for_Jobs.when_getting_job_steps;
+
+public class and_storage_fails : given.all_dependencies
+{
+    IEnumerable<JobStep> _result;
+
+    async Task Because() => _result = await _service.GetJobSteps(new GetJobStepsRequest
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        JobId = Guid.NewGuid(),
+        Statuses = []
+    });
+
+    [Fact] void should_return_empty_steps() => _result.ShouldBeEmpty();
+    [Fact] void should_log_the_failure_as_error() => _logger.Entries.ShouldContain(LogLevel.Error);
+}

--- a/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/when_observing_jobs/and_storage_fails.cs
+++ b/Source/Kernel/Core.Specs/Services/Jobs/for_Jobs/when_observing_jobs/and_storage_fails.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Services.Jobs.for_Jobs.when_observing_jobs;
+
+public class and_storage_fails : given.all_dependencies
+{
+    IObservable<IEnumerable<Job>> _observable;
+    Exception _observedError;
+
+    void Because()
+    {
+        _observable = _service.ObserveJobs(new GetJobsRequest
+        {
+            EventStore = "test-store",
+            Namespace = "test-namespace"
+        });
+
+        _observable.Subscribe(
+            _ => { },
+            ex => _observedError = ex,
+            () => { });
+    }
+
+    [Fact] void should_error_the_observable_instead_of_completing_empty() => _observedError.ShouldNotBeNull();
+    [Fact] void should_surface_the_storage_exception() => _observedError.ShouldEqual(_exception);
+    [Fact] void should_log_the_failure_as_error() => _logger.Entries.ShouldContain(LogLevel.Error);
+}

--- a/Source/Kernel/Core/Services/Jobs/Jobs.cs
+++ b/Source/Kernel/Core/Services/Jobs/Jobs.cs
@@ -7,6 +7,7 @@ using Cratis.Chronicle.Contracts.Primitives;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Storage;
 using Cratis.Reactive;
+using Microsoft.Extensions.Logging;
 using ProtoBuf.Grpc;
 
 namespace Cratis.Chronicle.Services.Jobs;
@@ -16,7 +17,8 @@ namespace Cratis.Chronicle.Services.Jobs;
 /// </summary>
 /// <param name="grainFactory">The <see cref="IGrainFactory"/>.</param>
 /// <param name="storage">The <see cref="IStorage"/>.</param>
-internal sealed class Jobs(IGrainFactory grainFactory, IStorage storage) : IJobs
+/// <param name="logger">The <see cref="ILogger{TCategoryName}"/> for logging.</param>
+internal sealed class Jobs(IGrainFactory grainFactory, IStorage storage, ILogger<Jobs> logger) : IJobs
 {
     /// <inheritdoc/>
     public Task Stop(StopJob command, CallContext context = default) =>
@@ -64,7 +66,9 @@ internal sealed class Jobs(IGrainFactory grainFactory, IStorage storage) : IJobs
             return catchOrObserve.AsT0.CompletedBy(context.CancellationToken).Select(_ => _.ToContract());
         }
 
-        return Observable.Empty<IEnumerable<Job>>();
+        catchOrObserve.TryGetException(out var exception);
+        logger.FailedToObserveJobs(exception!, request.EventStore, request.Namespace);
+        return Observable.Throw<IEnumerable<Job>>(exception!);
     }
 
     /// <inheritdoc/>
@@ -80,6 +84,8 @@ internal sealed class Jobs(IGrainFactory grainFactory, IStorage storage) : IJobs
             return catchOrObserve.AsT0.ToContract();
         }
 
+        catchOrObserve.TryGetException(out var exception);
+        logger.FailedToGetJobSteps(exception!, request.JobId, request.EventStore, request.Namespace);
         return [];
     }
 }

--- a/Source/Kernel/Core/Services/Jobs/JobsLogging.cs
+++ b/Source/Kernel/Core/Services/Jobs/JobsLogging.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Services.Jobs;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static partial class JobsLogMessages
+{
+    /// <summary>
+    /// Logs a failure to observe jobs from storage.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> to log to.</param>
+    /// <param name="exception">The <see cref="Exception"/> that caused the failure.</param>
+    /// <param name="eventStore">The event store the jobs were observed for.</param>
+    /// <param name="namespace">The namespace the jobs were observed for.</param>
+    [LoggerMessage(LogLevel.Error, "Failed to observe jobs for event store {EventStore} and namespace {Namespace}")]
+    internal static partial void FailedToObserveJobs(this ILogger<Jobs> logger, Exception exception, string eventStore, string @namespace);
+
+    /// <summary>
+    /// Logs a failure to get job steps from storage.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> to log to.</param>
+    /// <param name="exception">The <see cref="Exception"/> that caused the failure.</param>
+    /// <param name="jobId">The identifier of the job the steps were requested for.</param>
+    /// <param name="eventStore">The event store the job steps were requested for.</param>
+    /// <param name="namespace">The namespace the job steps were requested for.</param>
+    [LoggerMessage(LogLevel.Error, "Failed to get job steps for job {JobId} in event store {EventStore} and namespace {Namespace}")]
+    internal static partial void FailedToGetJobSteps(this ILogger<Jobs> logger, Exception exception, Guid jobId, string eventStore, string @namespace);
+}

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -143,7 +143,7 @@ public static class ChronicleServerSiloBuilderExtensions
                 new Cratis.Chronicle.Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(grainFactory, storage),
                 new Cratis.Chronicle.Services.ReadModels.ReadModels(grainFactory, storage, expandoObjectConverter, sp.GetRequiredService<IReducerMediator>(), sp.GetRequiredService<IReadModelsCompliance>(), sp.GetRequiredService<IEventCompliance>(), jsonSerializerOptions),
                 new Cratis.Chronicle.Services.ReadModels.MaterializedReadModels(grainFactory, storage, sp.GetRequiredService<IReadModelsCompliance>()),
-                new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage),
+                new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage, sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Jobs.Jobs>>()),
                 new Cratis.Chronicle.Services.Seeding.EventSeeding(grainFactory),
                 new Cratis.Chronicle.Services.Security.Users(grainFactory, storage),
                 new Cratis.Chronicle.Services.Security.Applications(grainFactory, storage),


### PR DESCRIPTION
## Fixed

- Job monitoring no longer hides backend failures as an empty result. When the jobs storage fails, observing jobs now surfaces the error to the caller instead of an empty stream, and both observing jobs and reading job steps log the failure — so the Workbench no longer silently shows an empty list on a real fault
