### PR TITLE
Release when central package versions change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,12 @@ on:
       - "Docker/**"
       # Changes to the publish pipeline itself should be exercised by a release.
       - ".github/workflows/publish.yml"
+      # Central package management decides what the published packages depend on, so a version bump here
+      # changes what a consumer restores even though no file under Source changed. Without this the bump
+      # merged and cut nothing, leaving main referencing one version and the published packages another -
+      # a difference nothing reports, because the workflow that would have reported it never ran.
+      - "Directory.Packages.props"
+      - "Directory.Build.props"
 
 
 permissions:


### PR DESCRIPTION
## Changed

- The published packages reference `Cratis.Fundamentals` 7.17.1, up from 7.16.8. A concept held in a collection or a value map now serializes as its underlying value rather than as `{"value": ...}`, matching how a concept serializes everywhere else