### PR TITLE
Move C#-only captures and external-services docs to .NET client

### DIFF
--- a/Documentation/captures/capture-declaration-language/index.md
+++ b/Documentation/captures/capture-declaration-language/index.md
@@ -69,13 +69,7 @@ For API sources, `api` identifies a configured **[External Service](../../extern
 
 ### Configuring authentication
 
-**API sources** connect through a configured External Service. Configure the base URL and authentication once on the External Service; the capture simply references it by name:
-
-```csharp
-builder.FromApi("InvoicingApi", source => source
-    .OnRoute("/invoices")
-    .PollEvery("10m"));
-```
+**API sources** connect through a configured [External Service](/chronicle/external-services/). Configure the base URL and authentication once on the External Service; the capture simply references it by name — see the [Declarative Captures](/chronicle/clients/dotnet/captures/declarative/) example for what that reference looks like in the .NET client's builder API.
 
 **Webhook sources** are inbound and configure their authentication in code on the source builder:
 

--- a/Documentation/captures/declarative/toc.yml
+++ b/Documentation/captures/declarative/toc.yml
@@ -1,2 +1,0 @@
-- name: Overview
-  href: index.md

--- a/Documentation/captures/index.md
+++ b/Documentation/captures/index.md
@@ -12,16 +12,16 @@ A capture definition describes:
 - **Append rules**: which event to append and when to append it
 - **Scopes**: root, nested objects, and child collections
 
-Chronicle supports three authoring approaches:
+Chronicle supports three authoring approaches. Only the first is language-neutral — the other two are .NET client features, documented alongside the rest of the .NET client:
 
 - **Capture Declaration Language (CDL)** for text-based definitions
-- **Declarative C# API** for fluent definitions in code
-- **Model-bound C# API** for attribute-based definitions
+- **Declarative API** (.NET) for fluent definitions in code
+- **Model-bound API** (.NET) for attribute-based definitions
 
 ## Topics
 
 | Topic | Description |
 | ----- | ----------- |
 | [Capture Declaration Language](capture-declaration-language/index.md) | CDL syntax, semantics, and formal language specification |
-| [Declarative Captures](declarative/index.md) | Fluent C# API (`ICapturer` + `ICaptureBuilder`) |
-| [Model-Bound Captures](model-bound/index.md) | Attribute-based capture declarations |
+| [Declarative Captures](/chronicle/clients/dotnet/captures/declarative/) | .NET client fluent API (`ICapturer` + `ICaptureBuilder`) |
+| [Model-Bound Captures](/chronicle/clients/dotnet/captures/model-bound/) | .NET client attribute-based capture declarations |

--- a/Documentation/captures/model-bound/toc.yml
+++ b/Documentation/captures/model-bound/toc.yml
@@ -1,2 +1,0 @@
-- name: Overview
-  href: index.md

--- a/Documentation/captures/toc.yml
+++ b/Documentation/captures/toc.yml
@@ -2,7 +2,3 @@
   href: index.md
 - name: Capture Declaration Language
   href: capture-declaration-language/toc.yml
-- name: Declarative Captures
-  href: declarative/toc.yml
-- name: Model-Bound Captures
-  href: model-bound/toc.yml

--- a/Documentation/clients/dotnet/captures/declarative.md
+++ b/Documentation/clients/dotnet/captures/declarative.md
@@ -1,4 +1,7 @@
-# Declarative Captures
+---
+title: Declarative captures
+description: Fluent C# builder API for defining CDC captures in code — ICapturer, ICaptureBuilder, source configuration, mapping, and append rules.
+---
 
 Declarative captures use fluent C# builder APIs to define CDC behavior in code.
 
@@ -33,7 +36,7 @@ API source options:
 - `OnRoute(route)`
 - `PollEvery(interval)`
 
-`FromApi(api, ...)` references a configured [External Service](../../external-services/index.md) by name. The External Service holds the base URL and authentication, so no authentication is configured on the API source. If no route is configured, the External Service base URL is used directly.
+`FromApi(api, ...)` references a configured [External Service](/chronicle/external-services/) by name. The External Service holds the base URL and authentication, so no authentication is configured on the API source. If no route is configured, the External Service base URL is used directly.
 
 Webhook source options (webhook sources are inbound and configure their own authentication):
 

--- a/Documentation/clients/dotnet/captures/index.md
+++ b/Documentation/clients/dotnet/captures/index.md
@@ -1,0 +1,14 @@
+---
+title: Authoring captures in .NET
+description: The two .NET-only ways to author Chronicle captures in code — model-bound attributes and the declarative fluent builder — alongside the language-neutral Capture Declaration Language.
+---
+
+[Captures](/chronicle/captures/) turn external data changes into Chronicle events. Chronicle supports three ways to author a capture, and only one of them is language-neutral:
+
+| Approach | Language | Where it's documented |
+| --- | --- | --- |
+| Capture Declaration Language (CDL) | Text-based, any client | [Capture Declaration Language](/chronicle/captures/capture-declaration-language/) |
+| Declarative API | C# fluent builder | [Declarative Captures](declarative.md) |
+| Model-bound API | C# attributes | [Model-Bound Captures](model-bound.md) |
+
+The declarative and model-bound APIs are .NET client features — they compile to the same `CaptureDefinition` a CDL text file would, but the authoring surface itself is C#-specific.

--- a/Documentation/clients/dotnet/captures/model-bound.md
+++ b/Documentation/clients/dotnet/captures/model-bound.md
@@ -1,4 +1,7 @@
-# Model-Bound Captures
+---
+title: Model-bound captures
+description: Attribute-based capture declarations in the .NET client — source, key, append conditions, and field mappings declared with attributes.
+---
 
 Model-bound captures use attributes to declare source, key, append conditions, and field mappings.
 
@@ -19,8 +22,9 @@ public class InvoiceCapture;
 
 `ApiCapture` references a named API configuration. If `Route` is not set, the configured API base URL is used directly.
 
-> [!NOTE]
-> Authentication is not declared on the capture attribute. It is configured in code where the source is configured, so that secrets never live in the capture declaration. See [Configuring authentication](../capture-declaration-language/index.md#configuring-authentication).
+:::note
+Authentication is not declared on the capture attribute. It is configured in code where the source is configured, so that secrets never live in the capture declaration. See [Configuring authentication](/chronicle/captures/capture-declaration-language/#configuring-authentication).
+:::
 
 ## Append conditions on event types
 

--- a/Documentation/clients/dotnet/captures/toc.yml
+++ b/Documentation/clients/dotnet/captures/toc.yml
@@ -1,0 +1,6 @@
+- name: Overview
+  href: index.md
+- name: Declarative Captures
+  href: declarative.md
+- name: Model-Bound Captures
+  href: model-bound.md

--- a/Documentation/clients/dotnet/external-services.md
+++ b/Documentation/clients/dotnet/external-services.md
@@ -1,0 +1,20 @@
+---
+title: Registering External Services from code
+description: Register External Services programmatically from the .NET client, as an alternative to configuring them in the Workbench.
+---
+
+[External Services](/chronicle/external-services/) are usually configured in the Workbench, but the .NET client also exposes a programmatic API on `IEventStore`:
+
+```csharp
+// An HTTP service with bearer token authentication and a header
+await eventStore.ExternalServices.Register("CustomersApi", _ => _
+    .Http("https://api.example.com")
+    .WithBearerToken(token)
+    .WithHeader("X-Tenant", "acme"));
+
+// A PostgreSQL database service
+await eventStore.ExternalServices.Register("CustomersDb", _ => _
+    .PostgreSql("db.example.com", "customers", "postgres", password, port: 5432));
+```
+
+The builder also exposes `WithBasicAuth`, `WithOAuth`, `MsSql`, and `WithOption`.

--- a/Documentation/clients/dotnet/toc.yml
+++ b/Documentation/clients/dotnet/toc.yml
@@ -2,3 +2,7 @@
   href: index.md
 - name: Get started
   href: getting-started.md
+- name: Captures
+  href: captures/toc.yml
+- name: External Services
+  href: external-services.md

--- a/Documentation/external-services/index.md
+++ b/Documentation/external-services/index.md
@@ -38,23 +38,7 @@ External Services are configured per event store. In the **Workbench**, open an 
 
 Secrets (passwords, tokens, client secrets) are write-only from the Workbench — they are never returned by the read model that lists services.
 
-### Registering from code
-
-External Services can also be registered programmatically through the client SDK on `IEventStore`:
-
-```csharp
-// An HTTP service with bearer token authentication and a header
-await eventStore.ExternalServices.Register("CustomersApi", _ => _
-    .Http("https://api.example.com")
-    .WithBearerToken(token)
-    .WithHeader("X-Tenant", "acme"));
-
-// A PostgreSQL database service
-await eventStore.ExternalServices.Register("CustomersDb", _ => _
-    .PostgreSql("db.example.com", "customers", "postgres", password, port: 5432));
-```
-
-The builder also exposes `WithBasicAuth`, `WithOAuth`, `MsSql`, and `WithOption`.
+External Services can also be registered programmatically — see [Registering External Services from code](/chronicle/clients/dotnet/external-services/) in the .NET client docs.
 
 ## Using External Services from captures
 


### PR DESCRIPTION
## Fixed

- Model-bound and declarative captures were shared Chronicle docs pages, but both are C#-only authoring surfaces (attributes and a fluent builder) — no other client has an equivalent. This left raw `csharp` code fences in the shared docs, which the chronicle-client-docs shared-doc audit correctly flags as migration debt, and which was breaking the Documentation site's build (`Check Chronicle client docs` step). Moved both under `clients/dotnet/captures/`, alongside the rest of the .NET client docs, and updated the Captures overview page to link to their new location.
- Moved the "Registering from code" `ExternalServices.Register` example for the same reason — it's a .NET-only SDK API — to a new `clients/dotnet/external-services.md` page, leaving the shared External Services page (endpoint types, Workbench configuration) fully language-neutral.
- Replaced the one remaining stray `csharp` fence in the Capture Declaration Language page with a cross-reference to the new .NET declarative captures page instead of duplicating the code.

Verified locally: `node scripts/check-chronicle-client-docs.mjs --strict-toolchains` from `Documentation/web` reports 0 direct client-language fences in shared Chronicle docs (down from 4), and a full site build + internal-links check are both clean.