### PR TITLE
Register every event type with one read and one write

### DIFF
--- a/Source/Kernel/Concepts/Events/EventTypeToRegister.cs
+++ b/Source/Kernel/Concepts/Events/EventTypeToRegister.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Events;
+
+/// <summary>
+/// Represents an <see cref="EventTypeDefinition"/> to register together with the <see cref="EventTypeSource"/> it came from.
+/// </summary>
+/// <param name="Definition">The <see cref="EventTypeDefinition"/> to register.</param>
+/// <param name="Source">The <see cref="EventTypeSource"/> the event type came from.</param>
+/// <remarks>
+/// <see cref="EventTypeDefinition"/> carries the owner and tombstone metadata of an event type but not the source it
+/// came from - pairing the two is what makes it possible to register a whole batch of event types in one operation.
+/// </remarks>
+public record EventTypeToRegister(EventTypeDefinition Definition, EventTypeSource Source);

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -10,7 +10,6 @@ using Cratis.Chronicle.Events.EventSequences.Migrations;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
-using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Reactive;
 using ProtoBuf.Grpc;
 
@@ -40,128 +39,40 @@ internal sealed class EventTypes(
 #endif
         var eventTypesStorage = storage.GetEventStore(request.EventStore).EventTypes;
 
+        // A client registers every event type it knows about in one call, and every check below - does the event
+        // type exist, does this generation exist, has its schema changed - is answered by what is already stored.
+        // Reading all of it once keeps registration at a couple of round trips instead of a handful per event type.
+        var stored = (await eventTypesStorage.GetAllDefinitions()).ToDictionary(_ => _.Id);
+
         if (!skipValidation)
         {
             foreach (var eventType in request.Types)
             {
                 ValidateMigrationChain(eventType.Type.Id, eventType.Type.Generation, eventType.Migrations);
-                await ValidateSchemaNotChanged(eventType, eventTypesStorage);
+                await ValidateSchemaNotChanged(eventType, StoredFor(stored, eventType));
             }
         }
+
+        var eventTypesToRegister = new List<EventTypeToRegister>();
+        var newGenerationsPerEventType = new List<NewGenerations>();
 
         foreach (var eventType in request.Types)
         {
-            var schema = await JsonSchema.FromJsonAsync(eventType.Schema);
-            schema.EnsureComplianceMetadata();
-            var owner = (Concepts.Events.EventTypeOwner)(int)eventType.Owner;
-            var source = (Concepts.Events.EventTypeSource)(int)eventType.Source;
-            var eventTypeId = new EventTypeId(eventType.Type.Id);
-            var hasExistingEventType = await eventTypesStorage.HasFor(eventTypeId);
-
-            // Detect new generations before registration
-            var newGenerations = new List<(EventTypeGeneration Generation, string Schema)>();
-            foreach (var genDef in eventType.Generations)
-            {
-                if (!await eventTypesStorage.HasFor(eventTypeId, new EventTypeGeneration(genDef.Generation)))
-                {
-                    newGenerations.Add((new EventTypeGeneration(genDef.Generation), genDef.Schema));
-                }
-            }
-
-            if (eventType.Generations.Count == 0 && !await eventTypesStorage.HasFor(eventTypeId, new EventTypeGeneration(eventType.Type.Generation)))
-            {
-                newGenerations.Add((new EventTypeGeneration(eventType.Type.Generation), eventType.Schema));
-            }
-
-            bool mutated;
-            if (eventType.Migrations.Count > 0 || eventType.Generations.Count > 1)
-            {
-                // Register using full definition with all generations and migrations
-                var generations = new List<Concepts.Events.EventTypeGenerationDefinition>();
-                foreach (var genDef in eventType.Generations)
-                {
-                    var genSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
-                    genSchema.EnsureComplianceMetadata();
-                    generations.Add(new Concepts.Events.EventTypeGenerationDefinition(genDef.Generation, genSchema));
-                }
-
-                if (generations.Count == 0)
-                {
-                    generations.Add(new Concepts.Events.EventTypeGenerationDefinition(eventType.Type.ToChronicle().Generation, schema));
-                }
-
-                var filteredMigrations = eventType.Migrations.Where(m => m.FromGeneration != m.ToGeneration);
-                var migrations = filteredMigrations.Select(m =>
-                {
-                    var upcastJson = string.IsNullOrEmpty(m.UpcastJmesPath)
-                        ? new JsonObject()
-                        : JsonNode.Parse(m.UpcastJmesPath)?.AsObject() ?? new JsonObject();
-                    var downcastJson = string.IsNullOrEmpty(m.DowncastJmesPath)
-                        ? new JsonObject()
-                        : JsonNode.Parse(m.DowncastJmesPath)?.AsObject() ?? new JsonObject();
-
-                    if (!skipValidation)
-                    {
-                        ValidateMigrationProperties(eventType.Type.Id, m, upcastJson, downcastJson, generations);
-                    }
-
-                    return new Concepts.Events.EventTypeMigrationDefinition(
-                        m.FromGeneration,
-                        m.ToGeneration,
-                        [],
-                        upcastJson,
-                        downcastJson);
-                }).ToList();
-
-                var definition = new EventTypeDefinition(
-                    eventType.Type.ToChronicle().Id,
-                    owner,
-                    eventType.Type.Tombstone,
-                    generations,
-                    migrations);
-
-                mutated = await eventTypesStorage.Register(definition);
-            }
-            else
-            {
-                mutated = await eventTypesStorage.Register(
-                    eventType.Type.ToChronicle(),
-                    schema,
-                    owner,
-                    source);
-            }
-
-            // Evict the event type cache on every silo whenever the registration actually changed the stored
-            // document - a new generation, or a different owner, source, or tombstone. Idempotent
-            // re-registrations report no change, so client reconnects do not trigger cluster-wide eviction.
-            if (mutated)
-            {
-                await eventTypesCacheClient.Invalidate(request.EventStore, eventTypeId);
-            }
-
-            // Append system events for newly discovered event type generations.
-            if (newGenerations.Count > 0)
-            {
-                var systemEventSequence = grainFactory.GetSystemEventSequence(request.EventStore);
-
-                if (!hasExistingEventType)
-                {
-                    var firstGeneration = newGenerations.OrderBy(_ => _.Generation.Value).First();
-                    await systemEventSequence.Append(
-                        (EventSourceId)eventTypeId.Value,
-                        new EventTypeAdded(eventTypeId, firstGeneration.Generation, firstGeneration.Schema));
-                }
-                else
-                {
-                    foreach (var (generation, genSchema) in newGenerations)
-                    {
-                        await systemEventSequence.Append(
-                            (EventSourceId)eventTypeId.Value,
-                            new EventTypeGenerationAdded(eventTypeId, generation, genSchema));
-                    }
-                }
-            }
+            newGenerationsPerEventType.Add(GetNewGenerations(eventType, StoredFor(stored, eventType)));
+            eventTypesToRegister.Add(await CreateEventTypeToRegister(eventType, skipValidation));
         }
+
+        // Evict the event type cache on every silo whenever a registration actually changed the stored
+        // representation - a new generation, or a different owner, source, or tombstone. Idempotent
+        // re-registrations report no change, so client reconnects do not trigger cluster-wide eviction.
+        var mutated = await eventTypesStorage.Register(eventTypesToRegister);
+
+        foreach (var eventTypeId in mutated)
+        {
+            await eventTypesCacheClient.Invalidate(request.EventStore, eventTypeId);
+        }
+
+        await AppendSystemEventsForNewGenerations(request.EventStore, newGenerationsPerEventType);
     }
 
     /// <inheritdoc/>
