### PR TITLE
Take benchmark runs off the pull request critical path

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,10 +3,9 @@ name: Benchmarks
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-# Benchmarks on pull requests are covered by the `benchmarks` job in
-# dotnet-build.yml, which reuses that workflow's cached build instead of
-# compiling again from scratch. This workflow tracks the series on main,
-# where its cache key also lines up with the one publish.yml restores.
+# This is where the benchmark series lives. Pull requests only check that the benchmark projects still
+# build (the `benchmarks-build` job in dotnet-build.yml) - running them there added ~13 minutes to the
+# critical path for a result that could never fail the build.
 on:
   workflow_dispatch:
   push:
@@ -32,16 +31,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.PAT_WORKFLOWS }}
 
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
+      # Kept as its own step: when the build and the run share one step, a build failure is reported as a
+      # successful step and only surfaces later as "no benchmark result was found".
+      - name: Build Benchmarks
+        working-directory: ./Benchmarks/Chronicle.Benchmarks
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=false
+
       - name: Run Benchmarks
         working-directory: ./Benchmarks/Chronicle.Benchmarks
-        run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
+        run: dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
 
       - name: Find and Copy Results
         run: |
@@ -69,3 +73,19 @@ jobs:
         with:
           name: benchmark-data
           path: Documentation/benchmarks/benchmark-data.json
+
+      # The series used to reach the repository by way of a cache written on the pull request and restored at
+      # release time. With the run living here, commit it directly - the same shape coverage statistics use.
+      - name: Commit benchmark results
+        if: github.event_name == 'push'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add Documentation/benchmarks/benchmark-data.json
+          if git diff --staged --quiet; then
+            echo "No benchmark result changes to commit"
+          else
+            git commit -m "Update benchmark results [skip ci]"
+            git pull --rebase origin ${{ github.ref_name }}
+            git push
+          fi

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -26,6 +26,10 @@ on:
       - "Source/**/*.cs"
       - "Source/**/*.csproj"
       - "Integration/**"
+      # The benchmarks job builds these, so a change here has to run it. Without this a broken benchmark
+      # project lands green and fails on the next unrelated pull request instead.
+      - "Benchmarks/**/*.cs"
+      - "Benchmarks/**/*.csproj"
       - ".github/workflows/dotnet-build.yml"
       - ".github/workflows/integration.yml"
 
@@ -405,11 +409,15 @@ jobs:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
 
+      # Kept as its own step: when the build and the run share one step, a build failure is reported as a
+      # successful step and only surfaces three steps later as "no benchmark result was found".
+      - name: Build Benchmarks
+        working-directory: ./Benchmarks/Chronicle.Benchmarks
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=false
+
       - name: Run Benchmarks
         working-directory: ./Benchmarks/Chronicle.Benchmarks
-        run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
+        run: dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
 
       - name: Find and Copy Results
         run: |

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -384,11 +384,17 @@ jobs:
             "${{ github.sha }}" \
             "${{ github.event.head_commit.message || format('Coverage update for {0}', github.head_ref || github.ref_name) }}"
 
-  benchmarks:
+  # Running the benchmarks takes ~13 minutes and sits on the critical path behind dotnet-build, which made it
+  # the single thing deciding how long a pull request takes to go green. It cannot fail a build either
+  # (fail-on-alert is false), so the series is tracked on main by benchmarks.yml instead.
+  #
+  # What still has to hold per pull request is that the benchmark projects BUILD, or a broken one lands green
+  # and breaks main. Building them the way BenchmarkDotNet does - it regenerates and rebuilds with
+  # ArtifactsPath set, which changes which project references apply - is what catches that, and costs ~2
+  # minutes off the critical path rather than ~13 on it.
+  benchmarks-build:
     runs-on: ubuntu-latest
     needs: [dotnet-build]
-    outputs:
-      benchmark-cache-key: ${{ steps.export-benchmark-key.outputs.key }}
 
     steps:
       - name: Checkout code
@@ -405,40 +411,11 @@ jobs:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
 
-      - name: Run Benchmarks
-        working-directory: ./Benchmarks/Chronicle.Benchmarks
+      - name: Build benchmarks the way BenchmarkDotNet does
         run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
