### PR TITLE
Add an Aspire helper that provisions MongoDB as a replica set

### DIFF
--- a/Chronicle.slnx
+++ b/Chronicle.slnx
@@ -3,6 +3,7 @@
     <Folder Name="/Source/Clients/">
         <Project Path="Source/Clients/Api/Api.csproj" />
         <Project Path="Source/Clients/Aspire/Aspire.csproj" />
+        <Project Path="Source/Clients/Aspire.Specs/Aspire.Specs.csproj" />
         <Project Path="Source/Clients/AspNetCore/AspNetCore.csproj" />
         <Project Path="Source/Clients/AspNetCore.Specs/AspNetCore.Specs.csproj" />
         <Project Path="Source/Clients/Connections/Connections.csproj" />

--- a/Source/Clients/Aspire.Specs/Aspire.Specs.csproj
+++ b/Source/Clients/Aspire.Specs/Aspire.Specs.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Chronicle.Aspire.Specs</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Aspire</RootNamespace>
+        <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);ASPIREPROBES001;NU1903</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Aspire/Aspire.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.given;
+
+public class a_distributed_application_builder : Specification
+{
+    protected IDistributedApplicationBuilder _builder;
+
+    void Establish() => _builder = DistributedApplication.CreateBuilder([]);
+
+    protected static async Task<IEnumerable<string>> ArgumentsFor(IResource resource)
+    {
+        var args = new List<object>();
+        var context = new CommandLineArgsCallbackContext(args);
+        foreach (var annotation in resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>())
+        {
+            await annotation.Callback(context);
+        }
+        return args.Select(_ => _.ToString()!);
+    }
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_specifying_name_and_image_tag.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_specifying_name_and_image_tag.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.when_adding_mongo_db;
+
+public class and_specifying_name_and_image_tag : given.a_distributed_application_builder
+{
+    const string Name = "chronicle-mongo";
+    const string ImageTag = "7.0";
+
+    IResourceBuilder<IResourceWithConnectionString> _result;
+    ContainerResource _server;
+    ContainerImageAnnotation _image;
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicleMongoDB(Name, ImageTag);
+        _server = _builder.Resources.OfType<ContainerResource>().Single(_ => _.Name == $"{Name}-server");
+        _image = _server.Annotations.OfType<ContainerImageAnnotation>().Single();
+    }
+
+    [Fact] void should_name_the_connection_string_resource_as_specified() => _result.Resource.Name.ShouldEqual(Name);
+    [Fact] void should_use_the_specified_image_tag() => _image.Tag.ShouldEqual(ImageTag);
+    [Fact] void should_connect_through_the_named_server_endpoint() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain($"{Name}-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.host");
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_using_the_defaults.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_using_the_defaults.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.when_adding_mongo_db;
+
+public class and_using_the_defaults : given.a_distributed_application_builder
+{
+    IResourceBuilder<IResourceWithConnectionString> _result;
+    ContainerResource _server;
+    ContainerImageAnnotation _image;
+    EndpointAnnotation _endpoint;
+    IEnumerable<string> _arguments;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicleMongoDB();
+        _server = _builder.Resources.OfType<ContainerResource>().Single(_ => _.Name == "mongodb-server");
+        _image = _server.Annotations.OfType<ContainerImageAnnotation>().Single();
+        _endpoint = _server.Annotations.OfType<EndpointAnnotation>().Single();
+        _arguments = await ArgumentsFor(_server);
+    }
+
+    [Fact] void should_name_the_connection_string_resource_by_convention() => _result.Resource.Name.ShouldEqual("mongodb");
+    [Fact] void should_use_the_mongo_db_image() => _image.Image.ShouldEqual(ChronicleContainerImageTags.MongoDBImage);
+    [Fact] void should_use_the_default_image_tag() => _image.Tag.ShouldEqual(ChronicleContainerImageTags.MongoDBTag);
+    [Fact] void should_use_the_docker_hub_registry() => _image.Registry.ShouldEqual(ChronicleContainerImageTags.Registry);
+    [Fact] void should_name_the_endpoint_by_convention() => _endpoint.Name.ShouldEqual(ChronicleContainerImageTags.MongoDBEndpointName);
+    [Fact] void should_target_the_mongo_db_port() => _endpoint.TargetPort.ShouldEqual(27017);
+    [Fact] void should_run_the_command_through_a_shell() => _server.Entrypoint.ShouldEqual("/bin/sh");
+    [Fact] void should_pass_the_command_to_the_shell() => _arguments.First().ShouldEqual("-c");
+    [Fact] void should_start_mongod_as_a_replica_set() => _arguments.Last().ShouldContain($"mongod --replSet {ChronicleContainerImageTags.MongoDBReplicaSetName} --bind_ip_all");
+    [Fact] void should_initiate_the_replica_set() => _arguments.Last().ShouldContain($"rs.initiate({{ _id: \"{ChronicleContainerImageTags.MongoDBReplicaSetName}\"");
+    [Fact] void should_keep_mongod_as_the_container_entrypoint_process() => _arguments.Last().ShouldContain("exec docker-entrypoint.sh");
+    [Fact] void should_connect_directly_to_the_single_node() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain("directConnection=true");
+    [Fact] void should_connect_through_the_mongo_db_endpoint() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain($"mongodb://{{mongodb-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.host}}:{{mongodb-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.port}}/");
+}

