### PR TITLE
Give Kotlin compile daemon enough heap to build generated contracts

### DIFF
--- a/.github/workflows/kotlin-build.yml
+++ b/.github/workflows/kotlin-build.yml
@@ -1,0 +1,65 @@
+---
+name: Kotlin Build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_VERSION: "10.0.x"
+
+"on":
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "Source/Clients/Kotlin/**"
+      - "Source/Kernel/Contracts/**"
+      - "Source/Kernel/Protobuf/**"
+      - "Source/Tools/ProtoGenerator/**"
+
+jobs:
+  kotlin-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build Contracts
+        working-directory: ./Source/Kernel/Contracts
+        run: dotnet build -c Release
+
+      - name: Generate proto files
+        run: |
+          CONTRACTS_DLL="Source/Kernel/Contracts/bin/Release/net10.0/Cratis.Chronicle.Contracts.dll"
+          dotnet run \
+            --project Source/Tools/ProtoGenerator/ProtoGenerator.csproj -- \
+            "$CONTRACTS_DLL" \
+            Source/Kernel/Protobuf
+
+      - name: Copy proto files into Kotlin project
+        run: |
+          mkdir -p Source/Clients/Kotlin/src/main/proto
+          cp -r Source/Kernel/Protobuf/* Source/Clients/Kotlin/src/main/proto/
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Compile Kotlin client
+        working-directory: ./Source/Clients/Kotlin
+        run: gradle compileKotlin --no-configuration-cache

--- a/Source/Clients/Kotlin/gradle.properties
+++ b/Source/Clients/Kotlin/gradle.properties
@@ -1,0 +1,6 @@
+# The Kotlin compile daemon ran out of heap performing IR lowering over the large
+# protobuf/gRPC generated sources, failing :compileKotlin with
+# "OutOfMemoryError: GC overhead limit exceeded". Give both the Gradle daemon and
+# the Kotlin compile daemon enough heap to compile the generated contracts.
+org.gradle.jvmargs=-Xmx4g
+kotlin.daemon.jvmargs=-Xmx4g


### PR DESCRIPTION
# Summary

The Kotlin client failed to publish because `:compileKotlin` ran out of heap on the large generated protobuf/gRPC sources; this raises the Gradle and Kotlin daemon heaps.

## Fixed

- Kotlin client now publishes to Maven Central without the compiler running out of memory on the generated contracts.