### PR TITLE
Fix dictionary-shaped properties corrupting to arrays across storage engines

### DIFF
--- a/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/WithDictionaryProperty.cs
+++ b/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/WithDictionaryProperty.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Dynamic.for_ExpandoObjectExtensions;
+
+public record WithDictionaryProperty(IDictionary<string, string> Entries);

--- a/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_cloning_expando_object_with_a_dictionary_property.cs
+++ b/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_cloning_expando_object_with_a_dictionary_property.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+
+namespace Cratis.Chronicle.Dynamic.for_ExpandoObjectExtensions;
+
+public class when_cloning_expando_object_with_a_dictionary_property : Specification
+{
+    ExpandoObject _original;
+    IDictionary<string, object?> _clone;
+    Dictionary<object, object> _dictionary;
+
+    void Establish()
+    {
+        _dictionary = new Dictionary<object, object>
+        {
+            ["first"] = "firstValue",
+            ["second"] = "secondValue"
+        };
+
+        _original = new();
+        dynamic asDynamic = _original;
+        asDynamic.Entries = _dictionary;
+    }
+
+    void Because() => _clone = _original.Clone();
+
+    [Fact] void should_preserve_the_dictionary_type() => _clone["Entries"].ShouldBeOfExactType<Dictionary<object, object>>();
+    [Fact] void should_preserve_the_first_entry() => ((Dictionary<object, object>)_clone["Entries"]!)["first"].ShouldEqual("firstValue");
+    [Fact] void should_preserve_the_second_entry() => ((Dictionary<object, object>)_clone["Entries"]!)["second"].ShouldEqual("secondValue");
+    [Fact] void should_not_be_the_same_dictionary_instance() => ReferenceEquals(_clone["Entries"], _dictionary).ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_converting_object_with_dictionary_property_to_expando_object.cs
+++ b/Source/Infrastructure.Specs/Dynamic/for_ExpandoObjectExtensions/when_converting_object_with_dictionary_property_to_expando_object.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Dynamic.for_ExpandoObjectExtensions;
+
+public class when_converting_object_with_dictionary_property_to_expando_object : Specification
+{
+    Dictionary<string, string> _entries;
+    IDictionary<string, object?> _result;
+
+    void Establish() => _entries = new()
+    {
+        ["first"] = "firstValue",
+        ["second"] = "secondValue"
+    };
+
+    void Because() => _result = new WithDictionaryProperty(_entries).AsExpandoObject(camelCaseProperties: true);
+
+    [Fact] void should_keep_the_property_as_a_dictionary() => _result["entries"].ShouldBeOfExactType<Dictionary<object, object>>();
+    [Fact] void should_keep_the_first_entry() => ((Dictionary<object, object>)_result["entries"]!)["first"].ShouldEqual("firstValue");
+    [Fact] void should_keep_the_second_entry() => ((Dictionary<object, object>)_result["entries"]!)["second"].ShouldEqual("secondValue");
+}

--- a/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
+++ b/Source/Infrastructure/Dynamic/ExpandoObjectExtensions.cs
@@ -55,9 +55,25 @@ public static class ExpandoObjectExtensions
                 continue;
             }
 
+            if (value is ExpandoObject nested)
+            {
+                cloneAsDictionary.Add(key, nested.Clone());
+                continue;
+            }
+
             var valueType = value.GetType();
+
+            // A dictionary is also an IEnumerable<KeyValuePair<,>>, so it must be cloned key-by-key before
+            // the generic enumerable branch below gets a chance at it - that branch iterates any IEnumerable
+            // into a List<T>, which for a dictionary would silently replace it with a
+            // List<KeyValuePair<TKey, TValue>>, losing the dictionary shape entirely.
+            if (valueType.IsDictionary())
+            {
+                cloneAsDictionary.Add(key, CloneDictionary(value, valueType));
+                continue;
+            }
+
             if (!valueType.IsPrimitive &&
-                valueType != typeof(ExpandoObject) &&
                 valueType != typeof(string) &&
                 valueType != typeof(Guid) &&
                 valueType != typeof(byte[]) &&
@@ -74,7 +90,7 @@ public static class ExpandoObjectExtensions
             }
             else
             {
-                cloneAsDictionary.Add(key, value is ExpandoObject nested ? nested.Clone() : value.Clone());
+                cloneAsDictionary.Add(key, value.Clone());
             }
         }
 
