### PR TITLE
Serve the Workbench UI from the web root when it is not embedded

### DIFF
--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/given/a_file_provider.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/given/a_file_provider.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.given;
+
+/// <summary>
+/// An <see cref="IFileProvider"/> holding exactly the files it is given, so specs can express what each
+/// candidate location does and does not contain without touching the file system.
+/// </summary>
+/// <param name="files">The files the provider holds.</param>
+public class a_file_provider(params string[] files) : IFileProvider
+{
+    public static a_file_provider Empty() => new();
+
+    public IDirectoryContents GetDirectoryContents(string subpath) => NotFoundDirectoryContents.Singleton;
+
+    public IFileInfo GetFileInfo(string subpath) =>
+        files.Contains(subpath) ? new an_existing_file(subpath) : new NotFoundFileInfo(subpath);
+
+    public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/given/an_existing_file.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/given/an_existing_file.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.given;
+
+/// <summary>
+/// An <see cref="IFileInfo"/> for a file that exists - the counterpart to <see cref="NotFoundFileInfo"/>,
+/// carrying only what resolution looks at.
+/// </summary>
+/// <param name="name">The name of the file.</param>
+public class an_existing_file(string name) : IFileInfo
+{
+    public bool Exists => true;
+
+    public bool IsDirectory => false;
+
+    public DateTimeOffset LastModified => DateTimeOffset.MinValue;
+
+    public long Length => 0;
+
+    public string Name => name;
+
+    public string? PhysicalPath => null;
+
+    public Stream CreateReadStream() => new MemoryStream();
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_an_embedded_provider_holds_no_ui.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_an_embedded_provider_holds_no_ui.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving;
+
+/// <summary>
+/// An assembly can carry an embedded files manifest for reasons of its own, so a provider being resolvable
+/// is not evidence that it holds the UI - only the entry point is.
+/// </summary>
+public class and_an_embedded_provider_holds_no_ui : Specification
+{
+    given.a_file_provider _webRoot;
+    IFileProvider? _result;
+
+    void Establish() => _webRoot = new(WorkbenchUI.EntryPoint);
+
+    void Because() => _result = WorkbenchUI.Resolve(new given.a_file_provider("something-else.js"), _webRoot);
+
+    [Fact] void should_serve_from_the_web_root_provider() => _result.ShouldEqual(_webRoot);
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_both_embedded_and_in_the_web_root.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_both_embedded_and_in_the_web_root.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving;
+
+public class and_the_ui_is_both_embedded_and_in_the_web_root : Specification
+{
+    const string EmbeddedOnlyFile = "embedded-only.js";
+    const string WebRootOnlyFile = "web-root-only.js";
+
+    IFileProvider? _result;
+
+    void Because() => _result = WorkbenchUI.Resolve(
+        new given.a_file_provider(WorkbenchUI.EntryPoint, EmbeddedOnlyFile),
+        new given.a_file_provider(WorkbenchUI.EntryPoint, WebRootOnlyFile));
+
+    [Fact] void should_serve_the_entry_point() => _result!.GetFileInfo(WorkbenchUI.EntryPoint).Exists.ShouldBeTrue();
+    [Fact] void should_serve_files_only_the_embedded_provider_holds() => _result!.GetFileInfo(EmbeddedOnlyFile).Exists.ShouldBeTrue();
+    [Fact] void should_serve_files_only_the_web_root_provider_holds() => _result!.GetFileInfo(WebRootOnlyFile).Exists.ShouldBeTrue();
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_nowhere.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_nowhere.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving;
+
+/// <summary>
+/// A Kernel-only deployment ships no Workbench at all - that is a supported shape, not a failure, so
+/// resolution reports the absence and the caller keeps the server running without the UI.
+/// </summary>
+public class and_the_ui_is_nowhere : Specification
+{
+    IFileProvider? _result;
+
+    void Because() => _result = WorkbenchUI.Resolve(null, given.a_file_provider.Empty());
+
+    [Fact] void should_not_resolve_a_provider() => _result.ShouldBeNull();
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_only_embedded.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_only_embedded.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving;
+
+public class and_the_ui_is_only_embedded : Specification
+{
+    given.a_file_provider _embedded;
+    IFileProvider? _result;
+
+    void Establish() => _embedded = new(WorkbenchUI.EntryPoint);
+
+    void Because() => _result = WorkbenchUI.Resolve(_embedded, given.a_file_provider.Empty());
+
+    [Fact] void should_serve_from_the_embedded_provider() => _result.ShouldEqual(_embedded);
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_only_in_the_web_root.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving/and_the_ui_is_only_in_the_web_root.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving;
+
+/// <summary>
+/// The shape every container image has: the Kernel binary is published without the frontend output, so
+/// nothing is embedded, and the image ships the built UI as files in the web root instead.
+/// </summary>
+public class and_the_ui_is_only_in_the_web_root : Specification
+{
+    given.a_file_provider _webRoot;
+    IFileProvider? _result;
+
+    void Establish() => _webRoot = new(WorkbenchUI.EntryPoint);
+
+    void Because() => _result = WorkbenchUI.Resolve(null, _webRoot);
+
+    [Fact] void should_serve_from_the_web_root_provider() => _result.ShouldEqual(_webRoot);
+}

--- a/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving_embedded/and_the_assembly_has_nothing_embedded.cs
+++ b/Source/Kernel/Server.Specs/for_WorkbenchUI/when_resolving_embedded/and_the_assembly_has_nothing_embedded.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server.for_WorkbenchUI.when_resolving_embedded;
+
+/// <summary>
+/// Constructing a <see cref="ManifestEmbeddedFileProvider"/> over an assembly without an embedded files
+/// manifest throws, so the absence has to be detected up front rather than caught.
+/// </summary>
+public class and_the_assembly_has_nothing_embedded : Specification
+{
+    IFileProvider? _result;
+
+    void Because() => _result = WorkbenchUI.ResolveEmbedded(typeof(and_the_assembly_has_nothing_embedded).Assembly, "Whatever.Files");
+
+    [Fact] void should_not_resolve_a_provider() => _result.ShouldBeNull();
+}

--- a/Source/Kernel/Server/KernelLogMessages.cs
+++ b/Source/Kernel/Server/KernelLogMessages.cs
@@ -32,8 +32,8 @@ internal static partial class KernelLogMessages
     [LoggerMessage(LogLevel.Information, "Shutdown signal received. Chronicle Server is shutting down...")]
     internal static partial void ServerShuttingDown(this ILogger<Kernel> logger);
 
-    [LoggerMessage(LogLevel.Warning, "The Workbench feature is enabled but the Workbench UI is not embedded in this build - the server runs without serving the Workbench UI")]
-    internal static partial void WorkbenchUINotEmbedded(this ILogger<Kernel> logger);
+    [LoggerMessage(LogLevel.Warning, "The Workbench feature is enabled but the Workbench UI was not found - it is neither embedded in this build nor present in the web root '{WebRoot}' - the server runs without serving the Workbench UI")]
+    internal static partial void WorkbenchUINotAvailable(this ILogger<Kernel> logger, string webRoot);
 
     [LoggerMessage(LogLevel.Critical, "Unhandled exception occurred (terminating: {IsTerminating})")]
     internal static partial void UnhandledException(this ILogger<Kernel> logger, Exception exception, bool isTerminating);

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -17,7 +17,6 @@ using Cratis.Chronicle.Workbench;
 using Cratis.DependencyInjection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.Extensions.FileProviders;
 using ProtoBuf.Grpc.Configuration;
 using ProtoBuf.Grpc.Server;
 
@@ -280,17 +279,18 @@ app.UseRouting();
 
 app.UseCratisArc();
 
-// The Workbench UI is built once and embedded into Cratis.Chronicle.Workbench - the kernel serves
-// that same embedded asset set directly rather than expecting its own physical wwwroot. The
-// embedded manifest only exists when the frontend was built before the Workbench assembly - a
-// source build without the frontend output skips embedding entirely, and the kernel must keep
-// running without the UI rather than fail at startup.
+// The Workbench UI is built once and reaches a deployment either embedded into
+// Cratis.Chronicle.Workbench or as files in the web root next to the binary - see WorkbenchUI for
+// why both exist. Serve whichever is present, and keep running without the UI when neither is:
+// a Kernel-only deployment legitimately ships no Workbench.
 var workbenchAssembly = typeof(WorkbenchWebApplicationBuilderExtensions).Assembly;
-var hasWorkbenchUI = workbenchAssembly.GetManifestResourceNames().Contains("Microsoft.Extensions.FileProviders.Embedded.Manifest.xml");
-var serveWorkbench = chronicleOptions.Features.Workbench && chronicleOptions.Features.Api && hasWorkbenchUI;
-if (chronicleOptions.Features.Workbench && !hasWorkbenchUI)
+var workbenchFileProvider = WorkbenchUI.Resolve(
+    WorkbenchUI.ResolveEmbedded(workbenchAssembly, $"{typeof(WorkbenchWebApplicationBuilderExtensions).Namespace}.Files"),
+    app.Environment.WebRootFileProvider);
+var serveWorkbench = chronicleOptions.Features.Workbench && chronicleOptions.Features.Api && workbenchFileProvider is not null;
+if (chronicleOptions.Features.Workbench && workbenchFileProvider is null)
 {
-    logger.WorkbenchUINotEmbedded();
+    logger.WorkbenchUINotAvailable(app.Environment.WebRootPath ?? "<not set>");
 }
 
 var workbenchStaticFileOptions = new StaticFileOptions();
@@ -298,9 +298,6 @@ var workbenchStaticFileOptions = new StaticFileOptions();
 // Map workbench static files BEFORE authentication so they are publicly accessible
 if (serveWorkbench)
 {
-    var workbenchFileProvider = new ManifestEmbeddedFileProvider(
-        workbenchAssembly,
-        $"{typeof(WorkbenchWebApplicationBuilderExtensions).Namespace}.Files");
     workbenchStaticFileOptions = new StaticFileOptions { FileProvider = workbenchFileProvider };
     app.UseDefaultFiles(new DefaultFilesOptions { FileProvider = workbenchFileProvider });
     app.UseStaticFiles(workbenchStaticFileOptions);
@@ -368,7 +365,7 @@ app.MapPost(
 // Map workbench fallback route AFTER API endpoints to avoid conflicts
 if (serveWorkbench)
 {
-    app.MapFallbackToFile("index.html", workbenchStaticFileOptions).AllowAnonymous();
+    app.MapFallbackToFile(WorkbenchUI.EntryPoint, workbenchStaticFileOptions).AllowAnonymous();
 }
 
 using var cancellationToken = new CancellationTokenSource();

--- a/Source/Kernel/Server/WorkbenchUI.cs
+++ b/Source/Kernel/Server/WorkbenchUI.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.Extensions.FileProviders;
+
+namespace Cratis.Chronicle.Server;
+
+/// <summary>
+/// Represents the resolution of where the Workbench UI assets are served from.
+/// </summary>
+/// <remarks>
+/// The Workbench UI reaches a deployment in one of two ways, and the Kernel serves whichever is present:
+/// embedded into the Cratis.Chronicle.Workbench assembly - which only happens when the frontend output
+/// existed when that assembly was compiled - or as files in the web root next to the binary, which is how
+/// the container images ship it. Neither is guaranteed: a Kernel-only deployment has no Workbench UI at
+/// all, so resolution reports the absence instead of failing and the server keeps running without the UI.
+/// </remarks>
+public static class WorkbenchUI
+{
+    /// <summary>
+    /// The file the Workbench UI is entered through.
+    /// </summary>
+    /// <remarks>
+    /// Doubles as the marker for whether a file provider actually holds the UI - the providers considered
+    /// here exist for other reasons too, so their mere presence says nothing.
+    /// </remarks>
+    public const string EntryPoint = "index.html";
+
+    const string EmbeddedManifestResourceName = "Microsoft.Extensions.FileProviders.Embedded.Manifest.xml";
+
+    /// <summary>
+    /// Resolve the <see cref="IFileProvider"/> for the Workbench UI embedded into an assembly.
+    /// </summary>
+    /// <param name="workbenchAssembly">The <see cref="Assembly"/> the Workbench UI can be embedded into.</param>
+    /// <param name="filesRoot">The root the Workbench UI files are embedded under.</param>
+    /// <returns>The <see cref="IFileProvider"/> for the embedded UI, or null when this build has none embedded.</returns>
+    public static IFileProvider? ResolveEmbedded(Assembly workbenchAssembly, string filesRoot)
+    {
+        // ManifestEmbeddedFileProvider throws when the assembly carries no manifest, which is exactly what
+        // a build that did not have the frontend output available produces - so check before constructing.
+        if (!workbenchAssembly.GetManifestResourceNames().Contains(EmbeddedManifestResourceName))
+        {
+            return null;
+        }
+
+        return new ManifestEmbeddedFileProvider(workbenchAssembly, filesRoot);
+    }
+
+    /// <summary>
+    /// Resolve the <see cref="IFileProvider"/> to serve the Workbench UI from.
+    /// </summary>
+    /// <param name="embedded">The <see cref="IFileProvider"/> for the embedded UI, or null when nothing is embedded.</param>
+    /// <param name="webRoot">The <see cref="IFileProvider"/> for the web root the UI can be deployed to.</param>
+    /// <returns>The <see cref="IFileProvider"/> to serve from, or null when the UI is not part of this deployment.</returns>
+    public static IFileProvider? Resolve(IFileProvider? embedded, IFileProvider webRoot)
+    {
+        var candidates = new[] { embedded, webRoot }
+            .Where(candidate => candidate is not null && Holds(candidate))
+            .Select(candidate => candidate!)
+            .ToArray();
+
+        return candidates.Length switch
+        {
+            0 => null,
+            1 => candidates[0],
+            _ => new CompositeFileProvider(candidates)
+        };
+    }
+
+    static bool Holds(IFileProvider provider) => provider.GetFileInfo(EntryPoint).Exists;
+}


### PR DESCRIPTION
# Summary

The Workbench UI has been unreachable in every published container image since 16.3.0.

## Changed

- The Kernel serves the Workbench UI from the web root next to the binary as well as from the copy embedded in `Cratis.Chronicle.Workbench`, using whichever is present
- The warning logged when no Workbench UI can be found now names the web root that was checked

## Fixed

- The Workbench UI is reachable again in the published container images - `https://localhost:35000` serves the Workbench instead of returning 401
