### PR TITLE
Correct Kotlin and Java client coverage notes, and drop the no-op link check

### DIFF
--- a/.github/workflows/markdown-verification.yml
+++ b/.github/workflows/markdown-verification.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+# Links are verified by 'npm run check' in the Documentation repo, which builds
+# the aggregated site and therefore knows its routing. A crawler pointed at this
+# folder cannot resolve a site-level route (/chronicle/...) or an extension-less
+# path to a .mdx page, and reports every one of them as broken.
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
@@ -26,19 +30,3 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v18
         with:
           globs: 'Documentation/**/*.md'
-
-  link-verification:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check links in Documentation
-        uses: JustinBeckwith/linkinator-action@v1
-        with:
-          paths: 'Documentation/**/*.md'
-          markdown: true
-          recurse: true
-          redirects: allow
-          statusCodes: '403:ok'
-          linksToSkip: '^(https?:\/\/)?(localhost|127\.0\.0\.1)(:\d+)?(\/|$)'

--- a/Documentation/contributing/clients/index.mdx
+++ b/Documentation/contributing/clients/index.mdx
@@ -63,6 +63,19 @@ Track the client SDK issue before using this API from this language.
 
 The default synchronized tab key is `chronicle-client`, so choosing TypeScript in one tab group selects TypeScript in the other tab groups on that page. Use a custom `syncKey` only when tab groups should not follow each other.
 
+### Where "client X doesn't support this" belongs
+
+That unsupported snippet is the **only** place to state that a client does not support a workflow. Do not write it as prose on a shared page — no "this is currently C#-only", no "Kotlin and Java don't have an equivalent yet".
+
+A shared page cannot know when a client gains a capability. It lives in a different repo, on a different release cadence, with no CI that fails when the claim stops being true — so the claim silently rots, and the first person to notice is a reader who believes it. An unsupported snippet, by contrast, sits in the client repo next to the code, and the person adding the capability is already editing that folder.
+
+The rule is about **claims of absence**, not about describing differences. It is fine for a shared page to say that a client expresses the same capability through a different shape, as long as it does not assert that some client cannot do something:
+
+- ❌ "Kotlin, Java, and Elixir don't currently support targeting a non-default event sequence at all."
+- ✅ "TypeScript reaches the same result through the decorator's event-sequence parameter rather than a separate attribute."
+
+When a client does not support a workflow at all, leave the shared prose alone and let the tab carry it.
+
 ### Validation and CI
 
 Each client repo must also keep `Documentation/validate-client-snippets.py` wired into its `Client Snippet Verification` workflow. That workflow compiles the snippets against the client source when either `Documentation/client-snippets/**` or `Source/**` changes, so a client API change cannot silently leave the shared Chronicle docs stale.

--- a/Documentation/reactors/event-sequence.mdx
+++ b/Documentation/reactors/event-sequence.mdx
@@ -8,7 +8,7 @@ Apply `[EventSequence]` directly to your reactor class to pin it to a specific e
 
 <ChronicleClientTabs snippet="reactors/event-sequence/event-sequence-attribute" />
 
-TypeScript reaches the same result through the `reactor()` decorator's `eventSequenceId` parameter shown below rather than a separate attribute. Kotlin, Java, and Elixir don't currently support targeting a non-default event sequence at all.
+TypeScript reaches the same result through the `reactor()` decorator's `eventSequenceId` parameter, and Kotlin and Java through the `eventSequence` parameter on `@Reactor` — all shown under [Using the `[Reactor]` Attribute](#using-the-reactor-attribute) below, rather than as a separate attribute. Elixir doesn't currently support targeting a non-default event sequence at all.
 
 ## Using the `[Reactor]` Attribute
 

--- a/Documentation/reactors/once-only.mdx
+++ b/Documentation/reactors/once-only.mdx
@@ -32,5 +32,5 @@ being invoked more than once when it fails partway through.
 Reach for the method placement unless the entire reactor exists to do something that must not happen twice.
 
 :::note[Client coverage]
