### PR TITLE
Take the state machine surface off the observer grain contract

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
@@ -13,6 +13,7 @@ namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.given;
 public class a_catching_up_in_flight_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected CatchingUpInFlight _state;
     protected ObserverState _storedState;
     protected ObserverState _resultingStoredState;
@@ -24,7 +25,8 @@ public class a_catching_up_in_flight_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _observerKey = new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), EventSequenceId.Log);
 
         _definitionState = Substitute.For<IPersistentState<ObserverDefinition>>();
@@ -42,7 +44,7 @@ public class a_catching_up_in_flight_state : Specification
             _failuresState,
             _jobsManager,
             Substitute.For<ILogger<CatchingUpInFlight>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
 
         _storedState = new ObserverState
         {

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
@@ -24,5 +24,5 @@ public class and_observer_is_quarantined : given.a_catching_up_in_flight_state
         .DidNotReceive()
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
@@ -28,5 +28,5 @@ public class and_partition_is_already_failed : given.a_catching_up_in_flight_sta
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
             Arg.Is<CatchUpObserverPartitionRequest>(_ => _.Key == _partition));
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
@@ -16,5 +16,5 @@ public class and_there_are_no_in_flight_entries : given.a_catching_up_in_flight_
         .DidNotReceive()
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
@@ -37,5 +37,5 @@ public class and_there_are_pending_entries : given.a_catching_up_in_flight_state
 
     [Fact] void should_mark_first_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_firstPartition);
     [Fact] void should_mark_second_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_secondPartition);
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/given/an_observing_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/given/an_observing_state.cs
@@ -17,6 +17,7 @@ namespace Cratis.Chronicle.Observation.States.for_Observing.given;
 public class an_observing_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected IAppendedEventsQueues _appendedEventsQueues;
     protected IEventSequence _eventSequence;
     protected Observing _state;
@@ -44,7 +45,8 @@ public class an_observing_state : Specification
         _eventStoreNamespace = "some_namespace";
         _eventSequenceId = EventSequenceId.Log;
 
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _appendedEventsQueues = Substitute.For<IAppendedEventsQueues>();
         _appendedEventsQueue = Substitute.For<IAppendedEventsQueue>();
         _eventSequence = Substitute.For<IEventSequence>();
@@ -74,7 +76,7 @@ public class an_observing_state : Specification
             _definitionState,
             _eventSequence,
             Substitute.For<ILogger<Observing>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
         _storedState = new ObserverState
         {
             Identifier = _observerId,

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_events_missed_between_routing_and_subscribing.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_events_missed_between_routing_and_subscribing.cs
@@ -20,5 +20,5 @@ public class with_events_missed_between_routing_and_subscribing : given.an_obser
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
     [Fact] void should_subscribe_to_stream() => _appendedEventsQueues.Received(1).Subscribe(_observerKey, _eventTypes);
-    [Fact] void should_transition_back_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_back_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_no_events_missed_between_routing_and_subscribing.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_no_events_missed_between_routing_and_subscribing.cs
@@ -20,5 +20,5 @@ public class with_no_events_missed_between_routing_and_subscribing : given.an_ob
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
     [Fact] void should_subscribe_to_stream() => _appendedEventsQueues.Received(1).Subscribe(_observerKey, _eventTypes);
-    [Fact] void should_not_transition_back_to_routing() => _observer.DidNotReceive().TransitionTo<Routing>();
+    [Fact] void should_not_transition_back_to_routing() => _stateMachine.DidNotReceive().TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Replay/given/a_replay_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Replay/given/a_replay_state.cs
@@ -18,6 +18,7 @@ namespace Cratis.Chronicle.Observation.States.for_Replay.given;
 public class a_replay_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected ObserverKey _observerKey;
     protected IJobsManager _jobsManager;
     protected ObserverSubscription _subscription;
@@ -30,7 +31,8 @@ public class a_replay_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _observerId = Guid.NewGuid().ToString();
         _observerKey = new(_observerId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
         _jobsManager = Substitute.For<IJobsManager>();
@@ -45,7 +47,7 @@ public class a_replay_state : Specification
             _jobsManager,
             Substitute.For<IStorage>(),
             Substitute.For<ILogger<Replay>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
 
         _storedState = new ObserverState
         {

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/given/a_routing_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/given/a_routing_state.cs
@@ -18,6 +18,7 @@ namespace Cratis.Chronicle.Observation.States.for_Routing.given;
 public class a_routing_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected IEventSequence _eventSequence;
     protected Routing _state;
     protected ObserverState _storedState;
@@ -29,7 +30,8 @@ public class a_routing_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _eventSequence = Substitute.For<IEventSequence>();
         _observerKey = new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
         _definitionState = Substitute.For<IPersistentState<ObserverDefinition>>();
@@ -40,7 +42,7 @@ public class a_routing_state : Specification
             _definitionState,
             _eventSequence,
             Substitute.For<ILogger<Routing>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
         _storedState = new ObserverState
         {
             RunningState = ObserverRunningState.Unknown,

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_already_replaying.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_already_replaying.cs
@@ -12,6 +12,6 @@ public class and_it_is_already_replaying : given.a_routing_state
 
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
-    [Fact] void should_only_perform_one_transition() => _observer.Received(1).TransitionTo<IState<ObserverState>>();
-    [Fact] void should_transition_to_replay() => _observer.Received(1).TransitionTo<Replay>();
+    [Fact] void should_only_perform_one_transition() => _stateMachine.Received(1).TransitionTo<IState<ObserverState>>();
+    [Fact] void should_transition_to_replay() => _stateMachine.Received(1).TransitionTo<Replay>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_falling_behind.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_falling_behind.cs
@@ -19,6 +19,6 @@ public class and_it_is_falling_behind : given.a_routing_state
 
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
-    [Fact] void should_only_perform_one_transition() => _observer.Received(1).TransitionTo<IState<ObserverState>>();
+    [Fact] void should_only_perform_one_transition() => _stateMachine.Received(1).TransitionTo<IState<ObserverState>>();
     [Fact] void should_ask_observer_to_catchup() => _observer.Received(1).CatchUp();
 }

--- a/Source/Kernel/Core/Observation/IObserver.cs
+++ b/Source/Kernel/Core/Observation/IObserver.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
-using Cratis.Chronicle.StateMachines;
 using Cratis.Chronicle.Storage.Observation;
 using Orleans.Concurrency;
 
@@ -15,7 +14,12 @@ namespace Cratis.Chronicle.Observation;
 /// <summary>
 /// Defines an observer in the system.
 /// </summary>
-public interface IObserver : IStateMachine<ObserverState>, IGrainWithStringKey
+/// <remarks>
+/// The observer is implemented as a state machine internally, but that is an implementation concern and
+/// deliberately not part of this grain contract - state transitions are driven from within the observer
+/// implementation, never across a grain reference.
+/// </remarks>
+public interface IObserver : IGrainWithStringKey
 {
     /// <summary>
     /// Ensure the observer existence.


### PR DESCRIPTION
Removes `IStateMachine<ObserverState>` from the `IObserver` grain contract. No user-facing change — no caller ever invoked those members through a grain reference — so there are no release-note bullets. (#1601)