### PR TITLE
Upgrade actions/cache from v3 to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,7 +233,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |

--- a/.github/workflows/workbench-build.yml
+++ b/.github/workflows/workbench-build.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |


### PR DESCRIPTION
## Changed

- Continuous integration caching uses `actions/cache@v4`.
