### PR TITLE
Enable Orleans defunct-silo cleanup for MongoDB clustering

### DIFF
--- a/Documentation/hosting/configuration/clustering.md
+++ b/Documentation/hosting/configuration/clustering.md
@@ -45,6 +45,8 @@ Clustering configuration controls how multiple Chronicle Server nodes form one O
 | clusterId | string | chronicle | The cluster id - all nodes that should form one cluster must share it. |
 | serviceId | string | chronicle | The service id - all nodes that should form one cluster must share it. |
 | advertisedIP | string | | The IP address the silo advertises to other cluster members. Resolved from the machine's host name when not set; set it explicitly (e.g. `127.0.0.1`) when running multiple nodes on one machine. |
+| defunctSiloCleanupPeriod | timespan | 01:00:00 | How often defunct silo entries are swept out of the membership table when using `MongoDB` clustering. Without the sweep, dead entries from restarts and failed rollouts accumulate and slow down or block new nodes joining. Set to `00:00:00` to disable the sweep. |
+| defunctSiloExpiration | timespan | 03:00:00 | The age at which a defunct membership entry is removed by the sweep. A node never reuses a silo identity, so dead entries only have diagnostic value. |
 | roles.eventSequences | boolean | true | When `true`, event sequence grains can be activated on this node. When `false`, event sequence grains will not be placed on this node. |
 | roles.observers | boolean | true | When `true`, observer grains (reactors, reducers, projections) can be activated on this node. When `false`, observer grains will not be placed on this node. |
 

--- a/Source/Kernel/Core/Configuration/Clustering.cs
+++ b/Source/Kernel/Core/Configuration/Clustering.cs
@@ -48,4 +48,20 @@ public class Clustering
     /// running multiple nodes on one machine.
     /// </summary>
     public string? AdvertisedIP { get; set; }
+
+    /// <summary>
+    /// Gets how often defunct silo entries are swept out of the cluster membership table when
+    /// using <see cref="ClusteringType.MongoDB"/>. Without the sweep, repeated restarts and failed
+    /// rollouts accumulate dead silo entries forever, and new nodes stall validating against them
+    /// when joining. Set to <see cref="TimeSpan.Zero"/> to disable the sweep.
+    /// </summary>
+    public TimeSpan DefunctSiloCleanupPeriod { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Gets the age at which a defunct membership entry is removed by the sweep. A node never
+    /// reuses a silo identity (address + generation), so a dead entry only has diagnostic value —
+    /// a few hours keeps recent history around while keeping the table small enough for new nodes
+    /// to join quickly.
+    /// </summary>
+    public TimeSpan DefunctSiloExpiration { get; set; } = TimeSpan.FromHours(3);
 }

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -176,6 +176,16 @@ hostBuilder
                 options.ServiceId = clustering.ServiceId;
             });
 
+            // Self-heal the membership table: Orleans ships with the defunct-silo sweep disabled,
+            // so dead entries from restarts and failed rollouts accumulate until new nodes cannot join.
+            _.Configure<Orleans.Configuration.ClusterMembershipOptions>(options =>
+            {
+                options.DefunctSiloCleanupPeriod = clustering.DefunctSiloCleanupPeriod > TimeSpan.Zero
+                    ? clustering.DefunctSiloCleanupPeriod
+                    : null;
+                options.DefunctSiloExpiration = clustering.DefunctSiloExpiration;
+            });
+
             if (clustering.AdvertisedIP is { } advertisedIP)
             {
                 _.ConfigureEndpoints(System.Net.IPAddress.Parse(advertisedIP), clustering.SiloPort, clustering.GatewayPort);


### PR DESCRIPTION
## Added

- New `defunctSiloCleanupPeriod` and `defunctSiloExpiration` clustering configuration settings controlling how often defunct silo entries are swept out of the Orleans membership table and at what age they are removed. Defaults: sweep every hour, remove entries older than three hours; set the period to `00:00:00` to disable the sweep.

## Fixed

- Chronicle Server with MongoDB clustering now cleans up defunct silo membership entries automatically. Orleans ships with the cleanup disabled, so repeated restarts and failed rollouts accumulated dead silo entries forever, making joining nodes stall while validating against them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)