### PR TITLE
Reduce CI compute and fix the dead PR prerelease pipeline

### DIFF
--- a/.github/scripts/generate-integration-matrix.py
+++ b/.github/scripts/generate-integration-matrix.py
@@ -2,14 +2,18 @@
 """Generate the GitHub Actions matrix for the client integration specs.
 
 Every client integration namespace -- a directory under ``Integration/Client``
-that contains ``[Fact]`` tests -- runs against every infrastructure
-configuration (runtime mode x storage backend). Large namespaces are split
+that contains ``[Fact]`` tests -- runs against a set of infrastructure
+configurations (runtime mode x storage backend). Large namespaces are split
 into several shards that run as separate, parallel jobs so the slowest single
 job no longer gates the whole workflow.
 
 Sharding only changes how the work is distributed: every shard of a namespace
 together covers exactly the same tests as the un-sharded namespace would, so
-coverage across all five infrastructure configurations is preserved.
+coverage across the selected infrastructure configurations is preserved.
+
+Which configurations are selected depends on ``--all-providers``. Pull requests
+run the default backend only; the nightly schedule and manual dispatch run all
+of them.
 
 Balancing is by ``[Fact]`` count across test classes. Each spec file declares
 the facts on its first top-level class, so a shard targets a class with
@@ -20,6 +24,7 @@ a dotted ancestor of another, e.g. a genuine nested type, is folded into the
 same shard so the substring filter still owns it exactly once.)
 """
 
+import argparse
 import json
 import os
 import re
@@ -48,6 +53,13 @@ INFRA_CONFIGS = [
     ("outofprocess", "postgresql", True),
     ("outofprocess", "mssql", True),
 ]
+
+# Storage backends covered on every pull request. Running all five backends per
+# PR meant each shard was built and started five times over, and the four
+# non-default backends re-verified storage-provider behavior that the change
+# under review usually does not touch. The full set still runs on the nightly
+# schedule and on demand -- see --all-providers.
+DEFAULT_DATABASES = {"mongodb"}
 
 _NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z0-9_.]+)", re.MULTILINE)
 # A top-level type declaration starts at column 0 (no leading whitespace). The
@@ -146,11 +158,26 @@ def _shards_for(namespace):
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--all-providers",
+        action="store_true",
+        help="Include every storage backend. Without it only the backends in "
+        "DEFAULT_DATABASES are included, which is what pull requests run.",
+    )
+    args = parser.parse_args()
+
+    configs = [
+        config
+        for config in INFRA_CONFIGS
+        if args.all_providers or config[1] in DEFAULT_DATABASES
+    ]
+
     include = []
     for namespace in _namespaces_with_facts():
         fully_qualified = NAMESPACE_PREFIX + namespace
         for shard_label, test_filter in _shards_for(namespace):
-            for mode, database, needs_docker in INFRA_CONFIGS:
+            for mode, database, needs_docker in configs:
                 include.append(
                     {
                         "namespace": fully_qualified,

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,9 +3,13 @@ name: Benchmarks
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+# Benchmarks on pull requests are covered by the `benchmarks` job in
+# dotnet-build.yml, which reuses that workflow's cached build instead of
+# compiling again from scratch. This workflow tracks the series on main,
+# where its cache key also lines up with the one publish.yml restores.
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
     paths:
@@ -13,7 +17,9 @@ on:
       - 'Source/**'
 
 permissions:
-  contents: read
+  # `comment-on-alert` posts a commit comment on push events (it posts a PR
+  # comment on pull_request), and that needs contents: write.
+  contents: write
   deployments: write
   pull-requests: write
 

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -15,6 +15,10 @@ env:
 
 on:
   workflow_dispatch:
+  # Nightly full-coverage run. Pull requests cover the default storage backend
+  # only, so this is where sqlite, postgresql and mssql get exercised.
+  schedule:
+    - cron: "0 2 * * *"
   pull_request:
     branches:
       - "**"
@@ -209,6 +213,9 @@ jobs:
       # the Docker image still comes from dotnet-build.
       dotnet-cache-key: ${{ needs.dotnet-build-development.outputs.dotnet-cache-key }}
       chronicle-image: ${{ needs.dotnet-build.outputs.chronicle-image }}
+      # Every storage backend on the nightly schedule and on manual dispatch;
+      # pull requests run the default backend only.
+      all-providers: ${{ github.event_name != 'pull_request' }}
 
   integration-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/grpc-compatibility.yml
+++ b/.github/workflows/grpc-compatibility.yml
@@ -1,7 +1,11 @@
 name: gRPC Contract Compatibility
 
+# Scoped to this workflow by name rather than `github.workflow`. In a called
+# reusable workflow `github.workflow` resolves to the *caller*, so the generic
+# form produced a group identical to the caller's and the two runs contended
+# for the same slot.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: grpc-compatibility-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -44,10 +48,14 @@ jobs:
         with:
           path: current
 
+      # The `inputs` context is only populated for workflow_call, so on a plain
+      # pull_request `inputs.base-ref` was empty and checkout fell back to the
+      # triggering ref -- making the baseline identical to the current tree and
+      # the comparison below unable to report a breaking change.
       - name: Checkout base code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base-ref }}
