### PR TITLE
Fix the benchmarks job failing on every pull request

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -26,6 +26,10 @@ on:
       - "Source/**/*.cs"
       - "Source/**/*.csproj"
       - "Integration/**"
+      # The benchmarks job builds these, so a change here has to run it. Without this a broken benchmark
+      # project lands green and fails on the next unrelated pull request instead.
+      - "Benchmarks/**/*.cs"
+      - "Benchmarks/**/*.csproj"
       - ".github/workflows/dotnet-build.yml"
       - ".github/workflows/integration.yml"
 
@@ -405,11 +409,15 @@ jobs:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
 
+      # Kept as its own step: when the build and the run share one step, a build failure is reported as a
+      # successful step and only surfaces three steps later as "no benchmark result was found".
+      - name: Build Benchmarks
+        working-directory: ./Benchmarks/Chronicle.Benchmarks
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=false
+
       - name: Run Benchmarks
         working-directory: ./Benchmarks/Chronicle.Benchmarks
-        run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
+        run: dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
 
       - name: Find and Copy Results
         run: |

--- a/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
+++ b/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The client is referenced directly rather than picked up through the server: the server reference is
+         dropped when ArtifactsPath is set, which is how BenchmarkDotNet rebuilds this project before running,
+         and every benchmark here uses the client API. -->
+    <ProjectReference Include="../../Source/Clients/DotNET/DotNET.csproj" />
     <ProjectReference Include="../../Source/Clients/Connections/Connections.csproj" />
     <ProjectReference Include="../../Source/Infrastructure/Infrastructure.csproj" />
     <ProjectReference Include="../../Source/Kernel/Server/Server.csproj" Condition="'$(ArtifactsPath)' == ''" />

--- a/Benchmarks/merge-results.py
+++ b/Benchmarks/merge-results.py
@@ -23,3 +23,10 @@ combined = {
 
 with open('Benchmarks/results/combined.json', 'w') as fp:
     json.dump(combined, fp)
+
+# A run that discovers nothing still exports a well-formed file with an empty Benchmarks array. Say so here,
+# rather than letting the publishing step fail with the far less obvious "no benchmark result was found".
+if not benchmarks:
+    raise SystemExit(
+        f'No benchmarks were recorded across {len(files)} result file(s). '
+        'The run discovered no benchmarks, which usually means the benchmark project failed to build.')


### PR DESCRIPTION
Restores the benchmarks job, which failed on every pull request. No user-facing change, so there are no release-note bullets.