### PR TITLE
Fix .NET NuGet pack failing on net8/9 targets

### DIFF
--- a/Source/Clients/DotNET/DotNET.csproj
+++ b/Source/Clients/DotNET/DotNET.csproj
@@ -3,6 +3,10 @@
         <AssemblyName>Cratis.Chronicle</AssemblyName>
         <RootNamespace>Cratis.Chronicle</RootNamespace>
         <ContractsImplementationAssembly>Cratis.Chronicle.Contracts.Implementations</ContractsImplementationAssembly>
+        <!-- The net8.0/net9.0 analyzers raise IDE0301 on `FrozenDictionary<K,V>.Empty` and suggest `[]`,
+             which does not compile for FrozenDictionary (CS0144). Only surfaces when `dotnet pack`
+             builds the down-level targets (regular builds are net10.0), so suppress it here. -->
+        <NoWarn>$(NoWarn);IDE0301</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Fixed

- The .NET client NuGet packages now build for the net8.0 and net9.0 targets again, so the packages publish with the release
