### PR TITLE
Consolidated fixes and improvements

### DIFF
--- a/.ai/rules/reactors.md
+++ b/.ai/rules/reactors.md
@@ -37,6 +37,25 @@ public Task MethodName(TEvent @event, EventContext context)
 - **Return type** — `Task` or `void`, or a side-effect type (`TEvent`, `ReactorSideEffect`, or a collection of either) returned directly (sync) or wrapped in `Task<...>` (async). Prefer `Task`/async for real side effects, but synchronous returns are fully supported — there is no "always async" requirement.
 - **Method name** — can be anything descriptive. The name is for readability, not dispatch.
 
+## Handling replay differently — `[Replay]`
+
+A reactor sees the same event twice for different reasons: as it happens, and again when its observer is replayed. When those call for different work, mark a second handler for the same event type with **`[Replay]`** and it takes over for the duration of the replay.
+
+```csharp
+public class OrderNotifications(INotificationService notifications) : IReactor
+{
+    public Task OrderPlaced(OrderPlaced @event) => notifications.Notify($"Order {@event.Number} placed.");
+
+    [Replay]
+    public Task OrderPlacedDuringReplay(OrderPlaced @event) => Task.CompletedTask;
+}
+```
+
+- With a `[Replay]` handler, **only** it runs during replay — the regular handler does not also run.
+- Without one, the regular handler runs during replay exactly as before, so this changes nothing for existing reactors.
+- An event type handled *only* by a `[Replay]` handler is still subscribed to.
+- Reach for **`[OnceOnly]`** instead when the side effect should simply not happen again; use `[Replay]` when replay needs to do something *different* rather than nothing.
+
 ## Taking Dependencies
 
 Beyond the event and `EventContext`, a handler method can take any number of additional parameters as dependencies. Only the first parameter is fixed (it is the event that drives dispatch); every parameter after it is resolved when the method is invoked.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,10 +3,9 @@ name: Benchmarks
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-# Benchmarks on pull requests are covered by the `benchmarks` job in
-# dotnet-build.yml, which reuses that workflow's cached build instead of
-# compiling again from scratch. This workflow tracks the series on main,
-# where its cache key also lines up with the one publish.yml restores.
+# This is where the benchmark series lives. Pull requests only check that the benchmark projects still
+# build (the `benchmarks-build` job in dotnet-build.yml) - running them there added ~13 minutes to the
+# critical path for a result that could never fail the build.
 on:
   workflow_dispatch:
   push:
@@ -32,16 +31,21 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.PAT_WORKFLOWS }}
 
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
+      # Kept as its own step: when the build and the run share one step, a build failure is reported as a
+      # successful step and only surfaces later as "no benchmark result was found".
+      - name: Build Benchmarks
+        working-directory: ./Benchmarks/Chronicle.Benchmarks
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=false
+
       - name: Run Benchmarks
         working-directory: ./Benchmarks/Chronicle.Benchmarks
-        run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
+        run: dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
 
       - name: Find and Copy Results
         run: |
@@ -69,3 +73,19 @@ jobs:
         with:
           name: benchmark-data
           path: Documentation/benchmarks/benchmark-data.json
+
+      # The series used to reach the repository by way of a cache written on the pull request and restored at
+      # release time. With the run living here, commit it directly - the same shape coverage statistics use.
+      - name: Commit benchmark results
+        if: github.event_name == 'push'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add Documentation/benchmarks/benchmark-data.json
+          if git diff --staged --quiet; then
+            echo "No benchmark result changes to commit"
+          else
+            git commit -m "Update benchmark results [skip ci]"
+            git pull --rebase origin ${{ github.ref_name }}
+            git push
+          fi

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -26,6 +26,10 @@ on:
       - "Source/**/*.cs"
       - "Source/**/*.csproj"
       - "Integration/**"
+      # The benchmarks job builds these, so a change here has to run it. Without this a broken benchmark
+      # project lands green and fails on the next unrelated pull request instead.
+      - "Benchmarks/**/*.cs"
+      - "Benchmarks/**/*.csproj"
       - ".github/workflows/dotnet-build.yml"
       - ".github/workflows/integration.yml"
 
@@ -405,11 +409,15 @@ jobs:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
 
+      # Kept as its own step: when the build and the run share one step, a build failure is reported as a
+      # successful step and only surfaces three steps later as "no benchmark result was found".
+      - name: Build Benchmarks
+        working-directory: ./Benchmarks/Chronicle.Benchmarks
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=false
+
       - name: Run Benchmarks
         working-directory: ./Benchmarks/Chronicle.Benchmarks
-        run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
+        run: dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
 
       - name: Find and Copy Results
         run: |

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -384,11 +384,17 @@ jobs:
             "${{ github.sha }}" \
             "${{ github.event.head_commit.message || format('Coverage update for {0}', github.head_ref || github.ref_name) }}"
 
-  benchmarks:
+  # Running the benchmarks takes ~13 minutes and sits on the critical path behind dotnet-build, which made it
+  # the single thing deciding how long a pull request takes to go green. It cannot fail a build either
+  # (fail-on-alert is false), so the series is tracked on main by benchmarks.yml instead.
+  #
+  # What still has to hold per pull request is that the benchmark projects BUILD, or a broken one lands green
+  # and breaks main. Building them the way BenchmarkDotNet does - it regenerates and rebuilds with
+  # ArtifactsPath set, which changes which project references apply - is what catches that, and costs ~2
+  # minutes off the critical path rather than ~13 on it.
+  benchmarks-build:
     runs-on: ubuntu-latest
     needs: [dotnet-build]
-    outputs:
-      benchmark-cache-key: ${{ steps.export-benchmark-key.outputs.key }}
 
     steps:
       - name: Checkout code
@@ -405,40 +411,11 @@ jobs:
           path: ./**/bin
           key: ${{ env.DOTNET_CACHE }}
 
-      - name: Run Benchmarks
-        working-directory: ./Benchmarks/Chronicle.Benchmarks
+      - name: Build benchmarks the way BenchmarkDotNet does
         run: |
-          dotnet build -c Release /p:TreatWarningsAsErrors=false
-          dotnet run -c Release --no-build -- --filter '*' --exporters json --artifacts BenchmarkDotNet.Artifacts
-
-      - name: Find and Copy Results
-        run: |
-          mkdir -p Benchmarks/results
-          find Benchmarks/Chronicle.Benchmarks -path "*/BenchmarkDotNet.Artifacts/results/*.json" -type f -exec cp {} Benchmarks/results/ \;
-          test -n "$(find Benchmarks/results -maxdepth 1 -name '*.json' -print -quit)" || { echo "No benchmark JSON files were produced"; exit 1; }
-          ls -la Benchmarks/results/
-          python3 Benchmarks/merge-results.py
-
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Cratis Benchmarks
-          tool: 'benchmarkdotnet'
-          output-file-path: Benchmarks/results/combined.json
-          external-data-json-path: Documentation/benchmarks/benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '150%'
-          comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@einari'
-
-      - name: Cache benchmark results
-        uses: actions/cache@v4
-        with:
-          path: Documentation/benchmarks/benchmark-data.json
-          key: benchmark-cache-${{ github.sha }}
-
-      - name: Export benchmark cache key
-        id: export-benchmark-key
-        run: |
-          echo "key=benchmark-cache-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          dotnet build Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj \
+            -c Release /p:TreatWarningsAsErrors=false /p:DisableDockerBuild=true \
+            /p:ArtifactsPath="${RUNNER_TEMP}/benchmark-artifacts"
+          dotnet build Benchmarks/Chronicle.Benchmarks.Clustering/Chronicle.Benchmarks.Clustering.csproj \
+            -c Release /p:TreatWarningsAsErrors=false /p:DisableDockerBuild=true \
+            /p:ArtifactsPath="${RUNNER_TEMP}/benchmark-artifacts-clustering"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,50 +117,8 @@ jobs:
             git push
           fi
 