-
-      - name: Find and Copy Results
-        run: |
-          mkdir -p Benchmarks/results
-          find Benchmarks/Chronicle.Benchmarks -path "*/BenchmarkDotNet.Artifacts/results/*.json" -type f -exec cp {} Benchmarks/results/ \;
-          test -n "$(find Benchmarks/results -maxdepth 1 -name '*.json' -print -quit)" || { echo "No benchmark JSON files were produced"; exit 1; }
-          ls -la Benchmarks/results/
-          python3 Benchmarks/merge-results.py
-
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Cratis Benchmarks
-          tool: 'benchmarkdotnet'
-          output-file-path: Benchmarks/results/combined.json
-          external-data-json-path: Documentation/benchmarks/benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '150%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@einari'
-
-      - name: Cache benchmark results
-        uses: actions/cache@v4
-        with:
-          path: Documentation/benchmarks/benchmark-data.json
-          key: benchmark-cache-${{ github.sha }}
-
-      - name: Export benchmark cache key
-        id: export-benchmark-key
-        run: |
-          echo "key=benchmark-cache-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          dotnet build Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj \
+            -c Release /p:TreatWarningsAsErrors=false /p:DisableDockerBuild=true \
+            /p:ArtifactsPath="${RUNNER_TEMP}/benchmark-artifacts"
+          dotnet build Benchmarks/Chronicle.Benchmarks.Clustering/Chronicle.Benchmarks.Clustering.csproj \
+            -c Release /p:TreatWarningsAsErrors=false /p:DisableDockerBuild=true \
+            /p:ArtifactsPath="${RUNNER_TEMP}/benchmark-artifacts-clustering"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,50 +117,8 @@ jobs:
             git push
           fi
 
-  benchmark-results:
-    if: needs.release.outputs.publish == 'true' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    needs: [release]
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT_WORKFLOWS }}
-
-      - name: Restore cached benchmark results
-        uses: actions/cache@v4
-        with:
-          path: Documentation/benchmarks/benchmark-data.json
-          key: benchmark-cache-${{ github.sha }}
-          fail-on-cache-miss: false
-
-      - name: Check if benchmark data exists
-        id: check-benchmark
-        run: |
-          if [ -f "Documentation/benchmarks/benchmark-data.json" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No cached benchmark data found for commit ${{ github.sha }}, skipping"
-          fi
-
-      - name: Commit benchmark results
-        if: steps.check-benchmark.outputs.exists == 'true'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add Documentation/benchmarks/
-          if git diff --staged --quiet; then
-            echo "No benchmark result changes to commit"
-          else
-            git commit -m "Update benchmark results for release ${{ needs.release.outputs.version }} [skip ci]"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
-          fi
+  # Benchmark results are committed by benchmarks.yml when it runs on main, so there is no longer a cache
+  # written on the pull request for a release to restore.
 
   dotnet-x64:
     if: needs.release.outputs.publish == 'true'

--- a/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
+++ b/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The client is referenced directly rather than picked up through the server: the server reference is
+         dropped when ArtifactsPath is set, which is how BenchmarkDotNet rebuilds this project before running,
+         and every benchmark here uses the client API. -->
+    <ProjectReference Include="../../Source/Clients/DotNET/DotNET.csproj" />
     <ProjectReference Include="../../Source/Clients/Connections/Connections.csproj" />
     <ProjectReference Include="../../Source/Infrastructure/Infrastructure.csproj" />
     <ProjectReference Include="../../Source/Kernel/Server/Server.csproj" Condition="'$(ArtifactsPath)' == ''" />

--- a/Benchmarks/merge-results.py
+++ b/Benchmarks/merge-results.py
@@ -23,3 +23,10 @@ combined = {
 
 with open('Benchmarks/results/combined.json', 'w') as fp:
     json.dump(combined, fp)
+
+# A run that discovers nothing still exports a well-formed file with an empty Benchmarks array. Say so here,
+# rather than letting the publishing step fail with the far less obvious "no benchmark result was found".
+if not benchmarks:
+    raise SystemExit(
+        f'No benchmarks were recorded across {len(files)} result file(s). '
+        'The run discovered no benchmarks, which usually means the benchmark project failed to build.')


### PR DESCRIPTION
## Changed

- Benchmarks run on `main` rather than on every pull request. Pull requests now verify only that the benchmark projects build, which is what keeps a broken one from landing.
- Benchmark results are committed by the benchmark run on `main` instead of being carried from a pull request to the release through a cache.