### PR TITLE
Improve the diagnostic when compliance handling finds no schema for a property

### DIFF
--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_property_the_schema_does_not_declare.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_property_the_schema_does_not_declare.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+/// <summary>
+/// A stored document can carry a property its schema no longer declares — an event type that gained or renamed a
+/// property without a migration. The mismatch used to surface as a bare LINQ error naming nothing at all, so the
+/// diagnostic has to name the property, the subject, and what the schema does declare.
+/// </summary>
+public class when_releasing_a_property_the_schema_does_not_declare : given.a_value_handler_and_a_type_with_one_property
+{
+    const string Identifier = "request-42";
+    const string UnknownPropertyName = "propertyTheSchemaNeverHeardOf";
+
+    Exception _exception;
+
+    void Establish() => _input[UnknownPropertyName] = "some value";
+
+    async Task Because() => _exception = await Catch.Exception(() => _manager.Release(
+        EventStoreName.NotSet,
+        EventStoreNamespaceName.Default,
+        _schema,
+        Identifier,
+        _input));
+
+    [Fact] void should_fail_with_the_property_not_found_exception() => _exception.ShouldBeOfExactType<CompliancePropertyNotFoundInSchema>();
+
+    [Fact] void should_name_the_property_that_is_missing() => _exception.Message.ShouldContain(UnknownPropertyName);
+
+    [Fact] void should_name_the_subject_it_was_released_under() => _exception.Message.ShouldContain(Identifier);
+
+    [Fact] void should_name_the_action() => _exception.Message.ShouldContain(ComplianceMetadataActionFailed.ReleaseAction);
+
+    [Fact] void should_list_the_properties_the_schema_declares() => _exception.Message.ShouldContain(PropertyName);
+}

--- a/Source/Kernel/Core/Compliance/CompliancePropertyNotFoundInSchema.cs
+++ b/Source/Kernel/Core/Compliance/CompliancePropertyNotFoundInSchema.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Compliance;
+
+/// <summary>
+/// The exception that is thrown when a property in the JSON being handled has no matching property in the schema
+/// describing it.
+/// </summary>
+/// <remarks>
+/// Compliance handling walks the JSON document and looks every property up in the schema to find the compliance
+/// metadata that applies to it. A property with no schema counterpart means the document and the schema have
+/// drifted apart — typically a stored event whose event type gained or renamed a property without a migration.
+/// Without this exception the mismatch surfaced as a bare LINQ error naming neither the property nor the subject.
+/// </remarks>
+/// <param name="action">The action being performed — <c>apply</c> or <c>release</c>.</param>
+/// <param name="propertyPath">The path of the property that has no schema counterpart.</param>
+/// <param name="identifier">The compliance subject the value was being handled under.</param>
+/// <param name="knownPropertyNames">The property names the schema actually declares.</param>
+public class CompliancePropertyNotFoundInSchema(string action, string propertyPath, string identifier, IEnumerable<string> knownPropertyNames)
+    : Exception(BuildMessage(action, propertyPath, identifier, knownPropertyNames))
+{
+    static string BuildMessage(string action, string propertyPath, string identifier, IEnumerable<string> knownPropertyNames) =>
+        $"Could not {action} compliance metadata for property '{propertyPath}' of '{identifier}' because the schema does not declare it. The schema declares: {Describe(knownPropertyNames)}.";
+
+    static string Describe(IEnumerable<string> knownPropertyNames)
+    {
+        var names = knownPropertyNames.ToArray();
+        return names.Length == 0 ? "no properties" : string.Join(", ", names.Select(name => $"'{name}'"));
+    }
+}

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -87,7 +87,13 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
             if (schema.Properties is not null && value is not null)
             {
                 var propertyPath = string.IsNullOrEmpty(path) ? property : $"{path}.{property}";
-                var propertySchema = schema.GetFlattenedProperties().Single(_ => _.Name == property);
+                var flattenedProperties = schema.GetFlattenedProperties();
+
+                // FirstOrDefault rather than Single: a schema flattened across inheritance can declare the same
+                // property name more than once, and the duplicate is not a reason to fail the whole walk.
+                var propertySchema = flattenedProperties.FirstOrDefault(_ => _.Name == property) ??
+                    throw new CompliancePropertyNotFoundInSchema(actionName, propertyPath, identifier, flattenedProperties.Select(_ => _.Name));
+
                 var handlerApplied = false;
                 foreach (var metadata in propertySchema.GetComplianceMetadata().Concat(complianceMetadataForContainer).DistinctBy(_ => _.metadataType))
                 {


### PR DESCRIPTION
## Added

- `CompliancePropertyNotFoundInSchema`, thrown when a property being applied or released has no counterpart in the schema. The message names the property path, the compliance subject, and the properties the schema does declare. (#690)

## Fixed

- Applying or releasing compliance metadata for a property the schema does not declare no longer fails with a bare `Sequence contains no matching element`. (#690)
- Applying or releasing compliance metadata no longer fails when a schema flattened across inheritance declares the same property name more than once. (#690)