-  benchmark-results:
-    if: needs.release.outputs.publish == 'true' && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    needs: [release]
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT_WORKFLOWS }}
-
-      - name: Restore cached benchmark results
-        uses: actions/cache@v4
-        with:
-          path: Documentation/benchmarks/benchmark-data.json
-          key: benchmark-cache-${{ github.sha }}
-          fail-on-cache-miss: false
-
-      - name: Check if benchmark data exists
-        id: check-benchmark
-        run: |
-          if [ -f "Documentation/benchmarks/benchmark-data.json" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "No cached benchmark data found for commit ${{ github.sha }}, skipping"
-          fi
-
-      - name: Commit benchmark results
-        if: steps.check-benchmark.outputs.exists == 'true'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add Documentation/benchmarks/
-          if git diff --staged --quiet; then
-            echo "No benchmark result changes to commit"
-          else
-            git commit -m "Update benchmark results for release ${{ needs.release.outputs.version }} [skip ci]"
-            git pull --rebase origin ${{ github.ref_name }}
-            git push
-          fi
+  # Benchmark results are committed by benchmarks.yml when it runs on main, so there is no longer a cache
+  # written on the pull request for a release to restore.
 
   dotnet-x64:
     if: needs.release.outputs.publish == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -470,6 +470,20 @@ jobs:
           build-args: |
             VERSION=${{ needs.release.outputs.version }}
 
+      # Every image variant lands in the same Docker Hub repository, so the overview is updated here only.
+      # The description API needs a token with write scope, which the push credentials do not necessarily
+      # have - never fail a release over an overview that did not update.
+      - name: Update Docker Hub overview
+        if: needs.release.outputs.prerelease != 'true'
+        continue-on-error: true
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: cratis/chronicle
+          readme-filepath: ./Docker/README.md
+          short-description: "Event sourcing engine - stores events as the source of truth and keeps read models up to date from them."
+
   publish-docker-workbench:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest

--- a/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
+++ b/Benchmarks/Chronicle.Benchmarks/Chronicle.Benchmarks.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The client is referenced directly rather than picked up through the server: the server reference is
+         dropped when ArtifactsPath is set, which is how BenchmarkDotNet rebuilds this project before running,
+         and every benchmark here uses the client API. -->
+    <ProjectReference Include="../../Source/Clients/DotNET/DotNET.csproj" />
     <ProjectReference Include="../../Source/Clients/Connections/Connections.csproj" />
     <ProjectReference Include="../../Source/Infrastructure/Infrastructure.csproj" />
     <ProjectReference Include="../../Source/Kernel/Server/Server.csproj" Condition="'$(ArtifactsPath)' == ''" />

--- a/Benchmarks/merge-results.py
+++ b/Benchmarks/merge-results.py
@@ -23,3 +23,10 @@ combined = {
 
 with open('Benchmarks/results/combined.json', 'w') as fp:
     json.dump(combined, fp)
+
+# A run that discovers nothing still exports a well-formed file with an empty Benchmarks array. Say so here,
+# rather than letting the publishing step fail with the far less obvious "no benchmark result was found".
+if not benchmarks:
+    raise SystemExit(
+        f'No benchmarks were recorded across {len(files)} result file(s). '
+        'The run discovered no benchmarks, which usually means the benchmark project failed to build.')

--- a/Chronicle.slnx
+++ b/Chronicle.slnx
@@ -3,6 +3,7 @@
     <Folder Name="/Source/Clients/">
         <Project Path="Source/Clients/Api/Api.csproj" />
         <Project Path="Source/Clients/Aspire/Aspire.csproj" />
+        <Project Path="Source/Clients/Aspire.Specs/Aspire.Specs.csproj" />
         <Project Path="Source/Clients/AspNetCore/AspNetCore.csproj" />
         <Project Path="Source/Clients/AspNetCore.Specs/AspNetCore.Specs.csproj" />
         <Project Path="Source/Clients/Connections/Connections.csproj" />

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,70 @@
+# Cratis Chronicle
+
+Chronicle is an event sourcing engine. It stores events as the source of truth and keeps read models — projections and reducers — up to date from them, so your application reads state that is derived rather than mutated in place. It ships as a server you run alongside your application, with client SDKs that connect to it.
+
+- [Documentation](https://cratis.io)
+- [Source](https://github.com/Cratis/Chronicle)
+
+## Tags
+
+Every tag below is published from the same `cratis/chronicle` repository. `latest` follows the most recent stable release; use a version tag in production.
+
+| Tag | What it is |
+|---|---|
+| `<version>`, `latest` | The Chronicle server. Connects to a storage backend you provide. This is what you run in production. |
+| `<version>-development`, `latest-development` | The server with MongoDB embedded and started for you as a single-node replica set. For local development only — the database lives inside the container and goes away with it. |
+| `<version>-development-slim`, `latest-development-slim` | The development server without the embedded MongoDB, for when you bring your own database. |
+| `<version>-workbench`, `latest-workbench` | The Workbench UI on its own, served by nginx. Only needed when hosting the UI separately — the server images already serve it. |
+
+The server images are built for `linux/amd64` and `linux/arm64`. The workbench image is `linux/amd64`.
+
+## Quick start
+
+The development image is the fastest way to get something running — it needs nothing else:
+
+```shell
+docker run -p 35000:35000 cratis/chronicle:latest-development
+```
+
+The Workbench is then on <http://localhost:35000>, and clients connect to the same port.
+
+For the production image, point it at your own storage:
+
+```shell
+docker run -p 35000:35000 \
+  -e Cratis__Chronicle__Storage__Type=MongoDB \
+  -e Cratis__Chronicle__Storage__ConnectionDetails=mongodb://host.docker.internal:27017 \
+  cratis/chronicle:latest
+```
+
+> MongoDB storage requires a replica set — Chronicle uses transactions and change streams, neither of which a standalone `mongod` supports.
+
+## Ports
+
+| Port | Purpose |
+|---|---|
+| `35000` | Chronicle — client connections, the API, and the Workbench |
+| `11111` | Orleans silo-to-silo communication, when running more than one instance |
+| `30000` | Orleans gateway |
+
+## Configuration
+
+Configuration lives in `chronicle.json`. Every setting can be overridden with an environment variable by prefixing the path with `Cratis__Chronicle__` and separating levels with a double underscore.
+
+| Environment variable | Default | Purpose |
+|---|---|---|
+| `Cratis__Chronicle__Storage__Type` | `mongodb` | Storage backend: `mongodb`, `postgresql`, `mssql`, `sqlite` or `inmemory` |
+| `Cratis__Chronicle__Storage__ConnectionDetails` | `mongodb://localhost:27017` | Connection string for the backend |
+| `Cratis__Chronicle__Port` | `35000` | Port Chronicle listens on |
+| `Cratis__Chronicle__Authentication__Enabled` | `true` | Whether the Workbench and API require authentication |
+| `Cratis__Chronicle__Authentication__DefaultAdminPassword` | `ChangeMeNow!` | Password for the initial admin user — change it |
+| `Cratis__Chronicle__Features__Api` | `true` | Whether the HTTP API is exposed |
+| `Cratis__Chronicle__Features__Workbench` | `true` | Whether the Workbench UI is served |
+| `Cratis__Chronicle__Tls__CertificatePath` | | Certificate used for TLS |
+| `Cratis__Chronicle__Tls__CertificatePassword` | | Password for that certificate |
+| `Cratis__Chronicle__EncryptionCertificate__CertificatePath` | | Certificate used to encrypt values marked as personally identifiable |
+| `Cratis__Chronicle__EncryptionCertificate__CertificatePassword` | | Password for that certificate |
+
+## License
+
+MIT.

--- a/Documentation/client-snippets/concepts/correlation-identity-causation/renaming-an-identity.md
+++ b/Documentation/client-snippets/concepts/correlation-identity-causation/renaming-an-identity.md
@@ -1,0 +1,11 @@
+```csharp
+using Cratis.Chronicle;
+
+public static class RenamingAnIdentity
+{
+    public static async Task Rename(IEventStore eventStore)
+    {
+        await eventStore.Identities.Rename("subject-42", "Jane Austen");
+    }
+}
+```

--- a/Documentation/client-snippets/events/schema-representation/basic.md
+++ b/Documentation/client-snippets/events/schema-representation/basic.md
@@ -1,0 +1,21 @@
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Cratis.Chronicle.Schemas;
+
+[JsonSchemaType(typeof(string))]
+[JsonConverter(typeof(PostalCodeJsonConverter))]
+public class PostalCode(string value)
+{
+    public string Value { get; } = value;
+}
+
+public class PostalCodeJsonConverter : JsonConverter<PostalCode>
+{
+    public override PostalCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        new(reader.GetString()!);
+
+    public override void Write(Utf8JsonWriter writer, PostalCode value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.Value);
+}
+```

--- a/Documentation/client-snippets/hosting/aspire/mongo-replica-set-helper.md
+++ b/Documentation/client-snippets/hosting/aspire/mongo-replica-set-helper.md
@@ -1,0 +1,15 @@
+```csharp
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+public static class HostingAspireMongoReplicaSetHelper
+{
+    public static IResourceBuilder<ChronicleResource> ConfigureAppHost(IDistributedApplicationBuilder builder)
+    {
+        var mongo = builder.AddCratisChronicleMongoDB();
+
+        return builder.AddCratisChronicle(configure: chronicle => chronicle.WithMongoDB(mongo));
+    }
+}
+```

--- a/Documentation/client-snippets/reactors/replay/basic.md
+++ b/Documentation/client-snippets/reactors/replay/basic.md
@@ -1,0 +1,21 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+[EventType]
+public record ReplayAwareOrderPlaced(string OrderId);
+
+public class ReplayAwareOrderReactor : IReactor
+{
+    public void SendConfirmation(ReplayAwareOrderPlaced @event)
+    {
+        // Runs as the event happens.
+    }
+
+    [Replay]
+    public void RebuildProjectionCache(ReplayAwareOrderPlaced @event)
+    {
+        // Runs instead of SendConfirmation while the observer is replaying.
+    }
+}
+```

--- a/Documentation/concepts/correlation-identity-causation.mdx
+++ b/Documentation/concepts/correlation-identity-causation.mdx
@@ -23,6 +23,16 @@ Kotlin's correlation manager scopes the id per-thread (`ThreadLocal`); Elixir an
 
 Every client provides the same three sentinel identities for well-known cases — `System`, `NotSet`, and `Unknown` — and supports on-behalf-of delegation chains (an identity that acted *for* another identity) via a `withoutDuplicates()`/`without_duplicates/1` helper that collapses repeated subjects in a long chain.
 
+### Renaming an identity
+
+The name recorded alongside an identity is a display name, and people's names change. Renaming updates it in
+one place for every event that identity has ever caused — the events themselves are untouched, since the name
+is not part of the fact they record.
+
+<ChronicleClientTabs snippet="concepts/correlation-identity-causation/renaming-an-identity" />
+
+The subject is the identity's stable key. It is what events are recorded against, so it does not change.
+
 ## Causation
 
 <ChronicleClientTabs snippet="concepts/correlation-identity-causation/causation" />

--- a/Documentation/events/schema-representation.mdx
+++ b/Documentation/events/schema-representation.mdx
@@ -1,0 +1,26 @@
+# Overriding how a type appears in the schema
+
+Chronicle generates a JSON schema for every event and read model, and that schema is what the kernel stores
+against the event type and uses to materialize values back out. Most types map on their own — primitives
+directly, and `ConceptAs<T>` types as their underlying primitive.
+
+A type that serializes to something other than its shape needs to say so, or the generated schema describes
+the CLR structure while the stored JSON holds whatever the converter wrote. Annotate the type with
+`JsonSchemaType` to declare what it is really represented as:
+
+<ChronicleClientTabs snippet="events/schema-representation/basic" />
+
+The schema then describes a string, matching what the converter actually writes.
+
+Two things are preserved through the override:
+
+- **Compliance metadata.** A type marked `[PII]` keeps its compliance metadata after the redirect, so it is
+  still encrypted per subject.
+- **Nullability.** A nullable use of the type is still marked nullable in the schema.
+
+An explicit `JsonSchemaType` always wins over what Chronicle would otherwise infer, including the `ConceptAs<T>`
+handling.
+
+:::note[Client coverage]
+`JsonSchemaType` is currently C#-only.
+:::

--- a/Documentation/events/toc.yml
+++ b/Documentation/events/toc.yml
@@ -22,6 +22,8 @@
   href: concurrency.mdx
 - name: Cross-cutting properties
   href: cross-cutting-properties.mdx
+- name: Overriding schema representation
+  href: schema-representation.mdx
 - name: Revision
   href: revision.md
 - name: Redaction

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -42,7 +42,11 @@ Aspire's `builder.AddMongoDB("mongo")` starts a **standalone** `mongod`, so it d
 - A MongoDB Atlas connection string (`builder.AddConnectionString("...")`) — Atlas clusters are always replica sets.
 - Any self-hosted or cloud MongoDB cluster reached through a connection string.
 
-For local development against the slim image, run MongoDB as a **single-node replica set** container that initializes itself, and hand `WithMongoDB` a connection string carrying `?directConnection=true`:
+For local development against the slim image, `AddCratisChronicleMongoDB()` provisions this for you — a MongoDB container that initializes itself as a single-node replica set, handed back as a connection string carrying `?directConnection=true`:
+
+<ChronicleClientTabs snippet="hosting/aspire/mongo-replica-set-helper" />
+
+If you would rather define the container yourself, the same recipe written out in full is:
 
 <ChronicleClientTabs snippet="hosting/aspire/mongo-replica-set" />
 

--- a/Documentation/reactors/replay.mdx
+++ b/Documentation/reactors/replay.mdx
@@ -1,0 +1,26 @@
+# Replay
+
+A reactor sees the same event twice for different reasons: once as it happens, and again whenever its observer
+is replayed. Those often call for different work — a confirmation that should go out once when an order is
+placed has no business going out again while a read model is being rebuilt.
+
+Mark a second handler for the same event type with the `Replay` attribute and it takes over for the duration
+of the replay.
+
+<ChronicleClientTabs snippet="reactors/replay/basic" />
+
+The rules are:
+
+- With a `Replay` handler, **only** it runs during a replay — the regular handler does not also run.
+- Without one, the regular handler runs during a replay exactly as it always has, so adding this to one event
+  type changes nothing for the others.
+- An event type handled **only** by a `Replay` handler is still subscribed to, so the replay it exists for
+  delivers it.
+
+Reach for [OnceOnly](once-only) instead when the side effect should simply not happen again. Use `Replay` when
+a replay needs to do something *different* rather than nothing.
+
+:::note[Client coverage]
+`Replay` is currently C#-only — Kotlin, Java, Elixir, and TypeScript have no equivalent marker, so a replay
+always re-runs the regular handler in those clients.
+:::

--- a/Documentation/reactors/toc.yml
+++ b/Documentation/reactors/toc.yml
@@ -12,6 +12,8 @@
   href: external-event-store-subscriptions.mdx
 - name: OnceOnly
   href: once-only.mdx
+- name: Replay
+  href: replay.mdx
 - name: Filtering by appended event metadata
   href: filtering.mdx
   items:

--- a/Integration/Client/for_Reactors/ReactorWithReplayHandler.cs
+++ b/Integration/Client/for_Reactors/ReactorWithReplayHandler.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reactors;
+
+namespace Cratis.Chronicle.Integration.for_Reactors;
+
+/// <summary>
+/// Counts live and replay handling separately, so a spec can tell which handler the kernel's observation
+/// state actually selected once the event has been over the wire.
+/// </summary>
+[DependencyInjection.IgnoreConvention]
+public class ReactorWithReplayHandler : IReactor
+{
+    public int LiveHandled;
+    public int ReplayHandled;
+
+    public Task OnSomeEvent(SomeEvent evt, EventContext ctx)
+    {
+        Interlocked.Increment(ref LiveHandled);
+        return Task.CompletedTask;
+    }
+
+    [Replay]
+    public Task OnSomeEventDuringReplay(SomeEvent evt, EventContext ctx)
+    {
+        Interlocked.Increment(ref ReplayHandled);
+        return Task.CompletedTask;
+    }
+
+    public async Task WaitTillReplayHandledReaches(int count, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (ReplayHandled < count)
+        {
+            await Task.Delay(50, cts.Token);
+        }
+    }
+
+    public async Task WaitTillLiveHandledReaches(int count, TimeSpan? timeout = default)
+    {
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+        using var cts = new CancellationTokenSource(timeout.Value);
+        while (LiveHandled < count)
+        {
+            await Task.Delay(50, cts.Token);
+        }
+    }
+}

--- a/Integration/Client/for_Reactors/when_replaying/and_the_reactor_has_a_replay_handler.cs
+++ b/Integration/Client/for_Reactors/when_replaying/and_the_reactor_has_a_replay_handler.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Reactors;
+using context = Cratis.Chronicle.Integration.for_Reactors.when_replaying.and_the_reactor_has_a_replay_handler.context;
+
+namespace Cratis.Chronicle.Integration.for_Reactors.when_replaying;
+
+/// <summary>
+/// The replay handler is selected from EventObservationState on the event context, which the kernel stamps and
+/// ships to the client over gRPC. In-process specs take that context directly, so this is the only place the
+/// signal is proven to survive the wire during a real replay.
+/// </summary>
+/// <param name="context">The <see cref="context"/> the specs run against.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_the_reactor_has_a_replay_handler(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification<ChronicleFixture>(chronicleFixture)
+    {
+        public EventSourceId EventSourceId;
+        public ReactorWithReplayHandler Reactor;
+        public int LiveHandledBeforeReplay;
+
+        public override IEnumerable<Type> EventTypes => [typeof(SomeEvent)];
+        public override IEnumerable<Type> Reactors => [typeof(ReactorWithReplayHandler)];
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            Reactor = new ReactorWithReplayHandler();
+            services.AddSingleton(Reactor);
+        }
+
+        void Establish() => EventSourceId = "some source";
+
+        async Task Because()
+        {
+            var reactor = EventStore.Reactors.GetHandlerFor<ReactorWithReplayHandler>();
+            await reactor.WaitTillActive();
+
+            await EventStore.EventLog.Append(EventSourceId, new SomeEvent(42));
+            await Reactor.WaitTillLiveHandledReaches(1);
+            LiveHandledBeforeReplay = Reactor.LiveHandled;
+
+            var replayJobId = await EventStore.Reactors.Replay<ReactorWithReplayHandler>();
+            await EventStore.Jobs.WaitTillJobCompletesOrIsDeleted(replayJobId);
+            await Reactor.WaitTillReplayHandledReaches(1);
+        }
+    }
+
+    [Fact] void should_handle_the_event_live_when_it_is_appended() => Context.LiveHandledBeforeReplay.ShouldEqual(1);
+
+    [Fact] void should_handle_the_event_with_the_replay_handler_during_the_replay() => Context.Reactor.ReplayHandled.ShouldEqual(1);
+
+    [Fact] void should_not_handle_it_with_the_live_handler_again_during_the_replay() => Context.Reactor.LiveHandled.ShouldEqual(1);
+}

--- a/IssueAnalysis.md
+++ b/IssueAnalysis.md
@@ -62,6 +62,13 @@ No issues are currently flagged as potentially obsolete (none have been inactive
 
 <!-- HAND-WRITTEN SECTIONS START -->
 
+> **Check the issue is still open before picking anything up here.** The hand-written sections were written
+> against a much older tree and the repository has churned heavily since — projects were consolidated
+> (`Shared` → `Concepts`, `Grains`/`Grains.Interfaces`/`Services`/`Setup` → `Core`) and a good deal of what is
+> described below has shipped. On 2026-07-29 these were each verified against HEAD and closed as already
+> implemented, while still appearing in the tables below: #579, #784, #896, #962, #963, #1250, #1309, #1343,
+> #1345, #1396, #1536, #1537, #1791, #2290, #3421.
+
 ## 1. Already Implemented in Code
 
 These features exist in the current codebase in a substantially complete form. **All issues in this
@@ -110,7 +117,7 @@ These issues have sufficiently clear requirements to implement directly.
 | # | Issue | Notes |
 |---|-------|-------|
 | [#362](https://github.com/Cratis/Chronicle/issues/362) | Provide a codespaces / devcontainer | Add `.devcontainer/devcontainer.json` with Docker Compose configuration referencing the existing `docker-compose.yml`. |
-| [#482](https://github.com/Cratis/Chronicle/issues/482) | Enable CA1852 (sealed keyword) and apply it | `.editorconfig` currently has `dotnet_diagnostic.CA1852.severity = none`. Enable it, then add `sealed` to all eligible classes. |
+| [#482](https://github.com/Cratis/Chronicle/issues/482) | Enable CA1852 (sealed keyword) and apply it | Already enabled for production source — `AnalysisMode=AllEnabledByDefault` in `Directory.Build.props` turns it on, and the `dotnet_diagnostic.CA1852.severity = none` in `.editorconfig` sits under `[{**/*.Specs/**/*.cs,Integration/**/*.cs}]`, so it applies to specs only. CA1852 also covers only *internal* types and is skipped for assemblies exposing `InternalsVisibleTo`, which these do, so it buys little. The title's actual goal needs sealing *public* types, which removes the ability to subclass and is a breaking change — an API policy decision, not a mechanical sweep. |
 | [#523](https://github.com/Cratis/Chronicle/issues/523) | Optimize iterations of lists with `CollectionMarshal.AsSpan()` | Identify `List<T>` iterations in hot paths (event dispatch, serialization) and use `CollectionMarshal.AsSpan()`. |
 | [#547](https://github.com/Cratis/Chronicle/issues/547) | Proper error message when specifying same property twice in projection definitions | Add duplicate-key checks in `FromBuilder`, `JoinBuilder`, `CompositeKeyBuilder` etc. and throw a descriptive exception. |
 | [#579](https://github.com/Cratis/Chronicle/issues/579) | Add support for enums as values in projections (e.g. `.ToValue()`) | Handle `enum` types in `EventValueProviders.cs` and expression resolvers so enum values are correctly converted rather than failing. |

--- a/Source/Clients/AspNetCore.Specs/OpenTelemetry/for_TracerProviderBuilderExtensions/when_adding_chronicle_client_instrumentation.cs
+++ b/Source/Clients/AspNetCore.Specs/OpenTelemetry/for_TracerProviderBuilderExtensions/when_adding_chronicle_client_instrumentation.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Cratis.Chronicle.AspNetCore.OpenTelemetry;
+using Cratis.Chronicle.Diagnostics.OpenTelemetry.Tracing;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Cratis.Chronicle.AspNetCore.for_TracerProviderBuilderExtensions;
+
+/// <summary>
+/// An <see cref="ActivitySource"/> produces nothing until something listens to it by name, so registering the
+/// client's source is the whole of what this extension does. Both halves are asserted in one spec because an
+/// activity listener is process-wide, and separate spec classes would see each other's tracer provider.
+/// </summary>
+public class when_adding_chronicle_client_instrumentation : Specification
+{
+    static readonly ActivitySource _source = new(ClientActivity.SourceName);
+
+    TracerProvider _provider;
+    Activity _beforeAdding;
+    Activity _afterAdding;
+
+    void Because()
+    {
+        _beforeAdding = _source.StartActivity("some-client-operation");
+        _provider = Sdk.CreateTracerProviderBuilder().AddCratisChronicleInstrumentation().Build();
+        _afterAdding = _source.StartActivity("some-client-operation");
+    }
+
+    void Destroy()
+    {
+        _beforeAdding?.Dispose();
+        _afterAdding?.Dispose();
+        _provider?.Dispose();
+    }
+
+    [Fact] void should_not_record_client_activity_before_it_is_added() => _beforeAdding.ShouldBeNull();
+    [Fact] void should_record_client_activity_once_it_is_added() => _afterAdding.ShouldNotBeNull();
+    [Fact] void should_record_it_against_the_client_source() => _afterAdding.Source.Name.ShouldEqual(ClientActivity.SourceName);
+}

--- a/Source/Clients/Aspire.Specs/Aspire.Specs.csproj
+++ b/Source/Clients/Aspire.Specs/Aspire.Specs.csproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>Cratis.Chronicle.Aspire.Specs</AssemblyName>
+        <RootNamespace>Cratis.Chronicle.Aspire</RootNamespace>
+        <IsTestProject>true</IsTestProject>
+        <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);ASPIREPROBES001;NU1903</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Aspire/Aspire.csproj" />
+    </ItemGroup>
+</Project>

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.given;
+
+public class a_distributed_application_builder : Specification
+{
+    protected IDistributedApplicationBuilder _builder;
+
+    void Establish() => _builder = DistributedApplication.CreateBuilder([]);
+
+    protected static async Task<IEnumerable<string>> ArgumentsFor(IResource resource)
+    {
+        var args = new List<object>();
+        var context = new CommandLineArgsCallbackContext(args);
+        foreach (var annotation in resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>())
+        {
+            await annotation.Callback(context);
+        }
+        return args.Select(_ => _.ToString()!);
+    }
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_specifying_name_and_image_tag.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_specifying_name_and_image_tag.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.when_adding_mongo_db;
+
+public class and_specifying_name_and_image_tag : given.a_distributed_application_builder
+{
+    const string Name = "chronicle-mongo";
+    const string ImageTag = "7.0";
+
+    IResourceBuilder<IResourceWithConnectionString> _result;
+    ContainerResource _server;
+    ContainerImageAnnotation _image;
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicleMongoDB(Name, ImageTag);
+        _server = _builder.Resources.OfType<ContainerResource>().Single(_ => _.Name == $"{Name}-server");
+        _image = _server.Annotations.OfType<ContainerImageAnnotation>().Single();
+    }
+
+    [Fact] void should_name_the_connection_string_resource_as_specified() => _result.Resource.Name.ShouldEqual(Name);
+    [Fact] void should_use_the_specified_image_tag() => _image.Tag.ShouldEqual(ImageTag);
+    [Fact] void should_connect_through_the_named_server_endpoint() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain($"{Name}-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.host");
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_using_the_defaults.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleMongoDBDistributedApplicationBuilderExtensions/when_adding_mongo_db/and_using_the_defaults.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleMongoDBDistributedApplicationBuilderExtensions.when_adding_mongo_db;
+
+public class and_using_the_defaults : given.a_distributed_application_builder
+{
+    IResourceBuilder<IResourceWithConnectionString> _result;
+    ContainerResource _server;
+    ContainerImageAnnotation _image;
+    EndpointAnnotation _endpoint;
+    IEnumerable<string> _arguments;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicleMongoDB();
+        _server = _builder.Resources.OfType<ContainerResource>().Single(_ => _.Name == "mongodb-server");
+        _image = _server.Annotations.OfType<ContainerImageAnnotation>().Single();
+        _endpoint = _server.Annotations.OfType<EndpointAnnotation>().Single();
+        _arguments = await ArgumentsFor(_server);
+    }
+
+    [Fact] void should_name_the_connection_string_resource_by_convention() => _result.Resource.Name.ShouldEqual("mongodb");
+    [Fact] void should_use_the_mongo_db_image() => _image.Image.ShouldEqual(ChronicleContainerImageTags.MongoDBImage);
+    [Fact] void should_use_the_default_image_tag() => _image.Tag.ShouldEqual(ChronicleContainerImageTags.MongoDBTag);
+    [Fact] void should_use_the_docker_hub_registry() => _image.Registry.ShouldEqual(ChronicleContainerImageTags.Registry);
+    [Fact] void should_name_the_endpoint_by_convention() => _endpoint.Name.ShouldEqual(ChronicleContainerImageTags.MongoDBEndpointName);
+    [Fact] void should_target_the_mongo_db_port() => _endpoint.TargetPort.ShouldEqual(27017);
+    [Fact] void should_run_the_command_through_a_shell() => _server.Entrypoint.ShouldEqual("/bin/sh");
+    [Fact] void should_pass_the_command_to_the_shell() => _arguments.First().ShouldEqual("-c");
+    [Fact] void should_start_mongod_as_a_replica_set() => _arguments.Last().ShouldContain($"mongod --replSet {ChronicleContainerImageTags.MongoDBReplicaSetName} --bind_ip_all");
+    [Fact] void should_initiate_the_replica_set() => _arguments.Last().ShouldContain($"rs.initiate({{ _id: \"{ChronicleContainerImageTags.MongoDBReplicaSetName}\"");
+    [Fact] void should_keep_mongod_as_the_container_entrypoint_process() => _arguments.Last().ShouldContain("exec docker-entrypoint.sh");
+    [Fact] void should_connect_directly_to_the_single_node() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain("directConnection=true");
+    [Fact] void should_connect_through_the_mongo_db_endpoint() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldContain($"mongodb://{{mongodb-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.host}}:{{mongodb-server.bindings.{ChronicleContainerImageTags.MongoDBEndpointName}.port}}/");
+}

--- a/Source/Clients/Aspire/ChronicleContainerImageTags.cs
+++ b/Source/Clients/Aspire/ChronicleContainerImageTags.cs
@@ -34,9 +34,29 @@ public static class ChronicleContainerImageTags
     public const string DevelopmentSlimTag = "latest-development-slim";
 
     /// <summary>
+    /// MongoDB container image name.
+    /// </summary>
+    public const string MongoDBImage = "mongo";
+
+    /// <summary>
+    /// Tag for the MongoDB container image used by <c>AddCratisChronicleMongoDB</c>.
+    /// </summary>
+    public const string MongoDBTag = "8.0";
+
+    /// <summary>
+    /// Name of the single-node replica set that <c>AddCratisChronicleMongoDB</c> initiates.
+    /// </summary>
+    public const string MongoDBReplicaSetName = "rs0";
+
+    /// <summary>
     /// Name of the gRPC endpoint.
     /// </summary>
     public const string GrpcEndpointName = "grpc";
+
+    /// <summary>
+    /// Name of the MongoDB TCP endpoint.
+    /// </summary>
+    public const string MongoDBEndpointName = "tcp";
 
     /// <summary>
     /// Environment variable key for the Chronicle storage type (e.g. <c>MongoDB</c>).

--- a/Source/Clients/Aspire/ChronicleMongoDBDistributedApplicationBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleMongoDBDistributedApplicationBuilderExtensions.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods for adding a Chronicle-compatible MongoDB resource to an Aspire distributed application.
+/// </summary>
+public static class ChronicleMongoDBDistributedApplicationBuilderExtensions
+{
+    /// <summary>
+    /// The port <c>mongod</c> listens on inside the container.
+    /// </summary>
+    const int MongoDBPort = 27017;
+
+    /// <summary>
+    /// The script that initiates the single-node replica set, tolerating an already initiated one.
+    /// </summary>
+    static readonly string _initiateReplicaSetScript =
+        $"try {{ rs.status() }} catch (error) {{ rs.initiate({{ _id: \"{ChronicleContainerImageTags.MongoDBReplicaSetName}\", members: [{{ _id: 0, host: \"localhost:{MongoDBPort}\" }}] }}) }}";
+
+    /// <summary>
+    /// The container command that starts <c>mongod</c> as a replica set and initiates it once it accepts connections.
+    /// </summary>
+    /// <remarks>
+    /// The initiation runs in a background subshell that first polls until <c>mongod</c> answers a ping, because
+    /// <c>rs.initiate</c> fails against a server that has not finished starting. <c>exec docker-entrypoint.sh</c>
+    /// keeps <c>mongod</c> as PID 1 so it still receives container signals and drops privileges the way the
+    /// official image intends.
+    /// </remarks>
+    static readonly string _replicaSetEntrypointCommand =
+        "( until mongosh --quiet --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; do sleep 0.3; done; " +
+        $"mongosh --quiet --eval '{_initiateReplicaSetScript}' ) & " +
+        $"exec docker-entrypoint.sh mongod --replSet {ChronicleContainerImageTags.MongoDBReplicaSetName} --bind_ip_all";
+
+    /// <summary>
+    /// Adds a MongoDB resource configured the way Chronicle needs it — a self-initiating single-node replica set
+    /// exposed through a connection string with <c>directConnection=true</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Chronicle relies on MongoDB transactions and change streams, which a standalone <c>mongod</c> does not
+    /// support. Aspire's <c>AddMongoDB</c> starts exactly such a standalone server, so pointing Chronicle at it
+    /// leaves observers, projections, and observable queries silently doing nothing. This method starts the
+    /// official MongoDB image as a single-node replica set that initiates itself on first run, which is what
+    /// Chronicle needs for local development and testing.
+    /// </para>
+    /// <para>
+    /// The returned connection string carries <c>?directConnection=true</c>, so the driver talks to the
+    /// host-mapped port directly instead of following the replica-set member host advertised by the server —
+    /// that host (<c>localhost</c> inside the container) is not reachable from outside it, and following it
+    /// makes the driver hang.
+    /// </para>
+    /// <para>
+    /// Two resources are added: a container named <c>{name}-server</c> running MongoDB, and a connection-string
+    /// resource named <paramref name="name"/> that the returned builder represents. Pass the returned builder
+    /// straight to <see cref="Cratis.Chronicle.Aspire.ChronicleAspireBuilderExtensions.WithMongoDB"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resources to.</param>
+    /// <param name="name">The name for the connection-string resource. Defaults to <c>"mongodb"</c>.</param>
+    /// <param name="imageTag">
+    /// Optional tag for the MongoDB container image. Defaults to
+    /// <see cref="ChronicleContainerImageTags.MongoDBTag"/>.
+    /// </param>
+    /// <returns>An <see cref="IResourceBuilder{T}"/> for the MongoDB connection string.</returns>
+    /// <example>
+    /// <code>
+    /// var mongo = builder.AddCratisChronicleMongoDB();
+    /// builder.AddCratisChronicle("chronicle", chronicle => chronicle.WithMongoDB(mongo));
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<IResourceWithConnectionString> AddCratisChronicleMongoDB(
+        this IDistributedApplicationBuilder builder,
+        string name = "mongodb",
+        string? imageTag = default)
+    {
+        var server = builder
+            .AddContainer($"{name}-server", ChronicleContainerImageTags.MongoDBImage, imageTag ?? ChronicleContainerImageTags.MongoDBTag)
+            .WithImageRegistry(ChronicleContainerImageTags.Registry)
+            .WithEndpoint(targetPort: MongoDBPort, name: ChronicleContainerImageTags.MongoDBEndpointName)
+            .WithEntrypoint("/bin/sh")
+            .WithArgs("-c", _replicaSetEntrypointCommand);
+
+        var endpoint = server.GetEndpoint(ChronicleContainerImageTags.MongoDBEndpointName);
+
+        return builder.AddConnectionString(
+            name,
+            ReferenceExpression.Create($"mongodb://{endpoint.Property(EndpointProperty.Host)}:{endpoint.Property(EndpointProperty.Port)}/?directConnection=true"));
+    }
+}

--- a/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/given/an_identity_manager.cs
+++ b/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/given/an_identity_manager.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Identities;
+
+namespace Cratis.Chronicle.Identities.for_IdentityManager.given;
+
+public class an_identity_manager : Specification
+{
+    protected static readonly EventStoreName _eventStore = "the-store";
+    protected static readonly EventStoreNamespaceName _namespace = "the-namespace";
+
+    protected IIdentities _identities;
+    protected IdentityManager _manager;
+
+    void Establish()
+    {
+        _identities = Substitute.For<IIdentities>();
+
+        var services = Substitute.For<IServices>();
+        services.Identities.Returns(_identities);
+
+        var connection = Substitute.For<IChronicleConnection, IChronicleServicesAccessor>();
+        ((IChronicleServicesAccessor)connection).Services.Returns(services);
+
+        _manager = new IdentityManager(_eventStore, _namespace, connection);
+    }
+}

--- a/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/when_renaming_an_identity.cs
+++ b/Source/Clients/DotNET.Specs/Identities/for_IdentityManager/when_renaming_an_identity.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Identities;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.Identities.for_IdentityManager;
+
+public class when_renaming_an_identity : given.an_identity_manager
+{
+    const string IdentitySubject = "person-42";
+    const string NewName = "The New Name";
+
+    async Task Because() => await _manager.Rename(IdentitySubject, NewName);
+
+    [Fact]
+    async Task should_rename_the_identity_in_the_store() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.EventStore == _eventStore.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_in_the_namespace() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Namespace == _namespace.Value),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_for_the_subject() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Subject == IdentitySubject),
+            Arg.Any<CallContext>());
+
+    [Fact]
+    async Task should_rename_the_identity_to_the_new_name() =>
+        await _identities.Received(1).RenameIdentity(
+            Arg.Is<RenameIdentityRequest>(_ => _.Name == NewName),
+            Arg.Any<CallContext>());
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_getting_event_types_for/and_only_a_replay_handler_handles_a_type.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_getting_event_types_for/and_only_a_replay_handler_handles_a_type.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_getting_event_types_for;
+
+/// <summary>
+/// The event types drive what the reactor subscribes to. An event type handled only during replay still has to
+/// be subscribed to, or the replay it exists for would never deliver it.
+/// </summary>
+public class and_only_a_replay_handler_handles_a_type : Specification
+{
+    IImmutableList<EventType> _result;
+
+    void Because() => _result = ReactorInvoker.GetEventTypesFor(
+        new EventTypesForSpecifications([typeof(MyEvent)]),
+        typeof(ReactorWithOnlyAReplayHandler));
+
+    [Fact] void should_subscribe_to_the_event_type() => _result.Count.ShouldEqual(1);
+
+    class ReactorWithOnlyAReplayHandler : IReactor
+    {
+        [Replay]
+        public void HandleDuringReplay(MyEvent @event)
+        {
+        }
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_only_a_live_handler_exists_during_replay.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_only_a_live_handler_exists_during_replay.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// Every reactor written before replay handlers existed relies on its handler running during a replay, so an
+/// event type with no replay handler has to keep behaving exactly as it did.
+/// </summary>
+public class and_only_a_live_handler_exists_during_replay : Specification
+{
+    ReactorWithoutReplayHandler _reactor;
+    ReactorInvoker _invoker;
+
+    void Establish()
+    {
+        _reactor = new ReactorWithoutReplayHandler();
+        _invoker = new ReactorInvoker(
+            new EventTypesForSpecifications([typeof(MyEvent)]),
+            Substitute.For<IReactorMiddlewares>(),
+            typeof(ReactorWithoutReplayHandler),
+            new ActivatedArtifact(_reactor, typeof(ReactorWithoutReplayHandler), Substitute.For<ILogger<ActivatedArtifact>>()),
+            Substitute.For<ILogger<ReactorInvoker>>());
+    }
+
+    async Task Because() => await _invoker.Invoke(new MyEvent(), EventContext.Empty with { ObservationState = EventObservationState.Replay });
+
+    [Fact] void should_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(1);
+
+    class ReactorWithoutReplayHandler : IReactor
+    {
+        public int LiveCalls { get; private set; }
+
+        public void Handle(MyEvent @event) => LiveCalls++;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_being_replayed.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_being_replayed.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// The replay handler takes over for the duration of the replay, and the live handler does not also run -
+/// otherwise marking one would double the work rather than redirect it.
+/// </summary>
+public class and_the_event_is_being_replayed : given.a_reactor_with_a_replay_handler
+{
+    async Task Because() => await _invoker.Invoke(new MyEvent(), ContextObservedAs(EventObservationState.Replay));
+
+    [Fact] void should_call_the_replay_handler() => _reactor.ReplayCalls.ShouldEqual(1);
+    [Fact] void should_not_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(0);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_observed_for_the_first_time.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/and_the_event_is_observed_for_the_first_time.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking;
+
+/// <summary>
+/// Marking a replay handler must not change what happens on the live path.
+/// </summary>
+public class and_the_event_is_observed_for_the_first_time : given.a_reactor_with_a_replay_handler
+{
+    async Task Because() => await _invoker.Invoke(new MyEvent(), ContextObservedAs(EventObservationState.Initial));
+
+    [Fact] void should_call_the_live_handler() => _reactor.LiveCalls.ShouldEqual(1);
+    [Fact] void should_not_call_the_replay_handler() => _reactor.ReplayCalls.ShouldEqual(0);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/given/a_reactor_with_a_replay_handler.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/given/a_reactor_with_a_replay_handler.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ObserverInvoker.when_invoking.given;
+
+public class a_reactor_with_a_replay_handler : Specification
+{
+    protected ReactorWithReplayHandler _reactor;
+    protected ReactorInvoker _invoker;
+
+    void Establish()
+    {
+        _reactor = new ReactorWithReplayHandler();
+        _invoker = new ReactorInvoker(
+            new EventTypesForSpecifications([typeof(MyEvent)]),
+            Substitute.For<IReactorMiddlewares>(),
+            typeof(ReactorWithReplayHandler),
+            new ActivatedArtifact(_reactor, typeof(ReactorWithReplayHandler), Substitute.For<ILogger<ActivatedArtifact>>()),
+            Substitute.For<ILogger<ReactorInvoker>>());
+    }
+
+    protected static EventContext ContextObservedAs(EventObservationState observationState) =>
+        EventContext.Empty with { ObservationState = observationState };
+
+    public class ReactorWithReplayHandler : IReactor
+    {
+        public int LiveCalls { get; private set; }
+
+        public int ReplayCalls { get; private set; }
+
+        public void Handle(MyEvent @event) => LiveCalls++;
+
+        [Replay]
+        public void HandleDuringReplay(MyEvent @event) => ReplayCalls++;
+    }
+}

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/interface_handler_with_derived_events_and_multiple_invokers.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/interface_handler_with_derived_events_and_multiple_invokers.cs
@@ -48,8 +48,8 @@ public class interface_handler_with_derived_events_and_multiple_invokers : Speci
     [Fact] void should_succeed_for_the_second_invocation() => _secondResult.ExceptionResult.TryGetException(out _).ShouldBeFalse();
     [Fact] void should_invoke_the_interface_handler_for_the_first_derived_event() => _firstReactor.HandledEventTypes.ShouldContainOnly(typeof(MyFirstDerivedEventFromInterface));
     [Fact] void should_invoke_the_interface_handler_for_the_second_derived_event() => _secondReactor.HandledEventTypes.ShouldContainOnly(typeof(MySecondDerivedEventFromInterface));
-    [Fact] void should_call_before_invoke_for_each_event() => _middlewares.Received(2).BeforeInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
-    [Fact] void should_call_after_invoke_for_each_event() => _middlewares.Received(2).AfterInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_before_invoke_for_each_event() => _middlewares.Received(2).BeforeInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_after_invoke_for_each_event() => _middlewares.Received(2).AfterInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
 
     class TrackingReactor : IReactor
     {

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/void_handler_method.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactionInvoker/when_invoking/void_handler_method.cs
@@ -29,8 +29,10 @@ public class void_handler_method : Specification
     async Task Because() => _result = await _invoker.Invoke(new MyEvent(), EventContext.Empty);
 
     [Fact] void should_succeed() => _result.ExceptionResult.TryGetException(out _).ShouldBeFalse();
-    [Fact] void should_call_before_invoke() => _middlewares.Received(1).BeforeInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
-    [Fact] void should_call_after_invoke() => _middlewares.Received(1).AfterInvoke(Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_before_invoke() => _middlewares.Received(1).BeforeInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_call_after_invoke() => _middlewares.Received(1).AfterInvoke(Arg.Any<ReactorId>(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_tell_before_invoke_which_reactor_is_running() => _middlewares.Received(1).BeforeInvoke(typeof(ReactorWithVoidHandlerMethodForEventType).GetReactorId(), Arg.Any<EventContext>(), Arg.Any<object>());
+    [Fact] void should_tell_after_invoke_which_reactor_is_running() => _middlewares.Received(1).AfterInvoke(typeof(ReactorWithVoidHandlerMethodForEventType).GetReactorId(), Arg.Any<EventContext>(), Arg.Any<object>());
 
     class ReactorWithVoidHandlerMethodForEventType : IReactor
     {

--- a/Source/Clients/DotNET.Specs/Reactors/for_ReactorMiddlewares/when_invoking/and_a_middleware_only_implements_the_overload_without_the_reactor.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/for_ReactorMiddlewares/when_invoking/and_a_middleware_only_implements_the_overload_without_the_reactor.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reactors.for_ReactorMiddlewares.when_invoking;
+
+/// <summary>
+/// The overload carrying the reactor was added alongside the original one, so a middleware written before it
+/// existed still has to be called. The default interface implementation is what makes that hold.
+/// </summary>
+public class and_a_middleware_only_implements_the_overload_without_the_reactor : Specification
+{
+    MiddlewareWithoutReactor _middleware;
+    ReactorMiddlewares _middlewares;
+
+    void Establish()
+    {
+        _middleware = new MiddlewareWithoutReactor();
+        _middlewares = new([new ActivatedArtifact<IReactorMiddleware>(_middleware, Substitute.For<ILogger<ActivatedArtifact>>())]);
+    }
+
+    async Task Because()
+    {
+        await _middlewares.BeforeInvoke("some-reactor", EventContext.Empty, new MyEvent());
+        await _middlewares.AfterInvoke("some-reactor", EventContext.Empty, new MyEvent());
+    }
+
+    [Fact] void should_call_before_invoke() => _middleware.BeforeInvokeCalls.ShouldEqual(1);
+    [Fact] void should_call_after_invoke() => _middleware.AfterInvokeCalls.ShouldEqual(1);
+
+    class MiddlewareWithoutReactor : IReactorMiddleware
+    {
+        public int BeforeInvokeCalls { get; private set; }
+
+        public int AfterInvokeCalls { get; private set; }
+
+        public Task BeforeInvoke(EventContext eventContext, object @event)
+        {
+            BeforeInvokeCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task AfterInvoke(EventContext eventContext, object @event)
+        {
+            AfterInvokeCalls++;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_type_with_json_schema_type_override.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_pii_type_with_json_schema_type_override.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// Substituting the schema of a type adorned with <see cref="JsonSchemaTypeAttribute"/> must not drop the
+/// classification of the value it stands in for — the compliance metadata belongs to the value, not to the shape
+/// it happens to serialize as, and losing it here would persist a <c>[PII]</c> value in the clear.
+/// </summary>
+public class when_generating_schema_for_pii_type_with_json_schema_type_override : given.a_json_schema_generator_with_pii_support
+{
+    [PII]
+    [JsonSchemaType(typeof(string))]
+    [JsonConverter(typeof(SocialSecurityNumberJsonConverter))]
+    record SocialSecurityNumber(string Country, string Number);
+
+    class SocialSecurityNumberJsonConverter : JsonConverter<SocialSecurityNumber>
+    {
+        public override SocialSecurityNumber Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(string.Empty, reader.GetString() ?? string.Empty);
+
+        public override void Write(Utf8JsonWriter writer, SocialSecurityNumber value, JsonSerializerOptions options) => writer.WriteStringValue($"{value.Country}-{value.Number}");
+    }
+
+    record Citizen(SocialSecurityNumber Identification);
+
+    JsonSchema _result;
+
+    void Because() => _result = _generator.Generate(typeof(Citizen));
+
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_json_type() =>
+        _result.ActualProperties["identification"].Type.ShouldEqual(JsonObjectType.String);
+
+    [Fact] void should_have_compliance_metadata_on_the_substituted_schema() =>
+        _result.ActualProperties["identification"].HasComplianceMetadata().ShouldBeTrue();
+
+    [Fact] void should_have_pii_compliance_type_on_the_substituted_schema() =>
+        _result.ActualProperties["identification"].GetComplianceMetadata()
+            .Select(_ => _.metadataType)
+            .ShouldContain(ComplianceMetadataType.PII.Value);
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_json_schema_type_override.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_json_schema_type_override.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// A type bringing its own <see cref="JsonConverter"/> serializes as something other than its CLR shape, and
+/// System.Text.Json's schema exporter cannot see through the converter. Adorning the type with
+/// <see cref="JsonSchemaTypeAttribute"/> declares what the converter actually produces, so the schema — which is
+/// what the value is stored and read against — describes the wire form rather than the CLR form.
+/// </summary>
+public class when_generating_schema_for_type_with_json_schema_type_override : given.a_json_schema_generator
+{
+    [JsonSchemaType(typeof(Guid))]
+    [JsonConverter(typeof(TrackingCodeJsonConverter))]
+    record TrackingCode(Guid Value)
+    {
+        public string Display => Value.ToString("N");
+    }
+
+    class TrackingCodeJsonConverter : JsonConverter<TrackingCode>
+    {
+        public override TrackingCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => new(reader.GetGuid());
+
+        public override void Write(Utf8JsonWriter writer, TrackingCode value, JsonSerializerOptions options) => writer.WriteStringValue(value.Value);
+    }
+
+    record Shipment(TrackingCode Code, TrackingCode? PreviousCode);
+
+    JsonSchema _result;
+
+    void Because() => _result = _generator.Generate(typeof(Shipment));
+
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_format() => _result.ActualProperties[nameof(Shipment.Code)].Format.ShouldEqual("guid");
+    [Fact] void should_represent_the_adorned_type_with_the_declared_types_json_type() => _result.ActualProperties[nameof(Shipment.Code)].Type.ShouldEqual(JsonObjectType.String);
+    [Fact] void should_not_describe_the_clr_shape_of_the_adorned_type() => _result.ActualProperties[nameof(Shipment.Code)].ActualProperties.ShouldBeEmpty();
+    [Fact] void should_mark_the_optional_adorned_type_as_nullable() => _result.ActualProperties[nameof(Shipment.PreviousCode)].Format.ShouldEqual("guid?");
+    [Fact] void should_default_the_optional_adorned_type_to_null() => _result.ActualProperties[nameof(Shipment.PreviousCode)].GetDefaultValue(_typeFormats).ShouldBeNull();
+    [Fact] void should_default_the_required_adorned_type_to_its_type_default() => _result.ActualProperties[nameof(Shipment.Code)].GetDefaultValue(_typeFormats).ShouldNotBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_self_referencing_json_schema_type.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_type_with_self_referencing_json_schema_type.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator;
+
+/// <summary>
+/// A <see cref="JsonSchemaTypeAttribute"/> pointing at the type it adorns would substitute the type's schema with
+/// its own schema forever, so it is rejected with a message naming the offending type instead of overflowing the stack.
+/// </summary>
+public class when_generating_schema_for_type_with_self_referencing_json_schema_type : given.a_json_schema_generator
+{
+    [JsonSchemaType(typeof(Beacon))]
+    record Beacon(string Signal);
+
+    Exception _result;
+
+    void Because() => _result = Catch.Exception(() => _generator.Generate(typeof(Beacon)));
+
+    [Fact] void should_fail_with_self_referencing_json_schema_type() => _result.ShouldBeOfExactType<SelfReferencingJsonSchemaType>();
+}

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -244,6 +244,7 @@ public class EventStore : IEventStore
             loggerFactory.CreateLogger<EventSeeding>());
 
         PII = new Compliance.GDPR.PIIManager(eventStoreName, @namespace, connection);
+        Identities = new IdentityManager(eventStoreName, @namespace, connection);
 
         if (autoDiscoverAndRegister)
         {
@@ -307,6 +308,9 @@ public class EventStore : IEventStore
 
     /// <inheritdoc/>
     public Compliance.GDPR.IPIIManager PII { get; }
+
+    /// <inheritdoc/>
+    public IIdentityManager Identities { get; }
 
     /// <inheritdoc/>
     public async Task DiscoverAll()

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventStoreSubscriptions;
 using Cratis.Chronicle.ExternalServices;
+using Cratis.Chronicle.Identities;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections;
@@ -119,6 +120,11 @@ public interface IEventStore
     /// Gets the <see cref="IPIIManager"/> for managing PII encryption keys (GDPR right-to-erasure) for the event store.
     /// </summary>
     IPIIManager PII { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IIdentityManager"/> for managing identities for the event store.
+    /// </summary>
+    IIdentityManager Identities { get; }
 
     /// <summary>
     /// Discover all artifacts for the event store.

--- a/Source/Clients/DotNET/Identities/IIdentityManager.cs
+++ b/Source/Clients/DotNET/Identities/IIdentityManager.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Identities;
+
+/// <summary>
+/// Defines a manager of identities in the system.
+/// </summary>
+public interface IIdentityManager
+{
+    /// <summary>
+    /// Renames the name of an identity, identified by its subject.
+    /// </summary>
+    /// <param name="subject">The subject of the <see cref="Identity"/> to rename.</param>
+    /// <param name="name">The new name to give the identity.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// The subject is the stable identifier of the identity - the name is the display name and
+    /// can change over time, for instance when a person changes their name. Renaming an identity
+    /// affects every event and read model that refers to the identity, as the name is resolved
+    /// from the identity itself and not stored with what refers to it.
+    /// </remarks>
+    Task Rename(string subject, string name);
+}

--- a/Source/Clients/DotNET/Identities/IdentityManager.cs
+++ b/Source/Clients/DotNET/Identities/IdentityManager.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Identities;
+
+namespace Cratis.Chronicle.Identities;
+
+/// <summary>
+/// Represents an implementation of <see cref="IIdentityManager"/> that proxies to the Chronicle kernel over the client connection.
+/// </summary>
+/// <param name="eventStore">The <see cref="EventStoreName"/> the manager operates within.</param>
+/// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the manager operates within.</param>
+/// <param name="connection">The <see cref="IChronicleConnection"/> for talking to the kernel.</param>
+public class IdentityManager(
+    EventStoreName eventStore,
+    EventStoreNamespaceName @namespace,
+    IChronicleConnection connection) : IIdentityManager
+{
+    readonly IChronicleServicesAccessor _servicesAccessor = (connection as IChronicleServicesAccessor)!;
+
+    /// <inheritdoc/>
+    public Task Rename(string subject, string name) =>
+        _servicesAccessor.Services.Identities.RenameIdentity(new RenameIdentityRequest
+        {
+            EventStore = eventStore,
+            Namespace = @namespace,
+            Subject = subject,
+            Name = name
+        });
+}

--- a/Source/Clients/DotNET/Reactors/IReactorMiddleware.cs
+++ b/Source/Clients/DotNET/Reactors/IReactorMiddleware.cs
@@ -25,4 +25,30 @@ public interface IReactorMiddleware
     /// <param name="event">The actual event that it will be called with.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task AfterInvoke(EventContext eventContext, object @event);
+
+    /// <summary>
+    /// Invoked before the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event is being observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    /// <remarks>
+    /// This is the overload Chronicle calls. It defaults to the overload without the reactor, so a middleware
+    /// written before the reactor was passed along keeps working; implement this one to know which reactor is running.
+    /// </remarks>
+    Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event) => BeforeInvoke(eventContext, @event);
+
+    /// <summary>
+    /// Invoked after the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event was observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    /// <remarks>
+    /// This is the overload Chronicle calls. It defaults to the overload without the reactor, so a middleware
+    /// written before the reactor was passed along keeps working; implement this one to know which reactor is running.
+    /// </remarks>
+    Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event) => AfterInvoke(eventContext, @event);
 }

--- a/Source/Clients/DotNET/Reactors/IReactorMiddlewares.cs
+++ b/Source/Clients/DotNET/Reactors/IReactorMiddlewares.cs
@@ -25,4 +25,22 @@ public interface IReactorMiddlewares : IAsyncDisposable
     /// <param name="event">The actual event that it will be called with.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task AfterInvoke(EventContext eventContext, object @event);
+
+    /// <summary>
+    /// Invoked before the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event is being observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event) => BeforeInvoke(eventContext, @event);
+
+    /// <summary>
+    /// Invoked after the actual invoke, for a known reactor.
+    /// </summary>
+    /// <param name="reactorId">The <see cref="ReactorId"/> of the reactor the event was observed for.</param>
+    /// <param name="eventContext"><see cref="EventContext"/> for the event.</param>
+    /// <param name="event">The actual event that it will be called with.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event) => AfterInvoke(eventContext, @event);
 }

--- a/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
@@ -54,8 +54,8 @@ public class ReactorInvoker(
     IReactorMethodArgumentsResolver? argumentsResolver = null,
     IServiceProvider? serviceProvider = null) : IReactorInvoker
 {
-    static readonly ConcurrentDictionary<Type, FrozenDictionary<Type, MethodInfo>> _methodsByEventTypeCache = [];
-    readonly FrozenDictionary<Type, MethodInfo> _methodsByEventType = MethodsByEventType.Get(targetType, eventTypes.AllClrTypes);
+    static readonly ConcurrentDictionary<Type, HandlerMethods> _methodsByEventTypeCache = [];
+    readonly HandlerMethods _methodsByEventType = MethodsByEventType.Get(targetType, eventTypes.AllClrTypes);
     readonly IReactorMethodArgumentsResolver _argumentsResolver = argumentsResolver ?? new ReactorMethodArgumentsResolver();
 
     /// <summary>
@@ -66,7 +66,7 @@ public class ReactorInvoker(
     /// <returns>Collection of discovered <see cref="EventType"/>.</returns>
     public static IImmutableList<EventType> GetEventTypesFor(IEventTypes eventTypes, Type reactorType) =>
         MethodsByEventType.Get(reactorType, eventTypes.AllClrTypes)
-            .Keys
+            .AllEventTypes
             .Select(eventTypes.GetEventTypeFor)
             .ToImmutableList();
 
@@ -79,7 +79,7 @@ public class ReactorInvoker(
         {
             var eventType = content.GetType();
 
-            if (_methodsByEventType.TryGetValue(eventType, out var method))
+            if (_methodsByEventType.TryGetHandlerFor(eventType, eventContext.ObservationState, out var method))
             {
                 await middlewares.BeforeInvoke(eventContext, content);
 
@@ -197,17 +197,52 @@ public class ReactorInvoker(
     ReactorContextValues BuildValues(EventContext eventContext) =>
         reactorContextValuesBuilder?.Build(activatedReactor.Instance, eventContext) ?? ReactorContextValues.Empty;
 
+    /// <summary>
+    /// The handler methods of a reactor, split by whether they take over during a replay.
+    /// </summary>
+    /// <param name="Live">The handlers to run as events happen.</param>
+    /// <param name="Replay">The handlers marked with <see cref="ReplayAttribute"/>, which take over during a replay.</param>
+    record HandlerMethods(FrozenDictionary<Type, MethodInfo> Live, FrozenDictionary<Type, MethodInfo> Replay)
+    {
+        /// <summary>
+        /// Gets every event type handled, whichever path handles it. An event type handled only by a replay
+        /// handler still has to be subscribed to, or the replay would have nothing to deliver.
+        /// </summary>
+        public IEnumerable<Type> AllEventTypes => Live.Keys.Union(Replay.Keys);
+
+        /// <summary>
+        /// Resolves the handler to run for an event type, given the state the event is being observed in.
+        /// </summary>
+        /// <param name="eventType">The event <see cref="Type"/> being observed.</param>
+        /// <param name="observationState">The <see cref="EventObservationState"/> the event arrives in.</param>
+        /// <param name="method">The resolved handler, when there is one.</param>
+        /// <returns>True if a handler was resolved, false otherwise.</returns>
+        public bool TryGetHandlerFor(Type eventType, EventObservationState observationState, out MethodInfo method)
+        {
+            // A replay handler takes over for the duration of the replay, and the live handler does not also run.
+            // Without one, the live handler keeps running during replay - which is what every reactor written
+            // before this existed relies on.
+            if (observationState.HasFlag(EventObservationState.Replay) && Replay.TryGetValue(eventType, out method!))
+            {
+                return true;
+            }
+
+            return Live.TryGetValue(eventType, out method!);
+        }
+    }
+
     static class MethodsByEventType
     {
-        public static FrozenDictionary<Type, MethodInfo> Get(Type targetType, IEnumerable<Type> eventTypes) =>
+        public static HandlerMethods Get(Type targetType, IEnumerable<Type> eventTypes) =>
             _methodsByEventTypeCache.GetOrAdd(
                 targetType,
                 static (key, keyEventTypes) => Build(key, keyEventTypes),
                 eventTypes);
 
-        static FrozenDictionary<Type, MethodInfo> Build(Type targetType, IEnumerable<Type> eventTypes)
+        static HandlerMethods Build(Type targetType, IEnumerable<Type> eventTypes)
         {
-            var methodsByEventType = new Dictionary<Type, MethodInfo>();
+            var liveMethodsByEventType = new Dictionary<Type, MethodInfo>();
+            var replayMethodsByEventType = new Dictionary<Type, MethodInfo>();
 
             foreach (var method in targetType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
@@ -225,6 +260,7 @@ public class ReactorInvoker(
                     continue;
                 }
 
+                var methodsByEventType = method.IsDefined(typeof(ReplayAttribute), false) ? replayMethodsByEventType : liveMethodsByEventType;
                 var eventParameterType = method.GetParameters()[0].ParameterType;
                 foreach (var eventType in eventParameterType.GetEventTypes(eventTypes))
                 {
@@ -232,7 +268,7 @@ public class ReactorInvoker(
                 }
             }
 
-            return methodsByEventType.ToFrozenDictionary();
+            return new(liveMethodsByEventType.ToFrozenDictionary(), replayMethodsByEventType.ToFrozenDictionary());
         }
     }
 }

--- a/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorInvoker.cs
@@ -81,7 +81,7 @@ public class ReactorInvoker(
 
             if (_methodsByEventType.TryGetValue(eventType, out var method))
             {
-                await middlewares.BeforeInvoke(eventContext, content);
+                await middlewares.BeforeInvoke(reactorId, eventContext, content);
 
                 var arguments = await _argumentsResolver.Resolve(
                     method,
@@ -117,7 +117,7 @@ public class ReactorInvoker(
             // So we catch and log any exceptions from the middlewares.
             try
             {
-                await middlewares.AfterInvoke(eventContext, content);
+                await middlewares.AfterInvoke(reactorId, eventContext, content);
             }
             catch (Exception ex)
             {

--- a/Source/Clients/DotNET/Reactors/ReactorMiddlewares.cs
+++ b/Source/Clients/DotNET/Reactors/ReactorMiddlewares.cs
@@ -16,23 +16,29 @@ namespace Cratis.Chronicle.Reactors;
 public class ReactorMiddlewares(ActivatedArtifact<IReactorMiddleware>[] activatedMiddlewares) : IReactorMiddlewares
 {
     /// <inheritdoc/>
-    public Task BeforeInvoke(EventContext eventContext, object @event)
+    public Task BeforeInvoke(EventContext eventContext, object @event) => BeforeInvoke(ReactorId.Unspecified, eventContext, @event);
+
+    /// <inheritdoc/>
+    public Task AfterInvoke(EventContext eventContext, object @event) => AfterInvoke(ReactorId.Unspecified, eventContext, @event);
+
+    /// <inheritdoc/>
+    public Task BeforeInvoke(ReactorId reactorId, EventContext eventContext, object @event)
     {
         if (activatedMiddlewares.Length == 0)
         {
             return Task.CompletedTask;
         }
-        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.BeforeInvoke(eventContext, @event)));
+        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.BeforeInvoke(reactorId, eventContext, @event)));
     }
 
     /// <inheritdoc/>
-    public Task AfterInvoke(EventContext eventContext, object @event)
+    public Task AfterInvoke(ReactorId reactorId, EventContext eventContext, object @event)
     {
         if (activatedMiddlewares.Length == 0)
         {
             return Task.CompletedTask;
         }
-        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.AfterInvoke(eventContext, @event)));
+        return Task.WhenAll(activatedMiddlewares.Select(_ => _.Instance.AfterInvoke(reactorId, eventContext, @event)));
     }
 
     /// <inheritdoc/>

--- a/Source/Clients/DotNET/Reactors/ReplayAttribute.cs
+++ b/Source/Clients/DotNET/Reactors/ReplayAttribute.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Reactors;
+
+/// <summary>
+/// Attribute used to mark a reactor handler method as the one to run while events are being replayed.
+/// </summary>
+/// <remarks>
+/// A reactor sees the same events twice for different reasons: as they happen, and again when its observer is
+/// replayed. Those often call for different work - a notification that should go out once when the event happens
+/// has no business going out again during a rebuild. Mark a second handler for the same event type with this
+/// attribute and it takes over for the duration of the replay, leaving the unmarked handler to the live path.
+/// <para>
+/// When an event type has no handler marked with this attribute, the regular handler runs during replay as
+/// before. When it has one, only the marked handler runs during replay - the regular handler does not also run.
+/// </para>
+/// <para>
+/// Use <see cref="OnceOnlyAttribute"/> instead when the side effect should simply not happen again on replay.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ReplayAttribute : Attribute;

--- a/Source/Clients/DotNET/Reducers/Reducers.cs
+++ b/Source/Clients/DotNET/Reducers/Reducers.cs
@@ -540,6 +540,11 @@ public class Reducers : IReducers
                 exceptionMessages = reduceResult.ErrorMessages;
                 exceptionStackTrace = reduceResult.StackTrace;
                 state = ObservationState.Failed;
+                _logger.ReducerFailed(
+                    handler.Id,
+                    appendedEvents[0].Context.SequenceNumber,
+                    appendedEvents[^1].Context.SequenceNumber,
+                    string.Join(Environment.NewLine, reduceResult.ErrorMessages));
             }
         }
         catch (Exception ex)

--- a/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
+++ b/Source/Clients/DotNET/Reducers/ReducersLogMessages.cs
@@ -19,6 +19,9 @@ internal static partial class ReducersLogMessages
     [LoggerMessage(LogLevel.Warning, "An error occurred while handling events with sequence number {StartSequenceNumber} to {EndSequenceNumber} was for Reducer {ReducerId}")]
     internal static partial void ErrorWhileHandlingEvents(this ILogger<Reducers> logger, Exception ex, EventSequenceNumber startSequenceNumber, EventSequenceNumber endSequenceNumber, ReducerId reducerId);
 
+    [LoggerMessage(LogLevel.Error, "Reducer {ReducerId} failed reducing events with sequence number {StartSequenceNumber} to {EndSequenceNumber}: {ErrorMessages}")]
+    internal static partial void ReducerFailed(this ILogger<Reducers> logger, ReducerId reducerId, EventSequenceNumber startSequenceNumber, EventSequenceNumber endSequenceNumber, string errorMessages);
+
     [LoggerMessage(LogLevel.Trace, "Handling of events received for Reducer {ReducerId} completed")]
     internal static partial void EventHandlingCompleted(this ILogger<Reducers> logger, ReducerId reducerId);
 

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -197,41 +197,35 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     static bool PropertyIsNullable(Type type, JsonSchemaExporterContext context) =>
         Nullable.GetUnderlyingType(type) is not null || IsAnnotatedNullable(context);
 
+    static void ThrowIfSelfReferencing(Type type, Type representedAs)
+    {
+        if (representedAs == type)
+        {
+            throw new SelfReferencingJsonSchemaType(type);
+        }
+    }
+
     JsonNode TransformNode(JsonSchemaExporterContext context, JsonNode schema)
     {
         var type = context.TypeInfo.Type;
         var formatType = Nullable.GetUnderlyingType(type) ?? type;
 
+        // An explicit [JsonSchemaType] declaration states what a type's own JsonConverter actually produces.
+        // System.Text.Json's schema exporter cannot introspect a custom converter, so without this the schema
+        // describes the CLR shape while the wire carries something else entirely — and the value stops
+        // round-tripping through the sink. It is resolved before the concept branch so an explicit declaration
+        // always wins over an inferred representation, and after the Nullable<> unwrap so that a nullable
+        // value type is recognized as its adorned underlying type.
+        if (formatType.GetCustomAttribute<JsonSchemaTypeAttribute>() is { } jsonSchemaType)
+        {
+            ThrowIfSelfReferencing(formatType, jsonSchemaType.Type);
+            return RepresentAs(jsonSchemaType.Type, type, context);
+        }
+
         // Handle concept types - redirect to the underlying primitive type's schema
         if (type.IsConcept())
         {
-            var underlyingType = type.GetConceptValueType();
-            var conceptSchema = context.TypeInfo.Options.GetJsonSchemaAsNode(underlyingType, _exporterOptions);
-
-            // Preserve nullable marker for concept types (e.g. EventSequenceNumber?).
-            // STJ's JsonSchemaExporter does not propagate NRT nullable markers through custom converters,
-            // so we check the actual property nullability via NullabilityInfoContext. When the property
-            // is nullable we append '?' to the format so that IsNullable() returns true and
-            // GetDefaultValue() returns null rather than the primitive default (e.g. 0 for ulong).
-            if (conceptSchema is JsonObject conceptSchemaObj)
-            {
-                if (_metadataResolver.HasMetadataFor(type))
-                {
-                    AddComplianceMetadata(conceptSchemaObj, _metadataResolver.GetMetadataFor(type));
-                }
-
-                if (PropertyIsNullable(type, context) &&
-                    conceptSchemaObj.TryGetPropertyValue("format", out var format))
-                {
-                    var formatStr = format!.GetValue<string>();
-                    if (!formatStr.EndsWith('?'))
-                    {
-                        conceptSchemaObj["format"] = formatStr + "?";
-                    }
-                }
-            }
-
-            return conceptSchema;
+            return RepresentAs(type.GetConceptValueType(), type, context);
         }
 
         // Handle enumerables whose element type is a concept (e.g. IReadOnlyList<Requirement>).
@@ -368,5 +362,47 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
         }
 
         return schema;
+    }
+
+    /// <summary>
+    /// Produces the schema of a different type in place of the declared type's own schema.
+    /// </summary>
+    /// <param name="representedAs">The <see cref="Type"/> whose schema describes what actually goes on the wire.</param>
+    /// <param name="declaredType">The declared <see cref="Type"/> being represented.</param>
+    /// <param name="context">The <see cref="JsonSchemaExporterContext"/> of the node being transformed.</param>
+    /// <returns>The schema node for <paramref name="representedAs"/>, carrying the declared type's metadata.</returns>
+    /// <remarks>
+    /// The declared type's compliance metadata has to travel onto the substituted schema — the classification
+    /// belongs to the value, not to the shape it happens to serialize as, and losing it here would persist a
+    /// <c>[PII]</c> value in the clear.
+    /// <para>
+    /// The nullable marker has to be re-applied for the same reason: System.Text.Json's schema exporter does not
+    /// propagate NRT nullable markers through custom converters, so the actual property nullability is read via
+    /// <see cref="NullabilityInfoContext"/>. When the property is nullable, '?' is appended to the format so that
+    /// <c>IsNullable()</c> returns true and <c>GetDefaultValue()</c> returns null rather than the primitive
+    /// default (e.g. 0 for ulong).
+    /// </para>
+    /// </remarks>
+    JsonNode RepresentAs(Type representedAs, Type declaredType, JsonSchemaExporterContext context)
+    {
+        var representedSchema = context.TypeInfo.Options.GetJsonSchemaAsNode(representedAs, _exporterOptions);
+        if (representedSchema is not JsonObject representedSchemaObject) return representedSchema;
+
+        if (_metadataResolver.HasMetadataFor(declaredType))
+        {
+            AddComplianceMetadata(representedSchemaObject, _metadataResolver.GetMetadataFor(declaredType));
+        }
+
+        if (PropertyIsNullable(declaredType, context) &&
+            representedSchemaObject.TryGetPropertyValue("format", out var format))
+        {
+            var formatValue = format!.GetValue<string>();
+            if (!formatValue.EndsWith('?'))
+            {
+                representedSchemaObject["format"] = formatValue + "?";
+            }
+        }
+
+        return representedSchema;
     }
 }

--- a/Source/Clients/DotNET/Schemas/JsonSchemaTypeAttribute.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaTypeAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas;
+
+/// <summary>
+/// Attribute used to override the type a type is represented as in the generated JSON schema.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="JsonSchemaTypeAttribute"/> class.
+/// <para>
+/// A type that brings its own <c>JsonConverter</c> serializes to something other than its own shape — a value
+/// object written as a single string, for instance. The generated schema is what Chronicle stores and reads
+/// values against, so it has to describe what actually goes on the wire; without this the schema would describe
+/// the CLR shape and the value would not round-trip. Adorn the type with this attribute to state what its
+/// converter actually produces, rather than depending on attributes from whichever schema library is in use.
+/// </para>
+/// </remarks>
+/// <param name="type">The <see cref="Type"/> the adorned type is represented as in the JSON schema.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class JsonSchemaTypeAttribute(Type type) : Attribute
+{
+    /// <summary>
+    /// Gets the <see cref="Type"/> the adorned type is represented as in the JSON schema.
+    /// </summary>
+    public Type Type { get; } = type;
+}

--- a/Source/Clients/DotNET/Schemas/SelfReferencingJsonSchemaType.cs
+++ b/Source/Clients/DotNET/Schemas/SelfReferencingJsonSchemaType.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas;
+
+/// <summary>
+/// The exception that is thrown when a type adorned with <see cref="JsonSchemaTypeAttribute"/> points at itself.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SelfReferencingJsonSchemaType"/> class.
+/// Generating the schema for such a type would recurse forever, so it is rejected up front with a message
+/// naming the offending type rather than being left to overflow the stack.
+/// </remarks>
+/// <param name="type"><see cref="Type"/> that represents itself.</param>
+public class SelfReferencingJsonSchemaType(Type type) : Exception($"Type '{type.FullName}' is adorned with a {nameof(JsonSchemaTypeAttribute)} that points at itself. Point it at the type its converter actually produces.");

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -85,6 +85,7 @@ public class EventStoreForTesting : IEventStore
     readonly Lazy<IUnitOfWorkManager> _unitOfWorkManager;
     readonly Lazy<IEventSeeding> _seeding;
     readonly Lazy<IPIIManager> _pii;
+    readonly Lazy<IIdentityManager> _identities;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStoreForTesting"/> class.
@@ -219,6 +220,7 @@ public class EventStoreForTesting : IEventStore
             _artifactActivator,
             NullLogger<EventSeeding>.Instance));
         _pii = new Lazy<IPIIManager>(() => new PIIManager(Name, Namespace, Connection));
+        _identities = new Lazy<IIdentityManager>(() => new IdentityManager(Name, Namespace, Connection));
     }
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
@@ -278,6 +280,9 @@ public class EventStoreForTesting : IEventStore
 
     /// <inheritdoc/>
     public IPIIManager PII => _pii.Value;
+
+    /// <inheritdoc/>
+    public IIdentityManager Identities => _identities.Value;
 
     /// <summary>
     /// Gets the <see cref="IJsonSchemaGenerator"/> used by this event store.

--- a/Source/Kernel/Concepts/Events/EventTypeToRegister.cs
+++ b/Source/Kernel/Concepts/Events/EventTypeToRegister.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Events;
+
+/// <summary>
+/// Represents an <see cref="EventTypeDefinition"/> to register together with the <see cref="EventTypeSource"/> it came from.
+/// </summary>
+/// <param name="Definition">The <see cref="EventTypeDefinition"/> to register.</param>
+/// <param name="Source">The <see cref="EventTypeSource"/> the event type came from.</param>
+/// <remarks>
+/// <see cref="EventTypeDefinition"/> carries the owner and tombstone metadata of an event type but not the source it
+/// came from - pairing the two is what makes it possible to register a whole batch of event types in one operation.
+/// </remarks>
+public record EventTypeToRegister(EventTypeDefinition Definition, EventTypeSource Source);

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_property_the_schema_does_not_declare.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_a_property_the_schema_does_not_declare.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
+
+/// <summary>
+/// A stored document can carry a property its schema no longer declares — an event type that gained or renamed a
+/// property without a migration. The mismatch used to surface as a bare LINQ error naming nothing at all, so the
+/// diagnostic has to name the property, the subject, and what the schema does declare.
+/// </summary>
+public class when_releasing_a_property_the_schema_does_not_declare : given.a_value_handler_and_a_type_with_one_property
+{
+    const string Identifier = "request-42";
+    const string UnknownPropertyName = "propertyTheSchemaNeverHeardOf";
+
+    Exception _exception;
+
+    void Establish() => _input[UnknownPropertyName] = "some value";
+
+    async Task Because() => _exception = await Catch.Exception(() => _manager.Release(
+        EventStoreName.NotSet,
+        EventStoreNamespaceName.Default,
+        _schema,
+        Identifier,
+        _input));
+
+    [Fact] void should_fail_with_the_property_not_found_exception() => _exception.ShouldBeOfExactType<CompliancePropertyNotFoundInSchema>();
+
+    [Fact] void should_name_the_property_that_is_missing() => _exception.Message.ShouldContain(UnknownPropertyName);
+
+    [Fact] void should_name_the_subject_it_was_released_under() => _exception.Message.ShouldContain(Identifier);
+
+    [Fact] void should_name_the_action() => _exception.Message.ShouldContain(ComplianceMetadataActionFailed.ReleaseAction);
+
+    [Fact] void should_list_the_properties_the_schema_declares() => _exception.Message.ShouldContain(PropertyName);
+}

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/given/a_catching_up_in_flight_state.cs
@@ -13,6 +13,7 @@ namespace Cratis.Chronicle.Observation.States.for_CatchingUpInFlight.given;
 public class a_catching_up_in_flight_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected CatchingUpInFlight _state;
     protected ObserverState _storedState;
     protected ObserverState _resultingStoredState;
@@ -24,7 +25,8 @@ public class a_catching_up_in_flight_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _observerKey = new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), EventSequenceId.Log);
 
         _definitionState = Substitute.For<IPersistentState<ObserverDefinition>>();
@@ -42,7 +44,7 @@ public class a_catching_up_in_flight_state : Specification
             _failuresState,
             _jobsManager,
             Substitute.For<ILogger<CatchingUpInFlight>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
 
         _storedState = new ObserverState
         {

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_observer_is_quarantined.cs
@@ -24,5 +24,5 @@ public class and_observer_is_quarantined : given.a_catching_up_in_flight_state
         .DidNotReceive()
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_partition_is_already_failed.cs
@@ -28,5 +28,5 @@ public class and_partition_is_already_failed : given.a_catching_up_in_flight_sta
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(
             Arg.Is<CatchUpObserverPartitionRequest>(_ => _.Key == _partition));
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_no_in_flight_entries.cs
@@ -16,5 +16,5 @@ public class and_there_are_no_in_flight_entries : given.a_catching_up_in_flight_
         .DidNotReceive()
         .Start<ICatchUpObserverPartition, CatchUpObserverPartitionRequest>(Arg.Any<CatchUpObserverPartitionRequest>());
 
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_CatchingUpInFlight/when_entering/and_there_are_pending_entries.cs
@@ -37,5 +37,5 @@ public class and_there_are_pending_entries : given.a_catching_up_in_flight_state
 
     [Fact] void should_mark_first_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_firstPartition);
     [Fact] void should_mark_second_partition_as_catching_up() => _resultingStoredState.CatchingUpPartitions.ShouldContain(_secondPartition);
-    [Fact] void should_transition_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/given/an_observing_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/given/an_observing_state.cs
@@ -17,6 +17,7 @@ namespace Cratis.Chronicle.Observation.States.for_Observing.given;
 public class an_observing_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected IAppendedEventsQueues _appendedEventsQueues;
     protected IEventSequence _eventSequence;
     protected Observing _state;
@@ -44,7 +45,8 @@ public class an_observing_state : Specification
         _eventStoreNamespace = "some_namespace";
         _eventSequenceId = EventSequenceId.Log;
 
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _appendedEventsQueues = Substitute.For<IAppendedEventsQueues>();
         _appendedEventsQueue = Substitute.For<IAppendedEventsQueue>();
         _eventSequence = Substitute.For<IEventSequence>();
@@ -74,7 +76,7 @@ public class an_observing_state : Specification
             _definitionState,
             _eventSequence,
             Substitute.For<ILogger<Observing>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
         _storedState = new ObserverState
         {
             Identifier = _observerId,

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_events_missed_between_routing_and_subscribing.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_events_missed_between_routing_and_subscribing.cs
@@ -20,5 +20,5 @@ public class with_events_missed_between_routing_and_subscribing : given.an_obser
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
     [Fact] void should_subscribe_to_stream() => _appendedEventsQueues.Received(1).Subscribe(_observerKey, _eventTypes);
-    [Fact] void should_transition_back_to_routing() => _observer.Received(1).TransitionTo<Routing>();
+    [Fact] void should_transition_back_to_routing() => _stateMachine.Received(1).TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_no_events_missed_between_routing_and_subscribing.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Observing/when_entering/with_no_events_missed_between_routing_and_subscribing.cs
@@ -20,5 +20,5 @@ public class with_no_events_missed_between_routing_and_subscribing : given.an_ob
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
     [Fact] void should_subscribe_to_stream() => _appendedEventsQueues.Received(1).Subscribe(_observerKey, _eventTypes);
-    [Fact] void should_not_transition_back_to_routing() => _observer.DidNotReceive().TransitionTo<Routing>();
+    [Fact] void should_not_transition_back_to_routing() => _stateMachine.DidNotReceive().TransitionTo<Routing>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Replay/given/a_replay_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Replay/given/a_replay_state.cs
@@ -18,6 +18,7 @@ namespace Cratis.Chronicle.Observation.States.for_Replay.given;
 public class a_replay_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected ObserverKey _observerKey;
     protected IJobsManager _jobsManager;
     protected ObserverSubscription _subscription;
@@ -30,7 +31,8 @@ public class a_replay_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _observerId = Guid.NewGuid().ToString();
         _observerKey = new(_observerId, Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
         _jobsManager = Substitute.For<IJobsManager>();
@@ -45,7 +47,7 @@ public class a_replay_state : Specification
             _jobsManager,
             Substitute.For<IStorage>(),
             Substitute.For<ILogger<Replay>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
 
         _storedState = new ObserverState
         {

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/given/a_routing_state.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/given/a_routing_state.cs
@@ -18,6 +18,7 @@ namespace Cratis.Chronicle.Observation.States.for_Routing.given;
 public class a_routing_state : Specification
 {
     protected IObserver _observer;
+    protected IStateMachine<ObserverState> _stateMachine;
     protected IEventSequence _eventSequence;
     protected Routing _state;
     protected ObserverState _storedState;
@@ -29,7 +30,8 @@ public class a_routing_state : Specification
 
     void Establish()
     {
-        _observer = Substitute.For<IObserver>();
+        _observer = Substitute.For<IObserver, IStateMachine<ObserverState>>();
+        _stateMachine = (IStateMachine<ObserverState>)_observer;
         _eventSequence = Substitute.For<IEventSequence>();
         _observerKey = new(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
         _definitionState = Substitute.For<IPersistentState<ObserverDefinition>>();
@@ -40,7 +42,7 @@ public class a_routing_state : Specification
             _definitionState,
             _eventSequence,
             Substitute.For<ILogger<Routing>>());
-        _state.SetStateMachine(_observer);
+        _state.SetStateMachine(_stateMachine);
         _storedState = new ObserverState
         {
             RunningState = ObserverRunningState.Unknown,

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_already_replaying.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_already_replaying.cs
@@ -12,6 +12,6 @@ public class and_it_is_already_replaying : given.a_routing_state
 
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
-    [Fact] void should_only_perform_one_transition() => _observer.Received(1).TransitionTo<IState<ObserverState>>();
-    [Fact] void should_transition_to_replay() => _observer.Received(1).TransitionTo<Replay>();
+    [Fact] void should_only_perform_one_transition() => _stateMachine.Received(1).TransitionTo<IState<ObserverState>>();
+    [Fact] void should_transition_to_replay() => _stateMachine.Received(1).TransitionTo<Replay>();
 }

--- a/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_falling_behind.cs
+++ b/Source/Kernel/Core.Specs/Observation/States/for_Routing/when_entering/and_it_is_falling_behind.cs
@@ -19,6 +19,6 @@ public class and_it_is_falling_behind : given.a_routing_state
 
     async Task Because() => _resultingStoredState = await _state.OnEnter(_storedState);
 
-    [Fact] void should_only_perform_one_transition() => _observer.Received(1).TransitionTo<IState<ObserverState>>();
+    [Fact] void should_only_perform_one_transition() => _stateMachine.Received(1).TransitionTo<IState<ObserverState>>();
     [Fact] void should_ask_observer_to_catchup() => _observer.Received(1).CatchUp();
 }

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/given/a_read_models_manager.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/given/a_read_models_manager.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.given;
+
+public class a_read_models_manager : Specification
+{
+    protected TestKitSilo _silo = new();
+    protected ReadModelsManager _manager;
+    protected IReadModel _readModelGrain;
+
+    protected static readonly EventStoreName _eventStore = "some-event-store";
+
+    async Task Establish()
+    {
+        _readModelGrain = Substitute.For<IReadModel>();
+        _silo.AddProbe(_ => _readModelGrain);
+        _manager = await _silo.CreateGrainAsync<ReadModelsManager>(_eventStore.Value);
+    }
+
+    protected static ReadModelDefinition DefinitionFor(ReadModelIdentifier identifier, ReadModelDisplayName displayName) => new(
+        identifier,
+        identifier.Value,
+        displayName,
+        ReadModelOwner.None,
+        ReadModelSource.Unknown,
+        ReadModelObserverType.NotSet,
+        ReadModelObserverIdentifier.Unspecified,
+        SinkDefinition.None,
+        new Dictionary<ReadModelGeneration, Schemas.JsonSchema>(),
+        []);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_a_definition_is_already_registered.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_a_definition_is_already_registered.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.when_registering;
+
+/// <summary>
+/// Registering is an upsert keyed on the identifier, so a client reconnecting with a changed read model replaces
+/// its definition rather than accumulating a second one alongside it.
+/// </summary>
+public class and_a_definition_is_already_registered : given.a_read_models_manager
+{
+    static readonly ReadModelDefinition _first = DefinitionFor("some-read-model", "First display name");
+    static readonly ReadModelDefinition _second = DefinitionFor("some-read-model", "Second display name");
+    static readonly ReadModelDefinition _other = DefinitionFor("some-other-read-model", "Another read model");
+
+    IEnumerable<ReadModelDefinition> _result;
+
+    async Task Establish() => await _manager.Register([_first, _other]);
+
+    async Task Because()
+    {
+        await _manager.Register([_second]);
+        _result = await _manager.GetDefinitions();
+    }
+
+    [Fact] void should_replace_the_definition_with_the_same_identifier() => _result.ShouldContain(_second);
+    [Fact] void should_not_keep_the_previous_definition() => _result.ShouldNotContain(_first);
+    [Fact] void should_leave_the_unrelated_definition_alone() => _result.ShouldContain(_other);
+    [Fact] void should_not_accumulate_duplicates() => _result.Count().ShouldEqual(2);
+    [Fact] async Task should_push_the_new_definition_to_the_read_model() => await _readModelGrain.Received(1).SetDefinition(_second);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_there_are_no_definitions.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsManager/when_registering/and_there_are_no_definitions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsManager.when_registering;
+
+/// <summary>
+/// A client with no read models still registers - a reactor-only application has none - and registering an empty
+/// set must not wipe what is already there. That is what makes the client's unconditional Register() call safe.
+/// </summary>
+public class and_there_are_no_definitions : given.a_read_models_manager
+{
+    static readonly ReadModelDefinition _existing = DefinitionFor("some-read-model", "Some read model");
+
+    IEnumerable<ReadModelDefinition> _result;
+
+    async Task Establish() => await _manager.Register([_existing]);
+
+    async Task Because()
+    {
+        await _manager.Register([]);
+        _result = await _manager.GetDefinitions();
+    }
+
+    [Fact] void should_keep_the_definition_that_was_already_registered() => _result.ShouldContainOnly(_existing);
+}

--- a/Source/Kernel/Core/Compliance/CompliancePropertyNotFoundInSchema.cs
+++ b/Source/Kernel/Core/Compliance/CompliancePropertyNotFoundInSchema.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Compliance;
+
+/// <summary>
+/// The exception that is thrown when a property in the JSON being handled has no matching property in the schema
+/// describing it.
+/// </summary>
+/// <remarks>
+/// Compliance handling walks the JSON document and looks every property up in the schema to find the compliance
+/// metadata that applies to it. A property with no schema counterpart means the document and the schema have
+/// drifted apart — typically a stored event whose event type gained or renamed a property without a migration.
+/// Without this exception the mismatch surfaced as a bare LINQ error naming neither the property nor the subject.
+/// </remarks>
+/// <param name="action">The action being performed — <c>apply</c> or <c>release</c>.</param>
+/// <param name="propertyPath">The path of the property that has no schema counterpart.</param>
+/// <param name="identifier">The compliance subject the value was being handled under.</param>
+/// <param name="knownPropertyNames">The property names the schema actually declares.</param>
+public class CompliancePropertyNotFoundInSchema(string action, string propertyPath, string identifier, IEnumerable<string> knownPropertyNames)
+    : Exception(BuildMessage(action, propertyPath, identifier, knownPropertyNames))
+{
+    static string BuildMessage(string action, string propertyPath, string identifier, IEnumerable<string> knownPropertyNames) =>
+        $"Could not {action} compliance metadata for property '{propertyPath}' of '{identifier}' because the schema does not declare it. The schema declares: {Describe(knownPropertyNames)}.";
+
+    static string Describe(IEnumerable<string> knownPropertyNames)
+    {
+        var names = knownPropertyNames.ToArray();
+        return names.Length == 0 ? "no properties" : string.Join(", ", names.Select(name => $"'{name}'"));
+    }
+}

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -87,7 +87,13 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
             if (schema.Properties is not null && value is not null)
             {
                 var propertyPath = string.IsNullOrEmpty(path) ? property : $"{path}.{property}";
-                var propertySchema = schema.GetFlattenedProperties().Single(_ => _.Name == property);
+                var flattenedProperties = schema.GetFlattenedProperties();
+
+                // FirstOrDefault rather than Single: a schema flattened across inheritance can declare the same
+                // property name more than once, and the duplicate is not a reason to fail the whole walk.
+                var propertySchema = flattenedProperties.FirstOrDefault(_ => _.Name == property) ??
+                    throw new CompliancePropertyNotFoundInSchema(actionName, propertyPath, identifier, flattenedProperties.Select(_ => _.Name));
+
                 var handlerApplied = false;
                 foreach (var metadata in propertySchema.GetComplianceMetadata().Concat(complianceMetadataForContainer).DistinctBy(_ => _.metadataType))
                 {

--- a/Source/Kernel/Core/Observation/IObserver.cs
+++ b/Source/Kernel/Core/Observation/IObserver.cs
@@ -6,7 +6,6 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
-using Cratis.Chronicle.StateMachines;
 using Cratis.Chronicle.Storage.Observation;
 using Orleans.Concurrency;
 
@@ -15,7 +14,12 @@ namespace Cratis.Chronicle.Observation;
 /// <summary>
 /// Defines an observer in the system.
 /// </summary>
-public interface IObserver : IStateMachine<ObserverState>, IGrainWithStringKey
+/// <remarks>
+/// The observer is implemented as a state machine internally, but that is an implementation concern and
+/// deliberately not part of this grain contract - state transitions are driven from within the observer
+/// implementation, never across a grain reference.
+/// </remarks>
+public interface IObserver : IGrainWithStringKey
 {
     /// <summary>
     /// Ensure the observer existence.

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -10,7 +10,6 @@ using Cratis.Chronicle.Events.EventSequences.Migrations;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
-using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Reactive;
 using ProtoBuf.Grpc;
 
@@ -40,128 +39,40 @@ internal sealed class EventTypes(
 #endif
         var eventTypesStorage = storage.GetEventStore(request.EventStore).EventTypes;
 
+        // A client registers every event type it knows about in one call, and every check below - does the event
+        // type exist, does this generation exist, has its schema changed - is answered by what is already stored.
+        // Reading all of it once keeps registration at a couple of round trips instead of a handful per event type.
+        var stored = (await eventTypesStorage.GetAllDefinitions()).ToDictionary(_ => _.Id);
+
         if (!skipValidation)
         {
             foreach (var eventType in request.Types)
             {
                 ValidateMigrationChain(eventType.Type.Id, eventType.Type.Generation, eventType.Migrations);
-                await ValidateSchemaNotChanged(eventType, eventTypesStorage);
+                await ValidateSchemaNotChanged(eventType, StoredFor(stored, eventType));
             }
         }
+
+        var eventTypesToRegister = new List<EventTypeToRegister>();
+        var newGenerationsPerEventType = new List<NewGenerations>();
 
         foreach (var eventType in request.Types)
         {
-            var schema = await JsonSchema.FromJsonAsync(eventType.Schema);
-            schema.EnsureComplianceMetadata();
-            var owner = (Concepts.Events.EventTypeOwner)(int)eventType.Owner;
-            var source = (Concepts.Events.EventTypeSource)(int)eventType.Source;
-            var eventTypeId = new EventTypeId(eventType.Type.Id);
-            var hasExistingEventType = await eventTypesStorage.HasFor(eventTypeId);
-
-            // Detect new generations before registration
-            var newGenerations = new List<(EventTypeGeneration Generation, string Schema)>();
-            foreach (var genDef in eventType.Generations)
-            {
-                if (!await eventTypesStorage.HasFor(eventTypeId, new EventTypeGeneration(genDef.Generation)))
-                {
-                    newGenerations.Add((new EventTypeGeneration(genDef.Generation), genDef.Schema));
-                }
-            }
-
-            if (eventType.Generations.Count == 0 && !await eventTypesStorage.HasFor(eventTypeId, new EventTypeGeneration(eventType.Type.Generation)))
-            {
-                newGenerations.Add((new EventTypeGeneration(eventType.Type.Generation), eventType.Schema));
-            }
-
-            bool mutated;
-            if (eventType.Migrations.Count > 0 || eventType.Generations.Count > 1)
-            {
-                // Register using full definition with all generations and migrations
-                var generations = new List<Concepts.Events.EventTypeGenerationDefinition>();
-                foreach (var genDef in eventType.Generations)
-                {
-                    var genSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
-                    genSchema.EnsureComplianceMetadata();
-                    generations.Add(new Concepts.Events.EventTypeGenerationDefinition(genDef.Generation, genSchema));
-                }
-
-                if (generations.Count == 0)
-                {
-                    generations.Add(new Concepts.Events.EventTypeGenerationDefinition(eventType.Type.ToChronicle().Generation, schema));
-                }
-
-                var filteredMigrations = eventType.Migrations.Where(m => m.FromGeneration != m.ToGeneration);
-                var migrations = filteredMigrations.Select(m =>
-                {
-                    var upcastJson = string.IsNullOrEmpty(m.UpcastJmesPath)
-                        ? new JsonObject()
-                        : JsonNode.Parse(m.UpcastJmesPath)?.AsObject() ?? new JsonObject();
-                    var downcastJson = string.IsNullOrEmpty(m.DowncastJmesPath)
-                        ? new JsonObject()
-                        : JsonNode.Parse(m.DowncastJmesPath)?.AsObject() ?? new JsonObject();
-
-                    if (!skipValidation)
-                    {
-                        ValidateMigrationProperties(eventType.Type.Id, m, upcastJson, downcastJson, generations);
-                    }
-
-                    return new Concepts.Events.EventTypeMigrationDefinition(
-                        m.FromGeneration,
-                        m.ToGeneration,
-                        [],
-                        upcastJson,
-                        downcastJson);
-                }).ToList();
-
-                var definition = new EventTypeDefinition(
-                    eventType.Type.ToChronicle().Id,
-                    owner,
-                    eventType.Type.Tombstone,
-                    generations,
-                    migrations);
-
-                mutated = await eventTypesStorage.Register(definition);
-            }
-            else
-            {
-                mutated = await eventTypesStorage.Register(
-                    eventType.Type.ToChronicle(),
-                    schema,
-                    owner,
-                    source);
-            }
-
-            // Evict the event type cache on every silo whenever the registration actually changed the stored
-            // document - a new generation, or a different owner, source, or tombstone. Idempotent
-            // re-registrations report no change, so client reconnects do not trigger cluster-wide eviction.
-            if (mutated)
-            {
-                await eventTypesCacheClient.Invalidate(request.EventStore, eventTypeId);
-            }
-
-            // Append system events for newly discovered event type generations.
-            if (newGenerations.Count > 0)
-            {
-                var systemEventSequence = grainFactory.GetSystemEventSequence(request.EventStore);
-
-                if (!hasExistingEventType)
-                {
-                    var firstGeneration = newGenerations.OrderBy(_ => _.Generation.Value).First();
-                    await systemEventSequence.Append(
-                        (EventSourceId)eventTypeId.Value,
-                        new EventTypeAdded(eventTypeId, firstGeneration.Generation, firstGeneration.Schema));
-                }
-                else
-                {
-                    foreach (var (generation, genSchema) in newGenerations)
-                    {
-                        await systemEventSequence.Append(
-                            (EventSourceId)eventTypeId.Value,
-                            new EventTypeGenerationAdded(eventTypeId, generation, genSchema));
-                    }
-                }
-            }
+            newGenerationsPerEventType.Add(GetNewGenerations(eventType, StoredFor(stored, eventType)));
+            eventTypesToRegister.Add(await CreateEventTypeToRegister(eventType, skipValidation));
         }
+
+        // Evict the event type cache on every silo whenever a registration actually changed the stored
+        // representation - a new generation, or a different owner, source, or tombstone. Idempotent
+        // re-registrations report no change, so client reconnects do not trigger cluster-wide eviction.
+        var mutated = await eventTypesStorage.Register(eventTypesToRegister);
+
+        foreach (var eventTypeId in mutated)
+        {
+            await eventTypesCacheClient.Invalidate(request.EventStore, eventTypeId);
+        }
+
+        await AppendSystemEventsForNewGenerations(request.EventStore, newGenerationsPerEventType);
     }
 
     /// <inheritdoc/>
@@ -232,6 +143,85 @@ internal sealed class EventTypes(
             Source = (Contracts.Events.EventTypeSource)(int)_.Source,
             Schema = _.Schema.ToJson()
         });
+    }
+
+    static EventTypeDefinition? StoredFor(Dictionary<EventTypeId, EventTypeDefinition> stored, EventTypeRegistration eventType) =>
+        stored.GetValueOrDefault(new EventTypeId(eventType.Type.Id));
+
+    static NewGenerations GetNewGenerations(EventTypeRegistration eventType, EventTypeDefinition? storedDefinition)
+    {
+        var eventTypeId = new EventTypeId(eventType.Type.Id);
+        var storedGenerations = storedDefinition?.Generations.Select(_ => _.Generation).ToHashSet() ?? [];
+
+        var generations = eventType.Generations
+            .Select(_ => (Generation: new EventTypeGeneration(_.Generation), _.Schema))
+            .Where(_ => !storedGenerations.Contains(_.Generation))
+            .ToList();
+
+        if (eventType.Generations.Count == 0 && !storedGenerations.Contains(new EventTypeGeneration(eventType.Type.Generation)))
+        {
+            generations.Add((new EventTypeGeneration(eventType.Type.Generation), eventType.Schema));
+        }
+
+        return new(eventTypeId, storedDefinition is not null, generations);
+    }
+
+    static async Task<EventTypeToRegister> CreateEventTypeToRegister(EventTypeRegistration eventType, bool skipValidation)
+    {
+        var generations = new List<Concepts.Events.EventTypeGenerationDefinition>();
+        foreach (var genDef in eventType.Generations)
+        {
+            var genSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
+            genSchema.EnsureComplianceMetadata();
+            generations.Add(new Concepts.Events.EventTypeGenerationDefinition(genDef.Generation, genSchema));
+        }
+
+        if (generations.Count == 0)
+        {
+            var schema = await JsonSchema.FromJsonAsync(eventType.Schema);
+            schema.EnsureComplianceMetadata();
+            generations.Add(new Concepts.Events.EventTypeGenerationDefinition(eventType.Type.ToChronicle().Generation, schema));
+        }
+
+        var migrations = eventType.Migrations
+            .Where(m => m.FromGeneration != m.ToGeneration)
+            .Select(m => CreateMigration(eventType.Type.Id, m, generations, skipValidation))
+            .ToList();
+
+        var definition = new EventTypeDefinition(
+            eventType.Type.ToChronicle().Id,
+            (Concepts.Events.EventTypeOwner)(int)eventType.Owner,
+            eventType.Type.Tombstone,
+            generations,
+            migrations);
+
+        return new(definition, (Concepts.Events.EventTypeSource)(int)eventType.Source);
+    }
+
+    static Concepts.Events.EventTypeMigrationDefinition CreateMigration(
+        string eventTypeId,
+        Contracts.Events.EventTypeMigrationDefinition migration,
+        List<Concepts.Events.EventTypeGenerationDefinition> generations,
+        bool skipValidation)
+    {
+        var upcastJson = string.IsNullOrEmpty(migration.UpcastJmesPath)
+            ? new JsonObject()
+            : JsonNode.Parse(migration.UpcastJmesPath)?.AsObject() ?? new JsonObject();
+        var downcastJson = string.IsNullOrEmpty(migration.DowncastJmesPath)
+            ? new JsonObject()
+            : JsonNode.Parse(migration.DowncastJmesPath)?.AsObject() ?? new JsonObject();
+
+        if (!skipValidation)
+        {
+            ValidateMigrationProperties(eventTypeId, migration, upcastJson, downcastJson, generations);
+        }
+
+        return new Concepts.Events.EventTypeMigrationDefinition(
+            migration.FromGeneration,
+            migration.ToGeneration,
+            [],
+            upcastJson,
+            downcastJson);
     }
 
     static void ValidateMigrationChain(string eventTypeId, uint currentGeneration, IList<Contracts.Events.EventTypeMigrationDefinition> migrations)
@@ -369,23 +359,26 @@ internal sealed class EventTypes(
         }
     }
 
-    static async Task ValidateSchemaNotChanged(EventTypeRegistration eventType, IEventTypesStorage eventTypesStorage)
+    static async Task ValidateSchemaNotChanged(EventTypeRegistration eventType, EventTypeDefinition? storedDefinition)
     {
-        var eventTypeId = new EventTypeId(eventType.Type.Id);
+        if (storedDefinition is null)
+        {
+            return;
+        }
 
         foreach (var genDef in eventType.Generations)
         {
             var generation = new EventTypeGeneration(genDef.Generation);
-            if (!await eventTypesStorage.HasFor(eventTypeId, generation))
+            var existingGeneration = storedDefinition.Generations.FirstOrDefault(_ => _.Generation == generation);
+            if (existingGeneration is null)
             {
                 continue;
             }
 
-            var existingSchema = await eventTypesStorage.GetFor(eventTypeId, generation);
             var newSchema = await JsonSchema.FromJsonAsync(genDef.Schema);
 
             // Storage applies EnsureComplianceMetadata() when deserializing a stored schema
-            // (in EventTypeConverters.ToKernel). Apply the same transformation to the incoming
+            // (in EventTypeConverters.ToDefinition). Apply the same transformation to the incoming
             // schema so both sides go through identical normalization before comparison.
             newSchema.EnsureComplianceMetadata();
 
@@ -393,10 +386,56 @@ internal sealed class EventTypes(
             // existing event schema (a nullable known value type that stored 'date-time-offset' now generates
             // 'date-time-offset?'). That marker only refines how an unset value materializes, not the data
             // shape, so a marker-only difference is not a breaking schema change.
-            if (!existingSchema.Schema.EqualsIgnoringNullableFormatMarkers(newSchema))
+            if (!existingGeneration.Schema.EqualsIgnoringNullableFormatMarkers(newSchema))
             {
                 throw new EventTypeSchemaChanged(eventType.Type.Id, genDef.Generation);
             }
         }
     }
+
+    async Task AppendSystemEventsForNewGenerations(EventStoreName eventStore, IEnumerable<NewGenerations> newGenerationsPerEventType)
+    {
+        var withNewGenerations = newGenerationsPerEventType.Where(_ => _.Generations.Count > 0).ToList();
+
+        if (withNewGenerations.Count == 0)
+        {
+            return;
+        }
+
+        var systemEventSequence = grainFactory.GetSystemEventSequence(eventStore);
+
+        foreach (var newGenerations in withNewGenerations)
+        {
+            var eventSourceId = (EventSourceId)newGenerations.EventTypeId.Value;
+
+            if (!newGenerations.EventTypeAlreadyStored)
+            {
+                var firstGeneration = newGenerations.Generations.OrderBy(_ => _.Generation.Value).First();
+                await systemEventSequence.Append(
+                    eventSourceId,
+                    new EventTypeAdded(newGenerations.EventTypeId, firstGeneration.Generation, firstGeneration.Schema));
+                continue;
+            }
+
+            foreach (var (generation, schema) in newGenerations.Generations)
+            {
+                await systemEventSequence.Append(
+                    eventSourceId,
+                    new EventTypeGenerationAdded(newGenerations.EventTypeId, generation, schema));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents the generations of an event type that are not yet stored, and whether the event type itself is
+    /// already stored - which is what decides between an <see cref="EventTypeAdded"/> and an
+    /// <see cref="EventTypeGenerationAdded"/> system event.
+    /// </summary>
+    /// <param name="EventTypeId">The <see cref="EventTypeId"/> the generations belong to.</param>
+    /// <param name="EventTypeAlreadyStored">Whether the event type is already stored.</param>
+    /// <param name="Generations">The generations that are not yet stored, with their schema as it came in.</param>
+    sealed record NewGenerations(
+        EventTypeId EventTypeId,
+        bool EventTypeAlreadyStored,
+        IReadOnlyList<(EventTypeGeneration Generation, string Schema)> Generations);
 }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/given/all_dependencies.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/given/all_dependencies.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.EventTypes;
 using KernelEventTypes = Cratis.Chronicle.Services.Events.EventTypes;
@@ -31,6 +32,21 @@ public class all_dependencies : Specification
         _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
         _eventStoreStorage.EventTypes.Returns(_eventTypesStorage);
         _grainFactory.GetGrain<IEventSequence>(Arg.Any<string>()).Returns(_systemEventSequence);
+        _eventTypesStorage.GetAllDefinitions().Returns([]);
+        _eventTypesStorage.Register(Arg.Any<IEnumerable<Concepts.Events.EventTypeToRegister>>()).Returns([]);
         _subject = new KernelEventTypes(_storage, _grainFactory, _eventTypesCacheClient);
     }
+
+    protected void StoredEventTypes(params Concepts.Events.EventTypeDefinition[] definitions) =>
+        _eventTypesStorage.GetAllDefinitions().Returns(definitions);
+
+    protected static Concepts.Events.EventTypeDefinition StoredEventType(string eventTypeId, params (uint Generation, string Schema)[] generations) =>
+        new(
+            eventTypeId,
+            Concepts.Events.EventTypeOwner.Client,
+            false,
+            generations.Select(_ => new Concepts.Events.EventTypeGenerationDefinition(
+                _.Generation,
+                JsonSchema.FromJsonAsync(_.Schema).GetAwaiter().GetResult())).ToArray(),
+            []);
 }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_event_type_already_exists_and_gets_new_generation.cs
@@ -4,7 +4,6 @@
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.Events.EventSequences.Migrations;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -12,28 +11,7 @@ public class and_event_type_already_exists_and_gets_new_generation : given.all_d
 {
     Exception _exception;
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration?>())
-            .Returns(callInfo =>
-            {
-                var generation = callInfo.ArgAt<EventTypeGeneration?>(1);
-
-                if (generation is null)
-                {
-                    return true;
-                }
-
-                return generation.Value == 1;
-            });
-
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync("{}").GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, "{}")));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_differs_only_by_a_nullable_marker.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_differs_only_by_a_nullable_marker.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -19,16 +17,7 @@ public class and_schema_differs_only_by_a_nullable_marker : given.all_dependenci
     const string StoredSchema = """{"type":"object","properties":{"name":{"type":"string"},"occurredAt":{"type":"string","format":"date-time-offset"}}}""";
     const string MarkerSchema = """{"type":"object","properties":{"name":{"type":"string"},"occurredAt":{"type":"string","format":"date-time-offset?"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(StoredSchema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, StoredSchema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_has_changed_for_existing_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_has_changed_for_existing_generation.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -13,16 +11,7 @@ public class and_schema_has_changed_for_existing_generation : given.all_dependen
     const string OriginalSchema = """{"type":"object","properties":{"name":{"type":"string"}}}""";
     const string ModifiedSchema = """{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(OriginalSchema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, OriginalSchema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_is_unchanged_for_existing_generation.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_schema_is_unchanged_for_existing_generation.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
-using Cratis.Chronicle.Schemas;
 
 namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
 
@@ -12,16 +10,7 @@ public class and_schema_is_unchanged_for_existing_generation : given.all_depende
     Exception _exception;
     const string Schema = """{"type":"object","properties":{"name":{"type":"string"}}}""";
 
-    void Establish()
-    {
-        _eventTypesStorage.HasFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>()).Returns(true);
-        _eventTypesStorage.GetFor(Arg.Any<EventTypeId>(), Arg.Any<EventTypeGeneration>())
-            .Returns(Task.FromResult(new Concepts.EventTypes.EventTypeSchema(
-                new Concepts.Events.EventType("some-event", 1),
-                Concepts.Events.EventTypeOwner.Client,
-                Concepts.Events.EventTypeSource.Code,
-                JsonSchema.FromJsonAsync(Schema).GetAwaiter().GetResult())));
-    }
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, Schema)));
 
     async Task Because() =>
         _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_a_changed_event_type.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_a_changed_event_type.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_storage_reports_a_changed_event_type : given.all_dependencies
+{
+    void Establish() =>
+        _eventTypesStorage.Register(Arg.Any<IEnumerable<EventTypeToRegister>>())
+            .Returns([new EventTypeId("changed-event")]);
+
+    async Task Because() =>
+        await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "changed-event", Generation = 1 },
+                    Schema = "{}"
+                },
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "unchanged-event", Generation = 1 },
+                    Schema = "{}"
+                }
+            ]
+        });
+
+    [Fact] void should_register_every_event_type_in_one_call() =>
+        _eventTypesStorage.Received(1).Register(Arg.Is<IEnumerable<EventTypeToRegister>>(_ => _.Count() == 2));
+    [Fact] void should_invalidate_the_changed_event_type() =>
+        _eventTypesCacheClient.Received(1).Invalidate(
+            Arg.Any<EventStoreName>(),
+            Arg.Is<EventTypeId>(_ => _.Value == "changed-event"));
+    [Fact] void should_not_invalidate_the_unchanged_event_type() =>
+        _eventTypesCacheClient.DidNotReceive().Invalidate(
+            Arg.Any<EventStoreName>(),
+            Arg.Is<EventTypeId>(_ => _.Value == "unchanged-event"));
+}

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_no_change.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_storage_reports_no_change.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+public class and_storage_reports_no_change : given.all_dependencies
+{
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, "{}")));
+
+    async Task Because() =>
+        await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 1 },
+                    Schema = "{}",
+                    Generations =
+                    {
+                        new Contracts.Events.EventTypeGenerationDefinition { Generation = 1, Schema = "{}" }
+                    }
+                }
+            ]
+        });
+
+    [Fact] void should_not_invalidate_any_event_type() =>
+        _eventTypesCacheClient.DidNotReceive().Invalidate(Arg.Any<EventStoreName>(), Arg.Any<EventTypeId>());
+    [Fact] void should_not_append_any_system_event() =>
+        _systemEventSequence.DidNotReceive().Append(Arg.Any<EventSourceId>(), Arg.Any<object>());
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/given/an_event_types_storage.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage.given;
+
+public class an_event_types_storage : Specification
+{
+    protected EventTypesStorage _storage;
+
+    void Establish() => _storage = new();
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_a_new_generation_for_an_existing_event_type.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_a_new_generation_for_an_existing_event_type.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_registering_a_new_generation_for_an_existing_event_type : given.an_event_types_storage
+{
+    IEnumerable<EventTypeDefinition> _definitions;
+
+    async Task Because()
+    {
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        await _storage.Register(new EventType("some-event", new EventTypeGeneration(2)), new JsonSchema());
+        _definitions = await _storage.GetAllDefinitions();
+    }
+
+    [Fact] void should_keep_both_generations() =>
+        _definitions.First().Generations.Select(_ => _.Generation)
+            .ShouldContainOnly(EventTypeGeneration.First, new EventTypeGeneration(2));
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_the_same_event_type_twice.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_registering_the_same_event_type_twice.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_registering_the_same_event_type_twice : given.an_event_types_storage
+{
+    IEnumerable<EventTypeDefinition> _definitions;
+
+    async Task Because()
+    {
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        await _storage.Register(new EventType("some-event", EventTypeGeneration.First), new JsonSchema());
+        _definitions = await _storage.GetAllDefinitions();
+    }
+
+    [Fact] void should_only_have_it_once() => _definitions.Count().ShouldEqual(1);
+    [Fact] void should_only_have_the_first_generation() =>
+        _definitions.First().Generations.Select(_ => _.Generation).ShouldContainOnly(EventTypeGeneration.First);
+}

--- a/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Reactive.Subjects;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventTypes;
@@ -17,15 +18,30 @@ namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes;
 /// <c>ExpandoObjectConverter</c> to fall back to generic unknown-type
 /// conversion - preserving all event content without schema-driven type coercion.
 /// No compliance rules, migrations, or validations are applied.
+/// What has been registered is remembered for the lifetime of the process, so that registering the same event
+/// types again - which every client does when it reconnects - is recognized as the no-op it is.
 /// </remarks>
 public class EventTypesStorage : IEventTypesStorage
 {
-    /// <inheritdoc/>
-    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
-        Task.FromResult(false);
+    readonly ConcurrentDictionary<EventTypeId, EventTypeDefinition> _definitions = new();
 
     /// <inheritdoc/>
-    public Task<bool> Register(EventTypeDefinition definition) => Task.FromResult(false);
+    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
+        Register(new EventTypeDefinition(type.Id, owner, type.Tombstone, [new EventTypeGenerationDefinition(type.Generation, schema)], []));
+
+    /// <inheritdoc/>
+    public Task<bool> Register(EventTypeDefinition definition)
+    {
+        _definitions.AddOrUpdate(
+            definition.Id,
+            static (_, incoming) => incoming,
+            static (_, existing, incoming) => Merge(existing, incoming),
+            definition);
+
+        // There is no cache anywhere to evict for an in-memory single-node store, so a registration never asks
+        // anyone to invalidate.
+        return Task.FromResult(false);
+    }
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() =>
@@ -37,7 +53,7 @@ public class EventTypesStorage : IEventTypesStorage
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions() =>
-        Task.FromResult(Enumerable.Empty<EventTypeDefinition>());
+        Task.FromResult<IEnumerable<EventTypeDefinition>>([.. _definitions.Values]);
 
     /// <inheritdoc/>
     public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) =>
@@ -75,4 +91,14 @@ public class EventTypesStorage : IEventTypesStorage
     public void Invalidate(EventTypeId eventTypeId)
     {
     }
+
+    static EventTypeDefinition Merge(EventTypeDefinition existing, EventTypeDefinition incoming) =>
+        incoming with
+        {
+            Generations = existing.Generations
+                .Where(_ => incoming.Generations.All(incomingGeneration => incomingGeneration.Generation != _.Generation))
+                .Concat(incoming.Generations)
+                .ToList(),
+            Migrations = incoming.Migrations.Any() ? incoming.Migrations : existing.Migrations
+        };
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_registering_a_batch_of_event_types.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventTypes/for_EventTypesStorage/when_registering_a_batch_of_event_types.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventTypes.for_EventTypesStorage;
+
+/// <summary>
+/// Registering a batch collapses to one read and one bulk write, and reports back only the event types whose
+/// stored document actually changed - that set is what drives cache invalidation and the system events the
+/// service appends, so reporting a type that did not change is as wrong as missing one that did.
+/// </summary>
+/// <param name="fixture">The shared <see cref="MongoDBFixture"/> providing a MongoDB container.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_registering_a_batch_of_event_types(MongoDBFixture fixture) : given.an_event_types_storage(fixture)
+{
+    const string FirstSchema = /*lang=json,strict*/ "{\"type\":\"object\",\"properties\":{\"something\":{\"type\":\"string\"}}}";
+    const string ChangedSchema = /*lang=json,strict*/ "{\"type\":\"object\",\"properties\":{\"somethingElse\":{\"type\":\"string\"}}}";
+
+    static readonly EventTypeId _first = "the-first-event-type";
+    static readonly EventTypeId _second = "the-second-event-type";
+
+    IEnumerable<EventTypeId> _firstRegistration;
+    IEnumerable<EventTypeId> _registeringTheSameAgain;
+    IEnumerable<EventTypeId> _registeringWithOneChanged;
+    long _storedCount;
+
+    async Task Because()
+    {
+        _firstRegistration = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, FirstSchema)]);
+        _registeringTheSameAgain = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, FirstSchema)]);
+        _registeringWithOneChanged = await _storage.Register([await ToRegister(_first, FirstSchema), await ToRegister(_second, ChangedSchema)]);
+        _storedCount = await _storedDocuments.CountDocumentsAsync(FilterDefinition<BsonDocument>.Empty);
+    }
+
+    [Fact] void should_report_every_event_type_as_changed_the_first_time() => _firstRegistration.ShouldContainOnly(_first, _second);
+    [Fact] void should_report_nothing_as_changed_when_registering_the_same_again() => _registeringTheSameAgain.ShouldBeEmpty();
+    [Fact] void should_report_only_the_event_type_that_changed() => _registeringWithOneChanged.ShouldContainOnly(_second);
+    [Fact] void should_store_one_document_per_event_type() => _storedCount.ShouldEqual(2L);
+
+    static async Task<EventTypeToRegister> ToRegister(EventTypeId id, string schemaJson) => new(
+        new EventTypeDefinition(
+            id,
+            EventTypeOwner.Client,
+            false,
+            [new EventTypeGenerationDefinition(EventTypeGeneration.First, await JsonSchema.FromJsonAsync(schemaJson))],
+            []),
+        EventTypeSource.Code);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/given/a_job_state_serializer.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/given/a_job_state_serializer.cs
@@ -3,7 +3,6 @@
 
 using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Jobs;
-using Cratis.Chronicle.Storage.Jobs;
 using MongoDB.Bson.Serialization;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Jobs.for_JobStateSerializer.given;
@@ -17,22 +16,9 @@ public class a_job_state_serializer : Specification
     {
         RegisterConceptSerializers();
 
-        if (!BsonClassMap.IsClassMapRegistered(typeof(JobState)))
-        {
-            BsonClassMap.RegisterClassMap<JobState>(cm =>
-            {
-                cm.AutoMap();
-                cm.MapMember(c => c.Id);
-                cm.MapMember(c => c.Details);
-                cm.MapMember(c => c.Type);
-                cm.MapMember(c => c.Status);
-                cm.MapMember(c => c.Created);
-                cm.MapMember(c => c.StatusChanges);
-                cm.MapMember(c => c.Progress);
-                cm.MapMember(c => c.Request);
-            });
-        }
-
+        // JobState itself is mapped by the server's own JobStateClassMap, registered for the whole assembly in
+        // SpecSerializationSetup. Mapping it here instead would unmap nothing and leave Request mapped, giving
+        // these specs a document shape the silo never writes.
         if (!BsonClassMap.IsClassMapRegistered(typeof(SampleJobRequest)))
         {
             BsonClassMap.RegisterClassMap<SampleJobRequest>(cm =>

--- a/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_deserializing_with_different_job_request.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_deserializing_with_different_job_request.cs
@@ -35,10 +35,16 @@ public class when_deserializing_with_different_job_request : given.a_job_state_s
 
     void Because()
     {
-        var bsonDocument = _original.ToBsonDocument();
+        // Round-trip through the serializer in both directions, the way the storage does. Serializing through
+        // the class map instead would write a document shape the silo never produces.
+        var bsonDocument = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(bsonDocument))
+        {
+            _serializer.Serialize(BsonSerializationContext.CreateRoot(writer), default, _original);
+        }
+
         using var reader = new BsonDocumentReader(bsonDocument);
-        var context = BsonDeserializationContext.CreateRoot(reader);
-        _result = _serializer.Deserialize(context, default);
+        _result = _serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader), default);
     }
 
     [Fact] void should_deserialize_job_id() => _result.Id.ShouldEqual(_original.Id);

--- a/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_deserializing_with_sample_job_request.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_deserializing_with_sample_job_request.cs
@@ -35,10 +35,16 @@ public class when_deserializing_with_sample_job_request : given.a_job_state_seri
 
     void Because()
     {
-        var bsonDocument = _original.ToBsonDocument();
+        // Round-trip through the serializer in both directions, the way the storage does. Serializing through
+        // the class map instead would write a document shape the silo never produces.
+        var bsonDocument = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(bsonDocument))
+        {
+            _serializer.Serialize(BsonSerializationContext.CreateRoot(writer), default, _original);
+        }
+
         using var reader = new BsonDocumentReader(bsonDocument);
-        var context = BsonDeserializationContext.CreateRoot(reader);
-        _result = _serializer.Deserialize(context, default);
+        _result = _serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader), default);
     }
 
     [Fact] void should_deserialize_job_id() => _result.Id.ShouldEqual(_original.Id);

