### PR TITLE
Release PII per property instead of failing the whole read

### DIFF
--- a/Documentation/client-snippets/code-analysis/chr0039/fix.md
+++ b/Documentation/client-snippets/code-analysis/chr0039/fix.md
@@ -1,0 +1,25 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Testing.EventSequences;
+using Xunit;
+
+[EventType]
+public record Chr0039AuthorRegisteredFixed(string Name);
+
+public class Chr0039WhenRegisteringAnAuthorFixed
+{
+    readonly IEventLog _eventLog = default!;
+
+    // Declaring the fact 'async Task' and awaiting the assertion makes the exception it throws
+    // observable, so the assertion can actually fail.
+    [Fact]
+    async Task should_have_appended_the_event() =>
+        await _eventLog.ShouldHaveAppendedEvent<Chr0039AuthorRegisteredFixed>(e => e.Name == "Jane Austen");
+
+    // Returning the Task works too — the test runner awaits it.
+    [Fact]
+    Task should_have_appended_exactly_one_event() =>
+        _eventLog.ShouldHaveTailSequenceNumber(EventSequenceNumber.First);
+}
+```

--- a/Documentation/client-snippets/code-analysis/chr0039/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0039/violation.md
@@ -1,0 +1,28 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Testing.EventSequences;
+using Xunit;
+
+[EventType]
+public record Chr0039AuthorRegistered(string Name);
+
+public class Chr0039WhenRegisteringAnAuthor
+{
+    readonly IEventLog _eventLog = default!;
+
+    // Warning CHR0039: 'ShouldHaveAppendedEvent' returns a Task that is never awaited, so the
+    // assertion can never fail. The fact is 'void', so the compiler's own CS4014 stays silent —
+    // this spec passes even though no Chr0039AuthorRegistered carries that name.
+    [Fact]
+    void should_have_appended_the_event() =>
+        _eventLog.ShouldHaveAppendedEvent<Chr0039AuthorRegistered>(e => e.Name == "Jane Austen");
+
+    // Warning CHR0039: the same trap in a block body.
+    [Fact]
+    void should_have_appended_exactly_one_event()
+    {
+        _eventLog.ShouldHaveTailSequenceNumber(EventSequenceNumber.First);
+    }
+}
+```

