### PR TITLE
Fix PR prerelease workflow that never ran a job

### DIFF
--- a/.github/workflows/grpc-compatibility.yml
+++ b/.github/workflows/grpc-compatibility.yml
@@ -1,7 +1,11 @@
 name: gRPC Contract Compatibility
 
+# Scoped to this workflow by name rather than `github.workflow`. In a called
+# reusable workflow `github.workflow` resolves to the *caller*, so the generic
+# form produced a group identical to the caller's and the two runs contended
+# for the same slot.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: grpc-compatibility-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -44,10 +48,14 @@ jobs:
         with:
           path: current
 
+      # The `inputs` context is only populated for workflow_call, so on a plain
+      # pull_request `inputs.base-ref` was empty and checkout fell back to the
+      # triggering ref -- making the baseline identical to the current tree and
+      # the comparison below unable to report a breaking change.
       - name: Checkout base code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base-ref }}
+          ref: ${{ inputs.base-ref || github.event.pull_request.base.ref || 'main' }}
           path: baseline
 
       - name: Setup .NET

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -14,8 +14,10 @@ env:
   WORKBENCH_CACHE: "web-cache-${{ github.sha }}"
 
 on:
+  # `edited` is deliberately absent: it fires on every PR title/description
+  # edit, which re-ran this whole prerelease pipeline for a text change.
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     branches:
       - "**"
     paths:
@@ -23,34 +25,8 @@ on:
       - ".github/workflows/**"
 
 jobs:
-  grpc-compatibility:
-    permissions:
-      contents: read
-    uses: ./.github/workflows/grpc-compatibility.yml
-    with:
-      base-ref: ${{ github.event.pull_request.base.ref }}
-
-  update-pr-with-breaking-changes:
-    runs-on: ubuntu-latest
-    needs: [grpc-compatibility]
-    if: needs.grpc-compatibility.outputs.has-breaking-changes == 'true'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Update PR description
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          .github/scripts/update-pr-description.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ needs.grpc-compatibility.outputs.breaking-changes }}"
-
   release:
     runs-on: ubuntu-latest
-    needs: [grpc-compatibility]
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -81,7 +57,7 @@ jobs:
             ${{ env.DOTNET9_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-output
         with:
           path: ./Source/Kernel/Server/out
@@ -108,7 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
@@ -116,7 +92,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -124,7 +100,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |
@@ -163,7 +139,7 @@ jobs:
             ${{ env.DOTNET9_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-dev-output
         with:
           path: ./Source/Kernel/Server/out/development
@@ -197,7 +173,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
@@ -249,22 +225,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-output
         with:
           path: ./Source/Kernel/Server/out
           key: ${{ env.KERNEL_CACHE }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
           key: ${{ env.WORKBENCH_CACHE }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
 
       - name: Download development outputs
         uses: actions/download-artifact@v4
@@ -298,7 +269,10 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Docker/Development/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # amd64 only for PR prereleases. arm64 has to be emulated through
+          # QEMU on GitHub-hosted runners, which dominated this job's runtime;
+          # the release build in publish.yml still ships both architectures.
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/cratis/chronicle:${{ needs.release.outputs.version }}


### PR DESCRIPTION
## Changed

- PR prerelease Docker images are built for `linux/amd64` only. Releases still ship both architectures.
- The PR prerelease pipeline no longer re-runs when a pull request title or description is edited.

## Fixed

- PR prerelease NuGet packages and Docker images are published again. Nothing had been published since 2026-04-19.
- gRPC contract compatibility is compared against the pull request's base branch instead of against the pull request itself, so breaking changes are reported again.

## Removed

- Automatic pull request description updates for detected gRPC breaking changes.
