### PR TITLE
Reference Cratis.Fundamentals 7.17.1

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -25,6 +25,12 @@ on:
     paths:
       - "Source/**/*.cs"
       - "Source/**/*.csproj"
+      # Central package management decides what every project in the repository compiles against, so a version
+      # bump here reaches further than any single project file - and reached it without building, because a
+      # change confined to these files matched none of the patterns above. Directory.Build.props for the same
+      # reason: it sets the properties the build runs under.
+      - "Directory.Packages.props"
+      - "Directory.Build.props"
       - "Integration/**"
       # The benchmarks job builds these, so a change here has to run it. Without this a broken benchmark
       # project lands green and fails on the next unrelated pull request instead.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.16.8" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.16.8" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
     <PackageVersion Include="Cratis.Arc" Version="20.69.3" />
     <PackageVersion Include="Cratis.Arc.Core" Version="20.69.3" />
     <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="20.69.3" />


### PR DESCRIPTION
## Changed

- References `Cratis.Fundamentals` 7.17.1, up from 7.16.8. A concept held in a collection or a value map now serializes as its underlying value rather than as `{"value": ...}`, matching how a concept serializes everywhere else