--- a/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_round_tripping_a_job_state_without_a_request.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Jobs/for_JobStateSerializer/when_round_tripping_a_job_state_without_a_request.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Chronicle.Storage.Jobs;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Jobs.for_JobStateSerializer;
+
+/// <summary>
+/// JobState.Request is declared as `default!`, so a state persisted before its request is assigned has no request
+/// to write - and Serialize only writes the field when the request is there. Reading such a document back has to
+/// work: the state carries its own status and progress, which is the whole reason it was written.
+/// </summary>
+public class when_round_tripping_a_job_state_without_a_request : given.a_job_state_serializer
+{
+    JobState _original;
+    JobState _result;
+    Exception _exception;
+
+    void Establish() => _original = new JobState
+    {
+        Id = JobId.New(),
+        Details = "Test Job",
+        Type = typeof(SampleJobRequest),
+        Status = JobStatus.Running,
+        Created = DateTimeOffset.UtcNow,
+        StatusChanges = [],
+        Progress = new JobProgress()
+    };
+
+    void Because() => _exception = Catch.Exception(() =>
+    {
+        var document = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(document))
+        {
+            _serializer.Serialize(BsonSerializationContext.CreateRoot(writer), default, _original);
+        }
+
+        using var reader = new BsonDocumentReader(document);
+        _result = _serializer.Deserialize(BsonDeserializationContext.CreateRoot(reader), default);
+    });
+
+    [Fact] void should_not_fail() => _exception.ShouldBeNull();
+    [Fact] void should_deserialize_job_id() => _result.Id.ShouldEqual(_original.Id);
+    [Fact] void should_deserialize_job_status() => _result.Status.ShouldEqual(_original.Status);
+    [Fact] void should_leave_the_request_unset() => _result.Request.ShouldBeNull();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverHandledCountsStorage/when_incrementing_and_removing_counts.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverHandledCountsStorage/when_incrementing_and_removing_counts.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Storage.MongoDB.Sinks;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Observation.for_ObserverHandledCountsStorage;
@@ -24,19 +22,6 @@ public class when_incrementing_and_removing_counts(MongoDBFixture fixture) : Spe
     static readonly EventTypeId _typeB = "b2222222-2222-2222-2222-222222222222";
     static readonly Key _partitionOne = "partition-one";
     static readonly Key _partitionTwo = "partition-two";
