### PR TITLE
Fix unit-of-work commit leak, concurrency scope, and current handling

### DIFF
--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/given/a_unit_of_work.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/given/a_unit_of_work.cs
@@ -15,6 +15,7 @@ public class a_unit_of_work : Specification
     protected IEventSequence _eventSequence;
     protected bool _onCompletedCalled;
     protected IEnumerable<EventForEventSourceId> _eventsAppended;
+    protected IDictionary<EventSourceId, ConcurrencyScope> _concurrencyScopesAppended;
     protected AppendManyResult _appendResult;
 
     void Establish()
@@ -35,6 +36,7 @@ public class a_unit_of_work : Specification
             .Returns(callInfo =>
             {
                 _eventsAppended = callInfo.Arg<IEnumerable<EventForEventSourceId>>();
+                _concurrencyScopesAppended = callInfo.Arg<IDictionary<EventSourceId, ConcurrencyScope>>();
                 return _appendResult;
             });
     }

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_append_throws.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_append_throws.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class and_append_throws : given.a_unit_of_work_with_two_events_for_different_event_source_ids_added_to_it
+{
+    Exception _thrownDuringAppend;
+    Exception _result;
+
+    void Establish()
+    {
+        _thrownDuringAppend = new InvalidOperationException("append failed");
+        _eventSequence
+            .AppendMany(
+                Arg.Any<IEnumerable<EventForEventSourceId>>(),
+                Arg.Any<CorrelationId?>(),
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<IDictionary<EventSourceId, ConcurrencyScope>>())
+            .Throws(_thrownDuringAppend);
+    }
+
+    async Task Because() => _result = await Catch.Exception(_unitOfWork.Commit);
+
+    [Fact] void should_propagate_the_exception() => _result.ShouldEqual(_thrownDuringAppend);
+    [Fact] void should_call_on_completed() => _onCompletedCalled.ShouldBeTrue();
+    [Fact] void should_be_completed() => _unitOfWork.IsCompleted.ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_second_event_for_same_source_has_no_concurrency_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/and_second_event_for_same_source_has_no_concurrency_scope.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class and_second_event_for_same_source_has_no_concurrency_scope : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _concurrencyScope;
+    Causation _causation;
+
+    protected override AppendManyResult GetAppendResult() => new()
+    {
+        CorrelationId = _correlationId,
+    };
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _concurrencyScope = new ConcurrencyScope(42UL, _eventSourceId);
+        _causation = new Causation(DateTimeOffset.UtcNow, "cause", new Dictionary<string, string>());
+
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, new FirstEvent(), _causation, concurrencyScope: _concurrencyScope);
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, new SecondEvent(), _causation);
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_still_apply_concurrency_for_the_source() => _concurrencyScopesAppended.ContainsKey(_eventSourceId).ShouldBeTrue();
+    [Fact] void should_keep_the_real_concurrency_scope() => _concurrencyScopesAppended[_eventSourceId].ShouldEqual(_concurrencyScope);
+
+    record FirstEvent();
+    record SecondEvent();
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWorkManager/when_a_completed_unit_is_not_the_current_one.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWorkManager/when_a_completed_unit_is_not_the_current_one.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWorkManager;
+
+public class when_a_completed_unit_is_not_the_current_one : given.a_unit_of_work_manager
+{
+    IUnitOfWork _first;
+    IUnitOfWork _second;
+    IUnitOfWork? _current;
+    bool _hasCurrent;
+
+    void Because()
+    {
+        _first = _manager.Begin(CorrelationId.New());
+        _second = _manager.Begin(CorrelationId.New());
+        _first.Dispose();
+        _hasCurrent = _manager.HasCurrent;
+        _current = _hasCurrent ? _manager.Current : null;
+    }
+
+    [Fact] void should_still_have_current() => _hasCurrent.ShouldBeTrue();
+    [Fact] void should_keep_the_second_unit_as_current() => _current.ShouldEqual(_second);
+    [Fact] void should_no_longer_hold_the_first_unit() => _manager.TryGetFor(_first.CorrelationId, out var _).ShouldBeFalse();
+    [Fact] void should_still_hold_the_second_unit() => _manager.TryGetFor(_second.CorrelationId, out var _).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET/EventSequences/Operations/EventSourceOperations.cs
+++ b/Source/Clients/DotNET/EventSequences/Operations/EventSourceOperations.cs
@@ -23,6 +23,15 @@ public class EventSourceOperations : IEventSourceOperations
     /// <inheritdoc/>
     public EventSourceOperations WithConcurrencyScope(ConcurrencyScope concurrencyScope)
     {
+        // A concurrency scope that has already been set for this event source must not be reset to
+        // NotSet by a later event added to the same source - that would silently drop the source
+        // from the concurrency check and disable optimistic concurrency. A real (non-NotSet) scope
+        // still overrides an earlier one.
+        if (concurrencyScope == ConcurrencyScope.NotSet && ConcurrencyScope != ConcurrencyScope.NotSet)
+        {
+            return this;
+        }
+
         ConcurrencyScope = concurrencyScope;
         return this;
     }

--- a/Source/Clients/DotNET/EventSequences/Operations/IEventSourceOperations.cs
+++ b/Source/Clients/DotNET/EventSequences/Operations/IEventSourceOperations.cs
@@ -27,6 +27,12 @@ public interface IEventSourceOperations
     /// </summary>
     /// <param name="concurrencyScope">The concurrency scope to set.</param>
     /// <returns>The current instance of <see cref="EventSourceOperations"/>.</returns>
+    /// <remarks>
+    /// A <see cref="ConcurrencyScope.NotSet"/> value does not override a scope that has already
+    /// been set for the event source, so that a later event added without a scope cannot silently
+    /// disable the concurrency check. A non-<see cref="ConcurrencyScope.NotSet"/> value overrides
+    /// any previously set scope.
+    /// </remarks>
     EventSourceOperations WithConcurrencyScope(ConcurrencyScope concurrencyScope);
 
     /// <summary>

--- a/Source/Clients/DotNET/Transactions/UnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWork.cs
@@ -86,18 +86,26 @@ public class UnitOfWork(
     {
         ThrowIfUnitOfWorkIsCompleted();
 
-        if (_eventSequenceOperations is not null)
+        try
         {
-            var result = await _eventSequenceOperations.Perform();
-            if (result.SequenceNumbers?.Any() == true)
+            if (_eventSequenceOperations is not null)
             {
-                _lastCommittedEventSequenceNumber = result.SequenceNumbers.MaxBy(_ => _.Value);
+                var result = await _eventSequenceOperations.Perform();
+                if (result.SequenceNumbers?.Any() == true)
+                {
+                    _lastCommittedEventSequenceNumber = result.SequenceNumbers.MaxBy(_ => _.Value);
+                }
+                _appendManyResult = result;
             }
-            _appendManyResult = result;
         }
-
-        _isCommitted = true;
-        _onCompleted(this);
+        finally
+        {
+            // Completion must run even when the append throws (RpcException, unknown event type,
+            // serialization error) - otherwise the unit leaks in the manager's dictionary and the
+            // AsyncLocal Current keeps pointing at a completed unit. The exception still propagates.
+            _isCommitted = true;
+            _onCompleted(this);
+        }
     }
 
     /// <inheritdoc/>

--- a/Source/Clients/DotNET/Transactions/UnitOfWorkManager.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWorkManager.cs
@@ -48,6 +48,12 @@ public class UnitOfWorkManager(IEventStore eventStore) : IUnitOfWorkManager
     void UnitOfWorkCompleted(IUnitOfWork unitOfWork)
     {
         _unitsOfWork.TryRemove(unitOfWork.CorrelationId, out _);
-        _current.Value = null!;
+
+        // Only clear Current when the completing unit is the current one - clearing unconditionally
+        // would wipe a different unit that became current while this one was still live.
+        if (ReferenceEquals(_current.Value, unitOfWork))
+        {
+            _current.Value = null!;
+        }
     }
 }


### PR DESCRIPTION
## Fixed

- A unit of work whose commit fails (for example a transient connection error during the append) no longer leaks — it is always removed from the manager and the current-unit reference is cleared, instead of accumulating and leaving a stale current unit
- Optimistic concurrency is no longer silently disabled when more than one event is added to the same event source and a later event carries no concurrency scope — an already-set scope is now kept
- Completing one unit of work no longer clears the current-unit reference when a different unit has since become current