+          ref: ${{ inputs.base-ref || github.event.pull_request.base.ref || 'main' }}
           path: baseline
 
       - name: Setup .NET

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,11 @@ on:
         description: "Chronicle Docker image to use for out-of-process tests"
         required: true
         type: string
+      all-providers:
+        description: "Run every storage backend rather than just the default one"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   discover:
@@ -24,14 +29,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Each client namespace runs against all five infrastructure configs;
+      # Each client namespace runs against the selected infrastructure configs;
       # large namespaces are additionally split into parallel shards so the
       # slowest single job no longer gates the whole run. The shard set covers
       # exactly the same tests as the un-sharded namespace -- see the script.
+      # Pull requests cover the default backend; the nightly schedule and
+      # manual dispatch pass all-providers to cover every backend.
       - name: Discover Client integration namespaces
         id: client
         run: |
-          echo "matrix=$(python3 .github/scripts/generate-integration-matrix.py)" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(python3 .github/scripts/generate-integration-matrix.py ${ALL_PROVIDERS:+--all-providers})" >> "$GITHUB_OUTPUT"
+        env:
+          ALL_PROVIDERS: ${{ inputs.all-providers && 'true' || '' }}
 
       - name: Discover Kernel integration namespaces
         id: kernel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,7 +233,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -14,8 +14,10 @@ env:
   WORKBENCH_CACHE: "web-cache-${{ github.sha }}"
 
 on:
+  # `edited` is deliberately absent: it fires on every PR title/description
+  # edit, which re-ran this whole prerelease pipeline for a text change.
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, synchronize, reopened]
     branches:
       - "**"
     paths:
@@ -23,34 +25,8 @@ on:
       - ".github/workflows/**"
 
 jobs:
-  grpc-compatibility:
-    permissions:
-      contents: read
-    uses: ./.github/workflows/grpc-compatibility.yml
-    with:
-      base-ref: ${{ github.event.pull_request.base.ref }}
-
-  update-pr-with-breaking-changes:
-    runs-on: ubuntu-latest
-    needs: [grpc-compatibility]
-    if: needs.grpc-compatibility.outputs.has-breaking-changes == 'true'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Update PR description
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          .github/scripts/update-pr-description.sh \
-            "${{ github.event.pull_request.number }}" \
-            "${{ needs.grpc-compatibility.outputs.breaking-changes }}"
-
   release:
     runs-on: ubuntu-latest