-`OnceOnly` is currently C#-only — Kotlin, Java, Elixir, and TypeScript have no equivalent marker, so a replay or retry always re-runs the full handler in those clients. Design side effects to be idempotent instead (see [Getting started with reactors](getting-started)).
+Elixir and TypeScript have no equivalent marker, so a replay always re-runs the full handler there. Design side effects to be idempotent instead (see [Getting started with reactors](getting-started)).
 :::

--- a/Documentation/reactors/replay.mdx
+++ b/Documentation/reactors/replay.mdx
@@ -21,6 +21,5 @@ Reach for [OnceOnly](once-only) instead when the side effect should simply not h
 a replay needs to do something *different* rather than nothing.
 
 :::note[Client coverage]
-`Replay` is currently C#-only — Kotlin, Java, Elixir, and TypeScript have no equivalent marker, so a replay
-always re-runs the regular handler in those clients.
+Elixir and TypeScript have no equivalent marker, so a replay always re-runs the regular handler there.
 :::

--- a/Documentation/reducers/event-processing.mdx
+++ b/Documentation/reducers/event-processing.mdx
@@ -3,7 +3,7 @@
 Understanding how reducers process events is crucial for building effective read models. This guide covers the event processing model, method patterns, and advanced techniques.
 
 :::note[Client coverage on this page]
-The patterns below are shown in C# and build on the shape already established in [Getting started with reducers](getting-started): Kotlin, Java, and TypeScript dispatch handlers with a fixed `(event, current)` shape and no `EventContext` parameter; Elixir dispatches through a single `reduce/3` callback that does receive a context map; only C# and Elixir can use event metadata (timestamps, sequence numbers) while computing the next state. The accumulation/state-transition/collection/time-window/conditional patterns on this page are illustrative C# idioms (`with` expressions, LINQ) rather than framework capabilities — the same ideas apply in every client using that language's own idioms for immutable updates.
+The patterns below are shown in C# and build on the shape already established in [Getting started with reducers](getting-started): Kotlin and Java dispatch handlers with an optional `EventContext` as a third parameter; TypeScript dispatches a fixed `(event, current)` shape with no context parameter; Elixir dispatches through a single `reduce/3` callback that does receive a context map. Every client except TypeScript can therefore use event metadata (timestamps, sequence numbers) while computing the next state. The accumulation/state-transition/collection/time-window/conditional patterns on this page are illustrative C# idioms (`with` expressions, LINQ) rather than framework capabilities — the same ideas apply in every client using that language's own idioms for immutable updates.
 :::
 
 ## Event Processing Model

--- a/Documentation/reducers/event-sequence.mdx
+++ b/Documentation/reducers/event-sequence.mdx
@@ -8,7 +8,7 @@ Apply `[EventSequence]` directly to your reducer class to pin it to a specific e
 
 <ChronicleClientTabs snippet="reducers/event-sequence/event-sequence-attribute" />
 
-TypeScript reaches the same result through the `reducer()` decorator's event-sequence parameter shown below rather than a separate attribute. Kotlin, Java, and Elixir don't currently support targeting a non-default event sequence for a reducer at all.
+TypeScript reaches the same result through the `reducer()` decorator's event-sequence parameter, and Kotlin and Java through the `eventSequence` parameter on `@Reducer` — all shown under [Using the `[Reducer]` Attribute](#using-the-reducer-attribute) below, rather than as a separate attribute. Elixir doesn't currently support targeting a non-default event sequence for a reducer at all.
 
 ## Using the `[Reducer]` Attribute
 

--- a/Documentation/reducers/getting-started.mdx
+++ b/Documentation/reducers/getting-started.mdx
@@ -24,7 +24,7 @@ Create a reducer by implementing `IReducerFor<TReadModel>` with methods for each
 
 <ChronicleClientTabs snippet="reducers/getting-started/reducer-implementation" />
 
