### PR TITLE
Expose identity renaming on the .NET client event store

### DIFF
--- a/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/given/an_identity_manager.cs
+++ b/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/given/an_identity_manager.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Identities;
+
+namespace Cratis.Chronicle.Identities.for_IdentityManager.given;
+
+public class an_identity_manager : Specification
+{
+    protected static readonly EventStoreName _eventStore = "the-store";
+    protected static readonly EventStoreNamespaceName _namespace = "the-namespace";
+
+    protected IIdentities _identities;
+    protected IdentityManager _manager;
+
+    void Establish()
+    {
+        _identities = Substitute.For<IIdentities>();
+
+        var services = Substitute.For<IServices>();
+        services.Identities.Returns(_identities);
+
+        var connection = Substitute.For<IChronicleConnection, IChronicleServicesAccessor>();
+        ((IChronicleServicesAccessor)connection).Services.Returns(services);
+
+        _manager = new IdentityManager(_eventStore, _namespace, connection);
+    }
+}

--- a/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/when_renaming_an_identity.cs
+++ b/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/when_renaming_an_identity.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Identities;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.Identities.for_IdentityManager;
+
+public class when_renaming_an_identity : given.an_identity_manager
+{
+    const string IdentitySubject = "person-42";
+    const string NewName = "The New Name";
+
+    async Task Because() => await _manager.Rename(IdentitySubject, NewName);
+
+    [Fact]
+    async Task should_rename_the_identity_in_the_store() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.EventStore == _eventStore.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_in_the_namespace() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Namespace == _namespace.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_for_the_subject() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Subject == IdentitySubject),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_to_the_new_name() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Name == NewName),
+            Arg.Any<CallContext>());
+}

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -244,6 +244,7 @@ public class EventStore : IEventStore
             loggerFactory.CreateLogger<EventSeeding>());
 
         PII = new Compliance.GDPR.PIIManager(eventStoreName, @namespace, connection);
+        Identities = new IdentityManager(eventStoreName, @namespace, connection);
 
         if (autoDiscoverAndRegister)
         {
@@ -307,6 +308,9 @@ public class EventStore : IEventStore
 
     /// <inheritdoc/>
     public Compliance.GDPR.IPIIManager PII { get; }
+
+    /// <inheritdoc/>
+    public IIdentityManager Identities { get; }
 
     /// <inheritdoc/>
     public async Task DiscoverAll()

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventStoreSubscriptions;
 using Cratis.Chronicle.ExternalServices;
+using Cratis.Chronicle.Identities;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
@@ -119,6 +120,11 @@ public interface IEventStore
     /// Gets the <see cref="IPIIManager"/> for managing PII encryption keys (GDPR right-to-erasure) for the event store.
     /// </summary>
     IPIIManager PII { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IIdentityManager"/> for managing identities for the event store.
+    /// </summary>
+    IIdentityManager Identities { get; }
 
     /// <summary>
     /// Discover all artifacts for the event store.

--- a/Source/Clients/DotNET/Identities/IIdentityManager.cs
+++ b/Source/Clients/DotNET/Identities/IIdentityManager.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Identities;
+
+/// <summary>
+/// Defines a manager of identities in the system.
+/// </summary>
+public interface IIdentityManager
+{
+    /// <summary>
+    /// Renames the name of an identity, identified by its subject.
+    /// </summary>
+    /// <param name="subject">The subject of the <see cref="Identity"/> to rename.</param>
+    /// <param name="name">The new name to give the identity.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// The subject is the stable identifier of the identity - the name is the display name and
+    /// can change over time, for instance when a person changes their name. Renaming an identity
+    /// affects every event and read model that refers to the identity, as the name is resolved
+    /// from the identity itself and not stored with what refers to it.
+    /// </remarks>
+    Task Rename(string subject, string name);
+}

--- a/Source/Clients/DotNET/Identities/IdentityManager.cs
+++ b/Source/Clients/DotNET/Identities/IdentityManager.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Identities;
+
+namespace Cratis.Chronicle.Identities;
+
+/// <summary>
+/// Represents an implementation of <see cref="IIdentityManager"/> that proxies to the Chronicle kernel over the client connection.
+/// </summary>
+/// <param name="eventStore">The <see cref="EventStoreName"/> the manager operates within.</param>
+/// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the manager operates within.</param>
+/// <param name="connection">The <see cref="IChronicleConnection"/> for talking to the kernel.</param>
+public class IdentityManager(
+    EventStoreName eventStore,
+    EventStoreNamespaceName @namespace,
+    IChronicleConnection connection) : IIdentityManager
+{
+    readonly IChronicleServicesAccessor _servicesAccessor = (connection as IChronicleServicesAccessor)!;
+
+    /// <inheritdoc/>
+    public Task Rename(string subject, string name) =>
+        _servicesAccessor.Services.Identities.RenameIdentity(new RenameIdentityRequest
+        {
+            EventStore = eventStore,
+            Namespace = @namespace,
+            Subject = subject,
+            Name = name
+        });
+}

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -85,6 +85,7 @@ public class EventStoreForTesting : IEventStore
     readonly Lazy<IUnitOfWorkManager> _unitOfWorkManager;
     readonly Lazy<IEventSeeding> _seeding;
     readonly Lazy<IPIIManager> _pii;
+    readonly Lazy<IIdentityManager> _identities;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStoreForTesting"/> class.
@@ -219,6 +220,7 @@ public class EventStoreForTesting : IEventStore
             _artifactActivator,
             NullLogger<EventSeeding>.Instance));
         _pii = new Lazy<IPIIManager>(() => new PIIManager(Name, Namespace, Connection));
+        _identities = new Lazy<IIdentityManager>(() => new IdentityManager(Name, Namespace, Connection));
     }
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
@@ -278,6 +280,9 @@ public class EventStoreForTesting : IEventStore
 
     /// <inheritdoc/>
     public IPIIManager PII => _pii.Value;
+
+    /// <inheritdoc/>
+    public IIdentityManager Identities => _identities.Value;
 
     /// <summary>
     /// Gets the <see cref="IJsonSchemaGenerator"/> used by this event store.


### PR DESCRIPTION
## Added

- `IEventStore.Identities` with `Rename(subject, name)`, exposing the identity renaming the kernel already supported to the .NET client. (#1684)