### PR TITLE
Tell reactor middlewares which reactor they are running for

### DIFF
--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/interface_handler_with_derived_events_and_multiple_invokers.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/interface_handler_with_derived_events_and_multiple_invokers.cs
@@ -48,8 +48,8 @@ public class interface_handler_with_derived_events_and_multiple_invokers : Speci
     [Fact] void should_succeed_for_the_second_invocation() => _secondResult.ExceptionResult.TryGetException(out _).ShouldBeFalse();
     [Fact] void should_invoke_the_interface_handler_for_the_first_derived_event() => _firstReactor.HandledEventTypes.ShouldContainOnly(typeof(MyFirstDerivedEventFromInterface));
     [Fact] void should_invoke_the_interface_handler_for_the_second_derived_event() => _secondReactor.HandledEventTypes.ShouldContainOnly(typeof(MySecondDerivedEventFromInterface));
-    [Fact] void should_call_before_invoke_for_each_event() => _middlewares.Received(2).BeforeInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
-    [Fact] void should_call_after_invoke_for_each_event() => _middlewares.Received(2).AfterInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_before_invoke_for_each_event() => _middlewares.Received(2).BeforeInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_after_invoke_for_each_event() => _middlewares.Received(2).AfterInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
 
     class TrackingReactor : IReactor
     {

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/void_handler_method.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/void_handler_method.cs
@@ -29,8 +29,10 @@ public class void_handler_method : Specification
     async Task Because() => _result = await _invoker.Invoke(new MyEvent(), EventContext.Empty);
 
     [Fact] void should_succeed() => _result.ExceptionResult.TryGetException(out _).ShouldBeFalse();
-    [Fact] void should_call_before_invoke() => _middlewares.Received(1).BeforeInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
-    [Fact] void should_call_after_invoke() => _middlewares.Received(1).AfterInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_before_invoke() => _middlewares.Received(1).BeforeInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_after_invoke() => _middlewares.Received(1).AfterInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_tell_before_invoke_which_reactor_is_running() => _middlewares.Received(1).BeforeInvoke(typeof(ReactorWithVoidHandlerMethodForEventType).GetReactorId(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_tell_after_invoke_which_reactor_is_running() => _middlewares.Received(1).AfterInvoke(typeof(ReactorWithVoidHandlerMethodForEventType).GetReactorId(), Arg.Any<EventContext>(), Arg.Any<object>());
 
     class ReactorWithVoidHandlerMethodForEventType : IReactor
     {

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactorMiddlewares/when_invoking/and_a_middleware_only_implements_the_overload_without_the_reactor.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactorMiddlewares/when_invoking/and_a_middleware_only_implements_the_overload_without_the_reactor.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ReactorMiddlewares.when_invoking;
+
+/// <summary>
+/// The overload carrying the reactor was added alongside the original one, so a middleware written before it
+/// existed still has to be called. The default interface implementation is what makes that hold.
+/// </summary>
+public class and_a_middleware_only_implements_the_overload_without_the_reactor : Specification
+{
+    MiddlewareWithoutReactor _middleware;
+    ReactorMiddlewares _middlewares;
+
+    void Establish()
+    {
+        _middleware = new MiddlewareWithoutReactor();
+        _middlewares = new([new ActivatedArtifact<IReactorMiddleware>(_middleware, Substitute.For<ILogger<ActivatedArtifact>>())]);
+    }
+
+    async Task Because()
+    {
+        await _middlewares.BeforeInvoke("some-reactor", EventContext.Empty, new MyEvent());
+        await _middlewares.AfterInvoke("some-reactor", EventContext.Empty, new MyEvent());
+    }
+
+    [Fact] void should_call_before_invoke() => _middleware.BeforeInvokeCalls.ShouldEqual(1);
+    [Fact] void should_call_after_invoke() => _middleware.AfterInvokeCalls.ShouldEqual(1);
+
+    class MiddlewareWithoutReactor : IReactorMiddleware
+    {
+        public int BeforeInvokeCalls { get; private set; }
+
+        public int AfterInvokeCalls { get; private set; }
+
+        public Task BeforeInvoke(EventContext eventContext, object @event)
+        {
+            BeforeInvokeCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task AfterInvoke(EventContext eventContext, object @event)
+        {
+            AfterInvokeCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/Clients/DotNET/Reactors/IReactorMiddleware.cs
+++ b/Source/Clients/DotNET/Reactors/IReactorMiddleware.cs
@@ -25,4 +25,30 @@ public interface IReactorMiddleware
     /// <param name="event">The actual event that it will be called with.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task AfterInvoke(EventContext eventContext, object @event);
+
+    /// <summary>
+    /// Invoked before the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event is being observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    /// <remarks>
+    /// This is the overload Chronicle calls. It defaults to the overload without the reactor, so a middleware
+    /// written before the reactor was passed along keeps working; implement this one to know which reactor is running.
+    /// </remarks>
+    Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event) => BeforeInvoke(eventContext, @event);
+
+    /// <summary>
+    /// Invoked after the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event was observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    /// <remarks>
+    /// This is the overload Chronicle calls. It defaults to the overload without the reactor, so a middleware
+    /// written before the reactor was passed along keeps working; implement this one to know which reactor is running.
+    /// </remarks>
+    Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event) => AfterInvoke(eventContext, @event);
 }

--- a/Source/Clients/DotNET/Reactors/IReactorMiddlewares.cs
+++ b/Source/Clients/DotNET/Reactors/IReactorMiddlewares.cs
@@ -25,4 +25,22 @@ public interface IReactorMiddlewares : IAsyncDisposable
     /// <param name="event">The actual event that it will be called with.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task AfterInvoke(EventContext eventContext, object @event);
+
+    /// <summary>
+    /// Invoked before the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event is being observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event) => BeforeInvoke(eventContext, @event);
+
+    /// <summary>
+    /// Invoked after the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event was observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event) => AfterInvoke(eventContext, @event);
 }

--- a/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
@@ -81,7 +81,7 @@ public class ReactorInvoker(
 
             if (_methodsByEventType.TryGetValue(eventType, out var method))
             {
-                await middlewares.BeforeInvoke(eventContext, content);
+                await middlewares.BeforeInvoke(reactorId, eventContext, content);
 
                 var arguments = await _argumentsResolver.Resolve(
                     method,
@@ -117,7 +117,7 @@ public class ReactorInvoker(
             // So we catch and log any exceptions from the middlewares.
             try
             {
-                await middlewares.AfterInvoke(eventContext, content);
+                await middlewares.AfterInvoke(reactorId, eventContext, content);
             }
             catch (Exception ex)
             {

--- a/Source/Clients/DotNET/Reactors/ReactorMiddlewares.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorMiddlewares.cs
@@ -16,23 +16,29 @@ namespace Cratis.Chronicle.Reactors;
 public class ReactorMiddlewares(ActivatedArtifact<IReactorMiddleware>[] activatedMiddlewares) : IReactorMiddlewares
 {
     /// <inheritdoc/>
-    public Task BeforeInvoke(EventContext eventContext, object @event)
+    public Task BeforeInvoke(EventContext eventContext, object @event) => BeforeInvoke(ReactorId.Unspecified, eventContext, @event);
+
+    /// <inheritdoc/>
+    public Task AfterInvoke(EventContext eventContext, object @event) => AfterInvoke(ReactorId.Unspecified, eventContext, @event);
+
+    /// <inheritdoc/>
+    public Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event)
     {
         if (activatedMiddlewares.Length == 0)
         {
             return Task.CompletedTask;
         }
-        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.BeforeInvoke(eventContext, @event)));
+        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.BeforeInvoke(reactorId, eventContext, @event)));
     }
 
     /// <inheritdoc/>
-    public Task AfterInvoke(EventContext eventContext, object @event)
+    public Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event)
     {
         if (activatedMiddlewares.Length == 0)
         {
             return Task.CompletedTask;
         }
-        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.AfterInvoke(eventContext, @event)));
+        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.AfterInvoke(reactorId, eventContext, @event)));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Added

- `IReactorMiddleware.BeforeInvoke` and `AfterInvoke` overloads that receive the `ReactorId` of the reactor observing the event. Chronicle calls these; they default to the existing overloads, so a middleware written against the previous interface keeps working unchanged. (#1009)