@@ -232,6 +143,85 @@ internal sealed class EventTypes(
             Source = (Contracts.Events.EventTypeSource)(int)_.Source,
             Schema = _.Schema.ToJson()
         });
+    }
+
+    static EventTypeDefinition? StoredFor(Dictionary<EventTypeId, EventTypeDefinition> stored, EventTypeRegistration eventType) =>
+        stored.GetValueOrDefault(new EventTypeId(eventType.Type.Id));
+
+    static NewGenerations GetNewGenerations(EventTypeRegistration eventType, EventTypeDefinition? storedDefinition)
+    {
+        var eventTypeId = new EventTypeId(eventType.Type.Id);
+        var storedGenerations = storedDefinition?.Generations.Select(_ => _.Generation).ToHashSet() ?? [];
+
+        var generations = eventType.Generations
+            .Select(_ => (Generation: new EventTypeGeneration(_.Generation), _.Schema))
+            .Where(_ => !storedGenerations.Contains(_.Generation))
+            .ToList();
+
+        if (eventType.Generations.Count == 0 && !storedGenerations.Contains(new EventTypeGeneration(eventType.Type.Generation)))
+        {
+            generations.Add((new EventTypeGeneration(eventType.Type.Generation), eventType.Schema));
+        }
+
+        return new(eventTypeId, storedDefinition is not null, generations);
+    }
+
+    static async Task<EventTypeToRegister> CreateEventTypeToRegister(EventTypeRegistration eventType, bool skipValidation)
+    {
+        var generations = new List<Concepts.Events.EventTypeGenerationDefinition>();
+        foreach (var genDef in eventType.Generations)
+        {
+            var genSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
+            genSchema.EnsureComplianceMetadata();
+            generations.Add(new Concepts.Events.EventTypeGenerationDefinition(genDef.Generation, genSchema));
+        }
+
+        if (generations.Count == 0)
+        {
+            var schema = await JsonSchema.FromJsonAsync(eventType.Schema);
+            schema.EnsureComplianceMetadata();
+            generations.Add(new Concepts.Events.EventTypeGenerationDefinition(eventType.Type.ToChronicle().Generation, schema));
+        }
+
+        var migrations = eventType.Migrations
+            .Where(m => m.FromGeneration != m.ToGeneration)
+            .Select(m => CreateMigration(eventType.Type.Id, m, generations, skipValidation))
+            .ToList();
+
+        var definition = new EventTypeDefinition(
+            eventType.Type.ToChronicle().Id,
+            (Concepts.Events.EventTypeOwner)(int)eventType.Owner,
+            eventType.Type.Tombstone,
+            generations,
+            migrations);
+
+        return new(definition, (Concepts.Events.EventTypeSource)(int)eventType.Source);
+    }
+
+    static Concepts.Events.EventTypeMigrationDefinition CreateMigration(
+        string eventTypeId,
+        Contracts.Events.EventTypeMigrationDefinition migration,
+        List<Concepts.Events.EventTypeGenerationDefinition> generations,
+        bool skipValidation)
+    {
+        var upcastJson = string.IsNullOrEmpty(migration.UpcastJmesPath)
+            ? new JsonObject()
+            : JsonNode.Parse(migration.UpcastJmesPath)?.AsObject() ?? new JsonObject();
+        var downcastJson = string.IsNullOrEmpty(migration.DowncastJmesPath)
+            ? new JsonObject()
+            : JsonNode.Parse(migration.DowncastJmesPath)?.AsObject() ?? new JsonObject();
+
+        if (!skipValidation)
+        {
+            ValidateMigrationProperties(eventTypeId, migration, upcastJson, downcastJson, generations);
+        }
+
+        return new Concepts.Events.EventTypeMigrationDefinition(
+            migration.FromGeneration,
+            migration.ToGeneration,
+            [],
+            upcastJson,
+            downcastJson);
     }
 
     static void ValidateMigrationChain(string eventTypeId, uint currentGeneration, IList<Contracts.Events.EventTypeMigrationDefinition> migrations)
