### PR TITLE
Fix read-model paging returning a short page

### DIFF
--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/given/instances_in_the_sink.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/given/instances_in_the_sink.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.ReadModels.for_ReadModels.given;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_getting_instances_with_paging.given;
+
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+public class instances_in_the_sink : all_dependencies
+{
+    protected const int TotalInstances = 15;
+    protected List<string> _backingInstances = null!;
+    protected Contracts.ReadModels.IMaterializedReadModels _materializedReadModelsService = null!;
+
+    void Establish()
+    {
+        _projections.HasFor(typeof(PagedReadModel)).Returns(true);
+        _reducers.HasFor(typeof(PagedReadModel)).Returns(false);
+
+        _backingInstances = Enumerable.Range(0, TotalInstances)
+            .Select(index => JsonSerializer.Serialize(new PagedReadModel { Name = $"Item{index}" }))
+            .ToList();
+
+        // Model the server contract: its effective offset is always Page * PageSize, and it returns
+        // PageSize instances from that offset.
+        _materializedReadModelsService = Substitute.For<Contracts.ReadModels.IMaterializedReadModels>();
+        _materializedReadModelsService
+            .GetInstances(Arg.Any<GetInstancesRequest>())
+            .Returns(call =>
+            {
+                var request = call.Arg<GetInstancesRequest>();
+                var offset = Math.Max(0, request.Page * request.PageSize);
+                var page = _backingInstances.Skip(offset).Take(request.PageSize).ToList();
+                return new GetInstancesResponse
+                {
+                    Instances = page,
+                    TotalCount = _backingInstances.Count,
+                    Page = request.Page,
+                    PageSize = request.PageSize
+                };
+            });
+
+        _services.MaterializedReadModels.Returns(_materializedReadModelsService);
+    }
+
+    public class PagedReadModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}
+#pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_non_page_aligned_skip.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_non_page_aligned_skip.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_getting_instances_with_paging;
+
+public class with_a_non_page_aligned_skip : given.instances_in_the_sink
+{
+    IEnumerable<PagedReadModel> _result = [];
+
+    async Task Because() => _result = await _readModels.Materialized.GetInstances<PagedReadModel>(5, 10);
+
+    [Fact] void should_return_the_full_requested_window() => _result.Count().ShouldEqual(10);
+
+    [Fact] void should_return_the_window_in_order() =>
+        _result.Select(instance => instance.Name).SequenceEqual(Enumerable.Range(5, 10).Select(index => $"Item{index}")).ShouldBeTrue();
+
+    [Fact] void should_request_a_covering_range_from_the_start() =>
+        _materializedReadModelsService.Received(1).GetInstances(Arg.Is<GetInstancesRequest>(request => request.Page == 0 && request.PageSize == 15));
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_page_aligned_skip.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_page_aligned_skip.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_getting_instances_with_paging;
+
+public class with_a_page_aligned_skip : given.instances_in_the_sink
+{
+    IEnumerable<PagedReadModel> _result = [];
+
+    async Task Because() => _result = await _readModels.Materialized.GetInstances<PagedReadModel>(10, 5);
+
+    [Fact] void should_return_the_expected_page() => _result.Count().ShouldEqual(5);
+
+    [Fact] void should_return_the_page_in_order() =>
+        _result.Select(instance => instance.Name).SequenceEqual(Enumerable.Range(10, 5).Select(index => $"Item{index}")).ShouldBeTrue();
+
+    [Fact] void should_request_the_aligned_page_without_over_fetching() =>
+        _materializedReadModelsService.Received(1).GetInstances(Arg.Is<GetInstancesRequest>(request => request.Page == 2 && request.PageSize == 5));
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_zero_take.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_a_zero_take.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_getting_instances_with_paging;
+
+public class with_a_zero_take : given.instances_in_the_sink
+{
+    IEnumerable<PagedReadModel> _result = [];
+    Exception? _error;
+
+    async Task Because() => _error = await Catch.Exception(async () => _result = await _readModels.Materialized.GetInstances<PagedReadModel>(5, 0));
+
+    [Fact] void should_not_throw() => _error.ShouldBeNull();
+
+    [Fact] void should_return_no_instances() => _result.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_an_unlimited_take.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_with_paging/with_an_unlimited_take.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_getting_instances_with_paging;
+
+public class with_an_unlimited_take : given.instances_in_the_sink
+{
+    IEnumerable<PagedReadModel> _result = [];
+
+    async Task Because() => _result = await _readModels.Materialized.GetInstances<PagedReadModel>(0, InstanceCount.Unlimited);
+
+    [Fact] void should_return_all_instances() => _result.Count().ShouldEqual(TotalInstances);
+
+    [Fact] void should_request_an_unlimited_page_from_the_start() =>
+        _materializedReadModelsService.Received(1).GetInstances(Arg.Is<GetInstancesRequest>(request => request.Page == 0 && request.PageSize == int.MaxValue));
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_observing_instances_with_paging/given/instances_in_the_sink.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_observing_instances_with_paging/given/instances_in_the_sink.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.ReadModels.for_ReadModels.given;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_observing_instances_with_paging.given;
+
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+public class instances_in_the_sink : all_dependencies
+{
+    protected const int TotalInstances = 15;
+    protected List<string> _backingInstances = null!;
+    protected Contracts.ReadModels.IMaterializedReadModels _materializedReadModelsService = null!;
+
+    void Establish()
+    {
+        _projections.HasFor(typeof(PagedReadModel)).Returns(true);
+        _reducers.HasFor(typeof(PagedReadModel)).Returns(false);
+
+        _backingInstances = Enumerable.Range(0, TotalInstances)
+            .Select(index => JsonSerializer.Serialize(new PagedReadModel { Name = $"Item{index}" }))
+            .ToList();
+
+        // Model the server contract: its effective offset is always Page * PageSize, and it returns
+        // PageSize instances from that offset.
+        _materializedReadModelsService = Substitute.For<Contracts.ReadModels.IMaterializedReadModels>();
+        _materializedReadModelsService
+            .ObserveInstances(Arg.Any<ObserveInstancesRequest>())
+            .Returns(call =>
+            {
+                var request = call.Arg<ObserveInstancesRequest>();
+                var offset = Math.Max(0, request.Page * request.PageSize);
+                var page = _backingInstances.Skip(offset).Take(request.PageSize).ToList();
+                var response = new ObserveInstancesResponse
+                {
+                    Instances = page,
+                    TotalCount = _backingInstances.Count,
+                    Page = request.Page,
+                    PageSize = request.PageSize
+                };
+                return Observable.Return(response);
+            });
+
+        _services.MaterializedReadModels.Returns(_materializedReadModelsService);
+    }
+
+    public class PagedReadModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}
+#pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_observing_instances_with_paging/with_a_non_page_aligned_skip.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_observing_instances_with_paging/with_a_non_page_aligned_skip.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_observing_instances_with_paging;
+
+public class with_a_non_page_aligned_skip : given.instances_in_the_sink
+{
+    IEnumerable<PagedReadModel> _emitted = [];
+
+    async Task Because() => _emitted = await _readModels.Materialized.ObserveInstances<PagedReadModel>(5, 10).FirstAsync().ToTask();
+
+    [Fact] void should_emit_the_full_requested_window() => _emitted.Count().ShouldEqual(10);
+
+    [Fact] void should_emit_the_window_in_order() =>
+        _emitted.Select(instance => instance.Name).SequenceEqual(Enumerable.Range(5, 10).Select(index => $"Item{index}")).ShouldBeTrue();
+
+    [Fact] void should_request_a_covering_range_from_the_start() =>
+        _materializedReadModelsService.Received(1).ObserveInstances(Arg.Is<ObserveInstancesRequest>(request => request.Page == 0 && request.PageSize == 15));
+}

--- a/Source/Clients/DotNET/ReadModels/MaterializedReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/MaterializedReadModels.cs
@@ -48,35 +48,25 @@ public class MaterializedReadModels(
 
         // Get the read model identifier
         var readModelIdentifier = readModelType.GetReadModelIdentifier();
-        var pageSize = take.Value == InstanceCount.Unlimited.Value ? int.MaxValue : take.Value;
-        var page = 0;
-
-        // Calculate skip by converting to page-based pagination
-        if (skip.Value > 0 && take.Value > 0 && take.Value != InstanceCount.Unlimited.Value)
-        {
-            page = skip.Value / take.Value;
-        }
-
-        var skipWithinPage = skip.Value % take.Value;
+        var paging = CalculatePaging(skip, take);
 
         var request = new GetInstancesRequest
         {
             EventStore = eventStore.Name,
             Namespace = eventStore.Namespace,
             ReadModel = readModelIdentifier,
-            Page = page,
-            PageSize = pageSize
+            Page = paging.Page,
+            PageSize = paging.PageSize
         };
 
         var response = await chronicleServicesAccessor.Services.MaterializedReadModels.GetInstances(request);
         var instances = response.Instances
-            .Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!);
-
-        // If there's a remaining skip within the page, skip those instances
-        var result = skipWithinPage > 0 ? instances.Skip(skipWithinPage) : instances;
+            .Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!)
+            .Skip(paging.LocalSkip)
+            .Take(paging.LocalTake);
 
         // Release (decrypt) the instances before returning
-        return await ReleaseInstances(result);
+        return await ReleaseInstances(instances);
     }
 
     /// <inheritdoc/>
@@ -96,38 +86,72 @@ public class MaterializedReadModels(
 
         // Get the read model identifier
         var readModelIdentifier = readModelType.GetReadModelIdentifier();
-        var pageSize = take.Value == InstanceCount.Unlimited.Value ? int.MaxValue : take.Value;
-        var page = 0;
-
-        // Calculate skip by converting to page-based pagination
-        if (skip.Value > 0 && take.Value > 0 && take.Value != InstanceCount.Unlimited.Value)
-        {
-            page = skip.Value / take.Value;
-        }
-
-        var skipWithinPage = skip.Value % take.Value;
+        var paging = CalculatePaging(skip, take);
 
         var request = new ObserveInstancesRequest
         {
             EventStore = eventStore.Name,
             Namespace = eventStore.Namespace,
             ReadModel = readModelIdentifier,
-            Page = page,
-            PageSize = pageSize
+            Page = paging.Page,
+            PageSize = paging.PageSize
         };
 
         return chronicleServicesAccessor.Services.MaterializedReadModels.ObserveInstances(request)
             .SelectMany(async response =>
             {
                 var instances = response.Instances
-                    .Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!);
-
-                // If there's a remaining skip within the page, skip those instances
-                var filteredInstances = skipWithinPage > 0 ? instances.Skip(skipWithinPage) : instances;
+                    .Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!)
+                    .Skip(paging.LocalSkip)
+                    .Take(paging.LocalTake);
 
                 // Release (decrypt) the instances before returning
-                return await ReleaseInstances(filteredInstances);
+                return await ReleaseInstances(instances);
             });
+    }
+
+    /// <summary>
+    /// Translates a requested <paramref name="skip"/>/<paramref name="take"/> window into the server's
+    /// page-aligned paging contract plus the local slicing needed to return the exact window.
+    /// </summary>
+    /// <param name="skip">The number of instances to skip.</param>
+    /// <param name="take">The number of instances to take.</param>
+    /// <returns>The server page and page size to request, and the local skip and take to apply to the response.</returns>
+    /// <remarks>
+    /// The server only exposes page-aligned offsets (its effective offset is always <c>Page * PageSize</c>).
+    /// When <paramref name="skip"/> is a multiple of <paramref name="take"/> the requested window is exactly one
+    /// server page, so the page request is used directly. When it is not, the window <c>[skip, skip+take)</c>
+    /// straddles two server pages; a covering range is fetched from the start and sliced locally so the full
+    /// <paramref name="take"/> items are returned instead of only the tail of the first page.
+    /// </remarks>
+    static (int Page, int PageSize, int LocalSkip, int LocalTake) CalculatePaging(InstanceCountToSkip skip, InstanceCount take)
+    {
+        var skipCount = Math.Max(0, skip.Value);
+        var takeCount = take.Value;
+
+        // Unlimited take: fetch everything from the start and skip locally.
+        if (takeCount == InstanceCount.Unlimited.Value)
+        {
+            return (0, int.MaxValue, skipCount, int.MaxValue);
+        }
+
+        // A take of zero (or less) requests no instances — fetch nothing (and never divide by zero below).
+        if (takeCount <= 0)
+        {
+            return (0, 0, 0, 0);
+        }
+
+        // Page-aligned skip: the requested window is exactly one server page.
+        if (skipCount % takeCount == 0)
+        {
+            return (skipCount / takeCount, takeCount, 0, takeCount);
+        }
+
+        // Non-aligned skip: the window straddles two server pages. Fetch a covering range from the
+        // start (page size guarded against int overflow) and slice it locally to the requested window.
+        var coveringPageSize = (int)Math.Min(int.MaxValue, (long)skipCount + takeCount);
+
+        return (0, coveringPageSize, skipCount, takeCount);
     }
 
     async Task<IEnumerable<TReadModel>> ReleaseInstances<TReadModel>(IEnumerable<TReadModel> instances)


### PR DESCRIPTION
## Fixed

- Paging a read-model query with a skip that is not a multiple of the take now returns the full requested number of instances instead of a short page. It also no longer throws when the take is zero
