### PR TITLE
Document join precedence over local writes and warn on the collision (CHR0042)

### DIFF
--- a/Documentation/client-snippets/code-analysis/chr0042/violation.md
+++ b/Documentation/client-snippets/code-analysis/chr0042/violation.md
@@ -1,0 +1,23 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+
+[EventType]
+public record Chr0042SideReleasedForSigning(Guid RequestId);
+
+[EventType]
+public record Chr0042RequestLost(bool IsContractRoundLive);
+
+// Warning CHR0042: Property 'IsContractRoundLive' is written both locally by
+// [SetValue<Chr0042SideReleasedForSigning>] and by the join with 'Chr0042RequestLost'.
+// The re-release writes true, but the join re-applies false on top — the latch
+// silently sticks and the row is withheld forever.
+[FromEvent<Chr0042SideReleasedForSigning>]
+public record Chr0042ContractSide(
+    [Key] Guid Id,
+    Guid RequestId,
+    [SetValue<Chr0042SideReleasedForSigning>(true)]
+    [Join<Chr0042RequestLost>(on: "RequestId")]
+    bool IsContractRoundLive);
+```

--- a/Documentation/code-analysis/CHR0042.mdx
+++ b/Documentation/code-analysis/CHR0042.mdx
@@ -1,0 +1,30 @@
+# CHR0042: A joined property is also written locally
+
+## Rule Description
+
+A read model property is written by both a local mapping and a join. The joined value always wins — a local write cannot reset the property, in whichever order the events arrive.
+
+A projection re-resolves its joins every time it handles one of the read model's own events and applies the joined properties *after* the local mappings. A property written from both sides therefore always ends up with the joined value once the joined stream has an event to pull from — see [join precedence](../projections/model-bound/joins#join-precedence).
+
+The trap this catches is the latch: a `bool` that a local event sets and a joined event clears. The shape compiles and reads correctly, but re-setting the flag locally is silently overwritten the next time any local event is handled — a permanent, errorless wrong value. If the property must reflect whichever fact happened most recently, give each fact its own property (for example, two timestamps) and compare them instead.
+
+Both spellings are covered: a model-bound member carrying both a local-write attribute (`[SetFrom<T>]`, `[SetValue<T>]`, `[SetFromContext<T>]`, an aggregate) and a `[Join<T>]`, and a fluent `From<T>` block whose `.Set(...)` property is also set explicitly by a sibling `.Join<T>(...)` in the same projection. Collisions caused by AutoMap rather than an explicit mapping are reported by [CHR0025](CHR0025) instead.
+
+## Severity
+
+Warning
+
+## Example
+
+<ChronicleClientTabs snippet="code-analysis/chr0042/violation" />
+
+## Why This Rule Exists
+
+The precedence itself is by design: a joined property is a mirror of the joined stream, and re-applying it is what keeps denormalized values (a name, a price) fresh — and what backfills them when the read model is created after the joined event already happened. When you combine a join with a local write *deliberately* — seed the value locally, let the join keep it fresh — the behavior is exactly what you want; suppress this diagnostic at the site to record that intent.
+
+What the rule exists for is the other reading of the same code: expecting the two writes to merge in stream order. Nothing fails when they don't — the read model just quietly holds the joined value — and on a surface built to catch missing work, a stuck latch means rows are withheld forever with no error and no log line. This rule turns that silent wrong value into a visible decision at compile time.
+
+## Related Rules
+
+- [CHR0025: Explicitly sourced read model property may be overwritten by AutoMap](CHR0025) — the same collision when AutoMap, not an explicit mapping, is what writes on top.
+- [CHR0038: [Join] of a [PII] value crosses the compliance subject](CHR0038) — another way a join that looks right silently is not.

--- a/Documentation/code-analysis/index.md
+++ b/Documentation/code-analysis/index.md
@@ -42,6 +42,7 @@ All rules follow the identifier format `CHR####`. Numbers are assigned sequentia
 | [CHR0037](CHR0037) | Event type migration generations must share one explicit [EventType] id | Warning | The two generations referenced by an EventTypeMigration must carry the same explicit [EventType] id and differ only by generation, or the migration never applies |
 | [CHR0038](CHR0038) | [Join] of a [PII] value crosses the compliance subject | Error | A join — model-bound or fluent — that copies a [PII] value from a stream keyed by something other than the read model's own subject cannot be decrypted and freezes the projection; it also puts that data beyond the owner's erasure |
 | [CHR0039](CHR0039) | Assertion result is discarded and can never fail | Warning | An awaitable-returning `Should*` assertion on a Cratis testing surface whose result is discarded throws on an awaitable nobody observes, so the assertion silently passes regardless of behavior and CS4014 does not fire outside an async method |