-    needs: [grpc-compatibility]
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -81,7 +57,7 @@ jobs:
             ${{ env.DOTNET9_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-output
         with:
           path: ./Source/Kernel/Server/out
@@ -108,7 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
@@ -116,7 +92,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -124,7 +100,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |
@@ -163,7 +139,7 @@ jobs:
             ${{ env.DOTNET9_VERSION }}
             ${{ env.DOTNET_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-dev-output
         with:
           path: ./Source/Kernel/Server/out/development
@@ -197,7 +173,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
@@ -249,22 +225,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: kernel-output
         with:
           path: ./Source/Kernel/Server/out
           key: ${{ env.KERNEL_CACHE }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: workbench-output
         with:
           path: ./Source/Workbench/wwwroot
           key: ${{ env.WORKBENCH_CACHE }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
 
       - name: Download development outputs
         uses: actions/download-artifact@v4
@@ -298,7 +269,10 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Docker/Development/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # amd64 only for PR prereleases. arm64 has to be emulated through
+          # QEMU on GitHub-hosted runners, which dominated this job's runtime;
+          # the release build in publish.yml still ships both architectures.
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/cratis/chronicle:${{ needs.release.outputs.version }}

--- a/.github/workflows/workbench-build.yml
+++ b/.github/workflows/workbench-build.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: |

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventSequenceStorage/given/a_replica_set_event_sequence_storage.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/for_EventSequenceStorage/given/a_replica_set_event_sequence_storage.cs
@@ -4,7 +4,6 @@
 using System.Dynamic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.EventTypes;
@@ -15,16 +14,12 @@ using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.Identities;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.for_EventSequenceStorage.given;
 
 public abstract class a_replica_set_event_sequence_storage(ReplicaSetMongoDBFixture fixture) : Specification
 {
-    static readonly object _registrationLock = new();
-    static bool _serializationRegistered;
-
     protected EventSequenceStorage _storage;
     protected EventType _eventType;
 
@@ -33,8 +28,6 @@ public abstract class a_replica_set_event_sequence_storage(ReplicaSetMongoDBFixt
 
     void Establish()
     {
-        EnsureBsonSerialization();
-
         _eventType = new EventType("some-event", EventTypeGeneration.First);
         _databaseName = $"chronicle_event_sequence_{Guid.NewGuid():N}";
         _client = new MongoClient(fixture.ConnectionString);
@@ -93,23 +86,4 @@ public abstract class a_replica_set_event_sequence_storage(ReplicaSetMongoDBFixt
         DateTimeOffset.UtcNow,
         new ExpandoObject(),
         EventHash.NotSet);
-
-    static void EnsureBsonSerialization()
-    {
-        lock (_registrationLock)
-        {
-            if (_serializationRegistered)
-            {
-                return;
-            }
-
-            BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-            if (!BsonClassMap.IsClassMapRegistered(typeof(Event)))
-            {
-                BsonClassMap.RegisterClassMap<Event>(classMap => new EventClassMap().Configure(classMap));
-            }
-
-            _serializationRegistered = true;
-        }
-    }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
@@ -21,11 +21,19 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// it, reading back any stored type that has no id member fails on the <c>_id</c> the server generated, which is a
 /// failure specs would see and production would not.
 /// </para>
+/// <para>
+/// The same reasoning applies to <see cref="EventClassMap"/>, which is what makes the event's sequence number the
+/// document <c>_id</c>. Any spec that merely renders a <c>Builders&lt;Event&gt;</c> expression — building an index
+/// key, for instance — makes the driver auto-register a default class map for <see cref="Event"/>, and a default
+/// map gives every appended event a generated <c>ObjectId</c> instead. Registering it lazily from a spec base
+/// therefore loses a race against unrelated spec classes running in parallel, silently dropping both the tail
+/// aggregation and the duplicate-sequence-number detection that depend on that mapping.
+/// </para>
 /// </remarks>
 internal static class SpecSerializationSetup
 {
     /// <summary>
-    /// Registers the server's MongoDB serialization conventions and providers.
+    /// Registers the server's MongoDB serialization conventions, providers and class maps.
     /// </summary>
     [ModuleInitializer]
     internal static void Initialize()
@@ -33,5 +41,6 @@ internal static class SpecSerializationSetup
         new ConventionPacks().Provide();
         ConventionRegistry.Register(Cratis.Arc.MongoDB.ConventionPacks.IgnoreExtraElements, new ConventionPack { new IgnoreExtraElementsConvention(true) }, _ => true);
         BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
+        BsonClassMap.RegisterClassMap<Event>(classMap => new EventClassMap().Configure(classMap));
     }
 }


### PR DESCRIPTION
## Added

- A nightly scheduled run of .NET Build & Integration covering every storage backend.

## Changed

- Client integration specs cover MongoDB in-process and out-of-process on pull requests. SQLite, PostgreSQL and SQL Server coverage moves to the nightly run and to manual dispatch.
- Benchmarks run on `main` rather than on every pull request. Pull request benchmarking is unchanged and still runs as part of .NET Build & Integration.
- PR prerelease Docker images are built for `linux/amd64` only. Releases still ship both architectures.
- The PR prerelease pipeline no longer re-runs when a pull request title or description is edited.

## Fixed

- PR prerelease NuGet packages and Docker images are published again. Nothing had been published since 2026-04-19.
- gRPC contract compatibility is compared against the pull request's base branch instead of against the pull request itself, so breaking changes are reported again.

## Removed

- Automatic pull request description updates for detected gRPC breaking changes.
