### PR TITLE
Update Cratis.Fundamentals to 7.16.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.7" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.7" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.8" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.8" />
     <PackageVersion Include="Cratis.Arc" Version="20.69.0" />
     <PackageVersion Include="Cratis.Arc.Core" Version="20.69.0" />
     <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.69.0" />


### PR DESCRIPTION
## Changed

- Updated `Cratis.Fundamentals` and `Cratis.Metrics.Roslyn` to 7.16.8.
