### PR TITLE
Cover one storage backend per pull request, all of them nightly

### DIFF
--- a/.github/scripts/generate-integration-matrix.py
+++ b/.github/scripts/generate-integration-matrix.py
@@ -2,14 +2,18 @@
 """Generate the GitHub Actions matrix for the client integration specs.
 
 Every client integration namespace -- a directory under ``Integration/Client``
-that contains ``[Fact]`` tests -- runs against every infrastructure
-configuration (runtime mode x storage backend). Large namespaces are split
+that contains ``[Fact]`` tests -- runs against a set of infrastructure
+configurations (runtime mode x storage backend). Large namespaces are split
 into several shards that run as separate, parallel jobs so the slowest single
 job no longer gates the whole workflow.
 
 Sharding only changes how the work is distributed: every shard of a namespace
 together covers exactly the same tests as the un-sharded namespace would, so
-coverage across all five infrastructure configurations is preserved.
+coverage across the selected infrastructure configurations is preserved.
+
+Which configurations are selected depends on ``--all-providers``. Pull requests
+run the default backend only; the nightly schedule and manual dispatch run all
+of them.
 
 Balancing is by ``[Fact]`` count across test classes. Each spec file declares
 the facts on its first top-level class, so a shard targets a class with
@@ -20,6 +24,7 @@ a dotted ancestor of another, e.g. a genuine nested type, is folded into the
 same shard so the substring filter still owns it exactly once.)
 """
 
+import argparse
 import json
 import os
 import re
@@ -48,6 +53,13 @@ INFRA_CONFIGS = [
     ("outofprocess", "postgresql", True),
     ("outofprocess", "mssql", True),
 ]
+
+# Storage backends covered on every pull request. Running all five backends per
+# PR meant each shard was built and started five times over, and the four
+# non-default backends re-verified storage-provider behavior that the change
+# under review usually does not touch. The full set still runs on the nightly
+# schedule and on demand -- see --all-providers.
+DEFAULT_DATABASES = {"mongodb"}
 
 _NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z0-9_.]+)", re.MULTILINE)
 # A top-level type declaration starts at column 0 (no leading whitespace). The
@@ -146,11 +158,26 @@ def _shards_for(namespace):
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--all-providers",
+        action="store_true",
+        help="Include every storage backend. Without it only the backends in "
+        "DEFAULT_DATABASES are included, which is what pull requests run.",
+    )
+    args = parser.parse_args()
+
+    configs = [
+        config
+        for config in INFRA_CONFIGS
+        if args.all_providers or config[1] in DEFAULT_DATABASES
+    ]
+
     include = []
     for namespace in _namespaces_with_facts():
         fully_qualified = NAMESPACE_PREFIX + namespace
         for shard_label, test_filter in _shards_for(namespace):
-            for mode, database, needs_docker in INFRA_CONFIGS:
+            for mode, database, needs_docker in configs:
                 include.append(
                     {
                         "namespace": fully_qualified,

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -15,6 +15,10 @@ env:
 
 on:
   workflow_dispatch:
+  # Nightly full-coverage run. Pull requests cover the default storage backend
+  # only, so this is where sqlite, postgresql and mssql get exercised.
+  schedule:
+    - cron: "0 2 * * *"
   pull_request:
     branches:
       - "**"
@@ -209,6 +213,9 @@ jobs:
       # the Docker image still comes from dotnet-build.
       dotnet-cache-key: ${{ needs.dotnet-build-development.outputs.dotnet-cache-key }}
       chronicle-image: ${{ needs.dotnet-build.outputs.chronicle-image }}
+      # Every storage backend on the nightly schedule and on manual dispatch;
+      # pull requests run the default backend only.
+      all-providers: ${{ github.event_name != 'pull_request' }}
 
   integration-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,11 @@ on:
         description: "Chronicle Docker image to use for out-of-process tests"
         required: true
         type: string
+      all-providers:
+        description: "Run every storage backend rather than just the default one"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   discover:
@@ -24,14 +29,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Each client namespace runs against all five infrastructure configs;
+      # Each client namespace runs against the selected infrastructure configs;
       # large namespaces are additionally split into parallel shards so the
       # slowest single job no longer gates the whole run. The shard set covers
       # exactly the same tests as the un-sharded namespace -- see the script.
+      # Pull requests cover the default backend; the nightly schedule and
+      # manual dispatch pass all-providers to cover every backend.
       - name: Discover Client integration namespaces
         id: client
         run: |
-          echo "matrix=$(python3 .github/scripts/generate-integration-matrix.py)" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(python3 .github/scripts/generate-integration-matrix.py ${ALL_PROVIDERS:+--all-providers})" >> "$GITHUB_OUTPUT"
+        env:
+          ALL_PROVIDERS: ${{ inputs.all-providers && 'true' || '' }}
 
       - name: Discover Kernel integration namespaces
         id: kernel


### PR DESCRIPTION
## Added

- A nightly scheduled run of .NET Build & Integration covering every storage backend.

## Changed

- Client integration specs cover MongoDB in-process and out-of-process on pull requests. SQLite, PostgreSQL and SQL Server coverage moves to the nightly run and to manual dispatch.
