### PR TITLE
Cover two pieces of public API that had no specs

### DIFF
--- a/Source/Clients/AspNetCore.Specs/OpenTelemetry/for_TracerProviderBuilderExtensions/when_adding_chronicle_client_instrumentation.cs
+++ b/Source/Clients/AspNetCore.Specs/OpenTelemetry/for_TracerProviderBuilderExtensions/when_adding_chronicle_client_instrumentation.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Cratis.Chronicle.AspNetCore.OpenTelemetry;
+using Cratis.Chronicle.Diagnostics.OpenTelemetry.Tracing;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Cratis.Chronicle.AspNetCore.for_TracerProviderBuilderExtensions;
+
+/// <summary>
+/// An <see cref="ActivitySource"/> produces nothing until something listens to it by name, so registering the
+/// client's source is the whole of what this extension does. Both halves are asserted in one spec because an
+/// activity listener is process-wide, and separate spec classes would see each other's tracer provider.
+/// </summary>
+public class when_adding_chronicle_client_instrumentation : Specification
+{
+    static readonly ActivitySource _source = new(ClientActivity.SourceName);
+
+    TracerProvider _provider;
+    Activity _beforeAdding;
+    Activity _afterAdding;
+
+    void Because()
+    {
+        _beforeAdding = _source.StartActivity("some-client-operation");
+        _provider = Sdk.CreateTracerProviderBuilder().AddCratisChronicleInstrumentation().Build();
+        _afterAdding = _source.StartActivity("some-client-operation");
+    }
+
+    void Destroy()
+    {
+        _beforeAdding?.Dispose();
+        _afterAdding?.Dispose();
+        _provider?.Dispose();
+    }
+
+    [Fact] void should_not_record_client_activity_before_it_is_added() => _beforeAdding.ShouldBeNull();
+    [Fact] void should_record_client_activity_once_it_is_added() => _afterAdding.ShouldNotBeNull();
+    [Fact] void should_record_it_against_the_client_source() => _afterAdding.Source.Name.ShouldEqual(ClientActivity.SourceName);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/given/a_read_models_manager.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/given/a_read_models_manager.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.given;
+
+public class a_read_models_manager : Specification
+{
+    protected TestKitSilo _silo = new();
+    protected ReadModelsManager _manager;
+    protected IReadModel _readModelGrain;
+
+    protected static readonly EventStoreName _eventStore = "some-event-store";
+
+    async Task Establish()
+    {
+        _readModelGrain = Substitute.For<IReadModel>();
+        _silo.AddProbe(_ => _readModelGrain);
+        _manager = await _silo.CreateGrainAsync<ReadModelsManager>(_eventStore.Value);
+    }
+
+    protected static ReadModelDefinition DefinitionFor(ReadModelIdentifier identifier, ReadModelDisplayName displayName) => new(
+        identifier,
+        identifier.Value,
+        displayName,
+        ReadModelOwner.None,
+        ReadModelSource.Unknown,
+        ReadModelObserverType.NotSet,
+        ReadModelObserverIdentifier.Unspecified,
+        SinkDefinition.None,
+        new Dictionary<ReadModelGeneration, Schemas.JsonSchema>(),
+        []);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_a_definition_is_already_registered.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_a_definition_is_already_registered.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.when_registering;
+
+/// <summary>
+/// Registering is an upsert keyed on the identifier, so a client reconnecting with a changed read model replaces
+/// its definition rather than accumulating a second one alongside it.
+/// </summary>
+public class and_a_definition_is_already_registered : given.a_read_models_manager
+{
+    static readonly ReadModelDefinition _first = DefinitionFor("some-read-model", "First display name");
+    static readonly ReadModelDefinition _second = DefinitionFor("some-read-model", "Second display name");
+    static readonly ReadModelDefinition _other = DefinitionFor("some-other-read-model", "Another read model");
+
+    IEnumerable<ReadModelDefinition> _result;
+
+    async Task Establish() => await _manager.Register([_first, _other]);
+
+    async Task Because()
+    {
+        await _manager.Register([_second]);
+        _result = await _manager.GetDefinitions();
+    }
+
+    [Fact] void should_replace_the_definition_with_the_same_identifier() => _result.ShouldContain(_second);
+    [Fact] void should_not_keep_the_previous_definition() => _result.ShouldNotContain(_first);
+    [Fact] void should_leave_the_unrelated_definition_alone() => _result.ShouldContain(_other);
+    [Fact] void should_not_accumulate_duplicates() => _result.Count().ShouldEqual(2);
+    [Fact] async Task should_push_the_new_definition_to_the_read_model() => await _readModelGrain.Received(1).SetDefinition(_second);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_there_are_no_definitions.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_there_are_no_definitions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.when_registering;
+
+/// <summary>
+/// A client with no read models still registers - a reactor-only application has none - and registering an empty
+/// set must not wipe what is already there. That is what makes the client's unconditional Register() call safe.
+/// </summary>
+public class and_there_are_no_definitions : given.a_read_models_manager
+{
+    static readonly ReadModelDefinition _existing = DefinitionFor("some-read-model", "Some read model");
+
+    IEnumerable<ReadModelDefinition> _result;
+
+    async Task Establish() => await _manager.Register([_existing]);
+
+    async Task Because()
+    {
+        await _manager.Register([]);
+        _result = await _manager.GetDefinitions();
+    }
+
+    [Fact] void should_keep_the_definition_that_was_already_registered() => _result.ShouldContainOnly(_existing);
+}


### PR DESCRIPTION
Adds specs for `ReadModelsManager` and `AddCratisChronicleInstrumentation`, neither of which had any. Spec-only, so there are no release-note bullets.