--- a/Source/Clients/Aspire/ChronicleContainerImageTags.cs
+++ b/Source/Clients/Aspire/ChronicleContainerImageTags.cs
@@ -34,9 +34,29 @@ public static class ChronicleContainerImageTags
     public const string DevelopmentSlimTag = "latest-development-slim";
 
     /// <summary>
+    /// MongoDB container image name.
+    /// </summary>
+    public const string MongoDBImage = "mongo";
+
+    /// <summary>
+    /// Tag for the MongoDB container image used by <c>AddCratisChronicleMongoDB</c>.
+    /// </summary>
+    public const string MongoDBTag = "8.0";
+
+    /// <summary>
+    /// Name of the single-node replica set that <c>AddCratisChronicleMongoDB</c> initiates.
+    /// </summary>
+    public const string MongoDBReplicaSetName = "rs0";
+
+    /// <summary>
     /// Name of the gRPC endpoint.
     /// </summary>
     public const string GrpcEndpointName = "grpc";
+
+    /// <summary>
+    /// Name of the MongoDB TCP endpoint.
+    /// </summary>
+    public const string MongoDBEndpointName = "tcp";
 
     /// <summary>
     /// Environment variable key for the Chronicle storage type (e.g. <c>MongoDB</c>).

--- a/Source/Clients/Aspire/ChronicleMongoDBDistributedApplicationBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleMongoDBDistributedApplicationBuilderExtensions.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods for adding a Chronicle-compatible MongoDB resource to an Aspire distributed application.
+/// </summary>
+public static class ChronicleMongoDBDistributedApplicationBuilderExtensions
+{
+    /// <summary>
+    /// The port <c>mongod</c> listens on inside the container.
+    /// </summary>
+    const int MongoDBPort = 27017;
+
+    /// <summary>
+    /// The script that initiates the single-node replica set, tolerating an already initiated one.
+    /// </summary>
+    static readonly string _initiateReplicaSetScript =
+        $"try {{ rs.status() }} catch (error) {{ rs.initiate({{ _id: \"{ChronicleContainerImageTags.MongoDBReplicaSetName}\", members: [{{ _id: 0, host: \"localhost:{MongoDBPort}\" }}] }}) }}";
+
+    /// <summary>
+    /// The container command that starts <c>mongod</c> as a replica set and initiates it once it accepts connections.
+    /// </summary>
+    /// <remarks>
+    /// The initiation runs in a background subshell that first polls until <c>mongod</c> answers a ping, because
+    /// <c>rs.initiate</c> fails against a server that has not finished starting. <c>exec docker-entrypoint.sh</c>
+    /// keeps <c>mongod</c> as PID 1 so it still receives container signals and drops privileges the way the
+    /// official image intends.
+    /// </remarks>
+    static readonly string _replicaSetEntrypointCommand =
+        "( until mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do sleep 0.3; done; " +
+        $"mongosh --quiet --eval '{_initiateReplicaSetScript}' ) & " +
+        $"exec docker-entrypoint.sh mongod --replSet {ChronicleContainerImageTags.MongoDBReplicaSetName} --bind_ip_all";
+
+    /// <summary>
+    /// Adds a MongoDB resource configured the way Chronicle needs it — a self-initiating single-node replica set
+    /// exposed through a connection string with <c>directConnection=true</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Chronicle relies on MongoDB transactions and change streams, which a standalone <c>mongod</c> does not
+    /// support. Aspire's <c>AddMongoDB</c> starts exactly such a standalone server, so pointing Chronicle at it
+    /// leaves observers, projections, and observable queries silently doing nothing. This method starts the
+    /// official MongoDB image as a single-node replica set that initiates itself on first run, which is what
+    /// Chronicle needs for local development and testing.
+    /// </para>
+    /// <para>
+    /// The returned connection string carries <c>?directConnection=true</c>, so the driver talks to the
+    /// host-mapped port directly instead of following the replica-set member host advertised by the server —
+    /// that host (<c>localhost</c> inside the container) is not reachable from outside it, and following it
+    /// makes the driver hang.
+    /// </para>
+    /// <para>
+    /// Two resources are added: a container named <c>{name}-server</c> running MongoDB, and a connection-string
+    /// resource named <paramref name="name"/> that the returned builder represents. Pass the returned builder
+    /// straight to <see cref="Cratis.Chronicle.Aspire.ChronicleAspireBuilderExtensions.WithMongoDB"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resources to.</param>
+    /// <param name="name">The name for the connection-string resource. Defaults to <c>"mongodb"</c>.</param>
+    /// <param name="imageTag">
+    /// Optional tag for the MongoDB container image. Defaults to
+    /// <see cref="ChronicleContainerImageTags.MongoDBTag"/>.
+    /// </param>
+    /// <returns>An <see cref="IResourceBuilder{T}"/> for the MongoDB connection string.</returns>
+    /// <example>
+    /// <code>
+    /// var mongo = builder.AddCratisChronicleMongoDB();
+    /// builder.AddCratisChronicle("chronicle", chronicle => chronicle.WithMongoDB(mongo));
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<IResourceWithConnectionString> AddCratisChronicleMongoDB(
+        this IDistributedApplicationBuilder builder,
+        string name = "mongodb",
+        string? imageTag = default)
+    {
+        var server = builder
+            .AddContainer($"{name}-server", ChronicleContainerImageTags.MongoDBImage, imageTag ?? ChronicleContainerImageTags.MongoDBTag)
+            .WithImageRegistry(ChronicleContainerImageTags.Registry)
+            .WithEndpoint(targetPort: MongoDBPort, name: ChronicleContainerImageTags.MongoDBEndpointName)
+            .WithEntrypoint("/bin/sh")
+            .WithArgs("-c", _replicaSetEntrypointCommand);
+
+        var endpoint = server.GetEndpoint(ChronicleContainerImageTags.MongoDBEndpointName);
+
+        return builder.AddConnectionString(
+            name,
+            ReferenceExpression.Create($"mongodb://{endpoint.Property(EndpointProperty.Host)}:{endpoint.Property(EndpointProperty.Port)}/?directConnection=true"));
+    }
+}


### PR DESCRIPTION
## Added

- `AddCratisChronicleMongoDB()` for Aspire, provisioning a MongoDB container that initiates itself as a single-node replica set and hands back a `directConnection` connection string — which is what Chronicle requires and what a plain MongoDB resource does not provide. (#3400)