### PR TITLE
Register the observer partition counts class map before any spec runs

### DIFF
--- a/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverHandledCountsStorage/when_incrementing_and_removing_counts.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverHandledCountsStorage/when_incrementing_and_removing_counts.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Storage.MongoDB.Sinks;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Observation.for_ObserverHandledCountsStorage;
@@ -24,19 +22,6 @@ public class when_incrementing_and_removing_counts(MongoDBFixture fixture) : Spe
     static readonly EventTypeId _typeB = "b2222222-2222-2222-2222-222222222222";
     static readonly Key _partitionOne = "partition-one";
     static readonly Key _partitionTwo = "partition-two";
-
-    static when_incrementing_and_removing_counts()
-    {
-        BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-        if (!BsonClassMap.IsClassMapRegistered(typeof(ObserverPartitionCounts)))
-        {
-            BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(cm =>
-            {
-                cm.AutoMap();
-                cm.MapIdProperty(_ => _.Id);
-            });
-        }
-    }
 
     IMongoClient _client = default!;
     string _databaseName = default!;

--- a/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverStateStorage/when_getting_an_observer_with_legacy_per_partition_counts.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverStateStorage/when_getting_an_observer_with_legacy_per_partition_counts.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Storage.MongoDB.Sinks;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using KernelObserverState = Cratis.Chronicle.Storage.Observation.ObserverState;
 
@@ -27,19 +25,6 @@ public class when_getting_an_observer_with_legacy_per_partition_counts(MongoDBFi
     static readonly EventTypeId _typeB = "b2222222-2222-2222-2222-222222222222";
     const string PartitionOne = "partition-one";
     const string PartitionTwo = "partition-two";
-
-    static when_getting_an_observer_with_legacy_per_partition_counts()
-    {
-        BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-        if (!BsonClassMap.IsClassMapRegistered(typeof(ObserverPartitionCounts)))
-        {
-            BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(cm =>
-            {
-                cm.AutoMap();
-                cm.MapIdProperty(_ => _.Id);
-            });
-        }
-    }
 
     IMongoClient _client = default!;
     string _databaseName = default!;

--- a/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using Cratis.Arc.MongoDB;
+using Cratis.Chronicle.Storage.MongoDB.Observation;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 
@@ -22,12 +23,20 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// failure specs would see and production would not.
 /// </para>
 /// <para>
-/// The same reasoning applies to <see cref="EventClassMap"/>, which is what makes the event's sequence number the
-/// document <c>_id</c>. Any spec that merely renders a <c>Builders&lt;Event&gt;</c> expression — building an index
-/// key, for instance — makes the driver auto-register a default class map for <see cref="Event"/>, and a default
-/// map gives every appended event a generated <c>ObjectId</c> instead. Registering it lazily from a spec base
-/// therefore loses a race against unrelated spec classes running in parallel, silently dropping both the tail
-/// aggregation and the duplicate-sequence-number detection that depend on that mapping.
+/// The same reasoning applies to every <see cref="IBsonClassMapFor{T}"/>. Take <see cref="EventClassMap"/>, which is
+/// what makes the event's sequence number the document <c>_id</c>: any spec that merely renders a
+/// <c>Builders&lt;Event&gt;</c> expression — building an index key, for instance — makes the driver auto-register a
+/// <em>default</em> class map for <see cref="Event"/>, and a default map gives every appended event a generated
+/// <c>ObjectId</c> instead. A lazy <c>IsClassMapRegistered</c> guard in a spec base then finds one already
+/// registered and skips the real one, so whichever spec touched the type first decides the mapping. That silently
+/// dropped both the tail aggregation and the duplicate-sequence-number detection when spec classes ran in parallel.
+/// </para>
+/// <para>
+/// So a class map a spec depends on is registered here rather than lazily from the spec that needs it. This is not
+/// yet every <see cref="IBsonClassMapFor{T}"/> the server registers: the <c>JobState</c> specs map
+/// <c>JobState.Request</c>, while the server's <c>JobStateClassMap</c> deliberately unmaps it and lets
+/// <c>JobStateSerializer</c> own it, so registering the server's map here fails them. That divergence is a
+/// fidelity gap in those specs, not something to paper over from this file.
 /// </para>
 /// </remarks>
 internal static class SpecSerializationSetup
@@ -42,5 +51,6 @@ internal static class SpecSerializationSetup
         ConventionRegistry.Register(Cratis.Arc.MongoDB.ConventionPacks.IgnoreExtraElements, new ConventionPack { new IgnoreExtraElementsConvention(true) }, _ => true);
         BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
         BsonClassMap.RegisterClassMap<Event>(classMap => new EventClassMap().Configure(classMap));
+        BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(classMap => new ObserverPartitionCountsClassMap().Configure(classMap));
     }
 }


### PR DESCRIPTION
Removes the last reachable instance of the lazy class-map registration that caused the event-sequence spec failures. No user-facing change, so there are no release-note bullets.