### PR TITLE
Fix the Workbench showing nothing against in-memory storage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.6" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.7" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.6" />
     <PackageVersion Include="Cratis.Arc" Version="20.66.1" />
     <PackageVersion Include="Cratis.Arc.Core" Version="20.66.1" />

--- a/Source/Kernel/Contracts/EventSequences/AppendRequest.cs
+++ b/Source/Kernel/Contracts/EventSequences/AppendRequest.cs
@@ -90,7 +90,7 @@ public class AppendRequest : IEventSequenceRequest
     /// Gets or sets the tags associated with the event.
     /// </summary>
     [ProtoMember(14, IsRequired = true)]
-    public IEnumerable<string> Tags { get; set; } = [];
+    public IEnumerable<string> Tags { get; set; } = new List<string>();
 
     /// <summary>
     /// Gets or sets the optional occurred time. If not set, the server will set it to approximately the time of append.

--- a/Source/Kernel/Contracts/Events/EventContext.cs
+++ b/Source/Kernel/Contracts/Events/EventContext.cs
@@ -94,7 +94,7 @@ public class EventContext
     /// Gets or sets the tags associated with the event.
     /// </summary>
     [ProtoMember(14, IsRequired = true)]
-    public IEnumerable<string> Tags { get; set; } = [];
+    public IEnumerable<string> Tags { get; set; } = new List<string>();
 
     /// <summary>
     /// Gets or sets the hash of the event content.

--- a/Source/Kernel/Contracts/Events/EventToAppend.cs
+++ b/Source/Kernel/Contracts/Events/EventToAppend.cs
@@ -49,7 +49,7 @@ public class EventToAppend
     /// Gets or sets the tags associated with the event.
     /// </summary>
     [ProtoMember(7, IsRequired = true)]
-    public IEnumerable<string> Tags { get; set; } = [];
+    public IEnumerable<string> Tags { get; set; } = new List<string>();
 
     /// <summary>
     /// Gets or sets the optional occurred time. If not set, the server will set it to approximately the time of append.