-Kotlin, Java, and TypeScript handler methods only receive the event and the current state — unlike C# and Elixir, they don't get an `EventContext` parameter, so they can't use an event's metadata (like `Occurred`) when computing the next state.
+TypeScript handler methods only receive the event and the current state — unlike C#, Kotlin, Java, and Elixir, they don't get an `EventContext` parameter, so they can't use an event's metadata (like `Occurred`) when computing the next state.
 
 ## Method Signatures
 
@@ -38,7 +38,7 @@ Reducer methods are discovered by convention and support the following signature
 
 <ChronicleClientTabs snippet="reducers/getting-started/async-signatures" />
 
-These overload tables are specific to C#'s method-overload-based dispatch. Kotlin, Java, and TypeScript each dispatch reducer handlers by matching the first parameter's event type against a fixed 2-parameter (event, current) shape — no context parameter. TypeScript's dispatch does `await` the handler, so an `async` handler works there; Kotlin and Java invoke the handler directly and cannot await it, so a suspend/async handler isn't supported in those two. Elixir dispatches through a single `reduce/3` callback per event, pattern-matched by struct type, which does receive a context map.
+These overload tables are specific to C#'s method-overload-based dispatch. Kotlin, Java, and TypeScript each dispatch reducer handlers by matching the first parameter's event type. Kotlin and Java accept `(event)`, `(event, current)`, and `(event, current, context)`; TypeScript accepts a fixed `(event, current)` shape with no context parameter. TypeScript's dispatch does `await` the handler, so an `async` handler works there; Kotlin and Java invoke the handler directly and cannot await it, so a suspend/async handler isn't supported in those two. Elixir dispatches through a single `reduce/3` callback per event, pattern-matched by struct type, which does receive a context map.
 
 **Key Points:**
 
@@ -60,7 +60,7 @@ You can customize the reducer using the `[Reducer]` attribute:
 - `eventSequence` - The event sequence to observe (defaults to the event log)
 - `isActive` - Whether the reducer actively observes events (defaults to `true`)
 
-Kotlin, Java, and Elixir only support setting a custom `id` — none of them currently support targeting a non-default event sequence or explicitly toggling active/passive from this attribute. TypeScript supports both `id` and the event sequence via the `reducer()` decorator's parameters, shown above.
+Kotlin and Java support all three parameters on `@Reducer`. TypeScript supports `id` and the event sequence via the `reducer()` decorator's parameters, shown above. Elixir only supports setting a custom `id`.
 
 ## Retrieving Reduced State
 

--- a/Documentation/reducers/passive-reducers.mdx
+++ b/Documentation/reducers/passive-reducers.mdx
@@ -3,7 +3,7 @@
 Passive reducers are registered with the kernel but do not actively observe and materialize events through the sink. This is useful when you want to compute read model state on-demand rather than maintaining it continuously.
 
 :::note[Client coverage]
-Passive reducers are currently C#-only. Kotlin's `@Reducer`, Elixir's `use Chronicle.Reducers.Reducer`, and TypeScript's `reducer()` decorator only support a custom `id` (and, for TypeScript, an event sequence) — none of them expose an `isActive` toggle or a read-model-level passive marker.
+Kotlin and Java expose the `isActive` toggle on `@Reducer` (Option 1 below). The read-model-level `[Passive]` marker (Option 2) is C#-only. Elixir's `use Chronicle.Reducers.Reducer` and TypeScript's `reducer()` decorator have neither.
 :::
 
 ## Understanding Passive vs Active Reducers

--- a/Documentation/tutorial/reacting.mdx
+++ b/Documentation/tutorial/reacting.mdx
@@ -30,7 +30,7 @@ For side effects that genuinely must never repeat — a physical letter, a payme
 
 <ChronicleClientTabs snippet="tutorial/reacting/once-only" />
 
