### PR TITLE
Move in-memory storage C# example into client tabs

### DIFF
--- a/Documentation/architecture.md
+++ b/Documentation/architecture.md
@@ -81,7 +81,7 @@ Keeping event processing in the kernel means your application stays thin: it exp
 
 - [Concepts](./concepts/) — each piece in depth, starting with the [Glossary](./concepts/glossary.md).
 - [Projections, reducers, and reactors](./concepts/observer-patterns.md) — what runs inside the kernel.
-- [Storage configuration](./hosting/configuration/storage.md) — MongoDB, PostgreSQL, Microsoft SQL Server, and SQLite.
+- [Storage configuration](./hosting/configuration/storage) — MongoDB, PostgreSQL, Microsoft SQL Server, and SQLite.
 - [CLI Chronicle commands](/cli/chronicle/) — operate events, observers, read models, jobs, and recommendations from a terminal.
 - [OpenTelemetry](./hosting/configuration/open-telemetry.md) — logs, traces, and metrics.
 - [Hosting](./hosting/) — running the kernel in development and production.

--- a/Documentation/client-snippets/hosting/configuration/storage/in-memory.md
+++ b/Documentation/client-snippets/hosting/configuration/storage/in-memory.md
@@ -1,0 +1,3 @@
+```csharp
+siloBuilder.AddChronicleToSilo(chronicle => chronicle.WithInMemory());
+```

--- a/Documentation/hosting/configuration/compliance-storage.md
+++ b/Documentation/hosting/configuration/compliance-storage.md
@@ -2,7 +2,7 @@
 
 Chronicle stores encryption keys alongside the rest of your application data by default. When you configure a dedicated compliance storage, those keys are stored in a separate, independently secured backend — such as HashiCorp Vault — so that key material never resides in the same database as the encrypted events.
 
-If no compliance storage is explicitly configured, Chronicle uses the general [storage](storage.md) backend for encryption keys.
+If no compliance storage is explicitly configured, Chronicle uses the general [storage](storage) backend for encryption keys.
 
 ## Configuration
 

--- a/Documentation/hosting/configuration/index.md
+++ b/Documentation/hosting/configuration/index.md
@@ -31,7 +31,7 @@ Chronicle Server can be configured using a `chronicle.json` file or environment 
 - [Configuration File](configuration-file.md) - Structure and location of `chronicle.json`.
 - [Root Properties](root-properties.md) - Ports and health check settings.
 - [Features](features.md) - Toggle API, Workbench, and OAuth authority.
-- [Storage](storage.md) - Configure the storage provider and connection details.
+- [Storage](storage) - Configure the storage provider and connection details.
 - [Observers](observers.md) - Retry and timeout settings for observer subscriptions.
 - [Read Models](read-models.md) - Configure replay retention for replay-generated read model versions.
 - [Events](events.md) - Configure event queues.

--- a/Documentation/hosting/configuration/storage.mdx
+++ b/Documentation/hosting/configuration/storage.mdx
@@ -73,9 +73,7 @@ The in-memory backend keeps every event sequence, observer, read-model sink, and
 
 When you host Chronicle programmatically, select the in-memory backend with the `WithInMemory()` builder extension instead of configuration:
 
-```csharp
-siloBuilder.AddChronicleToSilo(chronicle => chronicle.WithInMemory());
-```
+<ChronicleClientTabs snippet="hosting/configuration/storage/in-memory" />
 
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/Documentation/hosting/configuration/toc.yml
+++ b/Documentation/hosting/configuration/toc.yml
@@ -7,7 +7,7 @@
 - name: Features
   href: features.md
 - name: Storage
-  href: storage.md
+  href: storage.mdx
 - name: Compliance Storage
   href: compliance-storage.md
 - name: Clustering

--- a/Documentation/validate-client-snippets.py
+++ b/Documentation/validate-client-snippets.py
@@ -78,6 +78,9 @@ BODY_SNIPPETS = {
         ISiloBuilder siloBuilder = default!;
         KernelStorageSql::Cratis.Chronicle.Configuration.ChronicleOptions options = new();
     """,
+    "hosting/configuration/storage/in-memory": """
+        ISiloBuilder siloBuilder = default!;
+    """,
 }
 
 # Declaration-style snippets that need a namespace wrapper with aliases for Kernel-only
@@ -275,6 +278,9 @@ def generate_project() -> str:
             <Aliases>KernelStorageSql</Aliases>
         </ProjectReference>
         <ProjectReference Include="../../Source/Kernel/Storage.Sql/Storage.Sql.csproj">
+            <Aliases>KernelStorageSql</Aliases>
+        </ProjectReference>
+        <ProjectReference Include="../../Source/Kernel/Storage.InMemory/Storage.InMemory.csproj">
             <Aliases>KernelStorageSql</Aliases>
         </ProjectReference>
         <PackageReference Include="MongoDB.Driver" />


### PR DESCRIPTION
# Summary

The shared storage configuration page carried a direct C# code fence for the `WithInMemory()` hosting example, which fails the Documentation site's strict chronicle-client-docs audit — shared Chronicle pages must stay language neutral and render client code through synchronized client tabs. This broke the Documentation site build.

## Fixed

- Documentation site build failure caused by the in-memory storage example on the storage configuration page — the example now renders through the synchronized client tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)