### PR TITLE
Log reducer failures on the client

### DIFF
--- a/Source/Clients/DotNET/Reducers/Reducers.cs
+++ b/Source/Clients/DotNET/Reducers/Reducers.cs
@@ -540,6 +540,11 @@ public class Reducers : IReducers
                 exceptionMessages = reduceResult.ErrorMessages;
                 exceptionStackTrace = reduceResult.StackTrace;
                 state = ObservationState.Failed;
+                _logger.ReducerFailed(
+                    handler.Id,
+                    appendedEvents[0].Context.SequenceNumber,
+                    appendedEvents[^1].Context.SequenceNumber,
+                    string.Join(Environment.NewLine, reduceResult.ErrorMessages));
             }
         }
         catch (Exception ex)

--- a/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
+++ b/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
@@ -19,6 +19,9 @@ internal static partial class ReducersLogMessages
     [LoggerMessage(LogLevel.Warning, "An error occurred while handling events with sequence number {StartSequenceNumber} to {EndSequenceNumber} was for Reducer {ReducerId}")]
     internal static partial void ErrorWhileHandlingEvents(this ILogger<Reducers> logger, Exception ex, EventSequenceNumber startSequenceNumber, EventSequenceNumber endSequenceNumber, ReducerId reducerId);
 
+    [LoggerMessage(LogLevel.Error, "Reducer {ReducerId} failed reducing events with sequence number {StartSequenceNumber} to {EndSequenceNumber}: {ErrorMessages}")]
+    internal static partial void ReducerFailed(this ILogger<Reducers> logger, ReducerId reducerId, EventSequenceNumber startSequenceNumber, EventSequenceNumber endSequenceNumber, string errorMessages);
+
     [LoggerMessage(LogLevel.Trace, "Handling of events received for Reducer {ReducerId} completed")]
     internal static partial void EventHandlingCompleted(this ILogger<Reducers> logger, ReducerId reducerId);
 


### PR DESCRIPTION
## Fixed

- Reducer failures are written to the client log. A reducer method that throws was reported to the kernel as a failed observation without ever appearing in the client's own log, so the only way to see why a reducer stopped was to inspect kernel-side observer state. (#1395)