-
-    static when_incrementing_and_removing_counts()
-    {
-        BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-        if (!BsonClassMap.IsClassMapRegistered(typeof(ObserverPartitionCounts)))
-        {
-            BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(cm =>
-            {
-                cm.AutoMap();
-                cm.MapIdProperty(_ => _.Id);
-            });
-        }
-    }
 
     IMongoClient _client = default!;
     string _databaseName = default!;

--- a/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverStateStorage/when_getting_an_observer_with_legacy_per_partition_counts.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Observation/for_ObserverStateStorage/when_getting_an_observer_with_legacy_per_partition_counts.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Arc.MongoDB;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Storage.MongoDB.Sinks;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using KernelObserverState = Cratis.Chronicle.Storage.Observation.ObserverState;
 
@@ -27,19 +25,6 @@ public class when_getting_an_observer_with_legacy_per_partition_counts(MongoDBFi
     static readonly EventTypeId _typeB = "b2222222-2222-2222-2222-222222222222";
     const string PartitionOne = "partition-one";
     const string PartitionTwo = "partition-two";
-
-    static when_getting_an_observer_with_legacy_per_partition_counts()
-    {
-        BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-        if (!BsonClassMap.IsClassMapRegistered(typeof(ObserverPartitionCounts)))
-        {
-            BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(cm =>
-            {
-                cm.AutoMap();
-                cm.MapIdProperty(_ => _.Id);
-            });
-        }
-    }
 
     IMongoClient _client = default!;
     string _databaseName = default!;

--- a/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using Cratis.Arc.MongoDB;
+using Cratis.Chronicle.Storage.MongoDB.Observation;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 
@@ -22,12 +23,20 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// failure specs would see and production would not.
 /// </para>
 /// <para>
-/// The same reasoning applies to <see cref="EventClassMap"/>, which is what makes the event's sequence number the
-/// document <c>_id</c>. Any spec that merely renders a <c>Builders&lt;Event&gt;</c> expression — building an index
-/// key, for instance — makes the driver auto-register a default class map for <see cref="Event"/>, and a default
-/// map gives every appended event a generated <c>ObjectId</c> instead. Registering it lazily from a spec base
-/// therefore loses a race against unrelated spec classes running in parallel, silently dropping both the tail
-/// aggregation and the duplicate-sequence-number detection that depend on that mapping.
+/// The same reasoning applies to every <see cref="IBsonClassMapFor{T}"/>. Take <see cref="EventClassMap"/>, which is
+/// what makes the event's sequence number the document <c>_id</c>: any spec that merely renders a
+/// <c>Builders&lt;Event&gt;</c> expression — building an index key, for instance — makes the driver auto-register a
+/// <em>default</em> class map for <see cref="Event"/>, and a default map gives every appended event a generated
+/// <c>ObjectId</c> instead. A lazy <c>IsClassMapRegistered</c> guard in a spec base then finds one already
+/// registered and skips the real one, so whichever spec touched the type first decides the mapping. That silently
+/// dropped both the tail aggregation and the duplicate-sequence-number detection when spec classes ran in parallel.
+/// </para>
+/// <para>
+/// So a class map a spec depends on is registered here rather than lazily from the spec that needs it. This is not
+/// yet every <see cref="IBsonClassMapFor{T}"/> the server registers: the <c>JobState</c> specs map
+/// <c>JobState.Request</c>, while the server's <c>JobStateClassMap</c> deliberately unmaps it and lets
+/// <c>JobStateSerializer</c> own it, so registering the server's map here fails them. That divergence is a
+/// fidelity gap in those specs, not something to paper over from this file.
 /// </para>
 /// </remarks>
 internal static class SpecSerializationSetup
@@ -42,5 +51,6 @@ internal static class SpecSerializationSetup
         ConventionRegistry.Register(Cratis.Arc.MongoDB.ConventionPacks.IgnoreExtraElements, new ConventionPack { new IgnoreExtraElementsConvention(true) }, _ => true);
         BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
         BsonClassMap.RegisterClassMap<Event>(classMap => new EventClassMap().Configure(classMap));
+        BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(classMap => new ObserverPartitionCountsClassMap().Configure(classMap));
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/SpecSerializationSetup.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using Cratis.Arc.MongoDB;
-using Cratis.Chronicle.Storage.MongoDB.Observation;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 
@@ -32,11 +31,8 @@ namespace Cratis.Chronicle.Storage.MongoDB;
 /// dropped both the tail aggregation and the duplicate-sequence-number detection when spec classes ran in parallel.
 /// </para>
 /// <para>
-/// So a class map a spec depends on is registered here rather than lazily from the spec that needs it. This is not
-/// yet every <see cref="IBsonClassMapFor{T}"/> the server registers: the <c>JobState</c> specs map
-/// <c>JobState.Request</c>, while the server's <c>JobStateClassMap</c> deliberately unmaps it and lets
-/// <c>JobStateSerializer</c> own it, so registering the server's map here fails them. That divergence is a
-/// fidelity gap in those specs, not something to paper over from this file.
+/// So every <see cref="IBsonClassMapFor{T}"/> the server registers is registered here too, discovered the same way
+/// <c>AddCratisMongoDB</c> discovers them, rather than one at a time from whichever spec first needs one.
 /// </para>
 /// </remarks>
 internal static class SpecSerializationSetup
@@ -50,7 +46,28 @@ internal static class SpecSerializationSetup
         new ConventionPacks().Provide();
         ConventionRegistry.Register(Cratis.Arc.MongoDB.ConventionPacks.IgnoreExtraElements, new ConventionPack { new IgnoreExtraElementsConvention(true) }, _ => true);
         BsonSerializer.RegisterSerializationProvider(new ConceptSerializationProvider());
-        BsonClassMap.RegisterClassMap<Event>(classMap => new EventClassMap().Configure(classMap));
-        BsonClassMap.RegisterClassMap<ObserverPartitionCounts>(classMap => new ObserverPartitionCountsClassMap().Configure(classMap));
+        RegisterClassMaps();
+    }
+
+    static void RegisterClassMaps()
+    {
+        var classMaps = typeof(EventClassMap).Assembly
+            .GetTypes()
+            .Where(type => type is { IsAbstract: false, IsInterface: false, ContainsGenericParameters: false })
+            .Select(type => (Type: type, Interface: Array.Find(type.GetInterfaces(), _ => _.IsGenericType && _.GetGenericTypeDefinition() == typeof(IBsonClassMapFor<>))))
+            .Where(_ => _.Interface is not null);
+
+        foreach (var (type, @interface) in classMaps)
+        {
+            var documentType = @interface!.GetGenericArguments()[0];
+            if (BsonClassMap.IsClassMapRegistered(documentType))
+            {
+                continue;
+            }
+
+            var classMap = (BsonClassMap)Activator.CreateInstance(typeof(BsonClassMap<>).MakeGenericType(documentType))!;
+            @interface.GetMethod(nameof(IBsonClassMapFor<object>.Configure))!.Invoke(Activator.CreateInstance(type), [classMap]);
+            BsonClassMap.RegisterClassMap(classMap);
+        }
     }
 }