-Kotlin, Java, Elixir, and TypeScript don't currently have an equivalent to `[OnceOnly]` — replay/redaction exclusion for a specific handler is C#-only for now.
+Elixir and TypeScript don't currently have an equivalent to `[OnceOnly]` — replay/redaction exclusion for a specific handler is available in C#, Kotlin, and Java.
 
 Use it deliberately, though — the same guarantee means a `[OnceOnly]` handler also *won't* run again when you replay on purpose. Idempotent-by-design stays the default; `[OnceOnly]` is for the effects where "again" is worse than "never".
 

--- a/Documentation/verify-markdown.sh
+++ b/Documentation/verify-markdown.sh
@@ -21,9 +21,9 @@ fi
 echo "Working directory: $PWD"
 echo ""
 
-# Step 1: Markdown Linting
+# Markdown Linting
 echo "=========================================="
-echo "Step 1: Running markdownlint..."
+echo "Running markdownlint..."
 echo "=========================================="
 echo ""
 
@@ -32,8 +32,8 @@ if ! command -v npx &> /dev/null; then
     exit 1
 fi
 
-npx markdownlint-cli2 "Documentation/**/*.md"
-LINT_EXIT_CODE=$?
+LINT_EXIT_CODE=0
+npx markdownlint-cli2 "Documentation/**/*.md" || LINT_EXIT_CODE=$?
 
 echo ""
 if [ $LINT_EXIT_CODE -eq 0 ]; then
@@ -43,35 +43,22 @@ else
 fi
 echo ""
 
-# Step 2: Link Verification
-echo "=========================================="
-echo "Step 2: Running link verification..."
-echo "=========================================="
-echo ""
-echo "This may take a few minutes to check all links..."
-echo ""
+# Link verification lives in the Documentation repo, not here. These pages are
+# published through the aggregated docs site, where a link may be a site-level
+# route (/chronicle/...), or an extension-less path to a .mdx page. Only the site
+# build knows that routing; a crawler pointed at this folder cannot resolve any
+# of it and reports every such link as broken. Run `npm run check` in the
+# Documentation repo, which must end with 0 errors and 0 broken links.
 
-npx linkinator "Documentation/**/*.md" --markdown --recurse --verbosity error --status-code "403:ok" --skip "^(https?:\\/\\/)?(localhost|127\\.0\\.0\\.1)(:\\d+)?(\\/|$)"
-LINK_EXIT_CODE=$?
-
-echo ""
-if [ $LINK_EXIT_CODE -eq 0 ]; then
-    echo "✓ Link verification passed!"
-else
-    echo "✗ Link verification failed with exit code $LINK_EXIT_CODE"
-fi
-echo ""
-
-# Final summary
 echo "=========================================="
 echo "Summary"
 echo "=========================================="
-if [ $LINT_EXIT_CODE -eq 0 ] && [ $LINK_EXIT_CODE -eq 0 ]; then
+if [ $LINT_EXIT_CODE -eq 0 ]; then
     echo "✓ All checks passed!"
+    echo ""
+    echo "Links are verified by 'npm run check' in the Documentation repo."
     exit 0
 else
-    echo "✗ Some checks failed:"
-    [ $LINT_EXIT_CODE -ne 0 ] && echo "  - Markdown linting"
-    [ $LINK_EXIT_CODE -ne 0 ] && echo "  - Link verification"
+    echo "✗ Markdown linting failed."
     exit 1
 fi


### PR DESCRIPTION
# Summary

Client coverage notes said Kotlin and Java lacked reactor and reducer features they now have.

## Changed

- Coverage notes on the reactor, reducer, and tutorial pages now reflect that Kotlin and Java support `@OnceOnly`, `@Replay`, event sequence targeting, passive reducers, and an `EventContext` parameter on reducer handlers.

## Fixed

- The contributing guide now states that a claim a client does not support something belongs in that client's unsupported snippet, not in shared page prose.
