### PR TITLE
Read back a job state that has no request

### DIFF
--- a/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_round_tripping_a_job_state_without_a_request.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_round_tripping_a_job_state_without_a_request.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Storage.Jobs;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Jobs.for_JobStateSerializer;
+
+/// <summary>
+/// JobState.Request is declared as `default!`, so a state persisted before its request is assigned has no request
+/// to write - and Serialize only writes the field when the request is there. Reading such a document back has to
+/// work: the state carries its own status and progress, which is the whole reason it was written.
+/// </summary>
+public class when_round_tripping_a_job_state_without_a_request : given.a_job_state_serializer
+{
+    JobState _original;
+    JobState _result;
+    Exception _exception;
+
+    void Establish() => _original = new JobState
+    {
+        Id = JobId.New(),
+        Details = "Test Job",
+        Type = typeof(SampleJobRequest),
+        Status = JobStatus.Running,
+        Created = DateTimeOffset.UtcNow,
+        StatusChanges = [],
+        Progress = new JobProgress()
+    };
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+        {
+            _serializer.Serialize(BsonSerializationContext.CreateRoot(writer), default, _original);
+        }
+
+        using var reader = new BsonDocumentReader(document);
+        _result = _serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader), default);
+    });
+
+    [Fact] void should_not_fail() => _exception.ShouldBeNull();
+    [Fact] void should_deserialize_job_id() => _result.Id.ShouldEqual(_original.Id);
+    [Fact] void should_deserialize_job_status() => _result.Status.ShouldEqual(_original.Status);
+    [Fact] void should_leave_the_request_unset() => _result.Request.ShouldBeNull();
+}

--- a/Source/Kernel/Storage.MongoDB/Jobs/JobStateSerializer.cs
+++ b/Source/Kernel/Storage.MongoDB/Jobs/JobStateSerializer.cs
@@ -55,20 +55,28 @@ public class JobStateSerializer(IJobTypes jobTypes) : SerializerBase<JobState>
     {
         var actualType = args.NominalType ?? typeof(JobState);
         var (jobState, requestBookmark, endBookmark) = DeserializeJobStateExceptRequest(context, actualType);
-        context.Reader.ReturnToBookmark(requestBookmark);
-        var jobRequestClrType = jobTypes.GetRequestClrTypeForOrThrow(jobState.Type);
-        actualType.GetProperty(nameof(JobState.Request))!
-            .SetValue(jobState, BsonSerializer.Deserialize(context.Reader, jobRequestClrType));
 
-        context.Reader.ReturnToBookmark(endBookmark);
+        // Serialize only writes the request when there is one, and JobState.Request starts out unset, so a state
+        // persisted before its request was assigned has no request element to come back to. Leave it unset rather
+        // than returning to a bookmark that was never taken.
+        if (requestBookmark is not null)
+        {
+            context.Reader.ReturnToBookmark(requestBookmark);
+            var jobRequestClrType = jobTypes.GetRequestClrTypeForOrThrow(jobState.Type);
+            actualType.GetProperty(nameof(JobState.Request))!
+                .SetValue(jobState, BsonSerializer.Deserialize(context.Reader, jobRequestClrType));
+
+            context.Reader.ReturnToBookmark(endBookmark);
+        }
+
         context.Reader.ReadEndDocument();
         return jobState;
     }
 
-    static (JobState JobState, BsonReaderBookmark JobRequestBookmark, BsonReaderBookmark EndBookmark) DeserializeJobStateExceptRequest(BsonDeserializationContext context, Type actualType)
+    static (JobState JobState, BsonReaderBookmark? JobRequestBookmark, BsonReaderBookmark EndBookmark) DeserializeJobStateExceptRequest(BsonDeserializationContext context, Type actualType)
     {
         var jobState = (JobState)Activator.CreateInstance(actualType)!;
-        BsonReaderBookmark requestBookmark = default!;
+        BsonReaderBookmark? requestBookmark = null;
         context.Reader.ReadStartDocument();
         var bsonCLassMap = BsonClassMap.LookupClassMap(actualType).AllMemberMaps;
         while (context.Reader.ReadBsonType() != BsonType.EndOfDocument)


### PR DESCRIPTION
## Fixed

- Reading back a job whose request was not yet assigned no longer fails with a `NullReferenceException`, losing the status and progress the job state was written to record. (#3541)