@@ -369,23 +359,26 @@ internal sealed class EventTypes(
         }
     }
 
-    static async Task ValidateSchemaNotChanged(EventTypeRegistration eventType, IEventTypesStorage eventTypesStorage)
+    static async Task ValidateSchemaNotChanged(EventTypeRegistration eventType, EventTypeDefinition? storedDefinition)
     {
-        var eventTypeId = new EventTypeId(eventType.Type.Id);
+        if (storedDefinition is null)
+        {
+            return;
+        }
 
         foreach (var genDef in eventType.Generations)
         {
             var generation = new EventTypeGeneration(genDef.Generation);
-            if (!await eventTypesStorage.HasFor(eventTypeId, generation))
+            var existingGeneration = storedDefinition.Generations.FirstOrDefault(_ => _.Generation == generation);
+            if (existingGeneration is null)
             {
                 continue;
             }
 
-            var existingSchema = await eventTypesStorage.GetFor(eventTypeId, generation);
             var newSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
 
             // Storage applies EnsureComplianceMetadata() when deserializing a stored schema
-            // (in EventTypeConverters.ToKernel). Apply the same transformation to the incoming
+            // (in EventTypeConverters.ToDefinition). Apply the same transformation to the incoming
             // schema so both sides go through identical normalization before comparison.
             newSchema.EnsureComplianceMetadata();
 
@@ -393,10 +386,56 @@ internal sealed class EventTypes(
             // existing event schema (a nullable known value type that stored 'date-time-offset' now generates
             // 'date-time-offset?'). That marker only refines how an unset value materializes, not the data
             // shape, so a marker-only difference is not a breaking schema change.
-            if (!existingSchema.Schema.EqualsIgnoringNullableFormatMarkers(newSchema))
+            if (!existingGeneration.Schema.EqualsIgnoringNullableFormatMarkers(newSchema))
             {
                 throw new EventTypeSchemaChanged(eventType.Type.Id, genDef.Generation);
             }
         }
     }
+
+    async Task AppendSystemEventsForNewGenerations(EventStoreName eventStore, IEnumerable<NewGenerations> newGenerationsPerEventType)
+    {
+        var withNewGenerations = newGenerationsPerEventType.Where(_ => _.Generations.Count > 0).ToList();
+
+        if (withNewGenerations.Count == 0)
+        {
+            return;
+        }
+
+        var systemEventSequence = grainFactory.GetSystemEventSequence(eventStore);
+
+        foreach (var newGenerations in withNewGenerations)
+        {
+            var eventSourceId = (EventSourceId)newGenerations.EventTypeId.Value;
+
+            if (!newGenerations.EventTypeAlreadyStored)
+            {
+                var firstGeneration = newGenerations.Generations.OrderBy(_ => _.Generation.Value).First();
+                await systemEventSequence.Append(
+                    eventSourceId,
+                    new EventTypeAdded(newGenerations.EventTypeId, firstGeneration.Generation, firstGeneration.Schema));
+                continue;
+            }
+
+            foreach (var (generation, schema) in newGenerations.Generations)
+            {
+                await systemEventSequence.Append(
+                    eventSourceId,
+                    new EventTypeGenerationAdded(newGenerations.EventTypeId, generation, schema));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents the generations of an event type that are not yet stored, and whether the event type itself is
+    /// already stored - which is what decides between an <see cref="EventTypeAdded"/> and an
+    /// <see cref="EventTypeGenerationAdded"/> system event.
+    /// </summary>
+    /// <param name="EventTypeId">The <see cref="EventTypeId"/> the generations belong to.</param>
+    /// <param name="EventTypeAlreadyStored">Whether the event type is already stored.</param>
+    /// <param name="Generations">The generations that are not yet stored, with their schema as it came in.</param>
+    sealed record NewGenerations(
+        EventTypeId EventTypeId,
+        bool EventTypeAlreadyStored,
+        IReadOnlyList<(EventTypeGeneration Generation, string Schema)> Generations);
 }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/given/all_dependencies.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/given/all_dependencies.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.EventTypes;
 using KernelEventTypes = Cratis.Chronicle.Services.Events.EventTypes;
@@ -31,6 +32,21 @@ public class all_dependencies : Specification
         _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
         _eventStoreStorage.EventTypes.Returns(_eventTypesStorage);
         _grainFactory.GetGrain<IEventSequence>(Arg.Any<string>()).Returns(_systemEventSequence);
+        _eventTypesStorage.GetAllDefinitions().Returns([]);
+        _eventTypesStorage.Register(Arg.Any<IEnumerable<Concepts.Events.EventTypeToRegister>>()).Returns([]);
         _subject = new KernelEventTypes(_storage, _grainFactory, _eventTypesCacheClient);
     }
+
+    protected void StoredEventTypes(params Concepts.Events.EventTypeDefinition[] definitions) =>
+        _eventTypesStorage.GetAllDefinitions().Returns(definitions);
+
+    protected static Concepts.Events.EventTypeDefinition StoredEventType(string eventTypeId, params (uint Generation, string Schema)[] generations) =>
+        new(
+            eventTypeId,
+            Concepts.Events.EventTypeOwner.Client,
+            false,
+            generations.Select(_ => new Concepts.Events.EventTypeGenerationDefinition(
+                _.Generation,
+                JsonSchema.FromJsonAsync(_.Schema).GetAwaiter().GetResult())).ToArray(),
+            []);
 }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
@@ -4,7 +4,6 @@
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.Events.EventSequences.Migrations;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -12,28 +11,7 @@ public class and_event_type_already_exists_and_gets_new_generation : given.all_d
 {
     Exception _exception;
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration?>())
-            .Returns(callInfo =>
-            {
-                var generation = callInfo.ArgAt<EventTypeGeneration?>(1);
-
-                if (generation is null)
-                {
-                    return true;
-                }
-
-                return generation.Value == 1;
-            });
-
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync("{}").GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, "{}")));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_differs_only_by_a_nullable_marker.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_differs_only_by_a_nullable_marker.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -19,16 +17,7 @@ public class and_schema_differs_only_by_a_nullable_marker : given.all_dependenci
     const string StoredSchema = """{"type":"object","properties":{"name":{"type":"string"},"occurredAt":{"type":"string","format":"date-time-offset"}}}""";
     const string MarkerSchema = """{"type":"object","properties":{"name":{"type":"string"},"occurredAt":{"type":"string","format":"date-time-offset?"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(StoredSchema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, StoredSchema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_has_changed_for_existing_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_has_changed_for_existing_generation.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -13,16 +11,7 @@ public class and_schema_has_changed_for_existing_generation : given.all_dependen
     const string OriginalSchema = """{"type":"object","properties":{"name":{"type":"string"}}}""";
     const string ModifiedSchema = """{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(OriginalSchema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, OriginalSchema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_is_unchanged_for_existing_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_is_unchanged_for_existing_generation.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -12,16 +10,7 @@ public class and_schema_is_unchanged_for_existing_generation : given.all_depende
     Exception _exception;
     const string Schema = """{"type":"object","properties":{"name":{"type":"string"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(Schema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, Schema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_a_changed_event_type.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_a_changed_event_type.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_storage_reports_a_changed_event_type : given.all_dependencies
+{
+    void Establish() =>
+        _eventTypesStorage.Register(Arg.Any<IEnumerable<EventTypeToRegister>>())
+            .Returns([new EventTypeId("changed-event")]);
+
+    async Task Because() =>
+        await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "changed-event", Generation = 1 },
+                    Schema = "{}"
+                },
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "unchanged-event", Generation = 1 },
+                    Schema = "{}"
+                }
+            ]
+        });
+
+    [Fact] void should_register_every_event_type_in_one_call() =>
+        _eventTypesStorage.Received(1).Register(Arg.Is<IEnumerable<EventTypeToRegister>>(_ => _.Count() == 2));
+    [Fact] void should_invalidate_the_changed_event_type() =>
+        _eventTypesCacheClient.Received(1).Invalidate(
+            Arg.Any<EventStoreName>(),
+            Arg.Is<EventTypeId>(_ => _.Value == "changed-event"));
+    [Fact] void should_not_invalidate_the_unchanged_event_type() =>
+        _eventTypesCacheClient.DidNotReceive().Invalidate(
+            Arg.Any<EventStoreName>(),
+            Arg.Is<EventTypeId>(_ => _.Value == "unchanged-event"));
+}

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_no_change.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_no_change.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_storage_reports_no_change : given.all_dependencies
+{
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, "{}")));
+
+    async Task Because() =>
+        await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 1 },
+                    Schema = "{}",
+                    Generations =
+                    {
+                        new Contracts.Events.EventTypeGenerationDefinition { Generation = 1, Schema = "{}" }
+                    }
+                }
+            ]
+        });
+
+    [Fact] void should_not_invalidate_any_event_type() =>
+        _eventTypesCacheClient.DidNotReceive().Invalidate(Arg.Any<EventStoreName>(), Arg.Any<EventTypeId>());
+    [Fact] void should_not_append_any_system_event() =>
+        _systemEventSequence.DidNotReceive().Append(Arg.Any<EventSourceId>(), Arg.Any<object>());
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage.given;
+
+public class an_event_types_storage : Specification
+{
+    protected EventTypesStorage _storage;
+
+    void Establish() => _storage = new();
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_a_new_generation_for_an_existing_event_type.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_a_new_generation_for_an_existing_event_type.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_registering_a_new_generation_for_an_existing_event_type : given.an_event_types_storage
+{
+    IEnumerable<EventTypeDefinition> _definitions;
+
+    async Task Because()
+    {
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        await _storage.Register(new EventType("some-event", new EventTypeGeneration(2)), new JsonSchema());
+        _definitions = await _storage.GetAllDefinitions();
+    }
+
+    [Fact] void should_keep_both_generations() =>
+        _definitions.First().Generations.Select(_ => _.Generation)
+            .ShouldContainOnly(EventTypeGeneration.First, new EventTypeGeneration(2));
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_the_same_event_type_twice.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_the_same_event_type_twice.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_registering_the_same_event_type_twice : given.an_event_types_storage
+{
+    IEnumerable<EventTypeDefinition> _definitions;
+
+    async Task Because()
+    {
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        _definitions = await _storage.GetAllDefinitions();
+    }
+
+    [Fact] void should_only_have_it_once() => _definitions.Count().ShouldEqual(1);
+    [Fact] void should_only_have_the_first_generation() =>
+        _definitions.First().Generations.Select(_ => _.Generation).ShouldContainOnly(EventTypeGeneration.First);
+}

--- a/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Reactive.Subjects;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventTypes;
@@ -17,15 +18,30 @@ namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes;
 /// <c>ExpandoObjectConverter</c> to fall back to generic unknown-type
 /// conversion - preserving all event content without schema-driven type coercion.
 /// No compliance rules, migrations, or validations are applied.
+/// What has been registered is remembered for the lifetime of the process, so that registering the same event
+/// types again - which every client does when it reconnects - is recognized as the no-op it is.
 /// </remarks>
 public class EventTypesStorage : IEventTypesStorage
 {
-    /// <inheritdoc/>
-    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
-        Task.FromResult(false);
+    readonly ConcurrentDictionary<EventTypeId, EventTypeDefinition> _definitions = new();
 
     /// <inheritdoc/>
-    public Task<bool> Register(EventTypeDefinition definition) => Task.FromResult(false);
+    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
+        Register(new EventTypeDefinition(type.Id, owner, type.Tombstone, [new EventTypeGenerationDefinition(type.Generation, schema)], []));
+
+    /// <inheritdoc/>
+    public Task<bool> Register(EventTypeDefinition definition)
+    {
+        _definitions.AddOrUpdate(
+            definition.Id,
+            static (_, incoming) => incoming,
+            static (_, existing, incoming) => Merge(existing, incoming),
+            definition);
+
+        // There is no cache anywhere to evict for an in-memory single-node store, so a registration never asks
+        // anyone to invalidate.
+        return Task.FromResult(false);
+    }
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() =>
@@ -37,7 +53,7 @@ public class EventTypesStorage : IEventTypesStorage
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions() =>
-        Task.FromResult(Enumerable.Empty<EventTypeDefinition>());
+        Task.FromResult<IEnumerable<EventTypeDefinition>>([.. _definitions.Values]);
 
     /// <inheritdoc/>
     public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) =>
@@ -75,4 +91,14 @@ public class EventTypesStorage : IEventTypesStorage
     public void Invalidate(EventTypeId eventTypeId)
     {
     }
+
+    static EventTypeDefinition Merge(EventTypeDefinition existing, EventTypeDefinition incoming) =>
+        incoming with
+        {
+            Generations = existing.Generations
+                .Where(_ => incoming.Generations.All(incomingGeneration => incomingGeneration.Generation != _.Generation))
+                .Concat(incoming.Generations)
+                .ToList(),
+            Migrations = incoming.Migrations.Any() ? incoming.Migrations : existing.Migrations
+        };
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_registering_a_batch_of_event_types.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_registering_a_batch_of_event_types.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventTypes.for_EventTypesStorage;
+
+/// <summary>
+/// Registering a batch collapses to one read and one bulk write, and reports back only the event types whose
+/// stored document actually changed - that set is what drives cache invalidation and the system events the
+/// service appends, so reporting a type that did not change is as wrong as missing one that did.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_registering_a_batch_of_event_types(MongoDBFixture fixture) : given.an_event_types_storage(fixture)
+{
+    const string FirstSchema = /*lang=json,strict*/ "{\"type\":\"object\",\"properties\":{\"something\":{\"type\":\"string\"}}}";
+    const string ChangedSchema = /*lang=json,strict*/ "{\"type\":\"object\",\"properties\":{\"somethingElse\":{\"type\":\"string\"}}}";
+
+    static readonly EventTypeId _first = "the-first-event-type";
+    static readonly EventTypeId _second = "the-second-event-type";
+
+    IEnumerable<EventTypeId> _firstRegistration;
+    IEnumerable<EventTypeId> _registeringTheSameAgain;
+    IEnumerable<EventTypeId> _registeringWithOneChanged;
+    long _storedCount;
+
+    async Task Because()
+    {
+        _firstRegistration = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, FirstSchema)]);
+        _registeringTheSameAgain = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, FirstSchema)]);
+        _registeringWithOneChanged = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, ChangedSchema)]);
+        _storedCount = await _storedDocuments.CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty);
+    }
+
+    [Fact] void should_report_every_event_type_as_changed_the_first_time() => _firstRegistration.ShouldContainOnly(_first, _second);
+    [Fact] void should_report_nothing_as_changed_when_registering_the_same_again() => _registeringTheSameAgain.ShouldBeEmpty();
+    [Fact] void should_report_only_the_event_type_that_changed() => _registeringWithOneChanged.ShouldContainOnly(_second);
+    [Fact] void should_store_one_document_per_event_type() => _storedCount.ShouldEqual(2L);
+
+    static async Task<EventTypeToRegister> ToRegister(EventTypeId id, string schemaJson) => new(
+        new EventTypeDefinition(
+            id,
+            EventTypeOwner.Client,
+            false,
+            [new EventTypeGenerationDefinition(EventTypeGeneration.First, await JsonSchema.FromJsonAsync(schemaJson))],
+            []),
+        EventTypeSource.Code);
+}

--- a/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
@@ -159,6 +159,72 @@ public class EventTypesStorage(
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Collapses the whole batch into one read and one write: the current documents for every identifier are read in
+    /// a single query, compared in memory to work out which event types actually change anything, and only those are
+    /// written - as a single unordered bulk write. Every event type merges its generations into the stored document,
+    /// leaving generations another silo may have registered untouched, exactly as the single-event-type registration
+    /// does. Migrations are only written when the event type carries them, so a client that does not know about an
+    /// event type's migrations cannot erase them.
+    /// </remarks>
+    public async Task<IEnumerable<EventTypeId>> Register(IEnumerable<EventTypeToRegister> eventTypes)
+    {
+        var all = eventTypes.ToList();
+
+        if (all.Count == 0)
+        {
+            return [];
+        }
+
+        var collection = GetCollection();
+        var ids = all.ConvertAll(_ => _.Definition.Id);
+        using var cursor = await collection.FindAsync(Builders<EventType>.Filter.In(_ => _.Id, ids)).ConfigureAwait(false);
+        var stored = (await cursor.ToListAsync()).ToDictionary(_ => _.Id);
+
+        var writes = new List<WriteModel<EventType>>();
+        var mutated = new List<EventTypeId>();
+
+        foreach (var eventType in all)
+        {
+            var definition = eventType.Definition;
+            var schemas = definition.Generations.ToDictionary(
+                _ => _.Generation.ToString(),
+                _ => BsonDocument.Parse(_.Schema.ToJson()));
+            var migrations = definition.Migrations.Select(_ => new EventTypeMigration(
+                _.FromGeneration,
+                _.ToGeneration,
+                BsonDocument.Parse(_.UpcastJmesPath?.ToJsonString() ?? "{}"),
+                BsonDocument.Parse(_.DowncastJmesPath?.ToJsonString() ?? "{}"))).ToList();
+
+            stored.TryGetValue(definition.Id, out var existing);
+
+            if (!Changes(existing, eventType, schemas, migrations))
+            {
+                continue;
+            }
+
+            logger.Registering(definition.Id, EventTypeGeneration.First, eventStore);
+
+            writes.Add(new UpdateOneModel<EventType>(
+                Builders<EventType>.Filter.Eq(_ => _.Id, definition.Id),
+                BuildUpdate(eventType, schemas, migrations))
+            {
+                IsUpsert = true
+            });
+            mutated.Add(definition.Id);
+        }
+
+        if (writes.Count > 0)
+        {
+            await collection.BulkWriteAsync(writes, new BulkWriteOptions { IsOrdered = false }).ConfigureAwait(false);
+        }
+
+        mutated.ForEach(Invalidate);
+
+        return mutated;
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions()
     {
         using var result = await GetCollection().FindAsync(_ => true).ConfigureAwait(false);
@@ -252,6 +318,54 @@ public class EventTypesStorage(
                 _schemasByTypeAndGeneration.TryRemove(key, out _);
             }
         }
+    }
+
+    static bool Changes(
+        EventType? existing,
+        EventTypeToRegister eventType,
+        Dictionary<string, BsonDocument> schemas,
+        List<EventTypeMigration> migrations)
+    {
+        if (existing is null)
+        {
+            return true;
+        }
+
+        if (existing.Owner != eventType.Definition.Owner ||
+            existing.Source != eventType.Source ||
+            existing.Tombstone != eventType.Definition.Tombstone)
+        {
+            return true;
+        }
+
+        if (schemas.Any(_ => !existing.Schemas.TryGetValue(_.Key, out var storedSchema) || storedSchema != _.Value))
+        {
+            return true;
+        }
+
+        return migrations.Count > 0 && !migrations.SequenceEqual(existing.Migrations ?? []);
+    }
+
+    static UpdateDefinition<EventType> BuildUpdate(
+        EventTypeToRegister eventType,
+        Dictionary<string, BsonDocument> schemas,
+        List<EventTypeMigration> migrations)
+    {
+        var update = Builders<EventType>.Update
+            .Set(_ => _.Owner, eventType.Definition.Owner)
+            .Set(_ => _.Source, eventType.Source)
+            .Set(_ => _.Tombstone, eventType.Definition.Tombstone);
+
+        update = schemas.Aggregate(
+            update,
+            (current, schema) => current.Set($"{nameof(EventType.Schemas).ToCamelCase()}.{schema.Key}", schema.Value));
+
+        if (migrations.Count > 0)
+        {
+            update = update.Set(_ => _.Migrations, migrations);
+        }
+
+        return update;
     }
 
     bool InvalidateIfMutated(EventTypeId eventTypeId, bool mutated)

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/DelegatingEventTypesStorage.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/DelegatingEventTypesStorage.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage;
+
+/// <summary>
+/// Implements every member of <see cref="IEventTypesStorage"/> by delegating to another instance, deliberately
+/// leaving the batched Register to the interface's default implementation so it is the thing under test.
+/// </summary>
+/// <param name="inner">The <see cref="IEventTypesStorage"/> to delegate to.</param>
+public class DelegatingEventTypesStorage(IEventTypesStorage inner) : IEventTypesStorage
+{
+    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
+        inner.Register(type, schema, owner, source);
+
+    public Task<bool> Register(EventTypeDefinition definition) => inner.Register(definition);
+
+    public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() => inner.GetLatestForAllEventTypes();
+
+    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() => inner.ObserveLatestForAllEventTypes();
+
+    public Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions() => inner.GetAllDefinitions();
+
+    public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) => inner.GetDefinition(eventTypeId);
+
+    public Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(EventType eventType) => inner.GetAllGenerationsForEventType(eventType);
+
+    public Task<bool> HasFor(EventTypeId type, EventTypeGeneration? generation = default) => inner.HasFor(type, generation);
+
+    public Task<EventTypeSchema> GetFor(EventTypeId type, EventTypeGeneration? generation = default) => inner.GetFor(type, generation);
+
+    public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds) => inner.GetFor(eventTypeIds);
+
+    public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventType> eventTypes) => inner.GetFor(eventTypes);
+
+    public void Invalidate(EventTypeId eventTypeId) => inner.Invalidate(eventTypeId);
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/given/a_storage_without_its_own_batch_registration.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/given/a_storage_without_its_own_batch_registration.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.given;
+
+public class a_storage_without_its_own_batch_registration : Specification
+{
+    protected IEventTypesStorage _inner;
+    protected IEventTypesStorage _subject;
+
+    void Establish()
+    {
+        _inner = Substitute.For<IEventTypesStorage>();
+        _subject = new DelegatingEventTypesStorage(_inner);
+    }
+
+    protected static EventTypeToRegister EventTypeToRegisterFor(
+        string eventTypeId,
+        EventTypeMigrationDefinition[] migrations,
+        params uint[] generations) =>
+        new(
+            new EventTypeDefinition(
+                eventTypeId,
+                EventTypeOwner.Client,
+                false,
+                generations.Select(_ => new EventTypeGenerationDefinition(_, new JsonSchema())).ToArray(),
+                migrations),
+            EventTypeSource.Code);
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_a_single_generation_without_migrations.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_a_single_generation_without_migrations.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_an_event_type_has_a_single_generation_without_migrations : given.a_storage_without_its_own_batch_registration
+{
+    IEnumerable<EventTypeId> _result;
+
+    void Establish() =>
+        _inner.Register(Arg.Any<EventType>(), Arg.Any<JsonSchema>(), Arg.Any<EventTypeOwner>(), Arg.Any<EventTypeSource>())
+            .Returns(true);
+
+    async Task Because() => _result = await _subject.Register([EventTypeToRegisterFor("some-event", [], 1)]);
+
+    [Fact] void should_register_it_as_a_single_event_type() =>
+        _inner.Received(1).Register(
+            Arg.Is<EventType>(_ => _.Id.Value == "some-event" && _.Generation.Value == 1),
+            Arg.Any<JsonSchema>(),
+            EventTypeOwner.Client,
+            EventTypeSource.Code);
+    [Fact] void should_not_register_it_as_a_definition() =>
+        _inner.DidNotReceive().Register(Arg.Any<EventTypeDefinition>());
+    [Fact] void should_report_it_as_mutated() => _result.ShouldContainOnly(new EventTypeId("some-event"));
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_migrations.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_migrations.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_an_event_type_has_migrations : given.a_storage_without_its_own_batch_registration
+{
+    async Task Because() =>
+        await _subject.Register(
+        [
+            EventTypeToRegisterFor(
+                "some-event",
+                [new EventTypeMigrationDefinition(1, 2, [], new JsonObject(), new JsonObject())],
+                1,
+                2)
+        ]);
+
+    [Fact] void should_register_it_as_a_definition() =>
+        _inner.Received(1).Register(Arg.Is<EventTypeDefinition>(_ => _.Id.Value == "some-event"));
+    [Fact] void should_not_register_it_as_a_single_event_type() =>
+        _inner.DidNotReceive().Register(
+            Arg.Any<EventType>(),
+            Arg.Any<JsonSchema>(),
+            Arg.Any<EventTypeOwner>(),
+            Arg.Any<EventTypeSource>());
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_only_some_event_types_change.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_only_some_event_types_change.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_only_some_event_types_change : given.a_storage_without_its_own_batch_registration
+{
+    IEnumerable<EventTypeId> _result;
+
+    void Establish() =>
+        _inner.Register(Arg.Any<EventType>(), Arg.Any<JsonSchema>(), Arg.Any<EventTypeOwner>(), Arg.Any<EventTypeSource>())
+            .Returns(callInfo => callInfo.ArgAt<EventType>(0).Id.Value == "changed-event");
+
+    async Task Because() => _result = await _subject.Register(
+    [
+        EventTypeToRegisterFor("changed-event", [], 1),
+        EventTypeToRegisterFor("unchanged-event", [], 1)
+    ]);
+
+    [Fact] void should_only_report_the_changed_event_type() => _result.ShouldContainOnly(new EventTypeId("changed-event"));
+}

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
@@ -126,6 +126,10 @@ public static class EventTypeConverters
         var generations = eventType.Schemas.Select(kvp =>
         {
             var schema = JsonSchema.FromJson(kvp.Value);
+
+            // Normalize exactly like ToKernel does - callers compare a stored schema against an incoming one, and a
+            // difference in compliance metadata alone would read as a breaking schema change.
+            schema.EnsureComplianceMetadata();
             return new EventTypeGenerationDefinition(new EventTypeGeneration(kvp.Key), schema);
         }).ToList();
 

--- a/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
+++ b/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
@@ -36,6 +36,47 @@ public interface IEventTypesStorage
     Task<bool> Register(EventTypeDefinition definition);
 
     /// <summary>
+    /// Register a whole batch of <see cref="EventTypeToRegister">event types</see> in one operation.
+    /// </summary>
+    /// <param name="eventTypes">The <see cref="EventTypeToRegister">event types</see> to register.</param>
+    /// <returns>The <see cref="EventTypeId">identifiers</see> of the event types whose stored representation was created or changed.</returns>
+    /// <remarks>
+    /// A client registers every event type it knows about at startup, so doing it one at a time costs a round trip
+    /// per event type against the underlying store. Taking the whole batch lets an implementation collapse that into
+    /// a single read and a single write. The default implementation registers one at a time, so an implementation
+    /// only needs to override this when it can do better.
+    /// Only the identifiers of event types that actually changed are returned - re-registering identical event types
+    /// yields none, so routine client reconnects do not trigger cluster-wide cache eviction.
+    /// </remarks>
+    async Task<IEnumerable<EventTypeId>> Register(IEnumerable<EventTypeToRegister> eventTypes)
+    {
+        var mutated = new List<EventTypeId>();
+
+        foreach (var eventType in eventTypes)
+        {
+            var definition = eventType.Definition;
+            var generations = definition.Generations.ToList();
+
+            // A single generation without migrations is exactly what the simple registration expresses - anything
+            // else needs the full definition.
+            var changed = generations.Count == 1 && !definition.Migrations.Any()
+                ? await Register(
+                    new EventType(definition.Id, generations[0].Generation, definition.Tombstone),
+                    generations[0].Schema,
+                    definition.Owner,
+                    eventType.Source)
+                : await Register(definition);
+
+            if (changed)
+            {
+                mutated.Add(definition.Id);
+            }
+        }
+
+        return mutated;
+    }
+
+    /// <summary>
     /// Get the latest <see cref="EventTypeSchema">event schema</see> for all registered <see cref="EventType">event types</see>.
     /// </summary>
     /// <returns>A collection of <see cref="EventTypeSchema">event schemas</see>.</returns>


### PR DESCRIPTION
## Changed

- Registering event types on connect issues one read and one bulk write for the whole batch instead of several round trips per event type, so startup no longer scales its database round trips with the number of event types. (#984)