--- a/Source/Kernel/Server.Specs/Contracts/for_EventToAppend/when_round_tripping_an_event_with_tags.cs
+++ b/Source/Kernel/Server.Specs/Contracts/for_EventToAppend/when_round_tripping_an_event_with_tags.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Server.Contracts.for_EventToAppend;
+
+/// <summary>
+/// protobuf-net deserializes a repeated field into the instance the property was initialized with, and refuses to
+/// add to one that reports itself read-only. Defaulting the tags to a collection expression typed as
+/// <see cref="IEnumerable{T}"/> produced an array, so appending any event carrying a tag failed on the server.
+/// </summary>
+public class when_round_tripping_an_event_with_tags : Specification
+{
+    EventToAppend _source;
+    EventToAppend _result;
+
+    void Establish() => _source = new()
+    {
+        EventSourceId = "some-event-source",
+        EventType = new EventType { Id = "some-event-type", Generation = 1 },
+        Content = "{}",
+        Tags = new List<string> { "audit", "billing" },
+    };
+
+    void Because()
+    {
+        using var stream = new MemoryStream();
+        ProtoBuf.Serializer.Serialize(stream, _source);
+        stream.Position = 0;
+        _result = ProtoBuf.Serializer.Deserialize<EventToAppend>(stream);
+    }
+
+    [Fact] void should_carry_the_tags_across() => _result.Tags.ShouldContainOnly("audit", "billing");
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_getting_the_latest_for_all_event_types.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_getting_the_latest_for_all_event_types.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_getting_the_latest_for_all_event_types : given.an_event_types_storage
+{
+    static readonly EventTypeGeneration _second = EventTypeGeneration.First + 1;
+
+    IEnumerable<EventTypeSchema> _schemas;
+
+    async Task Establish()
+    {
+        await _storage.Register(new EventType("first-event", EventTypeGeneration.First), new JsonSchema(), EventTypeOwner.Client, EventTypeSource.User);
+        await _storage.Register(new EventType("second-event", EventTypeGeneration.First), new JsonSchema());
+        await _storage.Register(new EventType("second-event", _second), new JsonSchema());
+    }
+
+    async Task Because() => _schemas = await _storage.GetLatestForAllEventTypes();
+
+    [Fact] void should_return_every_registered_event_type() =>
+        _schemas.Select(_ => _.Type.Id).ShouldContainOnly(new EventTypeId("first-event"), new EventTypeId("second-event"));
+
+    [Fact] void should_return_the_latest_generation_of_each() =>
+        _schemas.Single(_ => _.Type.Id == "second-event").Type.Generation.ShouldEqual(_second);
+
+    [Fact] void should_carry_the_source_it_was_registered_with() =>
+        _schemas.Single(_ => _.Type.Id == "first-event").Source.ShouldEqual(EventTypeSource.User);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_observing_the_latest_for_all_event_types.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/EventTypes/for_EventTypesStorage/when_observing_the_latest_for_all_event_types.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes.for_EventTypesStorage;
+
+public class when_observing_the_latest_for_all_event_types : given.an_event_types_storage
+{
+    readonly List<IEnumerable<EventTypeSchema>> _received = [];
+
+    async Task Establish()
+    {
+        await _storage.Register(new EventType("registered-before-observing", EventTypeGeneration.First), new JsonSchema());
+        _storage.ObserveLatestForAllEventTypes().Subscribe(_received.Add);
+    }
+
+    async Task Because() => await _storage.Register(new EventType("registered-while-observing", EventTypeGeneration.First), new JsonSchema());
+
+    [Fact] void should_seed_the_observer_with_what_was_already_registered() =>
+        _received[0].Select(_ => _.Type.Id).ShouldContainOnly(new EventTypeId("registered-before-observing"));
+
+    [Fact] void should_notify_the_observer_of_the_new_registration() =>
+        _received[^1].Select(_ => _.Type.Id).ShouldContainOnly(
+            new EventTypeId("registered-before-observing"),
+            new EventTypeId("registered-while-observing"));
+
+    [Fact]
+    async Task should_not_affect_other_observers_when_one_completes()
+    {
+        var received = new List<IEnumerable<EventTypeSchema>>();
+        var leaving = _storage.ObserveLatestForAllEventTypes();
+        _storage.ObserveLatestForAllEventTypes().Subscribe(received.Add);
+        leaving.OnCompleted();
+
+        await _storage.Register(new EventType("registered-after-one-left", EventTypeGeneration.First), new JsonSchema());
+
+        received[^1].Select(_ => _.Type.Id).ShouldContain(new EventTypeId("registered-after-one-left"));
+    }
+}

--- a/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_an_event_store_is_added_while_observing.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_an_event_store_is_added_while_observing.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.InMemory.for_EventStoreStorages;
+
+public class when_an_event_store_is_added_while_observing : given.an_empty_registry
+{
+    static readonly EventStoreName _first = "FirstEventStore";
+    static readonly EventStoreName _second = "SecondEventStore";
+    readonly List<IEnumerable<EventStoreName>> _received = [];
+
+    void Establish()
+    {
+        _storages.GetOrCreate(_first);
+        _storages.Observe().Subscribe(_received.Add);
+    }
+
+    void Because() => _storages.GetOrCreate(_second);
+
+    [Fact] void should_notify_the_observer_of_the_added_event_store() => _received.Count.ShouldEqual(2);
+
+    [Fact] void should_include_both_event_stores_in_the_latest_notification() =>
+        _received[^1].ShouldContainOnly(_first, _second);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_observing.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_observing.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.InMemory.for_EventStoreStorages;
+
+public class when_observing : given.an_empty_registry
+{
+    static readonly EventStoreName _eventStore = "SomeEventStore";
+    readonly List<IEnumerable<EventStoreName>> _received = [];
+
+    void Establish() => _storages.GetOrCreate(_eventStore);
+
+    void Because() => _storages.Observe().Subscribe(_received.Add);
+
+    [Fact] void should_seed_the_observer_with_the_event_stores_registered_before_it_subscribed() =>
+        _received[0].ShouldContainOnly(_eventStore);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_one_observer_completes_its_subject.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/for_EventStoreStorages/when_one_observer_completes_its_subject.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.InMemory.for_EventStoreStorages;
+
+/// <summary>
+/// Callers complete the subject they are handed when their connection goes away - see
+/// <see cref="Reactive.ObservableExtensions.CompletedBy{TResult}"/>. Handing out a shared subject therefore let the
+/// first caller to disconnect end event-store observation for every other caller in the process.
+/// </summary>
+public class when_one_observer_completes_its_subject : given.an_empty_registry
+{
+    static readonly EventStoreName _first = "FirstEventStore";
+    static readonly EventStoreName _second = "SecondEventStore";
+    readonly List<IEnumerable<EventStoreName>> _received = [];
+
+    void Establish()
+    {
+        _storages.GetOrCreate(_first);
+
+        var leaving = _storages.Observe();
+        _storages.Observe().Subscribe(_received.Add);
+        leaving.OnCompleted();
+    }
+
+    void Because() => _storages.GetOrCreate(_second);
+
+    [Fact] void should_keep_notifying_the_remaining_observer() => _received.Count.ShouldEqual(2);
+
+    [Fact] void should_still_report_every_event_store() => _received[^1].ShouldContainOnly(_first, _second);
+
+    [Fact] void should_still_seed_an_observer_subscribing_afterwards()
+    {
+        var received = new List<IEnumerable<EventStoreName>>();
+        _storages.Observe().Subscribe(received.Add);
+        received[0].ShouldContainOnly(_first, _second);
+    }
+}

--- a/Source/Kernel/Storage.InMemory.Specs/for_Storage/when_observing_event_stores/and_event_stores_already_exist.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/for_Storage/when_observing_event_stores/and_event_stores_already_exist.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Storage.InMemory.for_Storage.when_observing_event_stores;
+
+public class and_event_stores_already_exist : given.a_storage
+{
+    static readonly EventStoreName _eventStore = "SomeEventStore";
+    readonly List<IEnumerable<EventStoreName>> _received = [];
+    IEnumerable<EventStoreName> _snapshot;
+
+    void Establish() => _storage.GetEventStore(_eventStore);
+
+    async Task Because()
+    {
+        _snapshot = await _storage.GetEventStores();
+        _storage.ObserveEventStores().Subscribe(_received.Add);
+    }
+
+    [Fact] void should_report_the_same_event_stores_the_snapshot_reports() => _received[0].ShouldContainOnly([.. _snapshot]);
+}

--- a/Source/Kernel/Storage.InMemory/ClusterStorage.cs
+++ b/Source/Kernel/Storage.InMemory/ClusterStorage.cs
@@ -16,7 +16,7 @@ public sealed class ClusterStorage(EventStoreStorages eventStoreStorages) : IClu
     public Task<IEnumerable<EventStoreName>> GetEventStores() => Task.FromResult(eventStoreStorages.Names);
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores() => eventStoreStorages.Observe;
+    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores() => eventStoreStorages.Observe();
 
     /// <inheritdoc/>
     public IEventStoreStorage CreateStorageForEventStore(EventStoreName eventStore, SinksFactory sinksFactory) =>

--- a/Source/Kernel/Storage.InMemory/EventStoreStorages.cs
+++ b/Source/Kernel/Storage.InMemory/EventStoreStorages.cs
@@ -34,6 +34,8 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
 
     readonly Subject<IEnumerable<EventStoreName>> _changes = new();
 
+    readonly Lock _publishing = new();
+
     /// <summary>
     /// Gets all the <see cref="EventStoreName">event stores</see> currently registered.
     /// </summary>
@@ -51,9 +53,16 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
     public ISubject<IEnumerable<EventStoreName>> Observe()
     {
         var subject = new ReplaySubject<IEnumerable<EventStoreName>>(1);
-        subject.OnNext(Names);
+        IDisposable subscription;
 
-        var subscription = _changes.Subscribe(subject.OnNext);
+        // Subscribing and seeding have to happen against a consistent set, or an event store added in between is
+        // missed entirely - which is exactly when stores appear, since every connecting client ensures its own.
+        lock (_publishing)
+        {
+            subscription = _changes.Subscribe(subject.OnNext);
+            subject.OnNext(Names);
+        }
+
         subject.Subscribe(_ => { }, _ => { }, subscription.Dispose);
 
         return subject;
@@ -84,7 +93,7 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
 
         if (ReferenceEquals(storage, created))
         {
-            _changes.OnNext([.. _eventStores.Keys]);
+            Publish();
         }
 
         return storage;
@@ -96,11 +105,19 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
     public void Clear()
     {
         _eventStores.Clear();
-        _changes.OnNext([]);
+        Publish();
     }
 
     /// <inheritdoc/>
     public void Dispose() => _changes.Dispose();
+
+    void Publish()
+    {
+        lock (_publishing)
+        {
+            _changes.OnNext([.. _eventStores.Keys]);
+        }
+    }
 
     SinksFactory CreateDefaultSinksFactory(EventStoreName eventStore) =>
         @namespace => new Cratis.Chronicle.Storage.Sinks.Sinks(eventStore, @namespace, sinkFactories);

--- a/Source/Kernel/Storage.InMemory/EventStoreStorages.cs
+++ b/Source/Kernel/Storage.InMemory/EventStoreStorages.cs
@@ -14,16 +14,25 @@ namespace Cratis.Chronicle.Storage.InMemory;
 /// Represents the process-wide registry of in-memory <see cref="IEventStoreStorage"/> instances.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Both <see cref="Storage"/> (node-level <see cref="IStorage"/>) and <see cref="ClusterStorage"/>
 /// (<see cref="IClusterStorage"/>) resolve event-store storage through this single registry, so the
 /// same in-memory event log is observed regardless of which entry point is used.
+/// </para>
+/// <para>
+/// The registry fans changes out over an internal subject that is never handed to a caller. Every caller of
+/// <see cref="Observe"/> gets its own subject, because callers complete the subject they are given when their
+/// connection goes away (see <see cref="Reactive.ObservableExtensions.CompletedBy{TResult}"/>) and completing a
+/// shared subject would silently end event-store observation for every other caller in the process.
+/// </para>
 /// </remarks>
 /// <param name="sinkFactories">All discovered <see cref="ISinkFactory"/> instances.</param>
 /// <param name="jobTypes">The <see cref="IJobTypes"/> for resolving job state types.</param>
 public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories, IJobTypes jobTypes) : IDisposable
 {
     readonly ConcurrentDictionary<EventStoreName, IEventStoreStorage> _eventStores = new();
-    readonly ReplaySubject<IEnumerable<EventStoreName>> _namesSubject = new(1);
+
+    readonly Subject<IEnumerable<EventStoreName>> _changes = new();
 
     /// <summary>
     /// Gets all the <see cref="EventStoreName">event stores</see> currently registered.
@@ -31,9 +40,24 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
     public IEnumerable<EventStoreName> Names => [.. _eventStores.Keys];
 
     /// <summary>
-    /// Gets an observable stream of the registered <see cref="EventStoreName">event stores</see>.
+    /// Creates an observable stream of the registered <see cref="EventStoreName">event stores</see>, seeded with the
+    /// current set and updated as event stores are added.
     /// </summary>
-    public ISubject<IEnumerable<EventStoreName>> Observe => _namesSubject;
+    /// <returns>A subject dedicated to the caller, which the caller owns and may complete.</returns>
+    /// <remarks>
+    /// Each call returns its own subject - the same semantics the MongoDB implementation provides by handing out a
+    /// fresh <see cref="BehaviorSubject{T}"/> per call. Completing it unsubscribes only that caller.
+    /// </remarks>
+    public ISubject<IEnumerable<EventStoreName>> Observe()
+    {
+        var subject = new ReplaySubject<IEnumerable<EventStoreName>>(1);
+        subject.OnNext(Names);
+
+        var subscription = _changes.Subscribe(subject.OnNext);
+        subject.Subscribe(_ => { }, _ => { }, subscription.Dispose);
+
+        return subject;
+    }
 
     /// <summary>
     /// Determines whether the registry contains a specific <see cref="EventStoreName"/>.
@@ -60,7 +84,7 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
 
         if (ReferenceEquals(storage, created))
         {
-            _namesSubject.OnNext([.. _eventStores.Keys]);
+            _changes.OnNext([.. _eventStores.Keys]);
         }
 
         return storage;
@@ -72,11 +96,11 @@ public sealed class EventStoreStorages(IInstancesOf<ISinkFactory> sinkFactories,
     public void Clear()
     {
         _eventStores.Clear();
-        _namesSubject.OnNext([]);
+        _changes.OnNext([]);
     }
 
     /// <inheritdoc/>
-    public void Dispose() => _namesSubject.Dispose();
+    public void Dispose() => _changes.Dispose();
 
     SinksFactory CreateDefaultSinksFactory(EventStoreName eventStore) =>
         @namespace => new Cratis.Chronicle.Storage.Sinks.Sinks(eventStore, @namespace, sinkFactories);

--- a/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
@@ -11,23 +11,33 @@ using Cratis.Chronicle.Storage.EventTypes;
 namespace Cratis.Chronicle.Storage.InMemory.Events.EventTypes;
 
 /// <summary>
-/// Represents a no-op in-memory implementation of <see cref="IEventTypesStorage"/>.
+/// Represents an in-memory implementation of <see cref="IEventTypesStorage"/>.
 /// </summary>
 /// <remarks>
-/// Returns an empty <see cref="JsonSchema"/> for every requested event type, which causes the
-/// <c>ExpandoObjectConverter</c> to fall back to generic unknown-type
-/// conversion - preserving all event content without schema-driven type coercion.
+/// <para>
+/// What has been registered is remembered for the lifetime of the process and read back, so tooling that lists event
+/// types - the Workbench among them - sees the same registrations against in-memory storage as against a database.
 /// No compliance rules, migrations, or validations are applied.
-/// What has been registered is remembered for the lifetime of the process, so that registering the same event
-/// types again - which every client does when it reconnects - is recognized as the no-op it is.
+/// </para>
+/// <para>
+/// An event type that was never registered still resolves to an empty <see cref="JsonSchema"/> rather than failing,
+/// which causes the <c>ExpandoObjectConverter</c> to fall back to generic unknown-type conversion - preserving all
+/// event content without schema-driven type coercion.
+/// </para>
 /// </remarks>
-public class EventTypesStorage : IEventTypesStorage
+public class EventTypesStorage : IEventTypesStorage, IDisposable
 {
     readonly ConcurrentDictionary<EventTypeId, EventTypeDefinition> _definitions = new();
+    readonly ConcurrentDictionary<EventTypeId, EventTypeSource> _sources = new();
+    readonly Subject<IEnumerable<EventTypeSchema>> _changes = new();
 
     /// <inheritdoc/>
-    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code) =>
-        Register(new EventTypeDefinition(type.Id, owner, type.Tombstone, [new EventTypeGenerationDefinition(type.Generation, schema)], []));
+    public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code)
+    {
+        _sources[type.Id] = source;
+
+        return Register(new EventTypeDefinition(type.Id, owner, type.Tombstone, [new EventTypeGenerationDefinition(type.Generation, schema)], []));
+    }
 
     /// <inheritdoc/>
     public Task<bool> Register(EventTypeDefinition definition)
@@ -38,18 +48,31 @@ public class EventTypesStorage : IEventTypesStorage
             static (_, existing, incoming) => Merge(existing, incoming),
             definition);
 
+        _changes.OnNext(Latest());
+
         // There is no cache anywhere to evict for an in-memory single-node store, so a registration never asks
         // anyone to invalidate.
         return Task.FromResult(false);
     }
 
     /// <inheritdoc/>
-    public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() =>
-        Task.FromResult(Enumerable.Empty<EventTypeSchema>());
+    public Task<IEnumerable<EventTypeSchema>> GetLatestForAllEventTypes() => Task.FromResult(Latest());
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes() =>
-        new ReplaySubject<IEnumerable<EventTypeSchema>>(1);
+    /// <remarks>
+    /// Each call gets its own subject seeded with the current registrations. Callers complete the subject they are
+    /// given when their connection goes away, so a shared one would end observation for everyone in the process.
+    /// </remarks>
+    public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes()
+    {
+        var subject = new ReplaySubject<IEnumerable<EventTypeSchema>>(1);
+        subject.OnNext(Latest());
+
+        var subscription = _changes.Subscribe(subject.OnNext);
+        subject.Subscribe(_ => { }, _ => { }, subscription.Dispose);
+
+        return subject;
+    }
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeDefinition>> GetAllDefinitions() =>
@@ -57,24 +80,28 @@ public class EventTypesStorage : IEventTypesStorage
 
     /// <inheritdoc/>
     public Task<EventTypeDefinition> GetDefinition(EventTypeId eventTypeId) =>
-        Task.FromResult(new EventTypeDefinition(
-            eventTypeId,
-            EventTypeOwner.Client,
-            false,
-            [new EventTypeGenerationDefinition(EventTypeGeneration.First, new JsonSchema())],
-            []));
+        Task.FromResult(_definitions.TryGetValue(eventTypeId, out var definition)
+            ? definition
+            : new EventTypeDefinition(
+                eventTypeId,
+                EventTypeOwner.Client,
+                false,
+                [new EventTypeGenerationDefinition(EventTypeGeneration.First, new JsonSchema())],
+                []));
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetAllGenerationsForEventType(EventType eventType) =>
-        Task.FromResult(Enumerable.Empty<EventTypeSchema>());
+        Task.FromResult(_definitions.TryGetValue(eventType.Id, out var definition)
+            ? definition.Generations.Select(generation => ToSchema(definition, generation))
+            : []);
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventTypeId> eventTypeIds) =>
-        Task.FromResult(Enumerable.Empty<EventTypeSchema>());
+        Task.FromResult<IEnumerable<EventTypeSchema>>([.. eventTypeIds.Select(LatestFor).OfType<EventTypeSchema>()]);
 
     /// <inheritdoc/>
     public Task<IEnumerable<EventTypeSchema>> GetFor(IEnumerable<EventType> eventTypes) =>
-        Task.FromResult(Enumerable.Empty<EventTypeSchema>());
+        Task.FromResult<IEnumerable<EventTypeSchema>>([.. eventTypes.Select(eventType => LatestFor(eventType.Id)).OfType<EventTypeSchema>()]);
 
     /// <inheritdoc/>
     public Task<bool> HasFor(EventTypeId type, EventTypeGeneration? generation = default) =>
@@ -83,6 +110,14 @@ public class EventTypesStorage : IEventTypesStorage
     /// <inheritdoc/>
     public Task<EventTypeSchema> GetFor(EventTypeId type, EventTypeGeneration? generation = default)
     {
+        if (_definitions.TryGetValue(type, out var definition) &&
+            Generation(definition, generation) is { } registered)
+        {
+            return Task.FromResult(ToSchema(definition, registered));
+        }
+
+        // An unregistered event type is not an error here - an empty schema makes the converter preserve the
+        // content as-is rather than coerce it.
         var eventType = new EventType(type, generation ?? EventTypeGeneration.First);
         return Task.FromResult(new EventTypeSchema(eventType, EventTypeOwner.Client, EventTypeSource.Code, new JsonSchema()));
     }
@@ -91,6 +126,18 @@ public class EventTypesStorage : IEventTypesStorage
     public void Invalidate(EventTypeId eventTypeId)
     {
     }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _changes.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    static EventTypeGenerationDefinition? Generation(EventTypeDefinition definition, EventTypeGeneration? generation) =>
+        generation is null
+            ? definition.Generations.OrderByDescending(_ => _.Generation.Value).FirstOrDefault()
+            : definition.Generations.FirstOrDefault(_ => _.Generation == generation);
 
     static EventTypeDefinition Merge(EventTypeDefinition existing, EventTypeDefinition incoming) =>
         incoming with
@@ -101,4 +148,19 @@ public class EventTypesStorage : IEventTypesStorage
                 .ToList(),
             Migrations = incoming.Migrations.Any() ? incoming.Migrations : existing.Migrations
         };
+
+    IEnumerable<EventTypeSchema> Latest() => [.. _definitions.Values.Select(LatestFor).OfType<EventTypeSchema>()];
+
+    EventTypeSchema? LatestFor(EventTypeId eventTypeId) =>
+        _definitions.TryGetValue(eventTypeId, out var definition) ? LatestFor(definition) : null;
+
+    EventTypeSchema? LatestFor(EventTypeDefinition definition) =>
+        Generation(definition, null) is { } generation ? ToSchema(definition, generation) : null;
+
+    EventTypeSchema ToSchema(EventTypeDefinition definition, EventTypeGenerationDefinition generation) =>
+        new(
+            new EventType(definition.Id, generation.Generation, definition.Tombstone),
+            definition.Owner,
+            _sources.TryGetValue(definition.Id, out var source) ? source : EventTypeSource.Code,
+            generation.Schema);
 }

