### PR TITLE
Replace raw C# fence in reactor scenario docs with a client snippet

### DIFF
--- a/Documentation/client-snippets/testing/reactors/scenario/services.md
+++ b/Documentation/client-snippets/testing/reactors/scenario/services.md
@@ -1,0 +1,38 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.Testing.Reactors;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+[EventType]
+public record TestingReactorScenarioServicesBookingCancelled(string BookingId);
+
+public interface ITestingReactorScenarioServicesNotifications
+{
+    Task Notify(string message);
+}
+
+public class TestingReactorScenarioServicesCancellationReactor(ITestingReactorScenarioServicesNotifications notifications) : IReactor
+{
+    public Task BookingCancelled(TestingReactorScenarioServicesBookingCancelled @event, EventContext context) =>
+        notifications.Notify($"Booking {@event.BookingId} was cancelled.");
+}
+
+public static class TestingReactorScenarioServices
+{
+    public static async Task Run()
+    {
+        var notifications = Substitute.For<ITestingReactorScenarioServicesNotifications>();
+
+        var scenario = new ReactorScenario<TestingReactorScenarioServicesCancellationReactor>();
+        scenario.Services.AddSingleton(notifications);
+
+        await scenario.Given
+            .ForEventSource("booking-123")
+            .Events(new TestingReactorScenarioServicesBookingCancelled("booking-123"));
+
+        await notifications.Received(1).Notify("Booking booking-123 was cancelled.");
+    }
+}
+```

--- a/Documentation/testing/reactors/scenario.mdx
+++ b/Documentation/testing/reactors/scenario.mdx
@@ -47,10 +47,7 @@ dotnet add package Cratis.Chronicle.Testing
 
 Register the mocks and stubs the reactor depends on through the scenario's `Services` collection — the same `IServiceCollection` you use to configure an application. Logging is registered for you, so a reactor that injects `ILogger<T>` activates without any extra setup:
 
-```csharp
-var scenario = new ReactorScenario<CancellationReactor>();
-scenario.Services.AddSingleton(notificationServiceMock);
-```
+<ChronicleClientTabs snippet="testing/reactors/scenario/services" />
 
 `Services` resolves both the reactor's constructor dependencies and any service-typed handler-method parameters. If a dependency is missing, the scenario throws `CannotActivateReactorForScenario`, naming the type it could not resolve.
 


### PR DESCRIPTION
## Fixed

- The reactor testing scenario documentation page carried a raw `csharp` code fence in the "Injecting dependencies" section, which the strict client-docs audit rejects (shared Chronicle docs must route client-language code through `ChronicleClientTabs` snippets so it renders per client SDK). The example is now a compile-validated snippet, so the docs site build passes again.