--- a/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventTypes/EventTypesStorage.cs
@@ -159,6 +159,72 @@ public class EventTypesStorage(
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Collapses the whole batch into one read and one write: the current documents for every identifier are read in
+    /// a single query, compared in memory to work out which event types actually change anything, and only those are
+    /// written - as a single unordered bulk write. Every event type merges its generations into the stored document,
+    /// leaving generations another silo may have registered untouched, exactly as the single-event-type registration
+    /// does. Migrations are only written when the event type carries them, so a client that does not know about an
+    /// event type's migrations cannot erase them.
+    /// </remarks>
+    public async Task<IEnumerable<EventTypeId>> Register(IEnumerable<EventTypeToRegister> eventTypes)
+    {
+        var all = eventTypes.ToList();
+
+        if (all.Count == 0)
+        {
+            return [];
+        }
+
+        var collection = GetCollection();
+        var ids = all.ConvertAll(_ => _.Definition.Id);
+        using var cursor = await collection.FindAsync(Builders<EventType>.Filter.In(_ => _.Id, ids)).ConfigureAwait(false);
+        var stored = (await cursor.ToListAsync()).ToDictionary(_ => _.Id);
+
+        var writes = new List<WriteModel<EventType>>();
+        var mutated = new List<EventTypeId>();
+
+        foreach (var eventType in all)
+        {
+            var definition = eventType.Definition;
+            var schemas = definition.Generations.ToDictionary(
+                _ => _.Generation.ToString(),
+                _ => BsonDocument.Parse(_.Schema.ToJson()));
+            var migrations = definition.Migrations.Select(_ => new EventTypeMigration(
+                _.FromGeneration,
+                _.ToGeneration,
+                BsonDocument.Parse(_.UpcastJmesPath?.ToJsonString() ?? "{}"),
+                BsonDocument.Parse(_.DowncastJmesPath?.ToJsonString() ?? "{}"))).ToList();
+
+            stored.TryGetValue(definition.Id, out var existing);
+
+            if (!Changes(existing, eventType, schemas, migrations))
+            {
+                continue;
+            }
+
+            logger.Registering(definition.Id, EventTypeGeneration.First, eventStore);
+
+            writes.Add(new UpdateOneModel<EventType>(
+                Builders<EventType>.Filter.Eq(_ => _.Id, definition.Id),
+                BuildUpdate(eventType, schemas, migrations))
+            {
+                IsUpsert = true
+            });
+            mutated.Add(definition.Id);
+        }
+
+        if (writes.Count > 0)
+        {
+            await collection.BulkWriteAsync(writes, new BulkWriteOptions { IsOrdered = false }).ConfigureAwait(false);
+        }
+
+        mutated.ForEach(Invalidate);
+
+        return mutated;
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions()
     {
         using var result = await GetCollection().FindAsync(_ => true).ConfigureAwait(false);
@@ -252,6 +318,54 @@ public class EventTypesStorage(
                 _schemasByTypeAndGeneration.TryRemove(key, out _);
             }
         }
+    }
+
+    static bool Changes(
+        EventType? existing,
+        EventTypeToRegister eventType,
+        Dictionary<string, BsonDocument> schemas,
+        List<EventTypeMigration> migrations)
+    {
+        if (existing is null)
+        {
+            return true;
+        }
+
+        if (existing.Owner != eventType.Definition.Owner ||
+            existing.Source != eventType.Source ||
+            existing.Tombstone != eventType.Definition.Tombstone)
+        {
+            return true;
+        }
+
+        if (schemas.Any(_ => !existing.Schemas.TryGetValue(_.Key, out var storedSchema) || storedSchema != _.Value))
+        {
+            return true;
+        }
+
+        return migrations.Count > 0 && !migrations.SequenceEqual(existing.Migrations ?? []);
+    }
+
+    static UpdateDefinition<EventType> BuildUpdate(
+        EventTypeToRegister eventType,
+        Dictionary<string, BsonDocument> schemas,
+        List<EventTypeMigration> migrations)
+    {
+        var update = Builders<EventType>.Update
+            .Set(_ => _.Owner, eventType.Definition.Owner)
+            .Set(_ => _.Source, eventType.Source)
+            .Set(_ => _.Tombstone, eventType.Definition.Tombstone);
+
+        update = schemas.Aggregate(
+            update,
+            (current, schema) => current.Set($"{nameof(EventType.Schemas).ToCamelCase()}.{schema.Key}", schema.Value));
+
+        if (migrations.Count > 0)
+        {
+            update = update.Set(_ => _.Migrations, migrations);
+        }
+
+        return update;
     }
 
     bool InvalidateIfMutated(EventTypeId eventTypeId, bool mutated)

--- a/Source/Kernel/Storage.MongoDB/Jobs/JobStateSerializer.cs
+++ b/Source/Kernel/Storage.MongoDB/Jobs/JobStateSerializer.cs
@@ -55,20 +55,28 @@ public class JobStateSerializer(IJobTypes jobTypes) : SerializerBase<JobState>
     {
         var actualType = args.NominalType ?? typeof(JobState);
         var (jobState, requestBookmark, endBookmark) = DeserializeJobStateExceptRequest(context, actualType);
-        context.Reader.ReturnToBookmark(requestBookmark);
-        var jobRequestClrType = jobTypes.GetRequestClrTypeForOrThrow(jobState.Type);
-        actualType.GetProperty(nameof(JobState.Request))!
-            .SetValue(jobState, BsonSerializer.Deserialize(context.Reader, jobRequestClrType));
 
-        context.Reader.ReturnToBookmark(endBookmark);
+        // Serialize only writes the request when there is one, and JobState.Request starts out unset, so a state
+        // persisted before its request was assigned has no request element to come back to. Leave it unset rather
+        // than returning to a bookmark that was never taken.
+        if (requestBookmark is not null)
+        {
+            context.Reader.ReturnToBookmark(requestBookmark);
+            var jobRequestClrType = jobTypes.GetRequestClrTypeForOrThrow(jobState.Type);
+            actualType.GetProperty(nameof(JobState.Request))!
+                .SetValue(jobState, BsonSerializer.Deserialize(context.Reader, jobRequestClrType));
+
+            context.Reader.ReturnToBookmark(endBookmark);
+        }
+
         context.Reader.ReadEndDocument();
         return jobState;
     }
 
-    static (JobState JobState, BsonReaderBookmark JobRequestBookmark, BsonReaderBookmark EndBookmark) DeserializeJobStateExceptRequest(BsonDeserializationContext context, Type actualType)
+    static (JobState JobState, BsonReaderBookmark? JobRequestBookmark, BsonReaderBookmark EndBookmark) DeserializeJobStateExceptRequest(BsonDeserializationContext context, Type actualType)
     {
         var jobState = (JobState)Activator.CreateInstance(actualType)!;
-        BsonReaderBookmark requestBookmark = default!;
+        BsonReaderBookmark? requestBookmark = null;
         context.Reader.ReadStartDocument();
         var bsonCLassMap = BsonClassMap.LookupClassMap(actualType).AllMemberMaps;
         while (context.Reader.ReadBsonType() != BsonType.EndOfDocument)

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/DelegatingEventTypesStorage.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/DelegatingEventTypesStorage.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage;
+
+/// <summary>
+/// Implements every member of <see cref="IEventTypesStorage"/> by delegating to another instance, deliberately
+/// leaving the batched Register to the interface's default implementation so it is the thing under test.
+/// </summary>
+/// <param name="inner">The <see cref="IEventTypesStorage"/> to delegate to.</param>
+public class DelegatingEventTypesStorage(IEventTypesStorage inner) : IEventTypesStorage
+{
+    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
+        inner.Register(type, schema, owner, source);
+
+    public Task<bool> Register(EventTypeDefinition definition) => inner.Register(definition);
+
+    public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() => inner.GetLatestForAllEventTypes();
+
+    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() => inner.ObserveLatestForAllEventTypes();
+
+    public Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions() => inner.GetAllDefinitions();
+
+    public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) => inner.GetDefinition(eventTypeId);
+
+    public Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(EventType eventType) => inner.GetAllGenerationsForEventType(eventType);
+
+    public Task<bool> HasFor(EventTypeId type, EventTypeGeneration? generation = default) => inner.HasFor(type, generation);
+
+    public Task<EventTypeSchema> GetFor(EventTypeId type, EventTypeGeneration? generation = default) => inner.GetFor(type, generation);
+
+    public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds) => inner.GetFor(eventTypeIds);
+
+    public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventType> eventTypes) => inner.GetFor(eventTypes);
+
+    public void Invalidate(EventTypeId eventTypeId) => inner.Invalidate(eventTypeId);
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/given/a_storage_without_its_own_batch_registration.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/given/a_storage_without_its_own_batch_registration.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.given;
+
+public class a_storage_without_its_own_batch_registration : Specification
+{
+    protected IEventTypesStorage _inner;
+    protected IEventTypesStorage _subject;
+
+    void Establish()
+    {
+        _inner = Substitute.For<IEventTypesStorage>();
+        _subject = new DelegatingEventTypesStorage(_inner);
+    }
+
+    protected static EventTypeToRegister EventTypeToRegisterFor(
+        string eventTypeId,
+        EventTypeMigrationDefinition[] migrations,
+        params uint[] generations) =>
+        new(
+            new EventTypeDefinition(
+                eventTypeId,
+                EventTypeOwner.Client,
+                false,
+                generations.Select(_ => new EventTypeGenerationDefinition(_, new JsonSchema())).ToArray(),
+                migrations),
+            EventTypeSource.Code);
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_a_single_generation_without_migrations.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_a_single_generation_without_migrations.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_an_event_type_has_a_single_generation_without_migrations : given.a_storage_without_its_own_batch_registration
+{
+    IEnumerable<EventTypeId> _result;
+
+    void Establish() =>
+        _inner.Register(Arg.Any<EventType>(), Arg.Any<JsonSchema>(), Arg.Any<EventTypeOwner>(), Arg.Any<EventTypeSource>())
+            .Returns(true);
+
+    async Task Because() => _result = await _subject.Register([EventTypeToRegisterFor("some-event", [], 1)]);
+
+    [Fact] void should_register_it_as_a_single_event_type() =>
+        _inner.Received(1).Register(
+            Arg.Is<EventType>(_ => _.Id.Value == "some-event" && _.Generation.Value == 1),
+            Arg.Any<JsonSchema>(),
+            EventTypeOwner.Client,
+            EventTypeSource.Code);
+    [Fact] void should_not_register_it_as_a_definition() =>
+        _inner.DidNotReceive().Register(Arg.Any<EventTypeDefinition>());
+    [Fact] void should_report_it_as_mutated() => _result.ShouldContainOnly(new EventTypeId("some-event"));
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_migrations.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_an_event_type_has_migrations.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_an_event_type_has_migrations : given.a_storage_without_its_own_batch_registration
+{
+    async Task Because() =>
+        await _subject.Register(
+        [
+            EventTypeToRegisterFor(
+                "some-event",
+                [new EventTypeMigrationDefinition(1, 2, [], new JsonObject(), new JsonObject())],
+                1,
+                2)
+        ]);
+
+    [Fact] void should_register_it_as_a_definition() =>
+        _inner.Received(1).Register(Arg.Is<EventTypeDefinition>(_ => _.Id.Value == "some-event"));
+    [Fact] void should_not_register_it_as_a_single_event_type() =>
+        _inner.DidNotReceive().Register(
+            Arg.Any<EventType>(),
+            Arg.Any<JsonSchema>(),
+            Arg.Any<EventTypeOwner>(),
+            Arg.Any<EventTypeSource>());
+}

--- a/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_only_some_event_types_change.cs
+++ b/Source/Kernel/Storage.Specs/EventTypes/for_IEventTypesStorage/when_registering_a_batch/and_only_some_event_types_change.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.EventTypes.for_IEventTypesStorage.when_registering_a_batch;
+
+public class and_only_some_event_types_change : given.a_storage_without_its_own_batch_registration
+{
+    IEnumerable<EventTypeId> _result;
+
+    void Establish() =>
+        _inner.Register(Arg.Any<EventType>(), Arg.Any<JsonSchema>(), Arg.Any<EventTypeOwner>(), Arg.Any<EventTypeSource>())
+            .Returns(callInfo => callInfo.ArgAt<EventType>(0).Id.Value == "changed-event");
+
+    async Task Because() => _result = await _subject.Register(
+    [
+        EventTypeToRegisterFor("changed-event", [], 1),
+        EventTypeToRegisterFor("unchanged-event", [], 1)
+    ]);
+
+    [Fact] void should_only_report_the_changed_event_type() => _result.ShouldContainOnly(new EventTypeId("changed-event"));
+}

--- a/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/EventTypes/EventTypeConverters.cs
@@ -126,6 +126,10 @@ public static class EventTypeConverters
         var generations = eventType.Schemas.Select(kvp =>
         {
             var schema = JsonSchema.FromJson(kvp.Value);
+
+            // Normalize exactly like ToKernel does - callers compare a stored schema against an incoming one, and a
+            // difference in compliance metadata alone would read as a breaking schema change.
+            schema.EnsureComplianceMetadata();
             return new EventTypeGenerationDefinition(new EventTypeGeneration(kvp.Key), schema);
         }).ToList();
 

--- a/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
+++ b/Source/Kernel/Storage/EventTypes/IEventTypesStorage.cs
@@ -36,6 +36,47 @@ public interface IEventTypesStorage
     Task<bool> Register(EventTypeDefinition definition);
 
     /// <summary>
+    /// Register a whole batch of <see cref="EventTypeToRegister">event types</see> in one operation.
+    /// </summary>
+    /// <param name="eventTypes">The <see cref="EventTypeToRegister">event types</see> to register.</param>
+    /// <returns>The <see cref="EventTypeId">identifiers</see> of the event types whose stored representation was created or changed.</returns>
+    /// <remarks>
+    /// A client registers every event type it knows about at startup, so doing it one at a time costs a round trip
+    /// per event type against the underlying store. Taking the whole batch lets an implementation collapse that into
+    /// a single read and a single write. The default implementation registers one at a time, so an implementation
+    /// only needs to override this when it can do better.
+    /// Only the identifiers of event types that actually changed are returned - re-registering identical event types
+    /// yields none, so routine client reconnects do not trigger cluster-wide cache eviction.
+    /// </remarks>
+    async Task<IEnumerable<EventTypeId>> Register(IEnumerable<EventTypeToRegister> eventTypes)
+    {
+        var mutated = new List<EventTypeId>();
+
+        foreach (var eventType in eventTypes)
+        {
+            var definition = eventType.Definition;
+            var generations = definition.Generations.ToList();
+
+            // A single generation without migrations is exactly what the simple registration expresses - anything
+            // else needs the full definition.
+            var changed = generations.Count == 1 && !definition.Migrations.Any()
+                ? await Register(
+                    new EventType(definition.Id, generations[0].Generation, definition.Tombstone),
+                    generations[0].Schema,
+                    definition.Owner,
+                    eventType.Source)
+                : await Register(definition);
+
+            if (changed)
+            {
+                mutated.Add(definition.Id);
+            }
+        }
+
+        return mutated;
+    }
+
+    /// <summary>
     /// Get the latest <see cref="EventTypeSchema">event schema</see> for all registered <see cref="EventType">event types</see>.
     /// </summary>
     /// <returns>A collection of <see cref="EventTypeSchema">event schemas</see>.</returns>


### PR DESCRIPTION
## Added

- `[Replay]` on a reactor handler method, marking it as the one to run while the observer is replaying. Only the marked handler runs during a replay; an event type without one behaves exactly as before. (#845)
- `IEventStore.Identities` with `Rename(subject, name)`, exposing the identity renaming the kernel already supported to the .NET client. (#1684)
- `[JsonSchemaType(typeof(T))]` on a type, overriding how it is represented in the JSON schema generated for events and read models. Compliance metadata and nullability are preserved. (#1470)
- `AddCratisChronicleMongoDB()` for Aspire, provisioning a MongoDB container that initiates itself as a single-node replica set and hands back a `directConnection` connection string. (#3400)
- `IReactorMiddleware.BeforeInvoke` and `AfterInvoke` overloads that receive the `ReactorId` of the reactor observing the event. Chronicle calls these; they default to the existing overloads, so a middleware written against the previous interface keeps working unchanged. (#1009)
- `CompliancePropertyNotFoundInSchema`, thrown when a property being applied or released has no counterpart in the schema. The message names the property path, the compliance subject, and the properties the schema does declare. (#690)
- An overview on the `cratis/chronicle` Docker Hub repository covering the published tag variants, ports, quick start and the environment variables that configure the server. (#1277)

## Changed

- Registering event types on connect issues one read and one bulk write for the whole batch instead of several round trips per event type, so startup no longer scales its database round trips with the number of event types. (#984)

## Fixed

- Reading back a job whose request was not yet assigned no longer fails with a `NullReferenceException`, losing the status and progress the job state was written to record. (#3541)
- Reducer failures are written to the client log. A reducer method that throws was reported to the kernel as a failed observation without ever appearing in the client's own log. (#1395)
- Applying or releasing compliance metadata for a property the schema does not declare no longer fails with a bare `Sequence contains no matching element`. (#690)
- Applying or releasing compliance metadata no longer fails when a schema flattened across inheritance declares the same property name more than once. (#690)