--- a/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/EventTypes/EventTypesStorage.cs
@@ -31,6 +31,8 @@ public class EventTypesStorage : IEventTypesStorage, IDisposable
     readonly ConcurrentDictionary<EventTypeId, EventTypeSource> _sources = new();
     readonly Subject<IEnumerable<EventTypeSchema>> _changes = new();
 
+    readonly Lock _publishing = new();
+
     /// <inheritdoc/>
     public Task<bool> Register(EventType type, JsonSchema schema, EventTypeOwner owner = EventTypeOwner.Client, EventTypeSource source = EventTypeSource.Code)
     {
@@ -48,7 +50,10 @@ public class EventTypesStorage : IEventTypesStorage, IDisposable
             static (_, existing, incoming) => Merge(existing, incoming),
             definition);
 
-        _changes.OnNext(Latest());
+        lock (_publishing)
+        {
+            _changes.OnNext(Latest());
+        }
 
         // There is no cache anywhere to evict for an in-memory single-node store, so a registration never asks
         // anyone to invalidate.
@@ -66,9 +71,16 @@ public class EventTypesStorage : IEventTypesStorage, IDisposable
     public ISubject<IEnumerable<EventTypeSchema>> ObserveLatestForAllEventTypes()
     {
         var subject = new ReplaySubject<IEnumerable<EventTypeSchema>>(1);
-        subject.OnNext(Latest());
+        IDisposable subscription;
 
-        var subscription = _changes.Subscribe(subject.OnNext);
+        // Subscribing and seeding have to happen against a consistent set, so a registration landing in between
+        // is not missed.
+        lock (_publishing)
+        {
+            subscription = _changes.Subscribe(subject.OnNext);
+            subject.OnNext(Latest());
+        }
+
         subject.Subscribe(_ => { }, _ => { }, subscription.Dispose);
 
         return subject;

--- a/Source/Kernel/Storage.InMemory/Storage.cs
+++ b/Source/Kernel/Storage.InMemory/Storage.cs
@@ -23,7 +23,7 @@ public sealed class Storage(EventStoreStorages eventStoreStorages, ISystemStorag
     public Task<bool> HasEventStore(EventStoreName eventStore) => Task.FromResult(eventStoreStorages.Has(eventStore));
 
     /// <inheritdoc/>
-    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores() => eventStoreStorages.Observe;
+    public ISubject<IEnumerable<EventStoreName>> ObserveEventStores() => eventStoreStorages.Observe();
 
     /// <inheritdoc/>
     public IEventStoreStorage GetEventStore(EventStoreName eventStore)

--- a/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
+++ b/Source/Kernel/Storage.Sql/Cluster/ClusterStorage.cs
@@ -15,13 +15,19 @@ namespace Cratis.Chronicle.Storage.Sql.Cluster;
 /// <summary>
 /// Represents an implementation of <see cref="IClusterStorage"/> for SQL.
 /// </summary>
+/// <remarks>
+/// Changes fan out over an internal subject that is never handed to a caller. Every caller of
+/// <see cref="ObserveEventStores"/> gets its own subject, because callers complete the subject they are given when
+/// their connection goes away (see <see cref="Reactive.ObservableExtensions.CompletedBy{TResult}"/>) and completing a
+/// shared subject would silently end event-store observation for every other caller in the process.
+/// </remarks>
 /// <param name="database">The <see cref="IDatabase"/> to use for storage operations.</param>
 /// <param name="sinkFactories"><see cref="IInstancesOf{T}"/> for getting all <see cref="ISinkFactory"/> instances.</param>
 /// <param name="jobTypes">The <see cref="IJobTypes"/> that knows about job types.</param>
 /// <param name="jsonSerializerOptions">The configured <see cref="JsonSerializerOptions"/> including all concept converters.</param>
 public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkFactories, IJobTypes jobTypes, JsonSerializerOptions jsonSerializerOptions) : IClusterStorage, IDisposable
 {
-    readonly BehaviorSubject<IEnumerable<EventStoreName>> _eventStoresSubject = new([]);
+    readonly Subject<IEnumerable<EventStoreName>> _eventStoresSubject = new();
 
     /// <inheritdoc/>
     public async Task<IEnumerable<EventStoreName>> GetEventStores()
@@ -34,13 +40,16 @@ public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkF
     /// <inheritdoc/>
     public ISubject<IEnumerable<EventStoreName>> ObserveEventStores()
     {
-        // Always push the current state so any new SSE subscriber receives the data once
-        // the async DB fetch completes — the Subject intermediary in InvokeAndWrapWithTransformSubject
-        // is a plain Subject (no replay), so the BehaviorSubject's synchronous initial emission
-        // is swallowed before the subscriber attaches. Re-pushing after each subscribe call ensures
-        // the subscriber gets data via the async emission that follows.
-        _ = PushEventStoresToSubjectAsync();
-        return _eventStoresSubject;
+        var subject = new ReplaySubject<IEnumerable<EventStoreName>>(1);
+
+        var subscription = _eventStoresSubject.Subscribe(subject.OnNext);
+        subject.Subscribe(_ => { }, _ => { }, subscription.Dispose);
+
+        // Seed the caller's own subject with the current state. The fetch is asynchronous, so the value lands
+        // after this method returns - the ReplaySubject holds on to it until the caller subscribes.
+        _ = PushEventStoresToSubjectAsync(subject);
+
+        return subject;
     }
 
     /// <inheritdoc/>
@@ -55,15 +64,15 @@ public class ClusterStorage(IDatabase database, IInstancesOf<ISinkFactory> sinkF
         await using var scope = await database.Cluster();
         await scope.DbContext.EventStores.Upsert(new EventStore { Name = eventStore });
         await scope.DbContext.SaveChangesAsync();
-        await PushEventStoresToSubjectAsync();
+        await PushEventStoresToSubjectAsync(_eventStoresSubject);
     }
 
     /// <inheritdoc/>
     public void Dispose() => _eventStoresSubject.Dispose();
 
-    async Task PushEventStoresToSubjectAsync()
+    async Task PushEventStoresToSubjectAsync(IObserver<IEnumerable<EventStoreName>> observer)
     {
         var stores = await GetEventStores();
-        _eventStoresSubject.OnNext(stores);
+        observer.OnNext(stores);
     }
 }


### PR DESCRIPTION
# Summary

Running a kernel with in-memory storage — what the Cratis Stage sandbox does — left the Workbench blank: no event stores on the front page, and no event types inside one. Three separate defects, all on the in-memory path.

The first observer of the event stores got data; every one after it got nothing, permanently. `ObserveEventStores` handed every caller the same process-wide subject, and callers complete the subject they are given when their connection goes away (`ObservableExtensions.CompletedBy` registers exactly that on the cancellation token), so the first client to disconnect completed it for the whole process. Separately, the in-memory event type storage recorded registrations but answered every read as though none existed. Both are now consistent with what the MongoDB implementation has always done.

## Fixed

- The Workbench lists event stores against in-memory and SQL storage. Each caller observing event stores now gets its own subject, so one client disconnecting no longer ends event store observation for every other client in the process.
- The Workbench lists event types against in-memory storage. Registered event types are now read back — `GetLatestForAllEventTypes`, `GetFor` and `GetAllGenerationsForEventType` returned an empty sequence regardless of what had been registered, and `ObserveLatestForAllEventTypes` returned a subject that was never fed. An event type nobody registered still resolves to an empty schema, so unknown event content is preserved as before.
- Observable queries no longer lose the first value when their source emits it synchronously on subscribe, via `Cratis.Fundamentals` 7.16.7. Every observable query backed by in-memory storage produced its first value that way.