### PR TITLE
Add [JsonSchemaType] to override a type's JSON schema representation

### DIFF
--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_type_with_json_schema_type_override.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_type_with_json_schema_type_override.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// Substituting the schema of a type adorned with <see cref="JsonSchemaTypeAttribute"/> must not drop the
+/// classification of the value it stands in for — the compliance metadata belongs to the value, not to the shape
+/// it happens to serialize as, and losing it here would persist a <c>[PII]</c> value in the clear.
+/// </summary>
+public class when_generating_schema_for_pii_type_with_json_schema_type_override : given.a_json_schema_generator_with_pii_support
+{
+    [PII]
+    [JsonSchemaType(typeof(string))]
+    [JsonConverter(typeof(SocialSecurityNumberJsonConverter))]
+    record SocialSecurityNumber(string Country, string Number);
+
+    class SocialSecurityNumberJsonConverter : JsonConverter<SocialSecurityNumber>
+    {
+        public override SocialSecurityNumber Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(string.Empty, reader.GetString() ?? string.Empty);
+
+        public override void Write(Utf8JsonWriter writer, SocialSecurityNumber value, JsonSerializerOptions options) => writer.WriteStringValue($"{value.Country}-{value.Number}");
+    }
+
+    record Citizen(SocialSecurityNumber Identification);
+
+    JsonSchema _result;
+
+    void Because() => _result = _generator.Generate(typeof(Citizen));
+
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_json_type() =>
+        _result.ActualProperties["identification"].Type.ShouldEqual(JsonObjectType.String);
+
+    [Fact] void should_have_compliance_metadata_on_the_substituted_schema() =>
+        _result.ActualProperties["identification"].HasComplianceMetadata().ShouldBeTrue();
+
+    [Fact] void should_have_pii_compliance_type_on_the_substituted_schema() =>
+        _result.ActualProperties["identification"].GetComplianceMetadata()
+            .Select(_ => _.metadataType)
+            .ShouldContain(ComplianceMetadataType.PII.Value);
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_json_schema_type_override.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_json_schema_type_override.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// A type bringing its own <see cref="JsonConverter"/> serializes as something other than its CLR shape, and
+/// System.Text.Json's schema exporter cannot see through the converter. Adorning the type with
+/// <see cref="JsonSchemaTypeAttribute"/> declares what the converter actually produces, so the schema — which is
+/// what the value is stored and read against — describes the wire form rather than the CLR form.
+/// </summary>
+public class when_generating_schema_for_type_with_json_schema_type_override : given.a_json_schema_generator
+{
+    [JsonSchemaType(typeof(Guid))]
+    [JsonConverter(typeof(TrackingCodeJsonConverter))]
+    record TrackingCode(Guid Value)
+    {
+        public string Display => Value.ToString("N");
+    }
+
+    class TrackingCodeJsonConverter : JsonConverter<TrackingCode>
+    {
+        public override TrackingCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(reader.GetGuid());
+
+        public override void Write(Utf8JsonWriter writer, TrackingCode value, JsonSerializerOptions options) => writer.WriteStringValue(value.Value);
+    }
+
+    record Shipment(TrackingCode Code, TrackingCode? PreviousCode);
+
+    JsonSchema _result;
+
+    void Because() => _result = _generator.Generate(typeof(Shipment));
+
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_format() => _result.ActualProperties[nameof(Shipment.Code)].Format.ShouldEqual("guid");
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_json_type() => _result.ActualProperties[nameof(Shipment.Code)].Type.ShouldEqual(JsonObjectType.String);
+    [Fact] void should_not_describe_the_clr_shape_of_the_adorned_type() => _result.ActualProperties[nameof(Shipment.Code)].ActualProperties.ShouldBeEmpty();
+    [Fact] void should_mark_the_optional_adorned_type_as_nullable() => _result.ActualProperties[nameof(Shipment.PreviousCode)].Format.ShouldEqual("guid?");
+    [Fact] void should_default_the_optional_adorned_type_to_null() => _result.ActualProperties[nameof(Shipment.PreviousCode)].GetDefaultValue(_typeFormats).ShouldBeNull();
+    [Fact] void should_default_the_required_adorned_type_to_its_type_default() => _result.ActualProperties[nameof(Shipment.Code)].GetDefaultValue(_typeFormats).ShouldNotBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_self_referencing_json_schema_type.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_self_referencing_json_schema_type.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// A <see cref="JsonSchemaTypeAttribute"/> pointing at the type it adorns would substitute the type's schema with
+/// its own schema forever, so it is rejected with a message naming the offending type instead of overflowing the stack.
+/// </summary>
+public class when_generating_schema_for_type_with_self_referencing_json_schema_type : given.a_json_schema_generator
+{
+    [JsonSchemaType(typeof(Beacon))]
+    record Beacon(string Signal);
+
+    Exception _result;
+
+    void Because() => _result = Catch.Exception(() => _generator.Generate(typeof(Beacon)));
+
+    [Fact] void should_fail_with_self_referencing_json_schema_type() => _result.ShouldBeOfExactType<SelfReferencingJsonSchemaType>();
+}

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -197,41 +197,35 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     static bool PropertyIsNullable(Type type, JsonSchemaExporterContext context) =>
         Nullable.GetUnderlyingType(type) is not null || IsAnnotatedNullable(context);
 
+    static void ThrowIfSelfReferencing(Type type, Type representedAs)
+    {
+        if (representedAs == type)
+        {
+            throw new SelfReferencingJsonSchemaType(type);
+        }
+    }
+
     JsonNode TransformNode(JsonSchemaExporterContext context, JsonNode schema)
     {
         var type = context.TypeInfo.Type;
         var formatType = Nullable.GetUnderlyingType(type) ?? type;
 
+        // An explicit [JsonSchemaType] declaration states what a type's own JsonConverter actually produces.
+        // System.Text.Json's schema exporter cannot introspect a custom converter, so without this the schema
+        // describes the CLR shape while the wire carries something else entirely — and the value stops
+        // round-tripping through the sink. It is resolved before the concept branch so an explicit declaration
+        // always wins over an inferred representation, and after the Nullable<> unwrap so that a nullable
+        // value type is recognized as its adorned underlying type.
+        if (formatType.GetCustomAttribute<JsonSchemaTypeAttribute>() is { } jsonSchemaType)
+        {
+            ThrowIfSelfReferencing(formatType, jsonSchemaType.Type);
+            return RepresentAs(jsonSchemaType.Type, type, context);
+        }
+
         // Handle concept types - redirect to the underlying primitive type's schema
         if (type.IsConcept())
         {
-            var underlyingType = type.GetConceptValueType();
-            var conceptSchema = context.TypeInfo.Options.GetJsonSchemaAsNode(underlyingType, _exporterOptions);
-
-            // Preserve nullable marker for concept types (e.g. EventSequenceNumber?).
-            // STJ's JsonSchemaExporter does not propagate NRT nullable markers through custom converters,
-            // so we check the actual property nullability via NullabilityInfoContext. When the property
-            // is nullable we append '?' to the format so that IsNullable() returns true and
-            // GetDefaultValue() returns null rather than the primitive default (e.g. 0 for ulong).
-            if (conceptSchema is JsonObject conceptSchemaObj)
-            {
-                if (_metadataResolver.HasMetadataFor(type))
-                {
-                    AddComplianceMetadata(conceptSchemaObj, _metadataResolver.GetMetadataFor(type));
-                }
-
-                if (PropertyIsNullable(type, context) &&
-                    conceptSchemaObj.TryGetPropertyValue("format", out var format))
-                {
-                    var formatStr = format!.GetValue<string>();
-                    if (!formatStr.EndsWith('?'))
-                    {
-                        conceptSchemaObj["format"] = formatStr + "?";
-                    }
-                }
-            }
-
-            return conceptSchema;
+            return RepresentAs(type.GetConceptValueType(), type, context);
         }
 
         // Handle enumerables whose element type is a concept (e.g. IReadOnlyList<Requirement>).
@@ -368,5 +362,47 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
         }
 
         return schema;
+    }
+
+    /// <summary>
+    /// Produces the schema of a different type in place of the declared type's own schema.
+    /// </summary>
+    /// <param name="representedAs">The <see cref="Type"/> whose schema describes what actually goes on the wire.</param>
+    /// <param name="declaredType">The declared <see cref="Type"/> being represented.</param>
+    /// <param name="context">The <see cref="JsonSchemaExporterContext"/> of the node being transformed.</param>
+    /// <returns>The schema node for <paramref name="representedAs"/>, carrying the declared type's metadata.</returns>
+    /// <remarks>
+    /// The declared type's compliance metadata has to travel onto the substituted schema — the classification
+    /// belongs to the value, not to the shape it happens to serialize as, and losing it here would persist a
+    /// <c>[PII]</c> value in the clear.
+    /// <para>
+    /// The nullable marker has to be re-applied for the same reason: System.Text.Json's schema exporter does not
+    /// propagate NRT nullable markers through custom converters, so the actual property nullability is read via
+    /// <see cref="NullabilityInfoContext"/>. When the property is nullable, '?' is appended to the format so that
+    /// <c>IsNullable()</c> returns true and <c>GetDefaultValue()</c> returns null rather than the primitive
+    /// default (e.g. 0 for ulong).
+    /// </para>
+    /// </remarks>
+    JsonNode RepresentAs(Type representedAs, Type declaredType, JsonSchemaExporterContext context)
+    {
+        var representedSchema = context.TypeInfo.Options.GetJsonSchemaAsNode(representedAs, _exporterOptions);
+        if (representedSchema is not JsonObject representedSchemaObject) return representedSchema;
+
+        if (_metadataResolver.HasMetadataFor(declaredType))
+        {
+            AddComplianceMetadata(representedSchemaObject, _metadataResolver.GetMetadataFor(declaredType));
+        }
+
+        if (PropertyIsNullable(declaredType, context) &&
+            representedSchemaObject.TryGetPropertyValue("format", out var format))
+        {
+            var formatValue = format!.GetValue<string>();
+            if (!formatValue.EndsWith('?'))
+            {
+                representedSchemaObject["format"] = formatValue + "?";
+            }
+        }
+
+        return representedSchema;
     }
 }