+| [CHR0042](CHR0042) | A joined property is also written locally | Warning | A property written by both a local mapping and a join — model-bound or fluent — always ends up with the joined value regardless of arrival order, so a local write can never reset it; a flag latched from both sides silently sticks |
 
 ## Quick Fixes
 

--- a/Documentation/code-analysis/toc.yml
+++ b/Documentation/code-analysis/toc.yml
@@ -68,3 +68,5 @@
   href: CHR0038.mdx
 - name: CHR0039 - Assertion result is discarded and can never fail
   href: CHR0039.mdx
+- name: CHR0042 - A joined property is also written locally
+  href: CHR0042.mdx

--- a/Documentation/projections/declarative/joins.mdx
+++ b/Documentation/projections/declarative/joins.mdx
@@ -26,6 +26,7 @@ Events come from different streams but are joined based on common identifiers:
 2. **Join conditions** specify which property links to other streams
 3. **Joined events** update properties when their event source ID matches the join key
 4. Join properties are updated whenever relevant events occur
+5. **Joined values take precedence** — a joined property is applied over any value a `From` block wrote for the same property, in whichever order the events arrived
 
 ## Join scenarios
 
@@ -36,6 +37,10 @@ Join keys are typically set from events that establish relationships — in the 
 ### Joining on the key
 
 Joins match events based on their event source ID and the join property — `.Join<GroupCreated>(j => j.On(m => m.GroupId))` links in group data whenever a `GroupCreated`/`GroupRenamed` event's event source ID matches the read model's `GroupId`.
+
+### Join precedence
+
+When a `From` block and a join write the same property, the joined value wins — regardless of arrival order. Whenever the projection handles a `From` event, Chronicle re-resolves the join against the joined stream's last stored event and applies the joined properties after the `From` mappings. A `From` block therefore cannot reset or clear a property a join has written; there is no "clear this joined value" operation. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them, rather than latching a single flag written from both sides.
 
 ### Multiple joins
 