--- a/Documentation/client-snippets/constraints/declarative/unique-event-type/mutually-exclusive.md
+++ b/Documentation/client-snippets/constraints/declarative/unique-event-type/mutually-exclusive.md
@@ -1,0 +1,28 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+[EventType]
+public record ConstraintsPersonAliasedTo(Guid Target);
+
+[EventType]
+public record ConstraintsPersonErased;
+
+public class ConstraintsPersonTerminalOutcome : IConstraint
+{
+    // Both declarations share one constraint name, so they become a single constraint:
+    // at most one event drawn from { ConstraintsPersonAliasedTo, ConstraintsPersonErased }
+    // per person. A person merged away can no longer be erased, and neither event can
+    // occur twice.
+    public void Define(IConstraintBuilder builder)
+    {
+        builder.Unique<ConstraintsPersonAliasedTo>(
+            name: "PersonTerminal",
+            message: "This person already has a terminal outcome.");
+
+        builder.Unique<ConstraintsPersonErased>(
+            name: "PersonTerminal",
+            message: "This person already has a terminal outcome.");
+    }
+}
+```

--- a/Documentation/code-analysis/CHR0039.mdx
+++ b/Documentation/code-analysis/CHR0039.mdx
@@ -1,0 +1,42 @@
+# CHR0039: Assertion result is discarded and can never fail
+
+## Rule Description
+
+The event-sequence assertions in `Cratis.Chronicle.Testing` — `ShouldHaveAppendedEvent<T>(...)` and `ShouldHaveTailSequenceNumber(...)`, in every overload — return a `Task`. They signal failure by throwing an `EventSequenceAssertionException` on that `Task`.
+
+Call one from a `void`-bodied fact and the `Task` is discarded, so the exception is never observed. The assertion becomes a no-op that passes no matter what the system under test does.
+
+Await the assertion and declare the containing member `async Task`, or return the `Task` so the test runner awaits it.
+
+## Severity
+
+Warning
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0039/violation" />
+
+The fix:
+
+<ChronicleClientTabs snippet="code-analysis/chr0039/fix" />
+
+## Why This Rule Exists
+
+The compiler already has a rule for a discarded `Task` — CS4014 — but it fires **only inside an `async` method**. A `void`-bodied fact is the natural and dominant shape of a spec, and it is exactly the shape where CS4014 says nothing. A zero-warning build is therefore blind to it.
+
+What makes this a genuine trap rather than ordinary async carelessness is that the *sibling* assertions on the same surface are synchronous and `void`:
+
+- `ShouldBeSuccessful()`
+- `ShouldHaveValidationErrors()`
+- `ShouldHaveConstraintViolation()` / `ShouldNotHaveConstraintViolation()`
+- `ShouldHaveConcurrencyViolations()`
+
+Discarding "the result" of those is exactly how they are meant to be used. Nothing at the call site signals that the event-sequence assertions behave differently, so the two shapes sit side by side in the same file and only one of them works.
+
+The failure mode is the worst one a test suite has: an assertion that appears to test something and tests nothing. The resulting false confidence survives review, CI, and time — and it hides real defects, because the assertion that would have caught a regression silently passes instead.
+
+The rule is scoped to `Task`-returning `Should*` methods on the Cratis testing surfaces, and only where the result is genuinely discarded — a statement on its own line, or the expression body of a `void` member. Awaiting, returning, assigning, or passing the `Task` along all count as observing it and are not flagged.
+
+## Related Rules
+
+- [Writing specs](/chronicle/testing/) — the testing surfaces this rule covers.

--- a/Documentation/code-analysis/toc.yml
+++ b/Documentation/code-analysis/toc.yml
@@ -66,3 +66,5 @@
   href: CHR0037.mdx
 - name: CHR0038 - [Join] of a [PII] value crosses the compliance subject
   href: CHR0038.mdx
+- name: CHR0039 - Assertion result is discarded and can never fail
+  href: CHR0039.mdx

--- a/Documentation/compliance/read-models.mdx
+++ b/Documentation/compliance/read-models.mdx
@@ -59,3 +59,21 @@ Read model queries are transparent to PII encryption. No changes to query code a
 <ChronicleClientTabs snippet="compliance/read-models/querying" />
 
 Chronicle decrypts PII fields automatically before returning results to the caller. When the encryption key has been deleted for a subject, `Name` returns an empty string — the caller receives an `Employee` record with an empty name, never an exception or partial result.
+
+### One property never fails the whole read
+
+Decryption is resolved per property, and a property that cannot be read never fails the read model or the query returning it:
+
+| The stored value | What the caller gets |
+|---|---|
+| Encrypted under this subject | The decrypted value. |
+| Encrypted, but the subject's key was deleted | An empty value — the erasure case above. |
+| Never encrypted under this subject | The value, untouched. |
+| Encrypted under a *different* subject | An empty value for that property, plus an error in the Kernel log naming the property, the subject, and the likely cause. |
+
+The third row matters when a `[PII]`-typed property is resolved in memory at the query edge — for display on a view whose own compliance subject is not that person — or when a property was marked `[PII]` after values had already been stored. Chronicle recognizes the shape of the values it encrypts, so a value it never encrypted is passed through rather than blanked or rejected.
+
+The fourth row is a modeling defect rather than a transient failure: a read model has one compliance subject and all of its PII is released under it. The [CHR0038](../code-analysis/CHR0038) analyzer catches the common cause — a `[Join]` copying a `[PII]` value out of another event source's stream — at build time. When one slips through, the property is degraded rather than the query, so the rest of the result is unaffected.
+
+> [!NOTE]
+> Applying PII behaves the opposite way, and deliberately so: if encryption fails on the way *in*, the operation fails. Storing a value that was meant to be protected, unprotected, is never an acceptable degradation.

--- a/Documentation/constraints/declarative/unique-event-type.mdx
+++ b/Documentation/constraints/declarative/unique-event-type.mdx
@@ -24,6 +24,16 @@ An optional name can be provided to identify the constraint. When not provided, 
 
 <ChronicleClientTabs snippet="constraints/declarative/unique-event-type/constraint-name" />
 
+## Mutually exclusive event types
+
+Declare several event types under the **same constraint name** and they become one constraint: at most one event drawn from that set is allowed per event source. Use it when an event source has more than one terminal outcome and the outcomes exclude each other — cancelled *or* completed, merged *or* erased, approved *or* permanently rejected.
+
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/mutually-exclusive" />
+
+Each event type still cannot occur twice — that is the single-type case of the same rule. What sharing the name adds is that the *first* of them to be appended blocks all of the others.
+
+Because this is enforced at append time it holds under concurrency, which a validator reading prior state cannot guarantee: that check and the append are not atomic, so two competing commands can both observe "no terminal event yet" and both succeed.
+
 ## How constraints are enforced
 
 When a constraint is registered, the Chronicle Kernel creates the indexes required to enforce it. Constraints are evaluated server-side during append, ensuring data integrity regardless of the client.

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/given/a_non_awaited_assertion_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/given/a_non_awaited_assertion_analyzer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.given;
+
+public class a_non_awaited_assertion_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        // Mirrors the real assertion surface: the event-sequence assertions return Task while the sibling
+        // result assertions are synchronous and void — the mix that makes the trap invisible at the call site.
+        return string.Join(Environment.NewLine,
+        [
+            "using System.Threading.Tasks;",
+            "",
+            "namespace Cratis.Chronicle.Testing.EventSequences",
+            "{",
+            "    public interface IEventSequence { }",
+            "    public static class EventSequenceShouldExtensions",
+            "    {",
+            "        public static Task ShouldHaveAppendedEvent<TEvent>(this IEventSequence eventSequence) => Task.CompletedTask;",
+            "        public static Task ShouldHaveTailSequenceNumber(this IEventSequence eventSequence, int expected) => Task.CompletedTask;",
+            "        public static void ShouldBeSuccessful(this IEventSequence eventSequence) { }",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            "    using Cratis.Chronicle.Testing.EventSequences;",
+            "",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_awaited.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_awaited.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.when_analyzing_an_assertion;
+
+public class and_it_is_awaited : given.a_non_awaited_assertion_analyzer
+{
+    const string Usage = """
+    public class AnEvent { }
+
+    public class Spec
+    {
+        IEventSequence _eventLog;
+
+        async Task should_have_appended_the_event() =>
+            await _eventLog.ShouldHaveAppendedEvent<AnEvent>();
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_discarded_as_a_statement.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_discarded_as_a_statement.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.when_analyzing_an_assertion;
+
+public class and_it_is_discarded_as_a_statement : given.a_non_awaited_assertion_analyzer
+{
+    const string Usage = """
+    public class Spec
+    {
+        IEventSequence _eventLog;
+
+        void should_have_the_expected_tail()
+        {
+            {|#0:_eventLog.ShouldHaveTailSequenceNumber(1)|};
+        }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.NonAwaitedAssertion, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning));
+
+    [Fact] Task should_report_the_discarded_assertion() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_discarded_from_a_void_expression_body.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_it_is_discarded_from_a_void_expression_body.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.when_analyzing_an_assertion;
+
+/// <summary>
+/// The reported shape — a void-bodied fact. CS4014 stays silent because the member is not async, so nothing
+/// but this analyzer tells the author the assertion can never fail.
+/// </summary>
+public class and_it_is_discarded_from_a_void_expression_body : given.a_non_awaited_assertion_analyzer
+{
+    const string Usage = """
+    public class AnEvent { }
+
+    public class Spec
+    {
+        IEventSequence _eventLog;
+
+        void should_have_appended_the_event() =>
+            {|#0:_eventLog.ShouldHaveAppendedEvent<AnEvent>()|};
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.NonAwaitedAssertion, Microsoft.CodeAnalysis.DiagnosticSeverity.Warning));
+
+    [Fact] Task should_report_the_discarded_assertion() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_the_assertion_is_synchronous.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_the_assertion_is_synchronous.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.when_analyzing_an_assertion;
+
+/// <summary>
+/// A void-returning assertion throws on the calling thread, so discarding "the result" is exactly how it is
+/// meant to be used. Flagging it would fire on most of the assertion surface.
+/// </summary>
+public class and_the_assertion_is_synchronous : given.a_non_awaited_assertion_analyzer
+{
+    const string Usage = """
+    public class Spec
+    {
+        IEventSequence _eventLog;
+
+        void should_be_successful() => _eventLog.ShouldBeSuccessful();
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_the_task_is_returned_to_the_caller.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_analyzing_an_assertion/and_the_task_is_returned_to_the_caller.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer.when_analyzing_an_assertion;
+
+/// <summary>
+/// Handing the Task back to the test runner observes it just as awaiting does — this is the shape the existing
+/// analyzer specs themselves use, and it must not be flagged.
+/// </summary>
+public class and_the_task_is_returned_to_the_caller : given.a_non_awaited_assertion_analyzer
+{
+    const string Usage = """
+    public class AnEvent { }
+
+    public class Spec
+    {
+        IEventSequence _eventLog;
+
+        Task should_have_appended_the_event() => _eventLog.ShouldHaveAppendedEvent<AnEvent>();
+
+        Task should_have_the_expected_tail()
+        {
+            return _eventLog.ShouldHaveTailSequenceNumber(1);
+        }
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_NonAwaitedAssertionAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_NonAwaitedAssertionAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.NonAwaitedAssertionAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0039_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.NonAwaitedAssertion).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/NonAwaitedAssertionAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/NonAwaitedAssertionAnalyzer.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports a <see cref="System.Threading.Tasks.Task"/>-returning testing assertion whose result is
+/// discarded, making the assertion incapable of ever failing.
+/// </summary>
+/// <remarks>
+/// The compiler's own CS4014 only fires inside an <see langword="async"/> method, and the natural shape of a
+/// spec is a <see langword="void"/>-bodied fact — precisely where CS4014 says nothing. The assertion's exception
+/// is thrown on a <see cref="System.Threading.Tasks.Task"/> nobody observes, so the spec passes no matter what
+/// the system does. Sibling assertions on the same surface are synchronous and <see langword="void"/>, so
+/// nothing at the call site hints that these particular ones behave differently.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NonAwaitedAssertionAnalyzer : DiagnosticAnalyzer
+{
+    const string AssertionMethodPrefix = "Should";
+    const string TestingNamespaceSegment = ".Testing.";
+    const string CratisNamespacePrefix = "Cratis.";
+    const string TaskTypeName = "System.Threading.Tasks.Task";
+
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.NonAwaitedAssertion,
+        title: "Assertion result is discarded and can never fail",
+        messageFormat: "'{0}' returns a Task that is never awaited, so the assertion can never fail. Await it and make the containing member 'async Task'.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Task-returning assertions throw on a Task the caller must observe. Discarding that Task from a void-bodied test silently turns the assertion into a no-op that passes regardless of behavior, and the compiler's CS4014 does not fire outside an async method. Await the assertion and declare the containing member as 'async Task'.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol methodSymbol)
+        {
+            return;
+        }
+
+        if (!IsTaskReturningAssertion(methodSymbol) || !IsResultDiscarded(invocation))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodSymbol.Name));
+    }
+
+    static bool IsTaskReturningAssertion(IMethodSymbol methodSymbol)
+    {
+        if (!methodSymbol.Name.StartsWith(AssertionMethodPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (methodSymbol.ReturnType.OriginalDefinition.ToDisplayString() != TaskTypeName)
+        {
+            return false;
+        }
+
+        var containingNamespace = methodSymbol.ContainingType?.ContainingNamespace?.ToDisplayString();
+        if (containingNamespace is null)
+        {
+            return false;
+        }
+
+        // Scoped to the Cratis testing surfaces so an unrelated Should-prefixed API is never flagged. The
+        // trailing dot makes the segment match a namespace that ends in '.Testing' as well as one nested below it.
+        return containingNamespace.StartsWith(CratisNamespacePrefix, StringComparison.Ordinal) &&
+               (containingNamespace + ".").Contains(TestingNamespaceSegment);
+    }
+
+    static bool IsResultDiscarded(InvocationExpressionSyntax invocation) =>
+        invocation.Parent switch
+        {
+            // A statement on its own line — nothing observes the returned Task.
+            ExpressionStatementSyntax => true,
+
+            // An expression body observes the Task only when the member hands it back to the caller.
+            ArrowExpressionClauseSyntax arrow => ReturnsVoid(arrow.Parent),
+
+            // Awaited, returned, assigned, or passed along — all observe it.
+            _ => false
+        };
+
+    static bool ReturnsVoid(SyntaxNode? member) =>
+        member switch
+        {
+            MethodDeclarationSyntax method => IsVoid(method.ReturnType),
+            LocalFunctionStatementSyntax local => IsVoid(local.ReturnType),
+            _ => false
+        };
+
+    static bool IsVoid(TypeSyntax returnType) =>
+        returnType is PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword };
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -195,4 +195,9 @@ public static class DiagnosticIds
     /// A model-bound [Join] copies a [PII] value from a stream keyed by something other than the read model's own compliance subject.
     /// </summary>
     public const string CrossSubjectPiiJoin = "CHR0038";
+
+    /// <summary>
+    /// A Task-returning testing assertion is discarded rather than awaited, so it can never fail.
+    /// </summary>
+    public const string NonAwaitedAssertion = "CHR0039";
 }

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_building_a_unique_event_constraint/with_several_event_types_sharing_a_name.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_building_a_unique_event_constraint/with_several_event_types_sharing_a_name.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Cratis.Chronicle.Events.Constraints.for_ConstraintBuilder.when_building_a_unique_event_constraint;
+
+/// <summary>
+/// Declaring several event types under one constraint name is how mutual exclusion is expressed — an event
+/// source terminal through either outcome may have one of them, never both and never twice. The definitions
+/// merge into a single constraint so that names stay unique across the built set.
+/// </summary>
+public class with_several_event_types_sharing_a_name : given.a_constraint_builder_with_owner
+{
+    const string ConstraintName = "PersonTerminal";
+
+    IImmutableList<IConstraintDefinition> _result;
+    EventType _aliasedEventType;
+    EventType _erasedEventType;
+
+    void Establish()
+    {
+        _aliasedEventType = new EventType(nameof(PersonAliasedTo), EventTypeGeneration.First);
+        _erasedEventType = new EventType(nameof(PersonErased), EventTypeGeneration.First);
+        _eventTypes.GetEventTypeFor(typeof(PersonAliasedTo)).Returns(_aliasedEventType);
+        _eventTypes.GetEventTypeFor(typeof(PersonErased)).Returns(_erasedEventType);
+    }
+
+    void Because()
+    {
+        _constraintBuilder.Unique<PersonAliasedTo>(name: ConstraintName);
+        _constraintBuilder.Unique<PersonErased>(name: ConstraintName);
+        _result = _constraintBuilder.Build();
+    }
+
+    [Fact] void should_merge_into_a_single_constraint() => _result.Count.ShouldEqual(1);
+    [Fact] void should_keep_the_shared_name() => _result[0].Name.Value.ShouldEqual(ConstraintName);
+    [Fact] void should_cover_both_event_types() =>
+        ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeIds.ShouldContainOnly([_aliasedEventType.Id, _erasedEventType.Id]);
+
+    record PersonAliasedTo();
+    record PersonErased();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_building_a_unique_event_constraint/with_the_same_event_type_declared_twice.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_building_a_unique_event_constraint/with_the_same_event_type_declared_twice.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Cratis.Chronicle.Events.Constraints.for_ConstraintBuilder.when_building_a_unique_event_constraint;
+
+/// <summary>
+/// Merging must not let the same event type accumulate — a duplicate declaration is redundant, not a second
+/// participant, and a repeated id would change the constraint's content-derived version on every rebuild.
+/// </summary>
+public class with_the_same_event_type_declared_twice : given.a_constraint_builder_with_owner
+{
+    const string ConstraintName = "PersonTerminal";
+
+    IImmutableList<IConstraintDefinition> _result;
+    EventType _eventType;
+
+    void Establish()
+    {
+        _eventType = new EventType(nameof(PersonErased), EventTypeGeneration.First);
+        _eventTypes.GetEventTypeFor(typeof(PersonErased)).Returns(_eventType);
+    }
+
+    void Because()
+    {
+        _constraintBuilder.Unique<PersonErased>(name: ConstraintName);
+        _constraintBuilder.Unique<PersonErased>(name: ConstraintName);
+        _result = _constraintBuilder.Build();
+    }
+
+    [Fact] void should_merge_into_a_single_constraint() => _result.Count.ShouldEqual(1);
+    [Fact] void should_cover_the_event_type_once() =>
+        ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeIds.ShouldContainOnly([_eventType.Id]);
+
+    record PersonErased();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract.cs
@@ -20,7 +20,7 @@ public class when_converting_to_contract : Specification
         _definition = new UniqueEventTypeConstraintDefinition(
             _constraintName,
             _ => "",
-            _eventType.Id,
+            [_eventType.Id],
             null);
     }
 
@@ -32,5 +32,5 @@ public class when_converting_to_contract : Specification
 
     [Fact] void should_have_correct_name() => _contract.Name.ShouldEqual(_constraintName.Value);
     [Fact] void should_have_correct_type() => _contract.Type.ShouldEqual(Contracts.Events.Constraints.ConstraintType.UniqueEventType);
-    [Fact] void should_event_type() => _definitionContract.EventTypeId.ShouldEqual(_eventType.Id.Value);
+    [Fact] void should_event_type() => _definitionContract.EventTypeIds.ShouldContainOnly([_eventType.Id.Value]);
 }

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintsProvider/when_providing.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintsProvider/when_providing.cs
@@ -37,11 +37,11 @@ public class when_providing : Specification
     void Because() => _result = new UniqueEventTypeConstraintsProvider(_clientArtifactsProvider, _eventTypes).Provide();
 
     [Fact] void should_return_two_constraints() => _result.Count.ShouldEqual(2);
-    [Fact] void should_return_constraint_for_first_event_type() => ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeId.ShouldEqual(_firstEventType.Id);
+    [Fact] void should_return_constraint_for_first_event_type() => ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeIds.ShouldContainOnly([_firstEventType.Id]);
     [Fact] void should_return_constraint_for_first_event_type_as_name() => ((UniqueEventTypeConstraintDefinition)_result[0]).Name.ShouldEqual((ConstraintName)nameof(FirstEvent));
     [Fact] void should_return_constraint_for_first_event_type_message() => ((UniqueEventTypeConstraintDefinition)_result[0]).MessageCallback(null!).ShouldEqual((ConstraintViolationMessage)FirstEventMessage);
 
-    [Fact] void should_return_constraint_for_second_event_type() => ((UniqueEventTypeConstraintDefinition)_result[1]).EventTypeId.ShouldEqual(_secondEventType.Id);
+    [Fact] void should_return_constraint_for_second_event_type() => ((UniqueEventTypeConstraintDefinition)_result[1]).EventTypeIds.ShouldContainOnly([_secondEventType.Id]);
     [Fact] void should_return_constraint_for_second_event_type_as_name() => ((UniqueEventTypeConstraintDefinition)_result[1]).Name.ShouldEqual((ConstraintName)nameof(SecondEvent));
     [Fact] void should_return_constraint_for_second_event_type_message() => ((UniqueEventTypeConstraintDefinition)_result[1]).MessageCallback(null!).ShouldEqual((ConstraintViolationMessage)SecondEventMessage);
 

--- a/Source/Clients/DotNET/Events/Constraints/ConstraintBuilder.cs
+++ b/Source/Clients/DotNET/Events/Constraints/ConstraintBuilder.cs
@@ -68,7 +68,7 @@ public class ConstraintBuilder(
         AddConstraint(ApplyScope(new UniqueEventTypeConstraintDefinition(
             name ?? eventType.Id.Value,
             messageCallback,
-            eventType.Id,
+            [eventType.Id],
             null)));
 
         return this;
@@ -83,9 +83,63 @@ public class ConstraintBuilder(
     /// <inheritdoc/>
     public IImmutableList<IConstraintDefinition> Build()
     {
-        ThrowIfDuplicateConstraintNames();
+        var constraints = MergeUniqueEventTypeConstraintsSharingName(_constraints);
+        ThrowIfDuplicateConstraintNames(constraints);
 
-        return _constraints.ToImmutableList();
+        return constraints.ToImmutableList();
+    }
+
+    /// <summary>
+    /// Merge unique event type constraints declared under the same name into a single definition.
+    /// </summary>
+    /// <param name="constraints">The constraints to merge.</param>
+    /// <returns>The constraints with same-named unique event type definitions merged.</returns>
+    /// <remarks>
+    /// Declaring <c>Unique&lt;A&gt;(name: x)</c> and <c>Unique&lt;B&gt;(name: x)</c> is how mutual exclusion is
+    /// expressed — the two become one constraint allowing at most one event from {A, B} per event source.
+    /// Merging happens here rather than downstream so that names stay unique across the built set, which
+    /// registration, change detection, and violation message resolution all rely on.
+    /// </remarks>
+    static List<IConstraintDefinition> MergeUniqueEventTypeConstraintsSharingName(IEnumerable<IConstraintDefinition> constraints)
+    {
+        var merged = new List<IConstraintDefinition>();
+        foreach (var constraint in constraints)
+        {
+            if (constraint is not UniqueEventTypeConstraintDefinition uniqueEventType)
+            {
+                merged.Add(constraint);
+                continue;
+            }
+
+            var existingIndex = merged.FindIndex(_ => _ is UniqueEventTypeConstraintDefinition && _.Name == constraint.Name);
+            if (existingIndex < 0)
+            {
+                merged.Add(uniqueEventType);
+                continue;
+            }
+
+            var existing = (UniqueEventTypeConstraintDefinition)merged[existingIndex];
+            merged[existingIndex] = existing with
+            {
+                EventTypeIds = existing.EventTypeIds.Concat(uniqueEventType.EventTypeIds).Distinct().ToArray()
+            };
+        }
+
+        return merged;
+    }
+
+    static void ThrowIfDuplicateConstraintNames(IEnumerable<IConstraintDefinition> constraints)
+    {
+        var violatingConstraints = constraints
+            .GroupBy(_ => _.Name)
+            .Where(_ => _.Count() > 1)
+            .Select(_ => _.Key)
+            .ToArray();
+
+        if (violatingConstraints.Length > 0)
+        {
+            throw new DuplicateConstraintNames(violatingConstraints);
+        }
     }
 
     ConstraintScope? GetScope()
@@ -115,19 +169,5 @@ public class ConstraintBuilder(
             UniqueEventTypeConstraintDefinition uniqueEventType => uniqueEventType with { Scope = scope },
             _ => definition
         };
-    }
-
-    void ThrowIfDuplicateConstraintNames()
-    {
-        var violatingConstraints = _constraints
-            .GroupBy(_ => _.Name)
-            .Where(_ => _.Count() > 1)
-            .Select(_ => _.Key)
-            .ToArray();
-
-        if (violatingConstraints.Length > 0)
-        {
-            throw new DuplicateConstraintNames(violatingConstraints);
-        }
     }
 }

--- a/Source/Clients/DotNET/Events/Constraints/ConstraintConverters.cs
+++ b/Source/Clients/DotNET/Events/Constraints/ConstraintConverters.cs
@@ -35,7 +35,7 @@ internal static class ConstraintConverters
         Type = (Contracts.Events.Constraints.ConstraintType)ConstraintType.UniqueEventType,
         Definition = new(new UniqueEventTypeConstraintDefinitionContract
         {
-            EventTypeId = definition.EventTypeId
+            EventTypeIds = definition.EventTypeIds.Select(_ => _.Value).ToList()
         }),
         Scope = definition.Scope?.ToContract()
     };

--- a/Source/Clients/DotNET/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
@@ -8,12 +8,17 @@ namespace Cratis.Chronicle.Events.Constraints;
 /// </summary>
 /// <param name="Name">Name of the constraint.</param>
 /// <param name="MessageCallback">the callback that provides the <see cref="ConstraintViolationMessage"/> of the constraint.</param>
-/// <param name="EventTypeId">The <see cref="EventTypeId"/> the constraint is for.</param>
+/// <param name="EventTypeIds">The <see cref="EventTypeId"/> values the constraint covers.</param>
 /// <param name="RemovedWith">The <see cref="Events.EventTypeId"/> of the event that removes the constraint.</param>
 /// <param name="Scope">The <see cref="ConstraintScope"/> for the constraint.</param>
+/// <remarks>
+/// The constraint allows at most one event drawn from the covered event types per event source. Declare several
+/// event types under one constraint name to make them mutually exclusive — an event source that is terminal
+/// through either of two outcomes can then have one of them, never both and never twice.
+/// </remarks>
 public record UniqueEventTypeConstraintDefinition(
     ConstraintName Name,
     ConstraintViolationMessageProvider MessageCallback,
-    EventTypeId EventTypeId,
+    IEnumerable<EventTypeId> EventTypeIds,
     EventTypeId? RemovedWith,
     ConstraintScope? Scope = default) : IConstraintDefinition;

--- a/Source/Clients/DotNET/Events/Constraints/UniqueEventTypeConstraintsProvider.cs
+++ b/Source/Clients/DotNET/Events/Constraints/UniqueEventTypeConstraintsProvider.cs
@@ -27,7 +27,7 @@ public class UniqueEventTypeConstraintsProvider(IClientArtifactsProvider clientA
                 return new UniqueEventTypeConstraintDefinition(
                     constraintName,
                     et => eventType.GetConstraintMessage() ?? string.Empty,
-                    eventTypes.GetEventTypeFor(eventType).Id,
+                    [eventTypes.GetEventTypeFor(eventType).Id],
                     removedWith);
             }).ToImmutableList();
 }

--- a/Source/Clients/Testing/EventSequences/EventScenario.cs
+++ b/Source/Clients/Testing/EventSequences/EventScenario.cs
@@ -179,7 +179,8 @@ public class EventScenario(
         var jsonSerializerOptions = Globals.JsonSerializerOptions ?? new JsonSerializerOptions();
         var eventCompliance = new KernelCore::Cratis.Chronicle.Events.EventCompliance(
             new KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager(
-                new KnownInstancesOf<KernelCore::Cratis.Chronicle.Compliance.IJsonCompliancePropertyValueHandler>()),
+                new KnownInstancesOf<KernelCore::Cratis.Chronicle.Compliance.IJsonCompliancePropertyValueHandler>(),
+                NullLogger<KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager>.Instance),
             new ExpandoObjectConverter(new TypeFormats()));
         var eventSequencesService = new KernelCore::Cratis.Chronicle.Services.EventSequences.EventSequences(
             grainFactory,

--- a/Source/Clients/Testing/EventSequences/InMemoryConstraintsStorage.cs
+++ b/Source/Clients/Testing/EventSequences/InMemoryConstraintsStorage.cs
@@ -61,7 +61,7 @@ internal sealed class InMemoryConstraintsStorage(ClientConstraints.ICanProvideCo
         {
             return new KernelConstraints::UniqueEventTypeConstraintDefinition(
                 (KernelConstraints::ConstraintName)uniqueType.Name.Value,
-                (KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId)uniqueType.EventTypeId.Value);
+                uniqueType.EventTypeIds.Select(_ => (KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId)_.Value).ToArray());
         }
 
         return null;

--- a/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
+++ b/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
@@ -69,7 +69,7 @@ internal static class InProcessEventSequence
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
 
         var eventTypeMigrations = new KernelMigrations::EventTypeMigrations(storage, expandoObjectConverter);
-        var jsonComplianceManager = new KernelCompliance::JsonComplianceManager(new KnownInstancesOf<KernelCompliance::IJsonCompliancePropertyValueHandler>());
+        var jsonComplianceManager = new KernelCompliance::JsonComplianceManager(new KnownInstancesOf<KernelCompliance::IJsonCompliancePropertyValueHandler>(), NullLogger<KernelCompliance::JsonComplianceManager>.Instance);
         var eventSerializer = new KernelEventSequences::EventSerializer(
             new InMemoryKernelEventTypes(),
             expandoObjectConverter,

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -356,7 +356,8 @@ public class EventStoreForTesting : IEventStore
         var grainFactory = new InProcessGrainFactory(grain);
         var eventCompliance = new KernelCore::Cratis.Chronicle.Events.EventCompliance(
             new KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager(
-                new KnownInstancesOf<KernelCore::Cratis.Chronicle.Compliance.IJsonCompliancePropertyValueHandler>()),
+                new KnownInstancesOf<KernelCore::Cratis.Chronicle.Compliance.IJsonCompliancePropertyValueHandler>(),
+                NullLogger<KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager>.Instance),
             new ExpandoObjectConverter(new TypeFormats()));
 
         var eventSequencesService = new KernelCore::Cratis.Chronicle.Services.EventSequences.EventSequences(

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -141,7 +141,7 @@ internal sealed class TestingServices(
             grainFactory,
             storage,
             new KernelEventCompliance(
-                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>()),
+                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
                 new ExpandoObjectConverter(new TypeFormats())),
             jsonSerializerOptions));
 
@@ -184,17 +184,17 @@ internal sealed class TestingServices(
             // object-reference lookups throw NotSupportedException), so no local silo details are needed.
             null!,
             new KernelReadModelsCompliance(
-                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>()),
+                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
                 new ExpandoObjectConverter(new TypeFormats())),
             new KernelEventCompliance(
-                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>()),
+                new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
                 new ExpandoObjectConverter(new TypeFormats())),
             jsonSerializerOptions));
 
     readonly Lazy<ICompliance> _compliance = new(() =>
         new KernelComplianceService(
             grainFactory,
-            new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>()),
+            new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
             NullLogger<KernelComplianceService>.Instance));
 
     /// <inheritdoc/>

--- a/Source/Kernel/Concepts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
+++ b/Source/Kernel/Concepts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
@@ -7,12 +7,47 @@ namespace Cratis.Chronicle.Concepts.Events.Constraints;
 /// Represents a definition of a unique event type constraint.
 /// </summary>
 /// <param name="Name">Name of the constraint.</param>
-/// <param name="EventTypeId">The <see cref="EventTypeId"/> the constraint is for.</param>
+/// <param name="EventTypeIds">The <see cref="EventTypeId"/> values the constraint covers.</param>
 /// <param name="Scope">The <see cref="ConstraintScope"/> for the constraint.</param>
-public record UniqueEventTypeConstraintDefinition(ConstraintName Name, EventTypeId EventTypeId, ConstraintScope? Scope = default) : IConstraintDefinition
+/// <remarks>
+/// The constraint allows at most one event drawn from the covered event types per event source. A single event
+/// type expresses "this event happens at most once"; several express mutual exclusion — an event source that is
+/// terminal through either of two outcomes can have one of them, never both and never twice.
+/// </remarks>
+public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerable<EventTypeId> EventTypeIds, ConstraintScope? Scope = default) : IConstraintDefinition
 {
     /// <inheritdoc/>
-    public bool Equals(IConstraintDefinition? other) => base.Equals(other);
+    public bool Equals(IConstraintDefinition? other) => Equals(other as UniqueEventTypeConstraintDefinition);
+
+    /// <summary>
+    /// Compare with another <see cref="UniqueEventTypeConstraintDefinition"/> by value.
+    /// </summary>
+    /// <param name="other">The definition to compare with.</param>
+    /// <returns>True if the definitions carry the same content, false otherwise.</returns>
+    /// <remarks>
+    /// The generated record equality would compare the event type ids by reference, and registration decides
+    /// whether a constraint changed by comparing the incoming definition to the stored one — so reference
+    /// equality would report every re-registration as a change. The collection is therefore compared by content.
+    /// </remarks>
+    public virtual bool Equals(UniqueEventTypeConstraintDefinition? other) =>
+        other is not null &&
+        Name == other.Name &&
+        Scope == other.Scope &&
+        EventTypeIds.SequenceEqual(other.EventTypeIds);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hashCode = default(HashCode);
+        hashCode.Add(Name);
+        hashCode.Add(Scope);
+        foreach (var eventTypeId in EventTypeIds)
+        {
+            hashCode.Add(eventTypeId);
+        }
+
+        return hashCode.ToHashCode();
+    }
 
     /// <inheritdoc/>
     public ConstraintChange CompareWith(IConstraintDefinition existing) => ConstraintChange.None;

--- a/Source/Kernel/Contracts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
+++ b/Source/Kernel/Contracts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
@@ -10,8 +10,12 @@ namespace Cratis.Chronicle.Contracts.Events.Constraints;
 public class UniqueEventTypeConstraintDefinition
 {
     /// <summary>
-    /// Gets or sets the event type identifier for the unique constraint.
+    /// Gets or sets the event type identifiers the unique constraint covers.
     /// </summary>
-    [ProtoMember(1)]
-    public string EventTypeId { get; set; }
+    /// <remarks>
+    /// At most one event drawn from these types is allowed per event source. Field 1 held the single
+    /// EventTypeId this replaces and is reserved so an older payload is ignored rather than misread.
+    /// </remarks>
+    [ProtoMember(2)]
+    public IList<string> EventTypeIds { get; set; }
 }

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing.cs
@@ -18,6 +18,7 @@ public class when_releasing : given.a_property_handler
     {
         _input = JsonValue.Create(Convert.ToBase64String(Encoding.UTF8.GetBytes("42")));
         _encryptedBytes = Encoding.UTF8.GetBytes(_decryptedString);
+        _encryption.IsEncrypted(Arg.Any<byte[]>()).Returns(true);
         _encryption.Decrypt(Arg.Any<byte[]>(), _key).Returns(_encryptedBytes);
     }
 

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_a_value_that_was_never_encrypted/and_it_does_not_carry_the_encryption_format.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_a_value_that_was_never_encrypted/and_it_does_not_carry_the_encryption_format.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.when_releasing_a_value_that_was_never_encrypted;
+
+/// <summary>
+/// The value decodes as base64 but carries none of the shape encryption produces, so it was never encrypted
+/// under this subject. Releasing it is a no-op — the subject owning a key says nothing about this value.
+/// </summary>
+public class and_it_does_not_carry_the_encryption_format : given.a_property_handler
+{
+    JsonNode _input;
+    JsonNode _result;
+
+    void Establish()
+    {
+        _input = JsonValue.Create(Convert.ToBase64String(Encoding.UTF8.GetBytes("Jane Doe")));
+        _encryption.IsEncrypted(Arg.Any<byte[]>()).Returns(false);
+    }
+
+    async Task Because() => _result = await _handler.Release(EventStoreName.NotSet, EventStoreNamespaceName.NotSet, Identifier, _input);
+
+    [Fact] void should_pass_the_value_through_untouched() => _result.ToString().ShouldEqual(_input.ToString());
+    [Fact] void should_not_attempt_to_decrypt() => _encryption.DidNotReceive().Decrypt(Arg.Any<byte[]>(), Arg.Any<EncryptionKey>());
+}

--- a/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_a_value_that_was_never_encrypted/and_it_is_not_base64.cs
+++ b/Source/Kernel/Core.Specs/Compliance/GDPR/for_PIICompliancePropertyValueHandler/when_releasing_a_value_that_was_never_encrypted/and_it_is_not_base64.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage.Compliance;
+
+namespace Cratis.Chronicle.Compliance.GDPR.for_PIICompliancePropertyValueHandler.when_releasing_a_value_that_was_never_encrypted;
+
+/// <summary>
+/// A display name resolved in memory at the query edge is plain text, not base64 — the shape that used to fail
+/// the entire enclosing query on a FormatException before it ever reached decryption.
+/// </summary>
+public class and_it_is_not_base64 : given.a_property_handler
+{
+    const string Plaintext = "Jane Doe";
+
+    JsonNode _result;
+
+    async Task Because() => _result = await _handler.Release(
+        EventStoreName.NotSet,
+        EventStoreNamespaceName.NotSet,
+        Identifier,
+        JsonValue.Create(Plaintext));
+
+    [Fact] void should_pass_the_value_through_untouched() => _result.ToString().ShouldEqual(Plaintext);
+    [Fact] void should_not_attempt_to_decrypt() => _encryption.DidNotReceive().Decrypt(Arg.Any<byte[]>(), Arg.Any<EncryptionKey>());
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_Encryption/when_checking_if_a_value_is_encrypted.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_Encryption/when_checking_if_a_value_is_encrypted.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Cratis.Chronicle.Compliance.for_Encryption;
+
+/// <summary>
+/// Releasing has to tell a value that was encrypted from one that never was — a value resolved in memory at the
+/// query edge, or one written before its property was marked [PII]. Without that, releasing the latter either
+/// blanks it (silent data loss) or throws (failing the whole query over one property).
+/// </summary>
+public class when_checking_if_a_value_is_encrypted : given.a_key
+{
+    [Fact] void should_recognize_a_value_it_encrypted() =>
+        _encryption.IsEncrypted(_encryption.Encrypt(Encoding.UTF8.GetBytes("sensitive"), _key)).ShouldBeTrue();
+
+    [Fact] void should_recognize_an_encrypted_empty_value() =>
+        _encryption.IsEncrypted(_encryption.Encrypt([], _key)).ShouldBeTrue();
+
+    [Fact] void should_not_recognize_plaintext() =>
+        _encryption.IsEncrypted(Encoding.UTF8.GetBytes("Jane Doe")).ShouldBeFalse();
+
+    [Fact] void should_not_recognize_plaintext_that_is_short_enough_to_decode_as_base64() =>
+        _encryption.IsEncrypted(Encoding.UTF8.GetBytes("Jane")).ShouldBeFalse();
+
+    [Fact] void should_not_recognize_no_value_at_all() =>
+        _encryption.IsEncrypted([]).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_list.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_list.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -45,6 +46,6 @@ public class a_value_handler_and_a_type_with_a_compliant_list : Specification
 
         _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
         _valueHandler.Type.Returns(_metadataType);
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler), NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_member_on_a_nested_object.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_member_on_a_nested_object.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -36,6 +37,6 @@ public class a_value_handler_and_a_type_with_a_compliant_member_on_a_nested_obje
 
         _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
         _valueHandler.Type.Returns(_metadataType);
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler), NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_value_object.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_compliant_value_object.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -47,6 +48,6 @@ public class a_value_handler_and_a_type_with_a_compliant_value_object : Specific
         _valueHandler.Release(string.Empty, string.Empty, Identifier, Arg.Any<JsonNode>())
             .Returns(callInfo => Task.FromResult<JsonNode>(JsonValue.Create(Encoding.UTF8.GetString(Convert.FromBase64String(callInfo.ArgAt<JsonNode>(3).GetValue<string>())))));
 
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler), NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_compliant_scalars.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_compliant_scalars.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -32,6 +33,6 @@ public class a_value_handler_and_a_type_with_a_list_of_compliant_scalars : Speci
 
         _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
         _valueHandler.Type.Returns(_metadataType);
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler), NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_member.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -36,6 +37,6 @@ public class a_value_handler_and_a_type_with_a_list_of_objects_with_a_compliant_
 
         _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
         _valueHandler.Type.Returns(_metadataType);
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler), NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_one_property.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/a_value_handler_and_a_type_with_one_property.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
@@ -21,6 +22,8 @@ public class a_value_handler_and_a_type_with_one_property : a_type_with_one_prop
 
         _valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
         _valueHandler.Type.Returns(_metadataType);
-        _manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler));
+        _manager = new(
+            new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(_valueHandler),
+            NullLogger<JsonComplianceManager>.Instance);
     }
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/no_value_handlers_and_a_type_with_one_property.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/given/no_value_handlers_and_a_type_with_one_property.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager.given;
 
 public class no_value_handlers_and_a_type_with_one_property : a_type_with_one_property
 {
     protected JsonComplianceManager manager;
 
-    void Establish() => manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>());
+    void Establish() => manager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(), NullLogger<JsonComplianceManager>.Instance);
 }

--- a/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_fails_with_a_decryption_error.cs
+++ b/Source/Kernel/Core.Specs/Compliance/for_JsonComplianceManager/when_releasing_fails_with_a_decryption_error.cs
@@ -9,36 +9,31 @@ namespace Cratis.Chronicle.Compliance.for_JsonComplianceManager;
 
 /// <summary>
 /// A release that fails to decrypt means the value was encrypted under a different subject — the classic cause
-/// being a projection join copying [PII] out of another event source's stream. The underlying cryptography only
-/// reports an opaque padding error, so the diagnostic has to name the property, the subject, and the likely cause.
+/// being a projection join copying [PII] out of another event source's stream. That is a real modeling defect,
+/// but it belongs to a single property: failing the release would take down every other property in the result
+/// and the query returning it. The property is surfaced as empty — the shape an erased subject already
+/// produces — and the diagnostic naming the property, the subject and the likely cause goes to the log.
 /// </summary>
 public class when_releasing_fails_with_a_decryption_error : given.a_value_handler_and_a_type_with_one_property
 {
     const string Identifier = "request-42";
 
     Exception _exception;
+    JsonObject _result;
 
     void Establish() =>
         _valueHandler
             .Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<string>(), Arg.Any<JsonNode>())
             .Returns<Task<JsonNode>>(_ => throw new CryptographicException("error:02000079:rsa routines::oaep decoding error"));
 
-    async Task Because() => _exception = await Catch.Exception(() => _manager.Release(
+    async Task Because() => _exception = await Catch.Exception(async () => _result = await _manager.Release(
         EventStoreName.NotSet,
         EventStoreNamespaceName.Default,
         _schema,
         Identifier,
         _input));
 
-    [Fact] void should_fail_with_the_compliance_action_exception() => _exception.ShouldBeOfExactType<ComplianceMetadataActionFailed>();
+    [Fact] void should_not_fail_the_release() => _exception.ShouldBeNull();
 
-    [Fact] void should_name_the_property() => _exception.Message.ShouldContain(PropertyName);
-
-    [Fact] void should_name_the_subject_it_was_released_under() => _exception.Message.ShouldContain(Identifier);
-
-    [Fact] void should_explain_the_value_belongs_to_another_subject() => _exception.Message.ShouldContain("encrypted under a different subject");
-
-    [Fact] void should_point_at_the_analyzer_that_prevents_it() => _exception.Message.ShouldContain("CHR0038");
-
-    [Fact] void should_keep_the_underlying_error() => _exception.InnerException.ShouldBeOfExactType<CryptographicException>();
+    [Fact] void should_surface_the_unreadable_property_as_empty() => _result[PropertyName].ToString().ShouldEqual(string.Empty);
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintDefinitionComparison/when_computing_version/and_definitions_are_equal_but_distinct_instances.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintDefinitionComparison/when_computing_version/and_definitions_are_equal_but_distinct_instances.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Events.Constraints;
 
 namespace Cratis.Chronicle.Events.Constraints.for_ConstraintDefinitionComparison.when_computing_version;
@@ -15,12 +16,12 @@ public class and_definitions_are_equal_but_distinct_instances : Specification
         _first = ConstraintDefinitionComparison.ComputeVersion(
         [
             new UniqueConstraintDefinition("unique-thing", [new UniqueConstraintEventDefinition("some-event", ["Some"])]),
-            new UniqueEventTypeConstraintDefinition("unique-type", "another-event")
+            new UniqueEventTypeConstraintDefinition("unique-type", [(EventTypeId)"another-event"])
         ]);
         _second = ConstraintDefinitionComparison.ComputeVersion(
         [
             new UniqueConstraintDefinition("unique-thing", [new UniqueConstraintEventDefinition("some-event", ["Some"])]),
-            new UniqueEventTypeConstraintDefinition("unique-type", "another-event")
+            new UniqueEventTypeConstraintDefinition("unique-type", [(EventTypeId)"another-event"])
         ]);
     }
 

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintValidationFactory/when_creating_with_different_constraint_definition_types.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintValidationFactory/when_creating_with_different_constraint_definition_types.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Storage;
@@ -38,7 +39,7 @@ public class when_creating_with_different_constraint_definition_types : Specific
         _eventStoreStorage.Constraints.Returns(_constraintsStorage);
         _constraintsStorage.GetDefinitions().Returns([
             new UniqueConstraintDefinition("SomeUniqueConstraint", []),
-            new UniqueEventTypeConstraintDefinition("SomeUniqueEventTypeConstraint", "SomeEventType")
+            new UniqueEventTypeConstraintDefinition("SomeUniqueEventTypeConstraint", [(EventTypeId)"SomeEventType"])
         ]);
 
         _factory = new ConstraintValidationFactory(_storage);

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintValidatorExtensions/when_creating_violation_from_validator/of_type_unique_event_type_constraint_validator.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_ConstraintValidatorExtensions/when_creating_violation_from_validator/of_type_unique_event_type_constraint_validator.cs
@@ -12,7 +12,7 @@ public class of_type_unique_event_type_constraint_validator : given.a_constraint
 
     IConstraintValidator _validator;
 
-    void Establish() => _validator = new UniqueEventTypeConstraintValidator(new UniqueEventTypeConstraintDefinition(ConstraintName, _eventType.Id), Substitute.For<IUniqueEventTypesConstraintsStorage>());
+    void Establish() => _validator = new UniqueEventTypeConstraintValidator(new UniqueEventTypeConstraintDefinition(ConstraintName, [_eventType.Id]), Substitute.For<IUniqueEventTypesConstraintsStorage>());
 
     void Because() => _result = _validator.CreateViolation(_context, _sequenceNumber, _message, _details);
 

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/given/a_unique_event_type_constraint_validator_with_valid_definition.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/given/a_unique_event_type_constraint_validator_with_valid_definition.cs
@@ -13,5 +13,5 @@ public class a_unique_event_type_constraint_validator_with_valid_definition : a_
 
     void Establish() => _context = new([], EventSourceId.New(), _eventType.Id, new());
 
-    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", _eventType.Id);
+    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", [_eventType.Id]);
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_does_not_support_event_type.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_does_not_support_event_type.cs
@@ -14,7 +14,7 @@ public class and_it_does_not_support_event_type : given.a_unique_event_type_cons
 
     void Establish() => _context = new([], EventSourceId.New(), "SomeEvent", new());
 
-    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", "SomeOtherEvent");
+    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", [(EventTypeId)"SomeOtherEvent"]);
 
     void Because() => _result = _validator.CanValidate(_context);
 

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_event_type.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_event_type.cs
@@ -16,7 +16,7 @@ public class and_it_supports_event_type : given.a_unique_event_type_constraint_v
 
     void Establish() => _context = new([], EventSourceId.New(), _eventType.Id, new());
 
-    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", _eventType.Id);
+    protected override UniqueEventTypeConstraintDefinition Definition => new("SomeConstraint", [_eventType.Id]);
 
     void Because() => _result = _validator.CanValidate(_context);
 

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_one_of_several_event_types.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_one_of_several_event_types.cs
@@ -16,7 +16,7 @@ public class and_it_supports_one_of_several_event_types : given.a_unique_event_t
 
     ConstraintValidationContext _context;
 
-    EventType _erasedEventType = new("PersonErased", 1);
+    readonly EventType _erasedEventType = new("PersonErased", 1);
 
     void Establish() => _context = new([], EventSourceId.New(), _erasedEventType.Id, new());
 

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_one_of_several_event_types.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_asking_can_validate/and_it_supports_one_of_several_event_types.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_asking_can_validate;
+
+/// <summary>
+/// A constraint covering several event types validates every one of them — that is what makes them mutually
+/// exclusive rather than independently unique.
+/// </summary>
+public class and_it_supports_one_of_several_event_types : given.a_unique_event_type_constraint_validator
+{
+    bool _result;
+
+    ConstraintValidationContext _context;
+
+    EventType _erasedEventType = new("PersonErased", 1);
+
+    void Establish() => _context = new([], EventSourceId.New(), _erasedEventType.Id, new());
+
+    protected override UniqueEventTypeConstraintDefinition Definition =>
+        new("PersonTerminal", [(EventTypeId)"PersonAliasedTo", _erasedEventType.Id]);
+
+    void Because() => _result = _validator.CanValidate(_context);
+
+    [Fact] void should_be_able_to_validate() => _result.ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_a_mutually_exclusive_event_type_was_already_appended.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_a_mutually_exclusive_event_type_was_already_appended.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Storage.Events.Constraints;
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_validating;
+
+/// <summary>
+/// The invariant CHR-25 asks for: an event source terminal through one outcome cannot then take the other. The
+/// validator asks storage about every covered event type, not only the one being appended — asking about just
+/// the incoming type would let the second outcome through, since that type itself has not been appended yet.
+/// </summary>
+public class and_a_mutually_exclusive_event_type_was_already_appended : Specification
+{
+    UniqueEventTypeConstraintValidator _validator;
+    IUniqueEventTypesConstraintsStorage _storage;
+    ConstraintValidationContext _context;
+    ConstraintValidationResult _result;
+
+    readonly EventType _aliasedEventType = new("PersonAliasedTo", 1);
+    readonly EventType _erasedEventType = new("PersonErased", 1);
+
+    void Establish()
+    {
+        _storage = Substitute.For<IUniqueEventTypesConstraintsStorage>();
+        var definition = new UniqueEventTypeConstraintDefinition(
+            "PersonTerminal",
+            [_aliasedEventType.Id, _erasedEventType.Id]);
+
+        _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
+        _context = new([], EventSourceId.New(), _erasedEventType.Id, new ExpandoObject());
+
+        // The person was already merged away — the sibling event type, not the one being appended.
+        _storage
+            .IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), Arg.Any<string>())
+            .Returns((false, (EventSequenceNumber)7U));
+    }
+
+    async Task Because() => _result = await _validator.Validate(_context);
+
+    [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
+    [Fact] void should_have_violations() => _result.Violations.ShouldNotBeEmpty();
+    [Fact] async Task should_ask_storage_about_every_covered_event_type() =>
+        await _storage.Received(1).IsAllowed(
+            Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_aliasedEventType.Id) && _.Contains(_erasedEventType.Id)),
+            Arg.Any<EventSourceId>(),
+            Arg.Any<string>());
+}

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed.cs
@@ -11,7 +11,7 @@ public class and_event_type_for_event_source_id_is_allowed : given.a_unique_even
 
     void Establish()
     {
-        _storage.IsAllowed(_eventType.Id, _context.EventSourceId).Returns((true, EventSequenceNumber.First));
+        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_eventType.Id)), _context.EventSourceId).Returns((true, EventSequenceNumber.First));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed_with_scope.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed_with_scope.cs
@@ -21,17 +21,17 @@ public class and_event_type_for_event_source_id_is_allowed_with_scope : Specific
         var eventType = new EventType("SomeEvent", 1);
         var definition = new UniqueEventTypeConstraintDefinition(
             "ScopedConstraint",
-            eventType.Id,
+            [eventType.Id],
             Scope: new ConstraintScope(EventSourceType: "MySourceType"));
 
         _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
         _context = new([], EventSourceId.New(), eventType.Id, new ExpandoObject(), eventSourceType: "MySourceType");
 
-        _storage.IsAllowed(eventType.Id, _context.EventSourceId, "est:MySourceType").Returns((true, EventSequenceNumber.First));
+        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((true, EventSequenceNumber.First));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);
 
     [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
-    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<EventTypeId>(), Arg.Any<EventSourceId>(), "est:MySourceType");
+    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), "est:MySourceType");
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
+
 namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_validating;
 
 public class and_event_type_for_event_source_id_is_not_allowed : given.a_unique_event_type_constraint_validator_with_valid_definition
@@ -9,7 +11,7 @@ public class and_event_type_for_event_source_id_is_not_allowed : given.a_unique_
 
     void Establish()
     {
-        _storage.IsAllowed(_eventType.Id, _context.EventSourceId).Returns((false, 43U));
+        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_eventType.Id)), _context.EventSourceId).Returns((false, 43U));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed_with_scope.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed_with_scope.cs
@@ -21,18 +21,18 @@ public class and_event_type_for_event_source_id_is_not_allowed_with_scope : Spec
         var eventType = new EventType("SomeEvent", 1);
         var definition = new UniqueEventTypeConstraintDefinition(
             "ScopedConstraint",
-            eventType.Id,
+            [eventType.Id],
             Scope: new ConstraintScope(EventSourceType: "MySourceType"));
 
         _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
         _context = new([], EventSourceId.New(), eventType.Id, new ExpandoObject(), eventSourceType: "MySourceType");
 
-        _storage.IsAllowed(eventType.Id, _context.EventSourceId, "est:MySourceType").Returns((false, 42U));
+        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((false, 42U));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);
 
     [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
     [Fact] void should_have_violations() => _result.Violations.ShouldNotBeEmpty();
-    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<EventTypeId>(), Arg.Any<EventSourceId>(), "est:MySourceType");
+    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), "est:MySourceType");
 }

--- a/Source/Kernel/Core.Specs/Events/for_EventCompliance/when_releasing_event_content/and_event_has_multiple_pii_properties.cs
+++ b/Source/Kernel/Core.Specs/Events/for_EventCompliance/when_releasing_event_content/and_event_has_multiple_pii_properties.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Events.for_EventCompliance.when_releasing_event_content;
 
@@ -51,7 +52,7 @@ public class and_event_has_multiple_pii_properties : Specification
         var encryption = new Encryption();
         var keyStorage = new InMemoryEncryptionKeyStorage();
         var piiHandler = new PIICompliancePropertyValueHandler(keyStorage, encryption);
-        _complianceManager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(piiHandler));
+        _complianceManager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(piiHandler), NullLogger<JsonComplianceManager>.Instance);
         _converter = new(new TypeFormats());
     }
 

--- a/Source/Kernel/Core.Specs/Patches/for_RebuildConstraintIndexes/when_applying_up/and_no_unique_constraints_are_registered.cs
+++ b/Source/Kernel/Core.Specs/Patches/for_RebuildConstraintIndexes/when_applying_up/and_no_unique_constraints_are_registered.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Events.Constraints;
 
@@ -10,7 +11,7 @@ public class and_no_unique_constraints_are_registered : given.a_rebuild_constrai
 {
     void Establish() =>
         _constraintsStorage.GetDefinitions().Returns(Task.FromResult<IEnumerable<IConstraintDefinition>>(
-            [new UniqueEventTypeConstraintDefinition("SomeConstraint", "SomeEvent")]));
+            [new UniqueEventTypeConstraintDefinition("SomeConstraint", [(EventTypeId)"SomeEvent"])]));
 
     async Task Because() => await _patch.Up();
 

--- a/Source/Kernel/Core.Specs/Patches/for_RebuildConstraintIndexes/when_applying_up/and_unique_constraints_are_registered.cs
+++ b/Source/Kernel/Core.Specs/Patches/for_RebuildConstraintIndexes/when_applying_up/and_unique_constraints_are_registered.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Jobs;
@@ -18,7 +19,7 @@ public class and_unique_constraints_are_registered : given.a_rebuild_constraint_
     void Establish()
     {
         _uniqueConstraint = new UniqueConstraintDefinition("SomeUniqueConstraint", [new("SomeEvent", ["SomeProperty"])]);
-        _uniqueEventTypeConstraint = new UniqueEventTypeConstraintDefinition("SomeUniqueEventTypeConstraint", "SomeOtherEvent");
+        _uniqueEventTypeConstraint = new UniqueEventTypeConstraintDefinition("SomeUniqueEventTypeConstraint", [(EventTypeId)"SomeOtherEvent"]);
 
         _constraintsStorage.GetDefinitions().Returns(Task.FromResult<IEnumerable<IConstraintDefinition>>(
             [_uniqueConstraint, _uniqueEventTypeConstraint]));

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_EncryptChangeset/when_performing/and_read_model_has_a_child_collection_with_pii.cs
@@ -12,6 +12,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_EncryptChangeset.when_performing;
 
@@ -49,7 +50,8 @@ public class and_read_model_has_a_child_collection_with_pii : Specification
         var typeFormats = new TypeFormats();
         var complianceManager = new JsonComplianceManager(
             new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
-                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())),
+            NullLogger<JsonComplianceManager>.Instance);
         var compliance = new ReadModelsCompliance(complianceManager, new ExpandoObjectConverter(typeFormats));
         var objectComparer = new ObjectComparer();
         _step = new EncryptChangeset(compliance, objectComparer, "test-store", "test-namespace");

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_round_tripping/and_state_with_multiple_pii_properties_is_reapplied.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_round_tripping/and_state_with_multiple_pii_properties_is_reapplied.cs
@@ -7,6 +7,7 @@ using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.ReadModels.for_ReadModelsCompliance.when_round_tripping;
 
@@ -76,7 +77,7 @@ public class and_state_with_multiple_pii_properties_is_reapplied : Specification
         var encryption = new Encryption();
         var keyStorage = new InMemoryEncryptionKeyStorage();
         var piiHandler = new PIICompliancePropertyValueHandler(keyStorage, encryption);
-        _complianceManager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(piiHandler));
+        _complianceManager = new(new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(piiHandler), NullLogger<JsonComplianceManager>.Instance);
         _converter = new(new TypeFormats());
         _compliance = new ReadModelsCompliance(_complianceManager, _converter);
 

--- a/Source/Kernel/Core/Compliance/Encryption.cs
+++ b/Source/Kernel/Core/Compliance/Encryption.cs
@@ -27,6 +27,7 @@ public class Encryption : IEncryption
     const int NonceSizeInBytes = 12;
     const int TagSizeInBytes = 16;
     const byte EnvelopeVersion = 1;
+    const int LegacyCiphertextSizeInBytes = KeySize / 8;
 
     static readonly byte[] _envelopeMagic = "CENV"u8.ToArray();
     static readonly RSAEncryptionPadding _keyWrapPadding = RSAEncryptionPadding.OaepSHA256;
@@ -65,6 +66,15 @@ public class Encryption : IEncryption
         {
             CryptographicOperations.ZeroMemory(dataKey);
         }
+    }
+
+    /// <inheritdoc/>
+    public bool IsEncrypted(byte[] bytes)
+    {
+        // A current value is identified by its envelope marker. A legacy value (raw RSA over the whole payload,
+        // see DecryptLegacy) carries no marker of its own, so what identifies it is its length — raw RSA always
+        // produced exactly one modulus-sized block.
+        return TryReadEnvelope(bytes, out _, out _, out _, out _) || bytes.Length == LegacyCiphertextSizeInBytes;
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
+++ b/Source/Kernel/Core/Compliance/GDPR/PIICompliancePropertyValueHandler.cs
@@ -50,11 +50,45 @@ public class PIICompliancePropertyValueHandler(IEncryptionKeyStorage encryptionK
             return JsonValue.Create(string.Empty);
         }
 
-        var encryptedAsString = value.ToString();
-        var encrypted = Convert.FromBase64String(encryptedAsString);
+        // Only a value this encryption produced can be released. One that carries none of its shape was never
+        // encrypted under this subject — it is resolved in memory at the query edge for display, or it predates
+        // the property being marked [PII]. Releasing it is a no-op, so pass it through: blanking it would be
+        // silent data loss indistinguishable from erasure, and throwing would fail an entire query over a
+        // single property.
+        if (!TryDecodeEncryptedValue(value.ToString(), out var encrypted))
+        {
+            return value;
+        }
+
         var decrypted = _encryption.Decrypt(encrypted, key);
         var decryptedAsString = Encoding.UTF8.GetString(decrypted);
         return JsonValue.Create(decryptedAsString);
+    }
+
+    bool TryDecodeEncryptedValue(string value, out byte[] encrypted)
+    {
+        encrypted = [];
+
+        // Base64 encodes four characters per three bytes, so anything else cannot be a value Apply produced.
+        if (value.Length == 0 || value.Length % 4 != 0)
+        {
+            return false;
+        }
+
+        var buffer = new byte[value.Length / 4 * 3];
+        if (!Convert.TryFromBase64String(value, buffer, out var bytesWritten))
+        {
+            return false;
+        }
+
+        var decoded = buffer[..bytesWritten];
+        if (!_encryption.IsEncrypted(decoded))
+        {
+            return false;
+        }
+
+        encrypted = decoded;
+        return true;
     }
 
     async Task<EncryptionKey> EnsureKeyFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, EncryptionKeyIdentifier identifier)

--- a/Source/Kernel/Core/Compliance/IEncryption.cs
+++ b/Source/Kernel/Core/Compliance/IEncryption.cs
@@ -31,4 +31,17 @@ public interface IEncryption
     /// <param name="key">Key to use.</param>
     /// <returns>Decrypted bytes.</returns>
     byte[] Decrypt(byte[] bytes, EncryptionKey key);
+
+    /// <summary>
+    /// Check whether bytes carry the shape this encryption produces.
+    /// </summary>
+    /// <param name="bytes">Bytes to check.</param>
+    /// <returns>True if the bytes could have been produced by <see cref="Encrypt"/>, false otherwise.</returns>
+    /// <remarks>
+    /// This tells apart a value that was encrypted from one that never was, so that releasing a value which
+    /// was never protected can be a no-op instead of an error. It is a structural check on the format only —
+    /// it says nothing about which subject's key the value belongs to, and a value it accepts can still fail
+    /// to decrypt.
+    /// </remarks>
+    bool IsEncrypted(byte[] bytes);
 }

--- a/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManager.cs
@@ -6,6 +6,7 @@ using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Schemas;
 using Cratis.DependencyInjection;
 using Cratis.Types;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Compliance;
 
@@ -16,8 +17,11 @@ namespace Cratis.Chronicle.Compliance;
 /// Initializes a new instance of the <see cref="JsonComplianceManager"/> class.
 /// </remarks>
 /// <param name="propertyValueHandlers">Instances of <see cref="IJsonCompliancePropertyValueHandler"/>.</param>
+/// <param name="logger"><see cref="ILogger"/> for logging.</param>
 [Singleton]
-public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHandler> propertyValueHandlers) : IJsonComplianceManager
+public class JsonComplianceManager(
+    IInstancesOf<IJsonCompliancePropertyValueHandler> propertyValueHandlers,
+    ILogger<JsonComplianceManager> logger) : IJsonComplianceManager
 {
     readonly Dictionary<ComplianceMetadataType, IJsonCompliancePropertyValueHandler> _propertyValueHandlers = propertyValueHandlers.ToDictionary(_ => _.Type, _ => _);
 
@@ -107,7 +111,20 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                         }
                         catch (Exception ex)
                         {
-                            throw new ComplianceMetadataActionFailed(actionName, propertyPath, identifier, ex);
+                            var failure = new ComplianceMetadataActionFailed(actionName, propertyPath, identifier, ex);
+
+                            // Applying has to fail loudly — storing PII that was never protected is never acceptable.
+                            // Releasing must not: a single unreadable property is no reason to fail an entire query,
+                            // so surface it as empty — the shape an erased subject already produces — and keep the
+                            // diagnostic, which names the property, the subject and the likely cause, in the log.
+                            if (actionName != ComplianceMetadataActionFailed.ReleaseAction)
+                            {
+                                throw failure;
+                            }
+
+                            logger.FailedToReleaseProperty(propertyPath, identifier, failure);
+                            json[property] = RestoreReleasedContainerShape(JsonValue.Create(string.Empty), propertySchema);
+                            handlerApplied = true;
                         }
                     }
                 }
@@ -176,7 +193,17 @@ public class JsonComplianceManager(IInstancesOf<IJsonCompliancePropertyValueHand
                             }
                             catch (Exception ex)
                             {
-                                throw new ComplianceMetadataActionFailed(actionName, elementPath, identifier, ex);
+                                var failure = new ComplianceMetadataActionFailed(actionName, elementPath, identifier, ex);
+
+                                // Same asymmetry as the property walk above — apply fails, release degrades the
+                                // single element so the rest of the array, and the query, still come back.
+                                if (actionName != ComplianceMetadataActionFailed.ReleaseAction)
+                                {
+                                    throw failure;
+                                }
+
+                                logger.FailedToReleaseProperty(elementPath, identifier, failure);
+                                array[i] = JsonValue.Create(string.Empty);
                             }
                         }
                     }

--- a/Source/Kernel/Core/Compliance/JsonComplianceManagerLogMessages.cs
+++ b/Source/Kernel/Core/Compliance/JsonComplianceManagerLogMessages.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Compliance;
+
+/// <summary>
+/// Log messages for <see cref="JsonComplianceManager"/>.
+/// </summary>
+internal static partial class JsonComplianceManagerLogMessages
+{
+    [LoggerMessage(LogLevel.Error, "Unable to release compliance metadata for property '{PropertyPath}' of '{Identifier}'. The property is surfaced as empty; every other property is unaffected")]
+    internal static partial void FailedToReleaseProperty(this ILogger<JsonComplianceManager> logger, string propertyPath, string identifier, Exception exception);
+}

--- a/Source/Kernel/Core/Events/Constraints/UniqueEventTypeConstraintValidator.cs
+++ b/Source/Kernel/Core/Events/Constraints/UniqueEventTypeConstraintValidator.cs
@@ -19,13 +19,16 @@ public class UniqueEventTypeConstraintValidator(
     public IConstraintDefinition Definition => definition;
 
     /// <inheritdoc/>
-    public bool CanValidate(ConstraintValidationContext context) => definition.EventTypeId == context.EventTypeId;
+    public bool CanValidate(ConstraintValidationContext context) => definition.EventTypeIds.Contains(context.EventTypeId);
 
     /// <inheritdoc/>
     public async Task<ConstraintValidationResult> Validate(ConstraintValidationContext context)
     {
         var scopeKey = definition.Scope.BuildScopeKey(context.EventSourceType, context.EventStreamType, context.EventStreamId);
-        var (isAllowed, sequenceNumber) = await storage.IsAllowed(context.EventTypeId, context.EventSourceId, scopeKey);
+
+        // Every covered event type is checked, not just the one being appended: the constraint allows at most
+        // one event from the set, so an event source that already has a sibling type blocks this one too.
+        var (isAllowed, sequenceNumber) = await storage.IsAllowed(definition.EventTypeIds, context.EventSourceId, scopeKey);
         return isAllowed ?
             ConstraintValidationResult.Success :
             new()

--- a/Source/Kernel/Core/Services/Events/Constraints/ConstraintConverters.cs
+++ b/Source/Kernel/Core/Services/Events/Constraints/ConstraintConverters.cs
@@ -33,7 +33,7 @@ internal static class ConstraintConverters
             Contracts.Events.Constraints.ConstraintType.UniqueEventType =>
                 new UniqueEventTypeConstraintDefinition(
                     constraint.Name,
-                    constraint.Definition.Value1!.EventTypeId,
+                    constraint.Definition.Value1!.EventTypeIds.Select(_ => (EventTypeId)_).ToArray(),
                     scope),
 
             _ => null!

--- a/Source/Kernel/Protobuf/events_constraints.proto
+++ b/Source/Kernel/Protobuf/events_constraints.proto
@@ -38,7 +38,8 @@ message UniqueConstraintEventDefinition {
    repeated string Properties = 2;
 }
 message UniqueEventTypeConstraintDefinition {
-   string EventTypeId = 1;
+   reserved 1;
+   repeated string EventTypeIds = 2;
 }
 service Constraints {
    rpc Register (RegisterConstraintsRequest) returns (.google.protobuf.Empty);

--- a/Source/Kernel/Storage.InMemory/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
@@ -21,13 +21,14 @@ public class UniqueEventTypesConstraintsStorage(
 {
     /// <inheritdoc/>
     public Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(
-        EventTypeId eventTypeId,
+        IEnumerable<EventTypeId> eventTypeIds,
         EventSourceId eventSourceId,
         string scopeKey = "")
     {
+        var coveredEventTypeIds = eventTypeIds.ToHashSet();
         var existing = eventSequenceStorage.Events
             .FirstOrDefault(_ =>
-                _.Context.EventType.Id == eventTypeId &&
+                coveredEventTypeIds.Contains(_.Context.EventType.Id) &&
                 _.Context.EventSourceId == eventSourceId);
 
         if (existing is not null)

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
@@ -12,6 +12,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -76,7 +77,8 @@ public abstract class a_child_collection_compliance_scenario(MongoDBFixture fixt
         var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
         ComplianceManager = new JsonComplianceManager(
             new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
-                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())),
+            NullLogger<JsonComplianceManager>.Instance);
         Compliance = new ReadModelsCompliance(ComplianceManager, complianceConverter);
 
         _databaseName = $"chronicle_child_collection_pii_{Guid.NewGuid():N}";

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
@@ -16,6 +16,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -76,7 +77,8 @@ public class when_a_projection_persists_a_child_collection_with_pii(when_a_proje
             var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
             var complianceManager = new JsonComplianceManager(
                 new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
-                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())),
+                NullLogger<JsonComplianceManager>.Instance);
             var compliance = new ReadModelsCompliance(complianceManager, complianceConverter);
             var objectComparer = new ObjectComparer();
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
@@ -16,6 +16,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -73,7 +74,8 @@ public class when_a_rekeyed_projection_persists_pii(MongoDBFixture fixture) : Sp
         var complianceConverter = new Cratis.Chronicle.Json.ExpandoObjectConverter(typeFormats);
         _complianceManager = new JsonComplianceManager(
             new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
-                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())));
+                new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())),
+            NullLogger<JsonComplianceManager>.Instance);
         _compliance = new ReadModelsCompliance(_complianceManager, complianceConverter);
 
         _databaseName = $"chronicle_rekeyed_pii_{Guid.NewGuid():N}";

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_round_trips_pii_through_both_sinks.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/when_a_reducer_round_trips_pii_through_both_sinks.cs
@@ -7,6 +7,7 @@ using Cratis.Chronicle.Compliance.GDPR;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Compliance;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_SinkParity;
 
@@ -59,7 +60,8 @@ public class when_a_reducer_round_trips_pii_through_both_sinks(MongoDBFixture fi
         new ReadModelsCompliance(
             new JsonComplianceManager(
                 new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(
-                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption()))),
+                    new PIICompliancePropertyValueHandler(new InMemoryEncryptionKeyStorage(), new Encryption())),
+                NullLogger<JsonComplianceManager>.Instance),
             new Cratis.Chronicle.Json.ExpandoObjectConverter(new TypeFormats()));
 
     [Fact] void should_round_trip_identically_across_sinks() => ParityReport.ShouldEqual(string.Empty);

--- a/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
@@ -18,9 +18,9 @@ public class UniqueEventTypesConstraintsStorage(IEventStoreNamespaceDatabase dat
     readonly IMongoCollection<Event> _collection = database.GetEventSequenceCollectionFor(eventSequenceId);
 
     /// <inheritdoc/>
-    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventTypeId eventTypeId, EventSourceId eventSourceId, string scopeKey = "")
+    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "")
     {
-        var filter = Builders<Event>.Filter.Eq(_ => _.Type, eventTypeId);
+        var filter = Builders<Event>.Filter.In(_ => _.Type, eventTypeIds);
         filter &= Builders<Event>.Filter.Eq(_ => _.EventSourceId, eventSourceId);
 
         using var result = await _collection.FindAsync(filter);

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueEventTypesConstraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueEventTypesConstraints/UniqueEventTypesConstraintsStorage.cs
@@ -19,14 +19,14 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.UniqueEventTypesCo
 public class UniqueEventTypesConstraintsStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, EventSequenceId eventSequenceId, IDatabase database) : IUniqueEventTypesConstraintsStorage
 {
     /// <inheritdoc/>
-    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventTypeId eventTypeId, EventSourceId eventSourceId, string scopeKey = "")
+    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "")
     {
         await using var scope = await database.EventSequenceTable(eventStore, @namespace, eventSequenceId);
 
-        var eventTypeIdValue = eventTypeId.Value;
+        var eventTypeIdValues = eventTypeIds.Select(_ => _.Value).ToArray();
         var eventSourceIdValue = eventSourceId.Value;
         var existing = await scope.DbContext.Events
-            .Where(e => e.Type == eventTypeIdValue &&
+            .Where(e => eventTypeIdValues.Contains(e.Type) &&
                        e.EventSourceId == eventSourceIdValue)
             .FirstOrDefaultAsync();
 

--- a/Source/Kernel/Storage/Events/Constraints/IUniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage/Events/Constraints/IUniqueEventTypesConstraintsStorage.cs
@@ -13,12 +13,16 @@ public interface IUniqueEventTypesConstraintsStorage
     /// <summary>
     /// Check if a constraint value exists.
     /// </summary>
-    /// <param name="eventTypeId"><see cref="EventType"/> to check.</param>
+    /// <param name="eventTypeIds">The <see cref="EventType"/> values the constraint covers.</param>
     /// <param name="eventSourceId"><see cref="EventSourceId"/> to check.</param>
     /// <param name="scopeKey">Optional scope key for scoped constraints.</param>
     /// <returns>
     /// Tuple containing a boolean saying whether or not its allowed to perform and the <see cref="EventSequenceNumber"/> for the item it violates.
     /// Returns <see cref="EventSequenceNumber.Unavailable"/> if it doesn't exist.
     /// </returns>
-    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(EventTypeId eventTypeId, EventSourceId eventSourceId, string scopeKey = "");
+    /// <remarks>
+    /// An append is allowed only when the event source carries none of the covered event types. Passing more
+    /// than one makes them mutually exclusive: the first of them to be appended blocks all of the others.
+    /// </remarks>
+    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "");
 }


### PR DESCRIPTION
# Summary

Releasing PII now degrades a single unreadable property instead of failing the whole read.

## Added

- Several event types declared under the same constraint name form one constraint allowing at most one event from that set per event source, making mutually exclusive outcomes enforceable at append time.
- `CHR0039` warns when a `Task`-returning testing assertion is discarded rather than awaited, where it can never fail and `CS4014` does not fire.

## Changed

- A `[PII]` value that Chronicle never encrypted is passed through untouched when releasing, instead of being blanked.

## Fixed

- Releasing a `[PII]` value encrypted under a different subject no longer fails the whole read model and the query returning it. That property is surfaced as empty and the diagnostic goes to the Kernel log.
- Releasing a `[PII]` value for a subject that never had an encryption key no longer returns an empty value indistinguishable from crypto-shredded erasure.
