### PR TITLE
Let a reactor handle an event differently while it is replaying

### DIFF
--- a/.ai/rules/reactors.md
+++ b/.ai/rules/reactors.md
@@ -37,6 +37,25 @@ public Task MethodName(TEvent @event, EventContext context)
 - **Return type** — `Task` or `void`, or a side-effect type (`TEvent`, `ReactorSideEffect`, or a collection of either) returned directly (sync) or wrapped in `Task<...>` (async). Prefer `Task`/async for real side effects, but synchronous returns are fully supported — there is no "always async" requirement.
 - **Method name** — can be anything descriptive. The name is for readability, not dispatch.
 
+## Handling replay differently — `[Replay]`
+
+A reactor sees the same event twice for different reasons: as it happens, and again when its observer is replayed. When those call for different work, mark a second handler for the same event type with **`[Replay]`** and it takes over for the duration of the replay.
+
+```csharp
+public class OrderNotifications(INotificationService notifications) : IReactor
+{
+    public Task OrderPlaced(OrderPlaced @event) => notifications.Notify($"Order {@event.Number} placed.");
+
+    [Replay]
+    public Task OrderPlacedDuringReplay(OrderPlaced @event) => Task.CompletedTask;
+}
+```
+
+- With a `[Replay]` handler, **only** it runs during replay — the regular handler does not also run.
+- Without one, the regular handler runs during replay exactly as before, so this changes nothing for existing reactors.
+- An event type handled *only* by a `[Replay]` handler is still subscribed to.
+- Reach for **`[OnceOnly]`** instead when the side effect should simply not happen again; use `[Replay]` when replay needs to do something *different* rather than nothing.
+
 ## Taking Dependencies
 
 Beyond the event and `EventContext`, a handler method can take any number of additional parameters as dependencies. Only the first parameter is fixed (it is the event that drives dispatch); every parameter after it is resolved when the method is invoked.

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_getting_event_types_for/and_only_a_replay_handler_handles_a_type.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_getting_event_types_for/and_only_a_replay_handler_handles_a_type.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_getting_event_types_for;
+
+/// <summary>
+/// The event types drive what the reactor subscribes to. An event type handled only during replay still has to
+/// be subscribed to, or the replay it exists for would never deliver it.
+/// </summary>
+public class and_only_a_replay_handler_handles_a_type : Specification
+{
+    IImmutableList<EventType> _result;
+
+    void Because() => _result = ReactorInvoker.GetEventTypesFor(
+        new EventTypesForSpecifications([typeof(MyEvent)]),
+        typeof(ReactorWithOnlyAReplayHandler));
+
+    [Fact] void should_subscribe_to_the_event_type() => _result.Count.ShouldEqual(1);
+
+    class ReactorWithOnlyAReplayHandler : IReactor
+    {
+        [Replay]
+        public void HandleDuringReplay(MyEvent @event)
+        {
+        }
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_only_a_live_handler_exists_during_replay.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_only_a_live_handler_exists_during_replay.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// Every reactor written before replay handlers existed relies on its handler running during a replay, so an
+/// event type with no replay handler has to keep behaving exactly as it did.
+/// </summary>
+public class and_only_a_live_handler_exists_during_replay : Specification
+{
+    ReactorWithoutReplayHandler _reactor;
+    ReactorInvoker _invoker;
+
+    void Establish()
+    {
+        _reactor = new ReactorWithoutReplayHandler();
+        _invoker = new ReactorInvoker(
+            new EventTypesForSpecifications([typeof(MyEvent)]),
+            Substitute.For<IReactorMiddlewares>(),
+            typeof(ReactorWithoutReplayHandler),
+            new ActivatedArtifact(_reactor, typeof(ReactorWithoutReplayHandler), Substitute.For<ILogger<ActivatedArtifact>>()),
+            Substitute.For<ILogger<ReactorInvoker>>());
+    }
+
+    async Task Because() => await _invoker.Invoke(new MyEvent(), EventContext.Empty with { ObservationState = EventObservationState.Replay });
+
+    [Fact] void should_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(1);
+
+    class ReactorWithoutReplayHandler : IReactor
+    {
+        public int LiveCalls { get; private set; }
+
+        public void Handle(MyEvent @event) => LiveCalls++;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_being_replayed.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_being_replayed.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// The replay handler takes over for the duration of the replay, and the live handler does not also run -
+/// otherwise marking one would double the work rather than redirect it.
+/// </summary>
+public class and_the_event_is_being_replayed : given.a_reactor_with_a_replay_handler
+{
+    async Task Because() => await _invoker.Invoke(new MyEvent(), ContextObservedAs(EventObservationState.Replay));
+
+    [Fact] void should_call_the_replay_handler() => _reactor.ReplayCalls.ShouldEqual(1);
+    [Fact] void should_not_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(0);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_observed_for_the_first_time.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_observed_for_the_first_time.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// Marking a replay handler must not change what happens on the live path.
+/// </summary>
+public class and_the_event_is_observed_for_the_first_time : given.a_reactor_with_a_replay_handler
+{
+    async Task Because() => await _invoker.Invoke(new MyEvent(), ContextObservedAs(EventObservationState.Initial));
+
+    [Fact] void should_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(1);
+    [Fact] void should_not_call_the_replay_handler() => _reactor.ReplayCalls.ShouldEqual(0);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/given/a_reactor_with_a_replay_handler.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/given/a_reactor_with_a_replay_handler.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking.given;
+
+public class a_reactor_with_a_replay_handler : Specification
+{
+    protected ReactorWithReplayHandler _reactor;
+    protected ReactorInvoker _invoker;
+
+    void Establish()
+    {
+        _reactor = new ReactorWithReplayHandler();
+        _invoker = new ReactorInvoker(
+            new EventTypesForSpecifications([typeof(MyEvent)]),
+            Substitute.For<IReactorMiddlewares>(),
+            typeof(ReactorWithReplayHandler),
+            new ActivatedArtifact(_reactor, typeof(ReactorWithReplayHandler), Substitute.For<ILogger<ActivatedArtifact>>()),
+            Substitute.For<ILogger<ReactorInvoker>>());
+    }
+
+    protected static EventContext ContextObservedAs(EventObservationState observationState) =>
+        EventContext.Empty with { ObservationState = observationState };
+
+    public class ReactorWithReplayHandler : IReactor
+    {
+        public int LiveCalls { get; private set; }
+
+        public int ReplayCalls { get; private set; }
+
+        public void Handle(MyEvent @event) => LiveCalls++;
+
+        [Replay]
+        public void HandleDuringReplay(MyEvent @event) => ReplayCalls++;
+    }
+}

--- a/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
@@ -54,8 +54,8 @@ public class ReactorInvoker(
     IReactorMethodArgumentsResolver? argumentsResolver = null,
     IServiceProvider? serviceProvider = null) : IReactorInvoker
 {
-    static readonly ConcurrentDictionary<Type, FrozenDictionary<Type, MethodInfo>> _methodsByEventTypeCache = [];
-    readonly FrozenDictionary<Type, MethodInfo> _methodsByEventType = MethodsByEventType.Get(targetType, eventTypes.AllClrTypes);
+    static readonly ConcurrentDictionary<Type, HandlerMethods> _methodsByEventTypeCache = [];
+    readonly HandlerMethods _methodsByEventType = MethodsByEventType.Get(targetType, eventTypes.AllClrTypes);
     readonly IReactorMethodArgumentsResolver _argumentsResolver = argumentsResolver ?? new ReactorMethodArgumentsResolver();
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ReactorInvoker(
     /// <returns>Collection of discovered <see cref="EventType"/>.</returns>
     public static IImmutableList<EventType> GetEventTypesFor(IEventTypes eventTypes, Type reactorType) =>
         MethodsByEventType.Get(reactorType, eventTypes.AllClrTypes)
-            .Keys
+            .AllEventTypes
             .Select(eventTypes.GetEventTypeFor)
             .ToImmutableList();
 
@@ -79,7 +79,7 @@ public class ReactorInvoker(
         {
             var eventType = content.GetType();
 
-            if (_methodsByEventType.TryGetValue(eventType, out var method))
+            if (_methodsByEventType.TryGetHandlerFor(eventType, eventContext.ObservationState, out var method))
             {
                 await middlewares.BeforeInvoke(eventContext, content);
 
@@ -197,17 +197,52 @@ public class ReactorInvoker(
     ReactorContextValues BuildValues(EventContext eventContext) =>
         reactorContextValuesBuilder?.Build(activatedReactor.Instance, eventContext) ?? ReactorContextValues.Empty;
 
+    /// <summary>
+    /// The handler methods of a reactor, split by whether they take over during a replay.
+    /// </summary>
+    /// <param name="Live">The handlers to run as events happen.</param>
+    /// <param name="Replay">The handlers marked with <see cref="ReplayAttribute"/>, which take over during a replay.</param>
+    record HandlerMethods(FrozenDictionary<Type, MethodInfo> Live, FrozenDictionary<Type, MethodInfo> Replay)
+    {
+        /// <summary>
+        /// Gets every event type handled, whichever path handles it. An event type handled only by a replay
+        /// handler still has to be subscribed to, or the replay would have nothing to deliver.
+        /// </summary>
+        public IEnumerable<Type> AllEventTypes => Live.Keys.Union(Replay.Keys);
+
+        /// <summary>
+        /// Resolves the handler to run for an event type, given the state the event is being observed in.
+        /// </summary>
+        /// <param name="eventType">The event <see cref="Type"/> being observed.</param>
+        /// <param name="observationState">The <see cref="EventObservationState"/> the event arrives in.</param>
+        /// <param name="method">The resolved handler, when there is one.</param>
+        /// <returns>True if a handler was resolved, false otherwise.</returns>
+        public bool TryGetHandlerFor(Type eventType, EventObservationState observationState, out MethodInfo method)
+        {
+            // A replay handler takes over for the duration of the replay, and the live handler does not also run.
+            // Without one, the live handler keeps running during replay - which is what every reactor written
+            // before this existed relies on.
+            if (observationState.HasFlag(EventObservationState.Replay) && Replay.TryGetValue(eventType, out method!))
+            {
+                return true;
+            }
+
+            return Live.TryGetValue(eventType, out method!);
+        }
+    }
+
     static class MethodsByEventType
     {
-        public static FrozenDictionary<Type, MethodInfo> Get(Type targetType, IEnumerable<Type> eventTypes) =>
+        public static HandlerMethods Get(Type targetType, IEnumerable<Type> eventTypes) =>
             _methodsByEventTypeCache.GetOrAdd(
                 targetType,
                 static (key, keyEventTypes) => Build(key, keyEventTypes),
                 eventTypes);
 
-        static FrozenDictionary<Type, MethodInfo> Build(Type targetType, IEnumerable<Type> eventTypes)
+        static HandlerMethods Build(Type targetType, IEnumerable<Type> eventTypes)
         {
-            var methodsByEventType = new Dictionary<Type, MethodInfo>();
+            var liveMethodsByEventType = new Dictionary<Type, MethodInfo>();
+            var replayMethodsByEventType = new Dictionary<Type, MethodInfo>();
 
             foreach (var method in targetType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
@@ -225,6 +260,7 @@ public class ReactorInvoker(
                     continue;
                 }
 
+                var methodsByEventType = method.IsDefined(typeof(ReplayAttribute), false) ? replayMethodsByEventType : liveMethodsByEventType;
                 var eventParameterType = method.GetParameters()[0].ParameterType;
                 foreach (var eventType in eventParameterType.GetEventTypes(eventTypes))
                 {
@@ -232,7 +268,7 @@ public class ReactorInvoker(
                 }
             }
 
-            return methodsByEventType.ToFrozenDictionary();
+            return new(liveMethodsByEventType.ToFrozenDictionary(), replayMethodsByEventType.ToFrozenDictionary());
         }
     }
 }

--- a/Source/Clients/DotNET/Reactors/ReplayAttribute.cs
+++ b/Source/Clients/DotNET/Reactors/ReplayAttribute.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Reactors;
+
+/// <summary>
+/// Attribute used to mark a reactor handler method as the one to run while events are being replayed.
+/// </summary>
+/// <remarks>
+/// A reactor sees the same events twice for different reasons: as they happen, and again when its observer is
+/// replayed. Those often call for different work - a notification that should go out once when the event happens
+/// has no business going out again during a rebuild. Mark a second handler for the same event type with this
+/// attribute and it takes over for the duration of the replay, leaving the unmarked handler to the live path.
+/// <para>
+/// When an event type has no handler marked with this attribute, the regular handler runs during replay as
+/// before. When it has one, only the marked handler runs during replay - the regular handler does not also run.
+/// </para>
+/// <para>
+/// Use <see cref="OnceOnlyAttribute"/> instead when the side effect should simply not happen again on replay.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ReplayAttribute : Attribute;


### PR DESCRIPTION
## Added

- `[Replay]` on a reactor handler method, marking it as the one to run while the observer is replaying. Only the marked handler runs during a replay; an event type without one behaves exactly as before. (#845)