--- a/Documentation/projections/declarative/joins.mdx
+++ b/Documentation/projections/declarative/joins.mdx
@@ -40,7 +40,7 @@ Joins match events based on their event source ID and the join property — `.Jo
 
 ### Join precedence
 
-When a `From` block and a join write the same property, the joined value wins — regardless of arrival order. Whenever the projection handles a `From` event, Chronicle re-resolves the join against the joined stream's last stored event and applies the joined properties after the `From` mappings. A `From` block therefore cannot reset or clear a property a join has written; there is no "clear this joined value" operation. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them, rather than latching a single flag written from both sides.
+When a `From` block and a join write the same property, the joined value wins — regardless of arrival order. Whenever the projection handles a `From` event, Chronicle re-resolves the join against the joined stream's last stored event and applies the joined properties after the `From` mappings. A `From` block therefore cannot reset or clear a property a join has written; there is no "clear this joined value" operation. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them, rather than latching a single flag written from both sides. The [CHR0042](../../code-analysis/CHR0042) analyzer warns when the same property is written from both sides.
 
 ### Multiple joins
 

--- a/Documentation/projections/model-bound/joins.mdx
+++ b/Documentation/projections/model-bound/joins.mdx
@@ -63,7 +63,7 @@ Here's a comprehensive example showing joins at multiple levels:
 When a `Join` and a local mapping — `SetFrom`, or an AutoMapped `FromEvent` property — target the same property, **the joined value wins, regardless of the order the events arrive**. Every time the projection handles one of the read model's own events, Chronicle re-resolves the join against the last stored event of the joined stream and applies the joined properties *after* the local mappings. Only while the joined stream has no matching event yet does a locally written value stay in place.
 
 :::caution
-A local mapping cannot reset or clear a property a join has written — there is no "clear this joined value" operation. A `bool` latch that a local event sets and a joined event clears will silently stick on the joined value, even when the local event is the most recent one. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them in the query instead.
+A local mapping cannot reset or clear a property a join has written — there is no "clear this joined value" operation. A `bool` latch that a local event sets and a joined event clears will silently stick on the joined value, even when the local event is the most recent one. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them in the query instead. The [CHR0042](../../code-analysis/CHR0042) analyzer warns when a property is written from both sides.
 :::
 
 ## Best Practices

--- a/Documentation/projections/model-bound/joins.mdx
+++ b/Documentation/projections/model-bound/joins.mdx
@@ -58,6 +58,14 @@ Here's a comprehensive example showing joins at multiple levels:
 - Event is about a different entity but shares a common key
 - Used for enrichment and denormalization
 
+## Join Precedence
+
+When a `Join` and a local mapping — `SetFrom`, or an AutoMapped `FromEvent` property — target the same property, **the joined value wins, regardless of the order the events arrive**. Every time the projection handles one of the read model's own events, Chronicle re-resolves the join against the last stored event of the joined stream and applies the joined properties *after* the local mappings. Only while the joined stream has no matching event yet does a locally written value stay in place.
+
+:::caution
+A local mapping cannot reset or clear a property a join has written — there is no "clear this joined value" operation. A `bool` latch that a local event sets and a joined event clears will silently stick on the joined value, even when the local event is the most recent one. If a property must reflect which fact happened most recently, give each fact its own property (for example, two timestamps) and compare them in the query instead.
+:::
+
 ## Best Practices
 
 1. **Use meaningful join keys** - Ensure the `on` parameter clearly identifies the relationship

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/given/a_fluent_join_overrides_local_write_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/given/a_fluent_join_overrides_local_write_analyzer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer.given;
+
+public class a_fluent_join_overrides_local_write_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using System.Linq.Expressions;",
+            "using Cratis.Chronicle.Projections;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Projections",
+            "{",
+            "    public interface ISetBuilder<TReadModel, TEvent, TProperty, TParentBuilder>",
+            "    {",
+            "        TParentBuilder To<TEventProperty>(Expression<Func<TEvent, TEventProperty>> accessor);",
+            "        TParentBuilder ToValue(TProperty value);",
+            "    }",
+            "",
+            "    public interface IReadModelPropertiesBuilder<TReadModel, TEvent, TBuilder>",
+            "    {",
+            "        ISetBuilder<TReadModel, TEvent, TProperty, TBuilder> Set<TProperty>(Expression<Func<TReadModel, TProperty>> accessor);",
+            "        TBuilder Increment<TProperty>(Expression<Func<TReadModel, TProperty>> accessor);",
+            "    }",
+            "",
+            "    public interface IFromBuilder<TReadModel, TEvent> : IReadModelPropertiesBuilder<TReadModel, TEvent, IFromBuilder<TReadModel, TEvent>>",
+            "    {",
+            "    }",
+            "",
+            "    public interface IJoinBuilder<TReadModel, TEvent> : IReadModelPropertiesBuilder<TReadModel, TEvent, IJoinBuilder<TReadModel, TEvent>>",
+            "    {",
+            "        IJoinBuilder<TReadModel, TEvent> On<TProperty>(Expression<Func<TReadModel, TProperty>> keyAccessor);",
+            "    }",
+            "",
+            "    public interface IProjectionBuilder<TReadModel, TBuilder>",
+            "    {",
+            "        TBuilder From<TEvent>(Action<IFromBuilder<TReadModel, TEvent>>? builderCallback = default);",
+            "        TBuilder Join<TEvent>(Action<IJoinBuilder<TReadModel, TEvent>>? builderCallback = default);",
+            "    }",
+            "",
+            "    public interface IProjectionBuilderFor<TReadModel> : IProjectionBuilder<TReadModel, IProjectionBuilderFor<TReadModel>>",
+            "    {",
+            "    }",
+            "",
+            "    public interface IProjectionFor<TReadModel>",
+            "    {",
+            "        void Define(IProjectionBuilderFor<TReadModel> builder);",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_a_sibling_join_sets_the_same_property.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_a_sibling_join_sets_the_same_property.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer.when_analyzing_from_blocks;
+
+public class and_a_sibling_join_sets_the_same_property : given.a_fluent_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+    public record RequestLost(Guid RequestId);
+
+    public record ContractSide(Guid Id, Guid RequestId, bool IsContractRoundLive);
+
+    public class ContractSideProjection : IProjectionFor<ContractSide>
+    {
+        public void Define(IProjectionBuilderFor<ContractSide> builder) => builder
+            .From<SideReleased>(b => b.Set({|#0:m => m.IsContractRoundLive|}).ToValue(true))
+            .Join<RequestLost>(j => j.On(m => m.RequestId).Set(m => m.IsContractRoundLive).ToValue(false));
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.JoinOverridesLocalWrite, DiagnosticSeverity.Warning, "IsContractRoundLive", "From<SideReleased>", "RequestLost"));
+
+    [Fact] Task should_report_the_join_overrides_local_write_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_no_join_exists.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_no_join_exists.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer.when_analyzing_from_blocks;
+
+public class and_no_join_exists : given.a_fluent_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+
+    public record ContractSide(Guid Id, Guid RequestId, bool IsContractRoundLive);
+
+    public class ContractSideProjection : IProjectionFor<ContractSide>
+    {
+        public void Define(IProjectionBuilderFor<ContractSide> builder) => builder
+            .From<SideReleased>(b => b.Set(m => m.IsContractRoundLive).ToValue(true));
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_the_join_belongs_to_another_projection.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_the_join_belongs_to_another_projection.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer.when_analyzing_from_blocks;
+
+public class and_the_join_belongs_to_another_projection : given.a_fluent_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+    public record RequestLost(Guid RequestId);
+
+    public record ContractSide(Guid Id, Guid RequestId, bool IsContractRoundLive);
+
+    public class ContractSideProjection : IProjectionFor<ContractSide>
+    {
+        public void Define(IProjectionBuilderFor<ContractSide> builder) => builder
+            .From<SideReleased>(b => b.Set(m => m.IsContractRoundLive).ToValue(true));
+    }
+
+    public class LostSideProjection : IProjectionFor<ContractSide>
+    {
+        public void Define(IProjectionBuilderFor<ContractSide> builder) => builder
+            .Join<RequestLost>(j => j.On(m => m.RequestId).Set(m => m.IsContractRoundLive).ToValue(false));
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_the_join_sets_a_different_property.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_analyzing_from_blocks/and_the_join_sets_a_different_property.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer.when_analyzing_from_blocks;
+
+public class and_the_join_sets_a_different_property : given.a_fluent_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+    public record RequestLost(Guid RequestId, DateTimeOffset LostAt);
+
+    public record ContractSide(Guid Id, Guid RequestId, bool IsContractRoundLive, DateTimeOffset LostAt);
+
+    public class ContractSideProjection : IProjectionFor<ContractSide>
+    {
+        public void Define(IProjectionBuilderFor<ContractSide> builder) => builder
+            .From<SideReleased>(b => b.Set(m => m.IsContractRoundLive).ToValue(true))
+            .Join<RequestLost>(j => j.On(m => m.RequestId).Set(m => m.LostAt).To(e => e.LostAt));
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_FluentJoinOverridesLocalWriteAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_FluentJoinOverridesLocalWriteAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.FluentJoinOverridesLocalWriteAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0042_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.JoinOverridesLocalWrite).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/given/a_join_overrides_local_write_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/given/a_join_overrides_local_write_analyzer.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer.given;
+
+public class a_join_overrides_local_write_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "using System;",
+            "using Cratis.Chronicle.Keys;",
+            "using Cratis.Chronicle.Projections.ModelBound;",
+            "",
+            "namespace System.Runtime.CompilerServices",
+            "{",
+            "    public sealed class IsExternalInit { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Keys",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]",
+            "    public sealed class KeyAttribute : Attribute { }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Projections.ModelBound",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]",
+            "    public sealed class JoinAttribute<TEvent> : Attribute",
+            "    {",
+            "        public JoinAttribute(string? on = null, string? eventPropertyName = null) { }",
+            "    }",
+            "",
+            "    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]",
+            "    public sealed class SetValueAttribute<TEvent> : Attribute",
+            "    {",
+            "        public SetValueAttribute(object value) { }",
+            "    }",
+            "",
+            "    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]",
+            "    public sealed class SetFromAttribute<TEvent> : Attribute",
+            "    {",
+            "        public SetFromAttribute(string? eventPropertyName = null) { }",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_a_member_is_written_both_locally_and_by_a_join.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_a_member_is_written_both_locally_and_by_a_join.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer.when_analyzing_members;
+
+public class and_a_member_is_written_both_locally_and_by_a_join : given.a_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+    public record RequestLost(bool IsContractRoundLive);
+
+    public record ContractSide(
+        [Key] Guid Id,
+        Guid RequestId,
+        {|#0:[SetValue<SideReleased>(true)] [Join<RequestLost>(on: "RequestId")] bool IsContractRoundLive|});
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.JoinOverridesLocalWrite, DiagnosticSeverity.Warning, "IsContractRoundLive", "[SetValue<SideReleased>]", "RequestLost"));
+
+    [Fact] Task should_report_the_join_overrides_local_write_diagnostic() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_join_stands_alone.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_join_stands_alone.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer.when_analyzing_members;
+
+public class and_the_join_stands_alone : given.a_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record RequestLost(bool IsContractRoundLive);
+
+    public record ContractSide(
+        [Key] Guid Id,
+        Guid RequestId,
+        [Join<RequestLost>(on: "RequestId")] bool IsContractRoundLive);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_local_write_stands_alone.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_local_write_stands_alone.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer.when_analyzing_members;
+
+public class and_the_local_write_stands_alone : given.a_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+
+    public record ContractSide(
+        [Key] Guid Id,
+        Guid RequestId,
+        [SetValue<SideReleased>(true)] bool IsContractRoundLive);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_writes_target_different_members.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_analyzing_members/and_the_writes_target_different_members.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer.when_analyzing_members;
+
+public class and_the_writes_target_different_members : given.a_join_overrides_local_write_analyzer
+{
+    const string Usage = """
+    public record SideReleased(Guid RequestId);
+    public record RequestLost(DateTimeOffset LostAt);
+
+    public record ContractSide(
+        [Key] Guid Id,
+        Guid RequestId,
+        [SetValue<SideReleased>(true)] bool IsContractRoundLive,
+        [Join<RequestLost>(on: "RequestId")] DateTimeOffset LostAt);
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_any_diagnostics() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_JoinOverridesLocalWriteAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_JoinOverridesLocalWriteAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.JoinOverridesLocalWriteAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0042_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.JoinOverridesLocalWrite).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/FluentJoinOverridesLocalWriteAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/FluentJoinOverridesLocalWriteAnalyzer.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports a fluent <c>From&lt;TEvent&gt;</c> block writing a property that a sibling
+/// <c>Join&lt;TOther&gt;</c> in the same projection also sets explicitly — a combination where the joined
+/// value always wins and the local write can never reset the property.
+/// </summary>
+/// <remarks>
+/// The model-bound equivalent is covered by <see cref="JoinOverridesLocalWriteAnalyzer"/>; both report
+/// <see cref="DiagnosticIds.JoinOverridesLocalWrite"/>. Only explicit mappings on both sides are correlated —
+/// values a join carries across via AutoMap are not modelled from syntax.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class FluentJoinOverridesLocalWriteAnalyzer : DiagnosticAnalyzer
+{
+    const string FromMethodName = "From";
+    const string JoinMethodName = "Join";
+    const string SetMethodName = "Set";
+    const string ProjectionBuilderInterfaceName = "IProjectionBuilder";
+    const string PropertiesBuilderInterfaceName = "IReadModelPropertiesBuilder";
+
+    /// <summary>
+    /// The property-builder methods that write a read model property from the block's own event.
+    /// </summary>
+    static readonly HashSet<string> LocalWriteMethodNames = new(StringComparer.Ordinal)
+    {
+        SetMethodName,
+        "Add",
+        "Subtract",
+        "Count",
+        "Increment",
+        "Decrement"
+    };
+
+    static readonly HashSet<string> JoinWriteMethodNames = new(StringComparer.Ordinal)
+    {
+        SetMethodName
+    };
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(JoinOverridesLocalWrite.Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax member ||
+            member.Name.Identifier.Text != FromMethodName ||
+            invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        if (GetProjectionMethod(context, invocation) is not { } from)
+        {
+            return;
+        }
+
+        var callback = invocation.ArgumentList.Arguments[0].Expression;
+        var localWrites = GetWrittenProperties(context, callback, from.ReadModelType, LocalWriteMethodNames).ToArray();
+        if (localWrites.Length == 0)
+        {
+            return;
+        }
+
+        var joins = GetSiblingJoins(context, invocation, from.ReadModelType).ToArray();
+
+        foreach (var write in localWrites)
+        {
+            ReportFirstCollidingJoin(context, write, joins, from.EventType);
+        }
+    }
+
+    static void ReportFirstCollidingJoin(
+        SyntaxNodeAnalysisContext context,
+        (string PropertyName, Location Location) write,
+        IEnumerable<(INamedTypeSymbol EventType, ImmutableHashSet<string> Properties)> joins,
+        INamedTypeSymbol fromEventType)
+    {
+        var join = joins.FirstOrDefault(join => join.Properties.Contains(write.PropertyName));
+        if (join.EventType is null)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            JoinOverridesLocalWrite.Rule,
+            write.Location,
+            write.PropertyName,
+            $"the From<{fromEventType.Name}> block",
+            join.EventType.Name));
+    }
+
+    /// <summary>
+    /// Find the joins declared alongside a <c>From</c> block for the same read model, with the properties each
+    /// sets explicitly.
+    /// </summary>
+    /// <param name="context">The analysis context.</param>
+    /// <param name="fromInvocation">The <c>From</c> invocation being analyzed.</param>
+    /// <param name="readModelType">The read model the <c>From</c> block projects into.</param>
+    /// <returns>Each sibling join's event type and explicitly set property names.</returns>
+    /// <remarks>
+    /// Siblings are scoped to the containing member — the <c>Define</c> method — and matched on the read model
+    /// type, so a join inside a child scope never collides with a root-level <c>From</c> of the same property
+    /// name.
+    /// </remarks>
+    static IEnumerable<(INamedTypeSymbol EventType, ImmutableHashSet<string> Properties)> GetSiblingJoins(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax fromInvocation,
+        INamedTypeSymbol readModelType)
+    {
+        var containingMember = fromInvocation.Ancestors().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+        if (containingMember is null)
+        {
+            yield break;
+        }
+
+        var joinInvocations = containingMember.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(invocation =>
+                invocation.Expression is MemberAccessExpressionSyntax member &&
+                member.Name.Identifier.Text == JoinMethodName &&
+                invocation.ArgumentList.Arguments.Count == 1);
+
+        foreach (var invocation in joinInvocations)
+        {
+            if (GetProjectionMethod(context, invocation) is not { } join ||
+                !SymbolEqualityComparer.Default.Equals(join.ReadModelType, readModelType))
+            {
+                continue;
+            }
+
+            var properties = GetWrittenProperties(context, invocation.ArgumentList.Arguments[0].Expression, readModelType, JoinWriteMethodNames)
+                .Select(write => write.PropertyName)
+                .ToImmutableHashSet(StringComparer.Ordinal);
+
+            if (!properties.IsEmpty)
+            {
+                yield return (join.EventType, properties);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolve a <c>From</c>/<c>Join</c> invocation to its event and read model types.
+    /// </summary>
+    /// <param name="context">The analysis context.</param>
+    /// <param name="invocation">The invocation to resolve.</param>
+    /// <returns>The event and read model types, or <see langword="null"/> when the call is not a projection builder's.</returns>
+    static (INamedTypeSymbol EventType, INamedTypeSymbol ReadModelType)? GetProjectionMethod(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation)
+    {
+        if (context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method ||
+            method.ContainingType?.OriginalDefinition.Name != ProjectionBuilderInterfaceName ||
+            method.TypeArguments.FirstOrDefault() is not INamedTypeSymbol eventType ||
+            method.ContainingType.TypeArguments.FirstOrDefault() is not INamedTypeSymbol readModelType)
+        {
+            return null;
+        }
+
+        return (eventType, readModelType);
+    }
+
+    /// <summary>
+    /// Find the read model properties a builder callback writes explicitly.
+    /// </summary>
+    /// <param name="context">The analysis context.</param>
+    /// <param name="builderCallback">The <c>From</c> or <c>Join</c> builder callback.</param>
+    /// <param name="readModelType">The read model the enclosing block projects into.</param>
+    /// <param name="methodNames">The property-writing builder methods to look for.</param>
+    /// <returns>Each written property's name and the location of the write.</returns>
+    static IEnumerable<(string PropertyName, Location Location)> GetWrittenProperties(
+        SyntaxNodeAnalysisContext context,
+        ExpressionSyntax builderCallback,
+        INamedTypeSymbol readModelType,
+        HashSet<string> methodNames)
+    {
+        foreach (var invocation in builderCallback.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is not MemberAccessExpressionSyntax member ||
+                !methodNames.Contains(member.Name.Identifier.Text) ||
+                invocation.ArgumentList.Arguments.Count == 0 ||
+                !IsPropertiesBuilderMethodFor(context, invocation, readModelType) ||
+                !TryGetSimpleMemberName(invocation.ArgumentList.Arguments[0].Expression, out var propertyName))
+            {
+                continue;
+            }
+
+            yield return (propertyName, invocation.ArgumentList.Arguments[0].Expression.GetLocation());
+        }
+    }
+
+    static bool IsPropertiesBuilderMethodFor(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation, INamedTypeSymbol readModelType) =>
+        context.SemanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
+        method.ContainingType?.OriginalDefinition.Name == PropertiesBuilderInterfaceName &&
+        method.ContainingType.TypeArguments.FirstOrDefault() is INamedTypeSymbol modelType &&
+        SymbolEqualityComparer.Default.Equals(modelType, readModelType);
+
+    static bool TryGetSimpleMemberName(ExpressionSyntax expression, out string name)
+    {
+        name = string.Empty;
+
+        if (expression is not SimpleLambdaExpressionSyntax lambda ||
+            lambda.Body is not MemberAccessExpressionSyntax memberAccess ||
+            memberAccess.Expression is not IdentifierNameSyntax identifier ||
+            identifier.Identifier.Text != lambda.Parameter.Identifier.Text)
+        {
+            return false;
+        }
+
+        name = memberAccess.Name.Identifier.Text;
+        return true;
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/JoinOverridesLocalWrite.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/JoinOverridesLocalWrite.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// The rule and shared reasoning behind <see cref="DiagnosticIds.JoinOverridesLocalWrite"/>, which is reported
+/// from both the model-bound and the fluent analyzer.
+/// </summary>
+static class JoinOverridesLocalWrite
+{
+    /// <summary>
+    /// The shared descriptor for the diagnostic.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.JoinOverridesLocalWrite,
+        title: "A joined property is also written locally",
+        messageFormat: "Property '{0}' is written both locally by {1} and by the join with '{2}'. The joined value is re-applied after local mappings and always takes precedence, so the local write cannot reset the property once a '{2}' event exists. If the join deliberately keeps this property fresh, suppress this diagnostic; otherwise give each fact its own property and derive the outcome from both.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A projection re-resolves its joins every time it handles one of the read model's own events and applies the joined properties after the local mappings, so a property written by both always ends up with the joined value — independent of the order the events arrived. A local write can therefore never reset or clear a joined property: the natural latch shape, where a local event sets a flag and a joined event clears it, compiles and reads correctly but silently sticks on the joined value forever. When the join is meant to keep the property fresh — seed it locally, refresh it from the joined stream — the precedence is exactly what you want; suppress the diagnostic at the site to record that intent. When the property must reflect whichever fact happened most recently, record each fact on its own property (for example two timestamps) and compare them instead of latching a single value from both sides. Collisions caused by AutoMap rather than an explicit mapping are covered separately by CHR0025.");
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/JoinOverridesLocalWriteAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/JoinOverridesLocalWriteAnalyzer.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that reports a model-bound read model member written by both an explicit local mapping
+/// (<c>[SetFrom]</c>, <c>[SetValue]</c>, an aggregate, …) and a <c>[Join&lt;TEvent&gt;]</c> — a combination
+/// where the joined value always wins and the local write can never reset the property.
+/// </summary>
+/// <remarks>
+/// The fluent equivalent is covered by <see cref="FluentJoinOverridesLocalWriteAnalyzer"/>; both report
+/// <see cref="DiagnosticIds.JoinOverridesLocalWrite"/>. AutoMap-driven collisions are the domain of CHR0025.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class JoinOverridesLocalWriteAnalyzer : DiagnosticAnalyzer
+{
+    const string ModelBoundNamespace = "Cratis.Chronicle.Projections.ModelBound";
+    const string JoinAttributeName = "JoinAttribute";
+    const string AttributeSuffix = "Attribute";
+
+    /// <summary>
+    /// The attributes that write a member from the read model's own events — the local half of the collision.
+    /// </summary>
+    static readonly HashSet<string> LocalWriteAttributeNames = new(StringComparer.Ordinal)
+    {
+        "SetFromAttribute",
+        "SetValueAttribute",
+        "SetFromContextAttribute",
+        "AddFromAttribute",
+        "SubtractFromAttribute",
+        "CountAttribute",
+        "IncrementAttribute",
+        "DecrementAttribute"
+    };
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(JoinOverridesLocalWrite.Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        foreach (var member in GetMergedMembers(typeSymbol))
+        {
+            AnalyzeMember(context, member);
+        }
+    }
+
+    static void AnalyzeMember(SymbolAnalysisContext context, (string Name, List<AttributeData> Attributes, Location? Location) member)
+    {
+        var join = member.Attributes.Find(IsJoin);
+        var local = member.Attributes.Find(IsLocalWrite);
+
+        if (join is null || local is null)
+        {
+            return;
+        }
+
+        var joinEventName = ((INamedTypeSymbol)join.AttributeClass!.TypeArguments[0]).Name;
+        var localShortName = local.AttributeClass!.Name.Substring(0, local.AttributeClass.Name.Length - AttributeSuffix.Length);
+        var localEventName = ((INamedTypeSymbol)local.AttributeClass.TypeArguments[0]).Name;
+        var location = join.ApplicationSyntaxReference?.GetSyntax().GetLocation() ?? member.Location;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            JoinOverridesLocalWrite.Rule,
+            location,
+            member.Name,
+            $"[{localShortName}<{localEventName}>]",
+            joinEventName));
+    }
+
+    /// <summary>
+    /// Enumerate the members of a type with the attributes of the property and its backing positional record
+    /// parameter merged.
+    /// </summary>
+    /// <param name="typeSymbol">The type to enumerate.</param>
+    /// <returns>Each member's name, merged attributes, and a location to fall back to.</returns>
+    /// <remarks>
+    /// An attribute written without an explicit target on a positional record lands on the primary constructor's
+    /// parameter rather than on the generated property. The two colliding attributes usually sit together, but
+    /// nothing forces that — targeting one at the property and one at the parameter still collides at runtime —
+    /// so the member is judged on the union of both.
+    /// </remarks>
+    static IEnumerable<(string Name, List<AttributeData> Attributes, Location? Location)> GetMergedMembers(INamedTypeSymbol typeSymbol)
+    {
+        var members = new Dictionary<string, (List<AttributeData> Attributes, Location? Location)>(StringComparer.Ordinal);
+
+        foreach (var property in typeSymbol.GetMembers().OfType<IPropertySymbol>().Where(property => !property.IsStatic))
+        {
+            Merge(members, property);
+        }
+
+        var primaryConstructor = typeSymbol.InstanceConstructors
+            .OrderByDescending(constructor => constructor.Parameters.Length)
+            .FirstOrDefault();
+
+        foreach (var parameter in primaryConstructor?.Parameters ?? [])
+        {
+            Merge(members, parameter);
+        }
+
+        return members.Select(member => (member.Key, member.Value.Attributes, member.Value.Location));
+    }
+
+    static void Merge(Dictionary<string, (List<AttributeData> Attributes, Location? Location)> members, ISymbol symbol)
+    {
+        if (!members.TryGetValue(symbol.Name, out var entry))
+        {
+            entry = ([], symbol.Locations.FirstOrDefault());
+            members[symbol.Name] = entry;
+        }
+
+        entry.Attributes.AddRange(symbol.GetAttributes());
+    }
+
+    static bool IsJoin(AttributeData attribute) =>
+        IsModelBoundWithEvent(attribute) &&
+        string.Equals(attribute.AttributeClass!.Name, JoinAttributeName, StringComparison.Ordinal);
+
+    static bool IsLocalWrite(AttributeData attribute) =>
+        IsModelBoundWithEvent(attribute) &&
+        LocalWriteAttributeNames.Contains(attribute.AttributeClass!.Name);
+
+    static bool IsModelBoundWithEvent(AttributeData attribute) =>
+        attribute.AttributeClass is { TypeArguments.Length: 1 } attributeClass &&
+        attributeClass.ContainingNamespace?.ToDisplayString() == ModelBoundNamespace &&
+        attributeClass.TypeArguments[0] is INamedTypeSymbol;
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -210,4 +210,9 @@ public static class DiagnosticIds
     /// An event-metadata filter attribute is applied to a projection, which cannot filter on event metadata.
     /// </summary>
     public const string InertEventFilterOnProjection = "CHR0041";
+
+    /// <summary>
+    /// A read model property is written by both a local mapping and a join, and the joined value always takes precedence.
+    /// </summary>
+    public const string JoinOverridesLocalWrite = "CHR0042";
 }


### PR DESCRIPTION
# Summary

A joined projection property always wins over a local write for the same property — this states that precedence in the docs and adds an analyzer that surfaces the collision.

## Added

- CHR0042 analyzer warning when a read model property is written by both a local mapping and a join, covering the model-bound attributes and the fluent builder

## Changed

- The projection joins documentation (model-bound and declarative) now states join precedence: a joined property is applied over any value a local mapping wrote for the same property, independent of arrival order