--- a/Source/Clients/DotNET/Schemas/JsonSchemaTypeAttribute.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaTypeAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas;
+
+/// <summary>
+/// Attribute used to override the type a type is represented as in the generated JSON schema.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="JsonSchemaTypeAttribute"/> class.
+/// <para>
+/// A type that brings its own <c>JsonConverter</c> serializes to something other than its own shape — a value
+/// object written as a single string, for instance. The generated schema is what Chronicle stores and reads
+/// values against, so it has to describe what actually goes on the wire; without this the schema would describe
+/// the CLR shape and the value would not round-trip. Adorn the type with this attribute to state what its
+/// converter actually produces, rather than depending on attributes from whichever schema library is in use.
+/// </para>
+/// </remarks>
+/// <param name="type">The <see cref="Type"/> the adorned type is represented as in the JSON schema.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class JsonSchemaTypeAttribute(Type type) : Attribute
+{
+    /// <summary>
+    /// Gets the <see cref="Type"/> the adorned type is represented as in the JSON schema.
+    /// </summary>
+    public Type Type { get; } = type;
+}

--- a/Source/Clients/DotNET/Schemas/SelfReferencingJsonSchemaType.cs
+++ b/Source/Clients/DotNET/Schemas/SelfReferencingJsonSchemaType.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas;
+
+/// <summary>
+/// The exception that is thrown when a type adorned with <see cref="JsonSchemaTypeAttribute"/> points at itself.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SelfReferencingJsonSchemaType"/> class.
+/// Generating the schema for such a type would recurse forever, so it is rejected up front with a message
+/// naming the offending type rather than being left to overflow the stack.
+/// </remarks>
+/// <param name="type"><see cref="Type"/> that represents itself.</param>
+public class SelfReferencingJsonSchemaType(Type type) : Exception($"Type '{type.FullName}' is adorned with a {nameof(JsonSchemaTypeAttribute)} that points at itself. Point it at the type its converter actually produces.");


### PR DESCRIPTION
## Added

- `[JsonSchemaType(typeof(T))]` on a type, overriding how it is represented in the JSON schema generated for events and read models. Compliance metadata and nullability are preserved. (#1470)