@@ -323,9 +339,45 @@ public static class ExpandoObjectExtensions
         }
     }
 
+    /// <summary>
+    /// Deep clone a dictionary value while preserving its key and value types.
+    /// </summary>
+    /// <param name="value">The dictionary instance to clone.</param>
+    /// <param name="dictionaryType">The runtime <see cref="Type"/> of <paramref name="value"/>.</param>
+    /// <returns>A cloned <see cref="IDictionary"/> with the same key and value types as <paramref name="dictionaryType"/>.</returns>
+    static IDictionary CloneDictionary(object value, Type dictionaryType)
+    {
+        var keyType = dictionaryType.GetKeyType();
+        var valueType = dictionaryType.GetValueType();
+        var clone = (Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(keyType, valueType)) as IDictionary)!;
+
+        var keyValuePairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+        var keyProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Key))!;
+        var valueProperty = keyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Value))!;
+
+        foreach (var keyValuePair in (IEnumerable)value)
+        {
+            var entryKey = keyProperty.GetValue(keyValuePair)!;
+            var entryValue = valueProperty.GetValue(keyValuePair);
+            clone[entryKey] = entryValue is ExpandoObject nestedEntry ? nestedEntry.Clone() : entryValue?.Clone();
+        }
+
+        return clone;
+    }
+
     static object GetActualValueFrom(object value, bool camelCaseProperties = false)
     {
         var valueType = value.GetType();
+
+        // A dictionary is also an IEnumerable<KeyValuePair<,>>, so it must be converted key-by-key before
+        // the generic enumerable branch below gets a chance at it - that branch would otherwise iterate
+        // its KeyValuePair<,> entries as plain elements, turning the dictionary into a list of
+        // { Key, Value } objects instead of preserving it as a dictionary.
+        if (valueType.IsDictionary())
+        {
+            return ConvertDictionaryValue(value, camelCaseProperties);
+        }
+
         if (!valueType.IsPrimitive &&
             !valueType.IsEnum &&
             valueType != typeof(string) &&
@@ -357,5 +409,16 @@ public static class ExpandoObjectExtensions
         }
 
         return value;
+    }
+
+    static Dictionary<object, object> ConvertDictionaryValue(object value, bool camelCaseProperties)
+    {
+        var result = new Dictionary<object, object>();
+        foreach (var entry in ((IEnumerable)value).GetKeyValuePairs())
+        {
+            result[entry.Key] = GetActualValueFrom(entry.Value, camelCaseProperties);
+        }
+
+        return result;
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_a_dictionary_property_is_set_then_a_sibling_property_changes.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
+
+/// <summary>
+/// Regression coverage for https://github.com/Cratis/Chronicle/issues/3568 - a dictionary-shaped
+/// (additionalProperties) property nested under a [Nested] object used to be silently corrupted into
+/// a List&lt;KeyValuePair&lt;,&gt;&gt; the moment the containing object's state was cloned to compute the
+/// next event's changeset, which serialized as an array of { Key, Value } documents instead of a BSON
+/// document, and could make the following update to a sibling property look like a no-op.
+/// </summary>
+[Collection(MongoDBCollection.Name)]
+public class and_a_dictionary_property_is_set_then_a_sibling_property_changes(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : IAsyncLifetime
+    {
+        const string ItemId = "item-1";
+
+        readonly ObjectComparer _objectComparer = new();
+
+        IMongoClient _client = default!;
+        IMongoDatabase _database = default!;
+        IMongoCollection<BsonDocument> _collection = default!;
+        Sink _sink = default!;
+        JsonSchema _schema = default!;
+        Key _key = default!;
+        string _databaseName = default!;
+
+        public BsonDocument? RawDocumentAfterFirstWrite;
+        public ExpandoObject? Result;
+
+        public async Task InitializeAsync()
+        {
+            _databaseName = $"chronicle_sink_specs_{Guid.NewGuid():N}";
+            _client = new MongoClient(fixture.ConnectionString);
+            _database = _client.GetDatabase(_databaseName);
+            _schema = CreateSchema();
+            _key = new Key(ItemId, ArrayIndexers.NoIndexers);
+
+            var readModel = CreateReadModelDefinition();
+            var typeFormats = new TypeFormats();
+            var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
+            var collections = new SinkCollections(readModel, _database);
+            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+            var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
+            _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
+            _collection = collections.GetCollection();
+
+            // First event: sets the whole "definition" nested object, including a dictionary-shaped
+            // "entries" property - exactly how a [SetFrom<DefinitionSet>] property mapper populates it,
+            // straight from the event's own parsed content, without cloning.
+            var definition = CreateDefinition("first title", ("first", "firstValue"));
+            var firstChangeset = new Changeset<AppendedEvent, ExpandoObject>(_objectComparer, CreateEvent(EventSequenceNumber.First), new ExpandoObject());
+            firstChangeset.SetProperties(
+                [PropertyMappers.FromEventValueProvider(new PropertyPath("definition"), _ => definition)],
+                ArrayIndexers.NoIndexers);
+            await _sink.ApplyChanges(_key, firstChangeset, EventSequenceNumber.First);
+
+            RawDocumentAfterFirstWrite = await _collection.Find(Builders<BsonDocument>.Filter.Eq("_id", ItemId)).SingleAsync();
+
+            // Second event: only renames the sibling "title" property. This is where the initial state
+            // gets read back and cloned by Changeset.SetProperties before the property mapper runs.
+            var initial = await _sink.FindOrDefault(_key);
+            var secondChangeset = new Changeset<AppendedEvent, ExpandoObject>(_objectComparer, CreateEvent(EventSequenceNumber.First + 1), initial!);
+            secondChangeset.SetProperties(
+                [PropertyMappers.FromEventValueProvider(new PropertyPath("definition.title"), _ => "second title")],
+                ArrayIndexers.NoIndexers);
+            await _sink.ApplyChanges(_key, secondChangeset, EventSequenceNumber.First + 1);
+
+            Result = await _sink.FindOrDefault(_key);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_databaseName is not null)
+            {
+                await _client.DropDatabaseAsync(_databaseName);
+            }
+        }
+
+        public IDictionary<string, object?> GetDefinition()
+        {
+            var result = (IDictionary<string, object?>)Result!;
+            return (IDictionary<string, object?>)result["definition"]!;
+        }
+
+        static ExpandoObject CreateDefinition(string title, params (string Key, string Value)[] entries)
+        {
+            var dictionary = new Dictionary<object, object>();
+            foreach (var (key, value) in entries)
+            {
+                dictionary[key] = value;
+            }
+
+            dynamic definition = new ExpandoObject();
+            definition.title = title;
+            definition.entries = dictionary;
+            return definition;
+        }
+
+        static AppendedEvent CreateEvent(EventSequenceNumber sequenceNumber)
+        {
+            var context = EventContext.From(
+                "test-store",
+                "test-namespace",
+                EventType.Unknown,
+                EventSourceType.Default,
+                ItemId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                sequenceNumber,
+                CorrelationId.NotSet);
+
+            return new AppendedEvent(context, new ExpandoObject());
+        }
+
+        static ReadModelDefinition CreateReadModelDefinition() =>
+            new(
+                "test-item-read-model",
+                "TestItemReadModel",
+                $"items_{Guid.NewGuid():N}",
+                ReadModelOwner.Client,
+                ReadModelSource.Code,
+                ReadModelObserverType.Projection,
+                ReadModelObserverIdentifier.Unspecified,
+                SinkDefinition.None,
+                new Dictionary<ReadModelGeneration, JsonSchema>
+                {
+                    { ReadModelGeneration.First, CreateSchema() }
+                },
+                []);
+
+        static JsonSchema CreateSchema() =>
+            JsonSchema.FromJson(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "title": { "type": "string" },
+                        "entries": {
+                          "type": "object",
+                          "additionalProperties": { "type": "string" }
+                        }
+                      },
+                      "required": ["title", "entries"]
+                    }
+                  },
+                  "required": ["id", "definition"]
+                }
+                """);
+    }
+
+    [Fact] void should_store_entries_as_a_document_after_the_first_write() =>
+        ctx.RawDocumentAfterFirstWrite!["definition"].AsBsonDocument["entries"].BsonType.ShouldEqual(BsonType.Document);
+    [Fact] void should_have_updated_the_title() => ((string)ctx.GetDefinition()["title"]!).ShouldEqual("second title");
+    [Fact] void should_still_have_the_entries_property() => ctx.GetDefinition()["entries"].ShouldNotBeNull();
+    [Fact] void should_preserve_the_dictionary_entry_after_the_sibling_update() =>
+        ((IDictionary<object, object>)ctx.GetDefinition()["entries"]!)["first"].ShouldEqual("firstValue");
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
@@ -24,6 +24,7 @@ namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
 /// next event's changeset, which serialized as an array of { Key, Value } documents instead of a BSON
 /// document, and could make the following update to a sibling property look like a no-op.
 /// </summary>
+/// <param name="ctx">The <see cref="context"/> for the spec.</param>
 [Collection(MongoDBCollection.Name)]
 public class and_a_dictionary_property_is_set_then_a_sibling_property_changes(context ctx) : IClassFixture<context>
 {

--- a/Source/Kernel/Storage.Sql.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_shaped_property_is_set.cs
+++ b/Source/Kernel/Storage.Sql.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_shaped_property_is_set.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SqlSink = Cratis.Chronicle.Storage.Sql.Sinks.Sink;
+
+namespace Cratis.Chronicle.Storage.Sql.Sinks.for_Sink.when_applying_changes;
+
+/// <summary>
+/// Regression coverage for https://github.com/Cratis/Chronicle/issues/3568 - a dictionary-shaped
+/// (additionalProperties) property used to be serialized as a JSON array of { "Key", "Value" }
+/// objects instead of a JSON object, because UnwrapForJson only recognized IDictionary&lt;string,
+/// object?&gt; and fell through to its generic IEnumerable branch for any other dictionary type -
+/// including the Dictionary&lt;object, object&gt; that a schema-defined dictionary property round-trips
+/// as.
+/// </summary>
+public class and_a_dictionary_shaped_property_is_set : Specification
+{
+    const string ContainerName = "test_read_models";
+
+    const string SchemaJson = """
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "entries": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        }
+        """;
+
+    readonly EventStoreName _eventStoreName = "test-event-store";
+    readonly EventStoreNamespaceName _namespace = "test-namespace";
+    readonly JsonSchema _schema = JsonSchema.FromJson(SchemaJson);
+
+    SqliteConnection _connection;
+    SqlSink _sink;
+    IDatabase _database;
+    Key _key;
+    ExpandoObject? _result;
+    IReadOnlyList<ProjectedColumn> _columns;
+
+    async Task Establish()
+    {
+        _columns = ProjectedColumns.ForSchema(_schema);
+        _key = new Key("parent-1", ArrayIndexers.NoIndexers);
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        await using (var context = CreateContext())
+        {
+            await context.Database.EnsureCreatedAsync();
+        }
+
+        _database = Substitute.For<IDatabase>();
+        _database.ReadModelTable(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<string>(), Arg.Any<IReadOnlyList<ProjectedColumn>>())
+            .Returns(_ => Task.FromResult(new DbContextScope<ReadModelDbContext>(CreateContext(), () => { })));
+
+        _sink = new SqlSink(
+            _eventStoreName,
+            _namespace,
+            CreateReadModelDefinition(),
+            _database,
+            new ExpandoObjectConverter(new TypeFormats()));
+    }
+
+    async Task Because()
+    {
+        var entries = new Dictionary<object, object>
+        {
+            ["first"] = "firstValue",
+            ["second"] = "secondValue"
+        };
+
+        var state = new ExpandoObject();
+        var changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        changeset.InitialState.Returns(new ExpandoObject());
+        Change[] changes = [new PropertiesChanged<ExpandoObject>(state, [new PropertyDifference(new PropertyPath("entries"), null, entries)])];
+        changeset.Changes.Returns(changes);
+
+        await _sink.ApplyChanges(_key, changeset, EventSequenceNumber.First);
+
+        _result = await _sink.FindOrDefault(_key);
+    }
+
+    void Destroy() => _connection.Dispose();
+
+    [Fact] void should_find_the_read_model() => _result.ShouldNotBeNull();
+    [Fact] void should_store_entries_as_a_dictionary() => GetEntries().ShouldBeOfExactType<Dictionary<object, object>>();
+    [Fact] void should_preserve_the_first_entry() => GetEntries()["first"].ShouldEqual("firstValue");
+    [Fact] void should_preserve_the_second_entry() => GetEntries()["second"].ShouldEqual("secondValue");
+
+    Dictionary<object, object> GetEntries() => (Dictionary<object, object>)((IDictionary<string, object?>)_result!)["entries"]!;
+
+    ReadModelDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ReadModelDbContext>()
+            .UseSqlite(_connection)
+            .AddConceptAsSupport()
+            .Options;
+
+        return new ReadModelDbContext(options, ContainerName, _columns, Substitute.For<IReadModelMigrator>());
+    }
+
+    ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-read-model",
+            "TestReadModel",
+            ContainerName,
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, _schema }
+            },
+            []);
+}

--- a/Source/Kernel/Storage.Sql/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.Sql/Sinks/Sink.cs
@@ -20,6 +20,7 @@ using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.ReadModels;
 using Cratis.Monads;
+using Cratis.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -1310,12 +1311,17 @@ public class Sink : ISink
             return dict;
         }
 
-        if (value is IDictionary<string, object?> dictionary)
+        // A schema-defined dictionary property (additionalProperties) round-trips as
+        // Dictionary<object, object> (not IDictionary<string, object?>), because its keys and values
+        // are typed by whatever the schema declares. Falling through to the generic IEnumerable branch
+        // below would iterate its KeyValuePair<,> entries as plain elements, serializing the dictionary
+        // as a JSON array of { "Key": ..., "Value": ... } objects instead of a JSON object.
+        if (value.GetType().IsDictionary() && value is IEnumerable dictionaryEntries)
         {
             var result = new Dictionary<string, object?>();
-            foreach (var kvp in dictionary)
+            foreach (var entry in dictionaryEntries.GetKeyValuePairs())
             {
-                result[kvp.Key] = UnwrapForJson(kvp.Value);
+                result[entry.Key] = UnwrapForJson(entry.Value);
             }
 
             return result;


### PR DESCRIPTION
## Summary

- Fixed `ExpandoObjectExtensions.Clone()` and `AsExpandoObject()` treating any dictionary as a plain enumerable and "listifying" it into a `List<KeyValuePair<,>>`, which serialized as an array of `{ Key, Value }` documents instead of an object. `Clone()` runs on every changeset computation, so a dictionary-shaped (`additionalProperties`) property could be corrupted the moment its containing state was cloned for the next event.
- Fixed the same class of bug independently in Storage.Sql's `UnwrapForJson`, which only recognized `IDictionary<string, object?>` and missed the `Dictionary<object, object>` shape a schema dictionary actually round-trips as.
- Since both fixes live in code shared by every storage engine (MongoDB, SQL Server, PostgreSQL, and the in-memory sink), all are covered by these changes.

## Fixed

- Dictionaries with `additionalProperties` schemas no longer get corrupted into an array of `{ Key, Value }` documents when their containing object's state is cloned for a subsequent event (#3568)
- SQL Server / PostgreSQL read models now correctly serialize schema-defined dictionary properties as JSON objects instead of arrays

## Test plan

- [x] `Infrastructure.Specs` — 2 new unit specs for `Clone()`/`AsExpandoObject()` covering dictionary values (confirmed failing before the fix, passing after)
- [x] `Storage.MongoDB.Specs` — new integration spec against a real MongoDB container proving a dictionary survives a first write and a subsequent sibling-property update
- [x] `Storage.Sql.Specs` — new SQLite-backed spec for the same scenario (confirmed failing before the fix, passing after)
- [x] `Storage.InMemory.Specs` and `Core.Specs` — full regression run, no failures
- [x] Debug and Release builds clean, zero warnings, for all touched/dependent projects