### PR TITLE
Release unique event type constraints and fix PII read model reads

### DIFF
--- a/Documentation/client-snippets/constraints/declarative/unique-event-type/releasing.md
+++ b/Documentation/client-snippets/constraints/declarative/unique-event-type/releasing.md
@@ -1,0 +1,21 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+[EventType]
+public record ConstraintsUniqueEventTypeShiftStarted(string Location);
+
+[EventType]
+public record ConstraintsUniqueEventTypeShiftEnded;
+
+public class ConstraintsUniqueEventTypeOneOpenShift : IConstraint
+{
+    // At most one open shift per employee. Ending the shift releases the constraint,
+    // so the next shift is allowed - without it the constraint could only say
+    // "at most one, ever", and the employee's second shift would be refused forever.
+    public void Define(IConstraintBuilder builder) =>
+        builder
+            .Unique<ConstraintsUniqueEventTypeShiftStarted>()
+            .RemovedWith<ConstraintsUniqueEventTypeShiftEnded>();
+}
+```

--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -34,6 +34,30 @@ It's tempting to make one `Customer` read model serve every screen. Resist it. T
 
 You rarely write code that *updates* a read model — you declare how events map onto it and let Chronicle do the folding. Start with [model-bound projections](../projections/model-bound/), where attributes on the read model record describe the mapping. When the mapping needs logic the attributes can't express cleanly, step up to the fluent [declarative projection builder](../projections/declarative/) (`IProjectionFor<T>`), and only reach for a [reducer](../reducers/) when the model is genuinely easier to express as code folding over previous state.
 
+## The constructor may not run
+
+Sooner or later you'll want to put a small piece of logic in the read model record itself — a normalizer that turns a `null` collection into an empty one, a computed default, a guard that rejects a value that should never arrive:
+
+```csharp
+// Don't rely on this. It may never execute.
+public record OrderSummary(OrderId Id, IEnumerable<LineItem> Lines)
+{
+    public IEnumerable<LineItem> Lines { get; init; } = Lines ?? [];
+}
+```
+
+Whether that line runs is not yours to decide. A read model instance is *materialized* by a deserializer, and a document deserializer is free to build the record without running either a constructor or the initializer. The MongoDB driver does exactly that: when the stored document doesn't carry every constructor parameter, it materializes the record uninitialized and assigns only the members the document actually has. A [child collection with no children](../read-models/empty-child-collections) is stored as an absent field, so this is the ordinary case, not an exotic one — and your normalizer never executes.
+
+Chronicle's own reader *does* construct the record, which makes this worse rather than better: the same line can work when you read through `IReadModels` and quietly fail when something reads that document with `IMongoCollection<T>`. And even where the constructor runs, a property declared in the record body gets its stored value assigned after construction, on top of whatever its initializer produced.
+
+So a guard written in a read model record is not a guard. Put the intent somewhere that always runs:
+
+| You want | Where it belongs |
+| --- | --- |
+| A collection that is never `null` | The declaration. A non-nullable collection property materializes as empty — see [Empty child collections](../read-models/empty-child-collections). |
+| A meaningful default before any event assigns the property | The projection — [SetValue](../projections/model-bound/set-value) or [initial values](../projections/declarative/initial-values) — so the default is part of the projected state every reader sees. |
+| A rule that rejects bad data | The write side, before the event is appended. A read model is derived from facts that already happened; refusing them here is too late to help. |
+
 ## Design for eventual consistency
 
 A *materialized* read model updates *after* the event is appended, so what's stored is [eventually consistent](../read-models/consistency.md). Design with that in mind: don't read a stored model back inside a command or reactor to make a decision (use a [constraint](../constraints/) for invariants instead), and prefer [observable queries](../scenarios/real-time-query) so the UI reflects changes the moment the projection catches up.

--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -46,7 +46,9 @@ public record OrderSummary(OrderId Id, IEnumerable<LineItem> Lines)
 }
 ```
 
-Whether that line runs is not yours to decide. A read model instance is *materialized* by a deserializer, and a document deserializer is free to build the record without running either a constructor or the initializer. The MongoDB driver does exactly that: when the stored document doesn't carry every constructor parameter, it materializes the record uninitialized and assigns only the members the document actually has. A [child collection with no children](../read-models/empty-child-collections) is stored as an absent field, so this is the ordinary case, not an exotic one — and your normalizer never executes.
+Whether that line runs is not yours to decide. A read model instance is *materialized* by a deserializer, and a document deserializer is free to build the record without running either a constructor or the initializer. The MongoDB driver does exactly that, and it is not conditional: for a record with a primary constructor it builds no creator map at all, so it creates the instance uninitialized and assigns the members by reflection. That happens on every document — a complete one just as much as one missing a field. Read a read model through `IMongoCollection<T>` and your normalizer never runs, ever.
+
+That makes the blast radius wider than a `null` collection. Any logic you put in the record body — a default, a clamp, a trim, a validation — is dead on that path, silently.
 
 Chronicle's own reader *does* construct the record, which makes this worse rather than better: the same line can work when you read through `IReadModels` and quietly fail when something reads that document with `IMongoCollection<T>`. And even where the constructor runs, a property declared in the record body gets its stored value assigned after construction, on top of whatever its initializer produced.
 

--- a/Documentation/constraints/declarative/unique-event-type.mdx
+++ b/Documentation/constraints/declarative/unique-event-type.mdx
@@ -24,6 +24,18 @@ An optional name can be provided to identify the constraint. When not provided, 
 
 <ChronicleClientTabs snippet="constraints/declarative/unique-event-type/constraint-name" />
 
+## Releasing a constraint
+
+Left alone the constraint says "at most one, ever". Most lifecycles repeat — a shift is worked and ended, a loan is taken and returned, a subscription is activated and cancelled — and for those, "ever" refuses the second legitimate cycle and there is nothing the caller can do about it.
+
+Call `.RemovedWith<T>()` to name the event that ends a cycle. A covered event then violates the constraint only when it comes **after** the most recent removal event on that event source, so the next cycle is free to start:
+
+<ChronicleClientTabs snippet="constraints/declarative/unique-event-type/releasing" />
+
+The removal applies to the constraint declared immediately before it, and it is per event source — one employee ending their shift opens their own next cycle and nobody else's. Declaring several event types under one name makes them a single constraint, and a single constraint has one removal event.
+
+The [model-bound form](../model-bound/unique-event-type) expresses the same thing with `[RemoveConstraint]` on the event that ends the cycle.
+
 ## Mutually exclusive event types
 
 Declare several event types under the **same constraint name** and they become one constraint: at most one event drawn from that set is allowed per event source. Use it when an event source has more than one terminal outcome and the outcomes exclude each other — cancelled *or* completed, merged *or* erased, approved *or* permanently rejected.

--- a/Documentation/get-started/_includes/mongodb.mdx
+++ b/Documentation/get-started/_includes/mongodb.mdx
@@ -14,4 +14,8 @@ itself — Chronicle's own read behavior does not travel with it. The one that b
 children, which is stored as an absent field: read through Chronicle and a non-nullable property comes back empty,
 read it with the driver and it comes back as whatever the driver does with a missing field. See
 [Empty child collections](/chronicle/read-models/empty-child-collections/).
+
+It doesn't travel the other way either: these conventions apply to the reads you make with the driver, never to a
+read model Chronicle hands back or injects into a command. See
+[What a MongoDB convention pack reaches](/chronicle/sinks/#what-a-mongodb-convention-pack-reaches).
 :::

--- a/Documentation/projections/declarative/initial-values.mdx
+++ b/Documentation/projections/declarative/initial-values.mdx
@@ -8,7 +8,7 @@ The exact API name depends on the client. .NET exposes `WithInitialValues`, whil
 
 Provide a factory that returns a fresh read model instance with the desired default values. Event mappings then apply on top of that initial state.
 
-Kotlin and Elixir don't have a `WithInitialValues`-style builder call, but they achieve the same result idiomatically: the read model's own constructor/struct default values become its initial state (see [Collections](#collections) below for a working example that doesn't need event context). This particular example also maps an event context property (`Occurred`), which neither client's fluent projection API can access yet.
+Kotlin and Elixir don't have a `WithInitialValues`-style builder call, but they reach the same result idiomatically: as the client builds the projection definition it registers, it reads the read model type's own declared defaults — Kotlin's primary-constructor defaults, Elixir's `defstruct` defaults — and captures them into that definition (see [Collections](#collections) below for a working example that doesn't need event context). That capture is why the defaults reach the stored state: they travel with the registered definition, exactly as `WithInitialValues` values do. Nothing runs the constructor when a document is later read — see [The constructor may not run](../../concepts/designing-read-models#the-constructor-may-not-run). This particular example also maps an event context property (`Occurred`), which neither client's fluent projection API can access yet.
 
 <ChronicleClientTabs snippet="projections/declarative/initial-values/basic" />
 

--- a/Documentation/read-models/empty-child-collections.mdx
+++ b/Documentation/read-models/empty-child-collections.mdx
@@ -44,6 +44,10 @@ The declaration is the decision point. There is no option to set and nothing to 
 
 The rule is applied when the instance is materialized, not when it is stored, so changing a declaration takes effect for instances that were written long before you changed it. Nothing needs replaying.
 
+:::caution
+A normalizer in the record — `IEnumerable<LineItem> Lines { get; init; } = Lines ?? [];` — looks like the obvious in-language fix, and it is not one. The MongoDB driver materializes a record without running its constructor whenever the stored document omits a member, which is exactly this case, so the normalizer never runs. [Designing read models](../concepts/designing-read-models#the-constructor-may-not-run) explains why the record body is the wrong place for it.
+:::
+
 ## Initial values do not reach a child collection
 
 [Initial values](../projections/declarative/initial-values) look like the place to say "this collection starts empty", and for a children collection they do nothing. The initial state is applied with every children path removed — the same exclusion, for the same replay reason — so an initial `Lines = []` is dropped before it reaches the sink.

--- a/Documentation/sinks/index.mdx
+++ b/Documentation/sinks/index.mdx
@@ -15,6 +15,23 @@ The default sink. Read model instances are stored as MongoDB documents, one docu
 
 This requires no additional setup — MongoDB is the default when you configure Chronicle.
 
+## What a MongoDB convention pack reaches
+
+Because read model instances land in MongoDB as documents, it's natural to assume that configuring the MongoDB driver configures how Chronicle hands read models back. It doesn't, and the gap is worth knowing before you spend an afternoon on it.
+
+A convention pack — whether you provide one through Arc's [ICanProvideMongoDBConventionPacks](/arc/backend/mongodb/convention-packs/) or call `ConventionRegistry.Register` yourself — is registered in the MongoDB driver's global convention registry. That registry configures the driver's class maps. So a convention pack reaches exactly as far as the driver does, and no further:
+
+| Path a read model takes | Does the convention pack apply |
+| --- | --- |
+| Your own `IMongoCollection<T>` query | Yes — the driver builds the instance from a class map |
+| Chronicle's read model APIs — by key, materialized, snapshots, watching | No |
+| A read model injected into a command's validator, `Provide()`, or `Handle()` | No |
+| The document the sink writes | No |
+
+Chronicle returns a read model as JSON and materializes it with `System.Text.Json`, so no `BsonClassMap` is consulted anywhere on that path. Command-side read model injection is the one that surprises people: it resolves through the same read model API, so a rename, a custom serializer, or an `IgnoreExtraElements` convention that is visibly working in your query code has no effect at all on the instance your command receives. And the sink writes the document from the projected state rather than from a class map of your type, so a convention pack doesn't change what gets stored either.
+
+That is what the convention registration in [Get started](/chronicle/get-started/) is for. It isn't configuring Chronicle — it's telling *your* driver how to map your type onto element names Chronicle has already chosen.
+
 ## SQL Sink
 
 The SQL sink treats the database as a document store. Each read model type gets its own table with two columns:

--- a/Integration/Client/for_EventSequence/when_appending/UniqueEventReleasedByRemovalConstraint.cs
+++ b/Integration/Client/for_EventSequence/when_appending/UniqueEventReleasedByRemovalConstraint.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending;
+
+public class UniqueEventReleasedByRemovalConstraint : IConstraint
+{
+    public const string Name = "UniqueUserOnboardingPerCycle";
+
+    public void Define(IConstraintBuilder builder) => builder
+        .Unique<UserOnboardingStarted>(name: Name)
+        .RemovedWith<UserRemoved>();
+}

--- a/Integration/Client/for_EventSequence/when_appending/with_unique_event_added_and_then_removed.cs
+++ b/Integration/Client/for_EventSequence/when_appending/with_unique_event_added_and_then_removed.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending.with_unique_event_added_and_then_removed.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending;
+
+/// <summary>
+/// The whole path for the per-event-source form of uniqueness: the constraint is declared on the client, registered
+/// over the wire, and enforced by the kernel against the real store. Every layer in between used to drop the removal
+/// event - the client discarded it before the contract, and the kernel had nowhere to put it - so a constraint
+/// declared as releasing behaved as "at most one, forever" with nothing anywhere reporting a problem.
+/// </summary>
+/// <param name="context">The <see cref="context"/> the specification runs against.</param>
+[Collection(ChronicleCollection.Name)]
+public class with_unique_event_added_and_then_removed(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification<ChronicleFixture>(chronicleFixture)
+    {
+        public override IEnumerable<Type> ConstraintTypes => [typeof(UniqueEventReleasedByRemovalConstraint)];
+        public override IEnumerable<Type> EventTypes => [typeof(UserOnboardingStarted), typeof(UserRemoved)];
+
+        UserOnboardingStarted _event;
+        UserRemoved _removedEvent;
+
+        public IAppendResult FirstResult { get; private set; }
+        public IAppendResult RemovedResult { get; private set; }
+        public IAppendResult NextCycleResult { get; private set; }
+        public IAppendResult SameCycleResult { get; private set; }
+
+        public void Establish()
+        {
+            _event = new UserOnboardingStarted(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            _removedEvent = new UserRemoved();
+        }
+
+        public async Task Because()
+        {
+            var eventSourceId = Guid.NewGuid().ToString();
+            FirstResult = await EventStore.EventLog.Append(eventSourceId, _event);
+            RemovedResult = await EventStore.EventLog.Append(eventSourceId, _removedEvent);
+            NextCycleResult = await EventStore.EventLog.Append(eventSourceId, _event);
+            SameCycleResult = await EventStore.EventLog.Append(eventSourceId, _event);
+        }
+    }
+
+    [Fact] void should_succeed_on_first_attempt() => Context.FirstResult.IsSuccess.ShouldBeTrue();
+    [Fact] void should_succeed_on_remove_attempt() => Context.RemovedResult.IsSuccess.ShouldBeTrue();
+    [Fact] void should_succeed_on_the_next_cycle() => Context.NextCycleResult.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_succeed_within_the_same_cycle() => Context.SameCycleResult.IsSuccess.ShouldBeFalse();
+}

--- a/Integration/Kernel/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_a_released_event_type_is_appended_again.cs
+++ b/Integration/Kernel/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_a_released_event_type_is_appended_again.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Events.Constraints;
+using Cratis.Chronicle.Storage.EventSequences;
+
+using ConceptsEventStoreName = Cratis.Chronicle.Concepts.EventStoreName;
+using ConceptsEventStoreNamespaceName = Cratis.Chronicle.Concepts.EventStoreNamespaceName;
+using context = Cratis.Chronicle.Kernel.Integration.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_a_released_event_type_is_appended_again.context;
+
+namespace Cratis.Chronicle.Kernel.Integration.Events.Constraints.for_UniqueEventTypesConstraintsStorage;
+
+/// <summary>
+/// The unique event type constraint keeps no index - it is answered by querying the event sequence collection - so
+/// "has this event source been released" is a database query, and the query is the whole behavior. A spec against
+/// the in-memory storage settles the semantics but says nothing about whether the MongoDB one expresses them: the
+/// two share a signature, not a contract.
+/// <para>
+/// This runs the real storage over a real store, with both event sources in one collection so the per-event-source
+/// filtering is exercised too. One borrower has an open loan, the other returned theirs.
+/// </para>
+/// </summary>
+/// <param name="context">The <see cref="context"/> the specification runs against.</param>
+[Collection(ChronicleCollection.Name)]
+public class when_a_released_event_type_is_appended_again(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification<ChronicleFixture>(fixture)
+    {
+        public bool IsAllowedForTheBorrowerWithAnOpenLoan;
+        public EventSequenceNumber SequenceNumberOfTheViolation = default!;
+        public bool IsAllowedForTheBorrowerWhoReturned;
+
+        readonly EventSequenceId _eventSequenceId = $"unique-event-type-release-{Guid.NewGuid():N}";
+        readonly EventSourceId _borrowerWithAnOpenLoan = $"borrower-open-{Guid.NewGuid():N}";
+        readonly EventSourceId _borrowerWhoReturned = $"borrower-returned-{Guid.NewGuid():N}";
+        readonly EventType _checkedOutEventType = new($"LoanCheckedOut-{Guid.NewGuid():N}", EventTypeGeneration.First);
+        readonly EventType _returnedEventType = new($"LoanReturned-{Guid.NewGuid():N}", EventTypeGeneration.First);
+
+        IEventSequenceStorage _eventSequence = default!;
+        IUniqueEventTypesConstraintsStorage _constraints = default!;
+
+        async Task Establish()
+        {
+            var eventStoreStorage = Services
+                .GetRequiredService<IStorage>()
+                .GetEventStore((ConceptsEventStoreName)Constants.EventStore);
+
+            // Appending goes through the schema, so the event types have to exist before there is anything to
+            // constrain. An empty schema is enough - the constraint reads the event's type and event source, never
+            // its content.
+            await eventStoreStorage.EventTypes.Register(_checkedOutEventType, new JsonSchema());
+            await eventStoreStorage.EventTypes.Register(_returnedEventType, new JsonSchema());
+
+            var namespaceStorage = eventStoreStorage.GetNamespace(ConceptsEventStoreNamespaceName.Default);
+
+            _eventSequence = namespaceStorage.GetEventSequence(_eventSequenceId);
+            _constraints = namespaceStorage.GetUniqueEventTypesConstraints(_eventSequenceId);
+
+            // One borrower opened a loan, returned it and opened another - so the current cycle is held by the
+            // event at sequence number 2, not the one at 0.
+            await Append(0, _checkedOutEventType, _borrowerWithAnOpenLoan);
+            await Append(1, _returnedEventType, _borrowerWithAnOpenLoan);
+            await Append(2, _checkedOutEventType, _borrowerWithAnOpenLoan);
+
+            // The other opened a loan and returned it, so nothing holds their constraint.
+            await Append(3, _checkedOutEventType, _borrowerWhoReturned);
+            await Append(4, _returnedEventType, _borrowerWhoReturned);
+        }
+
+        async Task Because()
+        {
+            (IsAllowedForTheBorrowerWithAnOpenLoan, SequenceNumberOfTheViolation) = await _constraints.IsAllowed(Definition, _borrowerWithAnOpenLoan);
+            (IsAllowedForTheBorrowerWhoReturned, _) = await _constraints.IsAllowed(Definition, _borrowerWhoReturned);
+        }
+
+        UniqueEventTypeConstraintDefinition Definition =>
+            new($"loan-open-{_eventSequenceId}", [_checkedOutEventType.Id], _returnedEventType.Id);
+
+        Task Append(EventSequenceNumber sequenceNumber, EventType eventType, EventSourceId eventSourceId) =>
+            _eventSequence.Append(
+                sequenceNumber,
+                EventSourceType.Default,
+                eventSourceId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                eventType,
+                CorrelationId.New(),
+                [],
+                [],
+                [],
+                DateTimeOffset.UtcNow,
+                new Dictionary<EventTypeGeneration, ExpandoObject> { { EventTypeGeneration.First, new ExpandoObject() } },
+                new Dictionary<EventTypeGeneration, EventHash>());
+    }
+
+    [Fact] void should_not_allow_a_covered_event_while_the_cycle_is_open() => Context.IsAllowedForTheBorrowerWithAnOpenLoan.ShouldBeFalse();
+    [Fact] void should_report_the_violation_from_the_open_cycle() => Context.SequenceNumberOfTheViolation.ShouldEqual((EventSequenceNumber)2U);
+    [Fact] void should_allow_a_covered_event_once_the_cycle_is_closed() => Context.IsAllowedForTheBorrowerWhoReturned.ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/and_a_unique_event_type_constraint_was_declared.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/and_a_unique_event_type_constraint_was_declared.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Cratis.Chronicle.Events.Constraints.for_ConstraintBuilder.when_declaring_a_removal_event;
+
+/// <summary>
+/// The removal seam the per-event-source form was missing. Without it the constraint can only say "at most one,
+/// forever" — expressible, but wrong for any lifecycle that repeats, and there was no way to say anything else.
+/// </summary>
+public class and_a_unique_event_type_constraint_was_declared : given.a_constraint_builder_with_owner
+{
+    IImmutableList<IConstraintDefinition> _result;
+    EventType _checkedOutEventType;
+    EventType _returnedEventType;
+
+    void Establish()
+    {
+        _checkedOutEventType = new EventType(nameof(LoanCheckedOut), EventTypeGeneration.First);
+        _returnedEventType = new EventType(nameof(LoanReturned), EventTypeGeneration.First);
+        _eventTypes.GetEventTypeFor(typeof(LoanCheckedOut)).Returns(_checkedOutEventType);
+        _eventTypes.GetEventTypeFor(typeof(LoanReturned)).Returns(_returnedEventType);
+    }
+
+    void Because()
+    {
+        _constraintBuilder
+            .Unique<LoanCheckedOut>(name: "LoanOpen")
+            .RemovedWith<LoanReturned>();
+
+        _result = _constraintBuilder.Build();
+    }
+
+    [Fact] void should_have_a_single_constraint() => _result.Count.ShouldEqual(1);
+    [Fact] void should_still_cover_the_declared_event_type() => ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeIds.ShouldContainOnly([_checkedOutEventType.Id]);
+    [Fact] void should_carry_the_removal_event() => ((UniqueEventTypeConstraintDefinition)_result[0]).RemovedWith.ShouldEqual(_returnedEventType.Id);
+
+    record LoanCheckedOut();
+    record LoanReturned();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/and_several_event_types_share_a_name.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/and_several_event_types_share_a_name.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Cratis.Chronicle.Events.Constraints.for_ConstraintBuilder.when_declaring_a_removal_event;
+
+/// <summary>
+/// Declarations sharing a name merge into one constraint, and one constraint has one removal event. It is declared on
+/// whichever declaration the author reached it from, so the merge coalesces rather than keeping the first
+/// declaration's value — otherwise a removal event declared on the second declaration is silently dropped and the
+/// constraint goes back to meaning "forever" with nothing reporting it.
+/// </summary>
+public class and_several_event_types_share_a_name : given.a_constraint_builder_with_owner
+{
+    const string ConstraintName = "LoanOpen";
+
+    IImmutableList<IConstraintDefinition> _result;
+    EventType _checkedOutEventType;
+    EventType _renewedEventType;
+    EventType _returnedEventType;
+
+    void Establish()
+    {
+        _checkedOutEventType = new EventType(nameof(LoanCheckedOut), EventTypeGeneration.First);
+        _renewedEventType = new EventType(nameof(LoanRenewed), EventTypeGeneration.First);
+        _returnedEventType = new EventType(nameof(LoanReturned), EventTypeGeneration.First);
+        _eventTypes.GetEventTypeFor(typeof(LoanCheckedOut)).Returns(_checkedOutEventType);
+        _eventTypes.GetEventTypeFor(typeof(LoanRenewed)).Returns(_renewedEventType);
+        _eventTypes.GetEventTypeFor(typeof(LoanReturned)).Returns(_returnedEventType);
+    }
+
+    void Because()
+    {
+        _constraintBuilder.Unique<LoanCheckedOut>(name: ConstraintName);
+        _constraintBuilder.Unique<LoanRenewed>(name: ConstraintName).RemovedWith<LoanReturned>();
+        _result = _constraintBuilder.Build();
+    }
+
+    [Fact] void should_merge_into_a_single_constraint() => _result.Count.ShouldEqual(1);
+    [Fact] void should_cover_both_event_types() => ((UniqueEventTypeConstraintDefinition)_result[0]).EventTypeIds.ShouldContainOnly([_checkedOutEventType.Id, _renewedEventType.Id]);
+    [Fact] void should_keep_the_removal_event() => ((UniqueEventTypeConstraintDefinition)_result[0]).RemovedWith.ShouldEqual(_returnedEventType.Id);
+
+    record LoanCheckedOut();
+    record LoanRenewed();
+    record LoanReturned();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/without_a_unique_event_type_constraint.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_ConstraintBuilder/when_declaring_a_removal_event/without_a_unique_event_type_constraint.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints.for_ConstraintBuilder.when_declaring_a_removal_event;
+
+/// <summary>
+/// The removal event releases the unique event type constraint it follows, so with nothing declared there is no
+/// constraint for it to belong to. Saying so out loud beats quietly recording an event type nothing reads — the
+/// author would get a constraint that never releases and no indication of why.
+/// </summary>
+public class without_a_unique_event_type_constraint : given.a_constraint_builder_with_owner
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _constraintBuilder.RemovedWith<LoanReturned>());
+
+    [Fact] void should_say_there_is_no_constraint_to_release() => _error.ShouldBeOfExactType<NoUniqueEventTypeConstraintToRemove>();
+
+    record LoanReturned();
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract/with_a_removal_event.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract/with_a_removal_event.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events.Constraints;
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintDefinition.when_converting_to_contract;
+
+/// <summary>
+/// The definition has carried a removal event all along and the conversion dropped it, so the kernel never saw one
+/// and enforced "at most one, forever" against a client that had declared otherwise. Nothing reported a problem: the
+/// value was discarded client-side, before the kernel was involved, and the constraint went on working — just not
+/// releasing.
+/// </summary>
+public class with_a_removal_event : Specification
+{
+    static readonly ConstraintName _constraintName = "LoanOpen";
+
+    UniqueEventTypeConstraintDefinition _definition;
+    EventType _checkedOutEventType;
+    EventType _returnedEventType;
+    Constraint _contract;
+
+    void Establish()
+    {
+        _checkedOutEventType = new EventType("LoanCheckedOut", EventTypeGeneration.First);
+        _returnedEventType = new EventType("LoanReturned", EventTypeGeneration.First);
+        _definition = new UniqueEventTypeConstraintDefinition(
+            _constraintName,
+            _ => string.Empty,
+            [_checkedOutEventType.Id],
+            _returnedEventType.Id);
+    }
+
+    void Because() => _contract = _definition.ToContract();
+
+    [Fact] void should_carry_the_removal_event() => _contract.RemovedWith.ShouldEqual(_returnedEventType.Id.Value);
+}

--- a/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract/without_a_removal_event.cs
+++ b/Source/Clients/DotNET.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_converting_to_contract/without_a_removal_event.cs
@@ -4,9 +4,9 @@
 using Cratis.Chronicle.Contracts.Events.Constraints;
 using UniqueEventTypeConstraintDefinitionContract = Cratis.Chronicle.Contracts.Events.Constraints.UniqueEventTypeConstraintDefinition;
 
-namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintDefinition;
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintDefinition.when_converting_to_contract;
 
-public class when_converting_to_contract : Specification
+public class without_a_removal_event : Specification
 {
     static ConstraintName _constraintName = "My Constraint";
     UniqueEventTypeConstraintDefinition _definition;
@@ -33,4 +33,5 @@ public class when_converting_to_contract : Specification
     [Fact] void should_have_correct_name() => _contract.Name.ShouldEqual(_constraintName.Value);
     [Fact] void should_have_correct_type() => _contract.Type.ShouldEqual(Contracts.Events.Constraints.ConstraintType.UniqueEventType);
     [Fact] void should_event_type() => _definitionContract.EventTypeIds.ShouldContainOnly([_eventType.Id.Value]);
+    [Fact] void should_have_no_removal_event() => _contract.RemovedWith.ShouldBeNull();
 }

--- a/Source/Clients/DotNET/Events/Constraints/ConstraintBuilder.cs
+++ b/Source/Clients/DotNET/Events/Constraints/ConstraintBuilder.cs
@@ -75,6 +75,20 @@ public class ConstraintBuilder(
     }
 
     /// <inheritdoc/>
+    public IConstraintBuilder RemovedWith<TRemovalEventType>()
+    {
+        var index = _constraints.FindLastIndex(_ => _ is UniqueEventTypeConstraintDefinition);
+        if (index < 0)
+        {
+            throw new NoUniqueEventTypeConstraintToRemove();
+        }
+
+        var removalEventType = eventTypes.GetEventTypeFor(typeof(TRemovalEventType));
+        _constraints[index] = ((UniqueEventTypeConstraintDefinition)_constraints[index]) with { RemovedWith = removalEventType.Id };
+        return this;
+    }
+
+    /// <inheritdoc/>
     public void AddConstraint(IConstraintDefinition constraint)
     {
         _constraints.Add(constraint);
@@ -99,6 +113,11 @@ public class ConstraintBuilder(
     /// expressed — the two become one constraint allowing at most one event from {A, B} per event source.
     /// Merging happens here rather than downstream so that names stay unique across the built set, which
     /// registration, change detection, and violation message resolution all rely on.
+    /// <para>
+    /// One constraint has one removal event, so the first declared for the name wins. Coalescing rather than
+    /// keeping the first declaration's value means a removal event declared on any of the merged declarations
+    /// survives, instead of being silently dropped because it was not declared on the first one.
+    /// </para>
     /// </remarks>
     static List<IConstraintDefinition> MergeUniqueEventTypeConstraintsSharingName(IEnumerable<IConstraintDefinition> constraints)
     {
@@ -121,7 +140,8 @@ public class ConstraintBuilder(
             var existing = (UniqueEventTypeConstraintDefinition)merged[existingIndex];
             merged[existingIndex] = existing with
             {
-                EventTypeIds = existing.EventTypeIds.Concat(uniqueEventType.EventTypeIds).Distinct().ToArray()
+                EventTypeIds = existing.EventTypeIds.Concat(uniqueEventType.EventTypeIds).Distinct().ToArray(),
+                RemovedWith = existing.RemovedWith ?? uniqueEventType.RemovedWith
             };
         }
 

--- a/Source/Clients/DotNET/Events/Constraints/ConstraintConverters.cs
+++ b/Source/Clients/DotNET/Events/Constraints/ConstraintConverters.cs
@@ -33,6 +33,7 @@ internal static class ConstraintConverters
     {
         Name = definition.Name,
         Type = (Contracts.Events.Constraints.ConstraintType)ConstraintType.UniqueEventType,
+        RemovedWith = definition.RemovedWith?.Value,
         Definition = new(new UniqueEventTypeConstraintDefinitionContract
         {
             EventTypeIds = definition.EventTypeIds.Select(_ => _.Value).ToList()

--- a/Source/Clients/DotNET/Events/Constraints/IConstraintBuilder.cs
+++ b/Source/Clients/DotNET/Events/Constraints/IConstraintBuilder.cs
@@ -55,6 +55,24 @@ public interface IConstraintBuilder
     IConstraintBuilder Unique<TEventType>(ConstraintViolationMessageProvider messageCallback, ConstraintName? name = default);
 
     /// <summary>
+    /// Indicate an event that releases the unique event type constraint most recently declared on this builder.
+    /// </summary>
+    /// <typeparam name="TRemovalEventType">Type of event that releases the constraint.</typeparam>
+    /// <returns>Builder for continuation.</returns>
+    /// <exception cref="NoUniqueEventTypeConstraintToRemove">Thrown when no unique event type constraint has been declared on the builder yet.</exception>
+    /// <remarks>
+    /// Without this the constraint can only say "at most one, forever". Most lifecycles cycle, so declare the event
+    /// that ends a cycle and the covered event types are allowed again for the next one — a covered event only
+    /// violates the constraint when it comes after the most recent removal event on the same event source.
+    /// <para>
+    /// It applies to the <see cref="Unique{TEventType}(ConstraintViolationMessage, ConstraintName)"/> declaration it
+    /// follows, which is why it belongs on the same chain. Declaring several event types under one constraint name
+    /// makes them one constraint, and the first removal event declared for that name is the one it is released with.
+    /// </para>
+    /// </remarks>
+    IConstraintBuilder RemovedWith<TRemovalEventType>();
+
+    /// <summary>
     /// Add a constraint to the builder.
     /// </summary>
     /// <param name="constraint"><see cref="Constraint"/> to add.</param>

--- a/Source/Clients/DotNET/Events/Constraints/NoUniqueEventTypeConstraintToRemove.cs
+++ b/Source/Clients/DotNET/Events/Constraints/NoUniqueEventTypeConstraintToRemove.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Constraints;
+
+/// <summary>
+/// Exception that gets thrown when a removal event is declared without a unique event type constraint to release.
+/// </summary>
+public class NoUniqueEventTypeConstraintToRemove()
+    : Exception("RemovedWith<TRemovalEventType>() releases the unique event type constraint it follows, and no Unique<TEventType>() has been declared on the builder");

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LoanCheckedOut.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LoanCheckedOut.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Event constrained to appear at most once per cycle through <see cref="UniqueAttribute"/> on the event type
+/// itself, where the cycle is ended by <see cref="LoanReturned"/> - the lifecycle shape the unique event type
+/// constraint could not express before it had a removal event.
+/// </summary>
+/// <param name="Title">The title that was checked out.</param>
+[EventType]
+[Unique(ConstraintName)]
+public record LoanCheckedOut(string Title)
+{
+    /// <summary>
+    /// The name of the unique event type constraint.
+    /// </summary>
+    public const string ConstraintName = "LoanOpen";
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LoanReturned.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/LoanReturned.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Releases the <see cref="LoanCheckedOut.ConstraintName"/> constraint through <see cref="RemoveConstraintAttribute"/>,
+/// so the next checkout for the same borrower starts a new cycle.
+/// </summary>
+[EventType]
+[RemoveConstraint(LoanCheckedOut.ConstraintName)]
+public record LoanReturned;

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/OneOpenShiftPerEmployee.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/OneOpenShiftPerEmployee.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Constraints;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// A fluent <see cref="IConstraint"/> allowing at most one open <see cref="ShiftStarted"/> per employee, released by
+/// <see cref="ShiftEnded"/>.
+/// </summary>
+public class OneOpenShiftPerEmployee : IConstraint
+{
+    /// <summary>
+    /// The name of the constraint.
+    /// </summary>
+    public const string Name = "OneOpenShiftPerEmployee";
+
+    /// <inheritdoc/>
+    public void Define(IConstraintBuilder builder) =>
+        builder
+            .Unique<ShiftStarted>(name: Name)
+            .RemovedWith<ShiftEnded>();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/ShiftEnded.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/ShiftEnded.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Ends the shift, releasing the <see cref="OneOpenShiftPerEmployee"/> constraint so the employee can start the next one.
+/// </summary>
+[EventType]
+public record ShiftEnded;

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/ShiftStarted.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/ShiftStarted.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// Event constrained to at most one open shift per employee by the fluent <see cref="OneOpenShiftPerEmployee"/>.
+/// </summary>
+/// <param name="Location">Where the shift is worked.</param>
+[EventType]
+public record ShiftStarted(string Location);

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_a_fluently_released_event_type_constraint_is_claimed_again.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_a_fluently_released_event_type_constraint_is_claimed_again.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// The fluent release path end to end: <c>builder.Unique&lt;T&gt;().RemovedWith&lt;TRemoval&gt;()</c>. The release is
+/// per event source, so one employee ending a shift opens their own next cycle and nobody else's.
+/// </summary>
+public class when_a_fluently_released_event_type_constraint_is_claimed_again : Specification, IDisposable
+{
+    static readonly EventSourceId _employee = EventSourceId.New();
+    static readonly EventSourceId _anotherEmployee = EventSourceId.New();
+
+    EventScenario _scenario;
+    AppendResult _firstShift;
+    AppendResult _shiftAfterTheEnd;
+    AppendResult _secondShiftInTheSameCycle;
+    AppendResult _shiftForAnotherEmployee;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because()
+    {
+        _firstShift = await _scenario.When
+            .ForEventSource(_employee)
+            .Events(new ShiftStarted("Warehouse"));
+
+        await _scenario.Given
+            .ForEventSource(_employee)
+            .Events(new ShiftEnded());
+
+        _shiftAfterTheEnd = await _scenario.When
+            .ForEventSource(_employee)
+            .Events(new ShiftStarted("Warehouse"));
+
+        _secondShiftInTheSameCycle = await _scenario.When
+            .ForEventSource(_employee)
+            .Events(new ShiftStarted("Front desk"));
+
+        _shiftForAnotherEmployee = await _scenario.When
+            .ForEventSource(_anotherEmployee)
+            .Events(new ShiftStarted("Warehouse"));
+    }
+
+    [Fact] void should_accept_the_first_shift() => _firstShift.ShouldBeSuccessful();
+    [Fact] void should_accept_a_shift_after_the_previous_one_ended() => _shiftAfterTheEnd.ShouldBeSuccessful();
+    [Fact] void should_reject_a_second_shift_within_the_same_cycle() => _secondShiftInTheSameCycle.ShouldHaveConstraintViolation(OneOpenShiftPerEmployee.Name);
+    [Fact] void should_accept_a_first_shift_for_another_employee() => _shiftForAnotherEmployee.ShouldBeSuccessful();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_a_released_event_type_constraint_is_claimed_again.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_a_released_event_type_constraint_is_claimed_again.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// The model-bound release path end to end: <c>[Unique]</c> on the event type and <c>[RemoveConstraint]</c> on the
+/// event that ends the cycle. The attribute was already resolved into a removal event on the client definition and
+/// then discarded on the way to the contract, so the documented behavior compiled, registered, and did nothing -
+/// the second cycle was refused forever with no indication of why.
+/// </summary>
+public class when_a_released_event_type_constraint_is_claimed_again : Specification, IDisposable
+{
+    static readonly EventSourceId _borrower = EventSourceId.New();
+
+    EventScenario _scenario;
+    AppendResult _firstCheckout;
+    AppendResult _return;
+    AppendResult _checkoutAfterTheReturn;
+    AppendResult _secondCheckoutInTheSameCycle;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because()
+    {
+        _firstCheckout = await _scenario.When
+            .ForEventSource(_borrower)
+            .Events(new LoanCheckedOut("Dune"));
+
+        _return = await _scenario.When
+            .ForEventSource(_borrower)
+            .Events(new LoanReturned());
+
+        _checkoutAfterTheReturn = await _scenario.When
+            .ForEventSource(_borrower)
+            .Events(new LoanCheckedOut("Neuromancer"));
+
+        _secondCheckoutInTheSameCycle = await _scenario.When
+            .ForEventSource(_borrower)
+            .Events(new LoanCheckedOut("Snow Crash"));
+    }
+
+    [Fact] void should_accept_the_first_checkout() => _firstCheckout.ShouldBeSuccessful();
+    [Fact] void should_accept_the_return() => _return.ShouldBeSuccessful();
+    [Fact] void should_accept_a_checkout_after_the_return() => _checkoutAfterTheReturn.ShouldBeSuccessful();
+    [Fact] void should_reject_a_second_checkout_within_the_same_cycle() => _secondCheckoutInTheSameCycle.ShouldHaveConstraintViolation(LoanCheckedOut.ConstraintName);
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing/EventSequences/InMemoryConstraintsStorage.cs
+++ b/Source/Clients/Testing/EventSequences/InMemoryConstraintsStorage.cs
@@ -59,9 +59,14 @@ internal sealed class InMemoryConstraintsStorage(ClientConstraints.ICanProvideCo
 
         if (client is ClientConstraints.UniqueEventTypeConstraintDefinition uniqueType)
         {
+            var removedWithForEventType = uniqueType.RemovedWith is not null
+                ? (KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId?)(KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId)uniqueType.RemovedWith.Value
+                : null;
+
             return new KernelConstraints::UniqueEventTypeConstraintDefinition(
                 (KernelConstraints::ConstraintName)uniqueType.Name.Value,
-                uniqueType.EventTypeIds.Select(_ => (KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId)_.Value).ToArray());
+                uniqueType.EventTypeIds.Select(_ => (KernelConcepts::Cratis.Chronicle.Concepts.Events.EventTypeId)_.Value).ToArray(),
+                removedWithForEventType);
         }
 
         return null;

--- a/Source/Kernel/Concepts.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_comparing_with_a_definition_declaring_another_removal_event.cs
+++ b/Source/Kernel/Concepts.Specs/Events/Constraints/for_UniqueEventTypeConstraintDefinition/when_comparing_with_a_definition_declaring_another_removal_event.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Events.Constraints.for_UniqueEventTypeConstraintDefinition;
+
+/// <summary>
+/// Registration decides whether a stored constraint is superseded by comparing it with the incoming definition, so
+/// the removal event has to take part in equality. Leaving it out makes adding, changing, or dropping the event that
+/// releases the constraint indistinguishable from re-registering the same definition — the store keeps the previous
+/// rule and every append after that is answered against a constraint the client no longer declares.
+/// </summary>
+/// <remarks>
+/// No reindex follows from the change: this constraint keeps no index, it is enforced by reading the appended events
+/// for the event source, so the next append already answers against the new definition.
+/// </remarks>
+public class when_comparing_with_a_definition_declaring_another_removal_event : Specification
+{
+    static readonly ConstraintName _name = "loan-open";
+    static readonly EventTypeId _coveredEventTypeId = "LoanCheckedOut";
+    static readonly EventTypeId _returnedEventTypeId = "LoanReturned";
+    static readonly EventTypeId _writtenOffEventTypeId = "LoanWrittenOff";
+
+    UniqueEventTypeConstraintDefinition _definition;
+    UniqueEventTypeConstraintDefinition _equivalent;
+    UniqueEventTypeConstraintDefinition _withAnotherRemovalEvent;
+    UniqueEventTypeConstraintDefinition _withoutRemovalEvent;
+
+    void Establish()
+    {
+        _definition = new(_name, [_coveredEventTypeId], _returnedEventTypeId);
+        _equivalent = new(_name, [_coveredEventTypeId], _returnedEventTypeId);
+        _withAnotherRemovalEvent = new(_name, [_coveredEventTypeId], _writtenOffEventTypeId);
+        _withoutRemovalEvent = new(_name, [_coveredEventTypeId]);
+    }
+
+    [Fact] void should_be_equal_to_an_equivalent_definition() => _definition.Equals(_equivalent).ShouldBeTrue();
+    [Fact] void should_hash_alike_as_an_equivalent_definition() => _definition.GetHashCode().ShouldEqual(_equivalent.GetHashCode());
+    [Fact] void should_not_be_equal_to_one_declaring_another_removal_event() => _definition.Equals(_withAnotherRemovalEvent).ShouldBeFalse();
+    [Fact] void should_not_be_equal_through_the_interface_to_one_declaring_another_removal_event() => _definition.Equals((IConstraintDefinition)_withAnotherRemovalEvent).ShouldBeFalse();
+    [Fact] void should_not_be_equal_to_one_declaring_no_removal_event() => _definition.Equals(_withoutRemovalEvent).ShouldBeFalse();
+    [Fact] void should_require_no_reindex() => _definition.CompareWith(_withAnotherRemovalEvent).ShouldEqual(ConstraintChange.None);
+}

--- a/Source/Kernel/Concepts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
+++ b/Source/Kernel/Concepts/Events/Constraints/UniqueEventTypeConstraintDefinition.cs
@@ -8,13 +8,19 @@ namespace Cratis.Chronicle.Concepts.Events.Constraints;
 /// </summary>
 /// <param name="Name">Name of the constraint.</param>
 /// <param name="EventTypeIds">The <see cref="EventTypeId"/> values the constraint covers.</param>
+/// <param name="RemovedWith">The <see cref="EventTypeId"/> of the event that releases the constraint.</param>
 /// <param name="Scope">The <see cref="ConstraintScope"/> for the constraint.</param>
 /// <remarks>
 /// The constraint allows at most one event drawn from the covered event types per event source. A single event
 /// type expresses "this event happens at most once"; several express mutual exclusion — an event source that is
 /// terminal through either of two outcomes can have one of them, never both and never twice.
+/// <para>
+/// With a removal event the "at most once" is per cycle rather than forever: a covered event violates the
+/// constraint only when it comes after the most recent removal event on the same event source. Without one the
+/// constraint can only say "forever", which no lifecycle that repeats can express.
+/// </para>
 /// </remarks>
-public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerable<EventTypeId> EventTypeIds, ConstraintScope? Scope = default) : IConstraintDefinition
+public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerable<EventTypeId> EventTypeIds, EventTypeId? RemovedWith = default, ConstraintScope? Scope = default) : IConstraintDefinition
 {
     readonly IEnumerable<EventTypeId>? _eventTypeIds = EventTypeIds;
 
@@ -51,10 +57,16 @@ public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerab
     /// The generated record equality would compare the event type ids by reference, and registration decides
     /// whether a constraint changed by comparing the incoming definition to the stored one — so reference
     /// equality would report every re-registration as a change. The collection is therefore compared by content.
+    /// <para>
+    /// The removal event is part of the comparison because it is part of what the constraint means. Leaving it out
+    /// would make adding, changing, or dropping the event that releases the constraint indistinguishable from a
+    /// re-registration of the same definition, so the stored definition would keep enforcing the previous rule.
+    /// </para>
     /// </remarks>
     public virtual bool Equals(UniqueEventTypeConstraintDefinition? other) =>
         other is not null &&
         Name == other.Name &&
+        RemovedWith == other.RemovedWith &&
         Scope == other.Scope &&
         EventTypeIds.SequenceEqual(other.EventTypeIds);
 
@@ -63,6 +75,7 @@ public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerab
     {
         var hashCode = default(HashCode);
         hashCode.Add(Name);
+        hashCode.Add(RemovedWith);
         hashCode.Add(Scope);
         foreach (var eventTypeId in EventTypeIds)
         {
@@ -73,5 +86,11 @@ public record UniqueEventTypeConstraintDefinition(ConstraintName Name, IEnumerab
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// A change is always detected — by <see cref="Equals(UniqueEventTypeConstraintDefinition)"/>, which registration
+    /// uses to decide whether the stored definition is superseded — but never requires reindexing, including when the
+    /// removal event changes. This constraint keeps no index: it is enforced by reading the appended events for the
+    /// event source, so the next append answers against the new definition with nothing to rebuild first.
+    /// </remarks>
     public ConstraintChange CompareWith(IConstraintDefinition existing) => ConstraintChange.None;
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_a_mutually_exclusive_event_type_was_already_appended.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_a_mutually_exclusive_event_type_was_already_appended.cs
@@ -35,7 +35,7 @@ public class and_a_mutually_exclusive_event_type_was_already_appended : Specific
 
         // The person was already merged away — the sibling event type, not the one being appended.
         _storage
-            .IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), Arg.Any<string>())
+            .IsAllowed(Arg.Any<UniqueEventTypeConstraintDefinition>(), Arg.Any<EventSourceId>(), Arg.Any<string>())
             .Returns((false, (EventSequenceNumber)7U));
     }
 
@@ -45,7 +45,7 @@ public class and_a_mutually_exclusive_event_type_was_already_appended : Specific
     [Fact] void should_have_violations() => _result.Violations.ShouldNotBeEmpty();
     [Fact] async Task should_ask_storage_about_every_covered_event_type() =>
         await _storage.Received(1).IsAllowed(
-            Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_aliasedEventType.Id) && _.Contains(_erasedEventType.Id)),
+            Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.EventTypeIds.Contains(_aliasedEventType.Id) && _.EventTypeIds.Contains(_erasedEventType.Id)),
             Arg.Any<EventSourceId>(),
             Arg.Any<string>());
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 
 namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_validating;
 
@@ -11,7 +12,7 @@ public class and_event_type_for_event_source_id_is_allowed : given.a_unique_even
 
     void Establish()
     {
-        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_eventType.Id)), _context.EventSourceId).Returns((true, EventSequenceNumber.First));
+        _storage.IsAllowed(Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.EventTypeIds.Contains(_eventType.Id)), _context.EventSourceId).Returns((true, EventSequenceNumber.First));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed_with_scope.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_allowed_with_scope.cs
@@ -27,11 +27,11 @@ public class and_event_type_for_event_source_id_is_allowed_with_scope : Specific
         _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
         _context = new([], EventSourceId.New(), eventType.Id, new ExpandoObject(), eventSourceType: "MySourceType");
 
-        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((true, EventSequenceNumber.First));
+        _storage.IsAllowed(Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.EventTypeIds.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((true, EventSequenceNumber.First));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);
 
     [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
-    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), "est:MySourceType");
+    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<UniqueEventTypeConstraintDefinition>(), Arg.Any<EventSourceId>(), "est:MySourceType");
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 
 namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_validating;
 
@@ -11,7 +11,7 @@ public class and_event_type_for_event_source_id_is_not_allowed : given.a_unique_
 
     void Establish()
     {
-        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(_eventType.Id)), _context.EventSourceId).Returns((false, 43U));
+        _storage.IsAllowed(Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.EventTypeIds.Contains(_eventType.Id)), _context.EventSourceId).Returns((false, 43U));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed_with_scope.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_event_type_for_event_source_id_is_not_allowed_with_scope.cs
@@ -27,12 +27,12 @@ public class and_event_type_for_event_source_id_is_not_allowed_with_scope : Spec
         _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
         _context = new([], EventSourceId.New(), eventType.Id, new ExpandoObject(), eventSourceType: "MySourceType");
 
-        _storage.IsAllowed(Arg.Is<IEnumerable<EventTypeId>>(_ => _.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((false, 42U));
+        _storage.IsAllowed(Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.EventTypeIds.Contains(eventType.Id)), _context.EventSourceId, "est:MySourceType").Returns((false, 42U));
     }
 
     async Task Because() => _result = await _validator.Validate(_context);
 
     [Fact] void should_not_be_valid() => _result.IsValid.ShouldBeFalse();
     [Fact] void should_have_violations() => _result.Violations.ShouldNotBeEmpty();
-    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<IEnumerable<EventTypeId>>(), Arg.Any<EventSourceId>(), "est:MySourceType");
+    [Fact] void should_pass_scope_key_to_storage() => _storage.Received(1).IsAllowed(Arg.Any<UniqueEventTypeConstraintDefinition>(), Arg.Any<EventSourceId>(), "est:MySourceType");
 }

--- a/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_the_constraint_declares_a_removal_event.cs
+++ b/Source/Kernel/Core.Specs/Events/Constraints/for_UniqueEventTypeConstraintValidator/when_validating/and_the_constraint_declares_a_removal_event.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Storage.Events.Constraints;
+
+namespace Cratis.Chronicle.Events.Constraints.for_UniqueEventTypeConstraintValidator.when_validating;
+
+/// <summary>
+/// Whether a covered event violates the constraint depends on the removal event as much as on the covered types —
+/// an event preceding the most recent release belongs to a closed cycle and blocks nothing. The validator therefore
+/// has to hand storage the whole definition; handing it only the covered event types is the shape that type-checks
+/// and silently answers the question the constraint is no longer asking.
+/// </summary>
+public class and_the_constraint_declares_a_removal_event : Specification
+{
+    UniqueEventTypeConstraintValidator _validator;
+    IUniqueEventTypesConstraintsStorage _storage;
+    ConstraintValidationContext _context;
+    ConstraintValidationResult _result;
+
+    readonly EventType _checkedOutEventType = new("LoanCheckedOut", EventTypeGeneration.First);
+    readonly EventType _returnedEventType = new("LoanReturned", EventTypeGeneration.First);
+
+    void Establish()
+    {
+        _storage = Substitute.For<IUniqueEventTypesConstraintsStorage>();
+        var definition = new UniqueEventTypeConstraintDefinition(
+            "LoanOpen",
+            [_checkedOutEventType.Id],
+            _returnedEventType.Id);
+
+        _validator = new UniqueEventTypeConstraintValidator(definition, _storage);
+        _context = new([], EventSourceId.New(), _checkedOutEventType.Id, new ExpandoObject());
+
+        _storage
+            .IsAllowed(Arg.Any<UniqueEventTypeConstraintDefinition>(), Arg.Any<EventSourceId>(), Arg.Any<string>())
+            .Returns((true, EventSequenceNumber.Unavailable));
+    }
+
+    async Task Because() => _result = await _validator.Validate(_context);
+
+    [Fact] void should_be_valid() => _result.IsValid.ShouldBeTrue();
+    [Fact] async Task should_hand_storage_the_removal_event() =>
+        await _storage.Received(1).IsAllowed(
+            Arg.Is<UniqueEventTypeConstraintDefinition>(_ => _.RemovedWith == _returnedEventType.Id),
+            _context.EventSourceId,
+            Arg.Any<string>());
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_releasing_json/and_document_carries_kernel_bookkeeping.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_releasing_json/and_document_carries_kernel_bookkeeping.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsCompliance.when_releasing_json;
+
+/// <summary>
+/// The compliance manager rejects every property the read model schema does not declare, so the whole of the
+/// kernel's own bookkeeping has to come off the document before it is handed over — not just the subject marker
+/// this method reads the identifier from.
+/// </summary>
+public class and_document_carries_kernel_bookkeeping : given.all_dependencies
+{
+    JsonObject _instance;
+    string _instanceBefore;
+    JsonObject _handedToComplianceManager;
+
+    void Establish()
+    {
+        _complianceManager.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<string>(),
+                Arg.Any<JsonObject>())
+            .Returns(callInfo =>
+            {
+                _handedToComplianceManager = callInfo.ArgAt<JsonObject>(4);
+                return Task.FromResult(new JsonObject { ["name"] = "decrypted-name" });
+            });
+
+        _instance = new JsonObject
+        {
+            [WellKnownProperties.Subject] = Identifier,
+            [WellKnownProperties.LastHandledEventSequenceNumber] = JsonValue.Create(42UL),
+            [WellKnownProperties.ReadModelInstanceInitialized] = true,
+            ["name"] = "encrypted-name"
+        };
+        _instanceBefore = _instance.ToJsonString();
+    }
+
+    async Task Because() => await _compliance.ReleaseJson(
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance);
+
+    [Fact] void should_hand_over_the_schema_declared_properties() => _handedToComplianceManager.Select(_ => _.Key).ShouldContainOnly(["name"]);
+    [Fact] void should_leave_the_document_it_was_given_unchanged() => _instance.ToJsonString().ShouldEqual(_instanceBefore);
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_releasing_json/and_schema_declares_a_bookkeeping_property.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_ReadModelsCompliance/when_releasing_json/and_schema_declares_a_bookkeeping_property.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelsCompliance.when_releasing_json;
+
+/// <summary>
+/// A read model may expose the sink watermark as a property of its own, and several do. Once the schema declares
+/// it, it is a property like any other: the compliance manager accepts it, so stripping it would drop data the
+/// read model asked for.
+/// </summary>
+public class and_schema_declares_a_bookkeeping_property : given.all_dependencies
+{
+    JsonObject _instance;
+    JsonObject _handedToComplianceManager;
+
+    void Establish()
+    {
+        _schemaWithPii.Properties[WellKnownProperties.LastHandledEventSequenceNumber] = new JsonSchemaProperty(
+            WellKnownProperties.LastHandledEventSequenceNumber,
+            new JsonObject { ["type"] = "integer" },
+            _schemaWithPii);
+
+        _complianceManager.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<string>(),
+                Arg.Any<JsonObject>())
+            .Returns(callInfo =>
+            {
+                _handedToComplianceManager = callInfo.ArgAt<JsonObject>(4);
+                return Task.FromResult(new JsonObject { ["name"] = "decrypted-name" });
+            });
+
+        _instance = new JsonObject
+        {
+            [WellKnownProperties.Subject] = Identifier,
+            [WellKnownProperties.LastHandledEventSequenceNumber] = JsonValue.Create(42UL),
+            ["name"] = "encrypted-name"
+        };
+    }
+
+    async Task Because() => await _compliance.ReleaseJson(
+        EventStore,
+        EventStoreNamespace,
+        _schemaWithPii,
+        _instance);
+
+    [Fact] void should_keep_the_declared_property() => _handedToComplianceManager[WellKnownProperties.LastHandledEventSequenceNumber]!.GetValue<ulong>().ShouldEqual(42UL);
+    [Fact] void should_still_strip_the_subject_marker() => _handedToComplianceManager.ContainsKey(WellKnownProperties.Subject).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Services/Events/Constraints/for_ConstraintConverters/when_converting_to_chronicle/and_the_constraint_is_a_unique_event_type_constraint_with_a_removal_event.cs
+++ b/Source/Kernel/Core.Specs/Services/Events/Constraints/for_ConstraintConverters/when_converting_to_chronicle/and_the_constraint_is_a_unique_event_type_constraint_with_a_removal_event.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using KernelUniqueEventTypeConstraintDefinition = Cratis.Chronicle.Concepts.Events.Constraints.UniqueEventTypeConstraintDefinition;
+using UniqueEventTypeConstraintDefinitionContract = Cratis.Chronicle.Contracts.Events.Constraints.UniqueEventTypeConstraintDefinition;
+
+namespace Cratis.Chronicle.Services.Events.Constraints.for_ConstraintConverters.when_converting_to_chronicle;
+
+/// <summary>
+/// The removal event travels on the constraint rather than inside the definition payload, which is why the value form
+/// reads it and this one used to walk past it. Dropping it here would leave the kernel enforcing "at most one,
+/// forever" against a client that declared otherwise, with nothing anywhere reporting a problem.
+/// </summary>
+public class and_the_constraint_is_a_unique_event_type_constraint_with_a_removal_event : Specification
+{
+    const string ConstraintNameValue = "LoanOpen";
+    static readonly EventTypeId _checkedOutEventTypeId = "LoanCheckedOut";
+    static readonly EventTypeId _returnedEventTypeId = "LoanReturned";
+
+    Contracts.Events.Constraints.Constraint _contract;
+    KernelUniqueEventTypeConstraintDefinition _result;
+
+    void Establish() => _contract = new()
+    {
+        Name = ConstraintNameValue,
+        Type = Contracts.Events.Constraints.ConstraintType.UniqueEventType,
+        RemovedWith = _returnedEventTypeId.Value,
+        Definition = new(new UniqueEventTypeConstraintDefinitionContract
+        {
+            EventTypeIds = [_checkedOutEventTypeId.Value]
+        })
+    };
+
+    void Because() => _result = (KernelUniqueEventTypeConstraintDefinition)_contract.ToChronicle();
+
+    [Fact] void should_have_the_constraint_name() => _result.Name.Value.ShouldEqual(ConstraintNameValue);
+    [Fact] void should_cover_the_event_type() => _result.EventTypeIds.ShouldContainOnly([_checkedOutEventTypeId]);
+    [Fact] void should_carry_the_removal_event() => _result.RemovedWith.ShouldEqual(_returnedEventTypeId);
+}

--- a/Source/Kernel/Core.Specs/Services/Events/Constraints/for_ConstraintConverters/when_converting_to_chronicle/and_the_constraint_is_a_unique_event_type_constraint_without_a_removal_event.cs
+++ b/Source/Kernel/Core.Specs/Services/Events/Constraints/for_ConstraintConverters/when_converting_to_chronicle/and_the_constraint_is_a_unique_event_type_constraint_without_a_removal_event.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using KernelUniqueEventTypeConstraintDefinition = Cratis.Chronicle.Concepts.Events.Constraints.UniqueEventTypeConstraintDefinition;
+using UniqueEventTypeConstraintDefinitionContract = Cratis.Chronicle.Contracts.Events.Constraints.UniqueEventTypeConstraintDefinition;
+
+namespace Cratis.Chronicle.Services.Events.Constraints.for_ConstraintConverters.when_converting_to_chronicle;
+
+/// <summary>
+/// A client that declares no removal event registers the constraint with none, and the constraint keeps meaning
+/// "at most one, forever".
+/// </summary>
+public class and_the_constraint_is_a_unique_event_type_constraint_without_a_removal_event : Specification
+{
+    static readonly EventTypeId _checkedOutEventTypeId = "LoanCheckedOut";
+
+    Contracts.Events.Constraints.Constraint _contract;
+    KernelUniqueEventTypeConstraintDefinition _result;
+
+    void Establish() => _contract = new()
+    {
+        Name = "LoanOpen",
+        Type = Contracts.Events.Constraints.ConstraintType.UniqueEventType,
+        Definition = new(new UniqueEventTypeConstraintDefinitionContract
+        {
+            EventTypeIds = [_checkedOutEventTypeId.Value]
+        })
+    };
+
+    void Because() => _result = (KernelUniqueEventTypeConstraintDefinition)_contract.ToChronicle();
+
+    [Fact] void should_have_no_removal_event() => _result.RemovedWith.ShouldBeNull();
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_passive_with_a_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_passive_with_a_pii_property.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_instance_by_key;
+
+/// <summary>
+/// A passive read model has no sink, so every keyed read falls through to the immediate projection and the
+/// projected document is released as JSON rather than through a schema round trip. That path stamps the internal
+/// subject marker onto the document so the compliance manager knows whose key to decrypt with, and the compliance
+/// manager walks every property it is handed against the read model schema — which declares no such marker. The
+/// compliance chain is wired for real here rather than substituted, because a substitute at that seam is exactly
+/// what hides the hand-off that fails.
+/// </summary>
+public class and_read_model_is_passive_with_a_pii_property : given.all_dependencies
+{
+    const string Key = "person-42";
+    const string EncryptedName = "encrypted-name";
+    const string DecryptedName = "decrypted-name";
+
+    GetInstanceByKeyResponse _result;
+    Exception _exception;
+
+    void Establish()
+    {
+        var schema = JsonSchema.FromType<ReadModelWithPersonalData>();
+        schema.Properties["name"].ExtensionData = new Dictionary<string, object?>
+        {
+            { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata("PII", string.Empty) } }
+        };
+
+        _readModelDefinition = _readModelDefinition with
+        {
+            Schemas = new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, schema } }
+        };
+        _readModel.GetDefinition().Returns(_readModelDefinition);
+
+        // Passive read model — the sink never holds data, so the lookup falls through to the immediate projection.
+        _sink.TypeId.Returns(SinkTypeId.None);
+
+        var immediateProjection = Substitute.For<IImmediateProjection>();
+        immediateProjection.GetModelInstance().Returns(new ProjectionResult(
+            new JsonObject { ["id"] = Key, ["name"] = EncryptedName },
+            1,
+            (EventSequenceNumber)42));
+        _grainFactory.GetGrain<IImmediateProjection>(Arg.Any<string>()).Returns(immediateProjection);
+
+        var valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
+        valueHandler.Type.Returns((ComplianceMetadataType)"PII");
+        valueHandler.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Key, Arg.Any<JsonNode>())
+            .Returns(Task.FromResult<JsonNode>(JsonValue.Create(DecryptedName)));
+
+        _service = new ReadModels(
+            _grainFactory,
+            _storage,
+            _expandoObjectConverter,
+            _reducerMediator,
+            _changesetMediator,
+            _localSiloDetails,
+            new ReadModelsCompliance(
+                new JsonComplianceManager(
+                    new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(valueHandler),
+                    NullLogger<JsonComplianceManager>.Instance),
+                _expandoObjectConverter),
+            _eventCompliance,
+            new JsonSerializerOptions());
+    }
+
+    async Task Because() => _exception = await Catch.Exception(async () => _result = await _service.GetInstanceByKey(new()
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModelIdentifier = _readModelDefinition.Identifier,
+        EventSequenceId = "event-log",
+        ReadModelKey = Key
+    }));
+
+    [Fact] void should_not_fail() => _exception.ShouldBeNull();
+    [Fact] void should_return_the_decrypted_read_model() => JsonSerializer.Deserialize<JsonElement>(_result.ReadModel).GetProperty("name").GetString().ShouldEqual(DecryptedName);
+    [Fact] void should_not_leak_the_subject_marker() => JsonSerializer.Deserialize<JsonElement>(_result.ReadModel).TryGetProperty(WellKnownProperties.Subject, out _).ShouldBeFalse();
+
+    record ReadModelWithPersonalData(string Id, string Name);
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_carries_kernel_bookkeeping.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_carries_kernel_bookkeeping.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_watching;
+
+/// <summary>
+/// The projection observer subscriber stamps the sink's last-handled-sequence-number watermark onto every
+/// changeset it pushes, after the schema round trip that would otherwise have dropped it. The read model's own
+/// schema does not declare it, and the compliance manager rejects every property the schema does not declare —
+/// so the release has to take kernel bookkeeping off the document before handing it over. The compliance chain
+/// is wired for real here rather than substituted, because a substitute at that seam is exactly what hides the
+/// hand-off that fails. The failure it guards against is silent: <c>OnChangeset</c> is one-way, so a throw on
+/// this path drops the changeset without surfacing anywhere and the watching client simply stops updating.
+/// </summary>
+public class and_document_carries_kernel_bookkeeping : given.all_dependencies
+{
+    const string Key = "person-42";
+    const string EncryptedName = "encrypted-name";
+    const string DecryptedName = "decrypted-name";
+
+    readonly List<ReadModelChangeset> _emitted = [];
+    IProjectionChangesetNotifier _notifier;
+    IReadModelChangesetSubscriber _subscriber;
+    TaskCompletionSource<ChangesetForwarder> _forwarderCaptured;
+    Exception _exception;
+
+    void Establish()
+    {
+        var schema = JsonSchema.FromType<ReadModelWithPersonalData>();
+        schema.Properties["name"].ExtensionData = new Dictionary<string, object?>
+        {
+            { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata("PII", string.Empty) } }
+        };
+
+        _readModelDefinition = _readModelDefinition with
+        {
+            Schemas = new Dictionary<Concepts.ReadModels.ReadModelGeneration, JsonSchema> { { (Concepts.ReadModels.ReadModelGeneration)1, schema } }
+        };
+        _readModel.GetDefinition().Returns(Task.FromResult(_readModelDefinition));
+
+        _forwarderCaptured = new();
+        _notifier = Substitute.For<IProjectionChangesetNotifier>();
+        _subscriber = Substitute.For<IReadModelChangesetSubscriber>();
+        _grainFactory.GetGrain<IProjectionChangesetNotifier>(Arg.Any<string>()).Returns(_notifier);
+        _grainFactory.GetGrain<IReadModelChangesetSubscriber>(Arg.Any<string>()).Returns(_subscriber);
+
+        _changesetMediator.When(m => m.Subscribe(Arg.Any<Guid>(), Arg.Any<ChangesetForwarder>()))
+            .Do(ci => _forwarderCaptured.SetResult(ci.Arg<ChangesetForwarder>()));
+
+        _notifier.Subscribe(Arg.Any<IReadModelChangesetSubscriber>()).Returns(Task.CompletedTask);
+        _notifier.Unsubscribe(Arg.Any<IReadModelChangesetSubscriber>()).Returns(Task.CompletedTask);
+
+        var valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
+        valueHandler.Type.Returns((ComplianceMetadataType)"PII");
+        valueHandler.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Key, Arg.Any<JsonNode>())
+            .Returns(Task.FromResult<JsonNode>(JsonValue.Create(DecryptedName)));
+
+        _service = new ReadModels(
+            _grainFactory,
+            _storage,
+            _expandoObjectConverter,
+            _reducerMediator,
+            _changesetMediator,
+            _localSiloDetails,
+            new ReadModelsCompliance(
+                new JsonComplianceManager(
+                    new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(valueHandler),
+                    NullLogger<JsonComplianceManager>.Instance),
+                _expandoObjectConverter),
+            _eventCompliance,
+            new JsonSerializerOptions());
+    }
+
+    async Task Because()
+    {
+        _service.Watch(
+            new WatchRequest { EventStore = "test-store", ReadModelIdentifier = "test-read-model" },
+            default).Subscribe(_emitted.Add);
+
+        var forwarder = await _forwarderCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Exactly the document ProjectionObserverSubscriber pushes: the schema round trip, plus the watermark
+        // stamped on top of it.
+        var document = new JsonObject
+        {
+            ["id"] = Key,
+            ["name"] = EncryptedName,
+            [WellKnownProperties.LastHandledEventSequenceNumber] = JsonValue.Create(42UL)
+        };
+
+        _exception = await Catch.Exception(async () => await forwarder(
+            "test-namespace",
+            Key,
+            document,
+            new Concepts.ReadModels.ReadModelChangeContext(
+                Concepts.ReadModels.ReadModelChangeType.Added,
+                Concepts.Events.EventSequenceNumber.First,
+                DateTimeOffset.UtcNow,
+                Cratis.Execution.CorrelationId.NotSet)));
+    }
+
+    [Fact] void should_not_fail() => _exception.ShouldBeNull();
+    [Fact] void should_stream_the_changeset() => _emitted.Count(_ => !_.Subscribed).ShouldEqual(1);
+    [Fact] void should_stream_the_decrypted_read_model() => JsonSerializer.Deserialize<JsonElement>(_emitted.Single(_ => !_.Subscribed).ReadModel).GetProperty("name").GetString().ShouldEqual(DecryptedName);
+
+    record ReadModelWithPersonalData(string Id, string Name);
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_is_owned_by_the_caller.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_is_owned_by_the_caller.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Compliance;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_watching;
+
+/// <summary>
+/// The changeset document on the observable path belongs to the notifier that pushed it, not to the release
+/// call — so releasing it must hand it back untouched. The compliance chain is wired for real here rather than
+/// substituted, because the real manager releases onto a clone: a substitute that returns the very instance it
+/// was given makes the release path look non-mutating when it is not.
+/// </summary>
+public class and_document_is_owned_by_the_caller : given.all_dependencies
+{
+    const string Key = "person-42";
+    const string EncryptedName = "encrypted-name";
+    const string DecryptedName = "decrypted-name";
+
+    readonly List<ReadModelChangeset> _emitted = [];
+    IProjectionChangesetNotifier _notifier;
+    IReadModelChangesetSubscriber _subscriber;
+    TaskCompletionSource<ChangesetForwarder> _forwarderCaptured;
+    JsonObject _document;
+    string _documentBefore;
+
+    void Establish()
+    {
+        var schema = JsonSchema.FromType<ReadModelWithPersonalData>();
+        schema.Properties["name"].ExtensionData = new Dictionary<string, object?>
+        {
+            { ComplianceJsonSchemaExtensions.ComplianceKey, new[] { new ComplianceSchemaMetadata("PII", string.Empty) } }
+        };
+
+        _readModelDefinition = _readModelDefinition with
+        {
+            Schemas = new Dictionary<Concepts.ReadModels.ReadModelGeneration, JsonSchema> { { (Concepts.ReadModels.ReadModelGeneration)1, schema } }
+        };
+        _readModel.GetDefinition().Returns(Task.FromResult(_readModelDefinition));
+
+        _forwarderCaptured = new();
+        _notifier = Substitute.For<IProjectionChangesetNotifier>();
+        _subscriber = Substitute.For<IReadModelChangesetSubscriber>();
+        _grainFactory.GetGrain<IProjectionChangesetNotifier>(Arg.Any<string>()).Returns(_notifier);
+        _grainFactory.GetGrain<IReadModelChangesetSubscriber>(Arg.Any<string>()).Returns(_subscriber);
+
+        _changesetMediator.When(m => m.Subscribe(Arg.Any<Guid>(), Arg.Any<ChangesetForwarder>()))
+            .Do(ci => _forwarderCaptured.SetResult(ci.Arg<ChangesetForwarder>()));
+
+        _notifier.Subscribe(Arg.Any<IReadModelChangesetSubscriber>()).Returns(Task.CompletedTask);
+        _notifier.Unsubscribe(Arg.Any<IReadModelChangesetSubscriber>()).Returns(Task.CompletedTask);
+
+        var valueHandler = Substitute.For<IJsonCompliancePropertyValueHandler>();
+        valueHandler.Type.Returns((ComplianceMetadataType)"PII");
+        valueHandler.Release(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Key, Arg.Any<JsonNode>())
+            .Returns(Task.FromResult<JsonNode>(JsonValue.Create(DecryptedName)));
+
+        _service = new ReadModels(
+            _grainFactory,
+            _storage,
+            _expandoObjectConverter,
+            _reducerMediator,
+            _changesetMediator,
+            _localSiloDetails,
+            new ReadModelsCompliance(
+                new JsonComplianceManager(
+                    new KnownInstancesOf<IJsonCompliancePropertyValueHandler>(valueHandler),
+                    NullLogger<JsonComplianceManager>.Instance),
+                _expandoObjectConverter),
+            _eventCompliance,
+            new JsonSerializerOptions());
+    }
+
+    async Task Because()
+    {
+        _service.Watch(
+            new WatchRequest { EventStore = "test-store", ReadModelIdentifier = "test-read-model" },
+            default).Subscribe(_emitted.Add);
+
+        var forwarder = await _forwarderCaptured.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        _document = new JsonObject { ["id"] = Key, ["name"] = EncryptedName };
+        _documentBefore = _document.ToJsonString();
+
+        await forwarder(
+            "test-namespace",
+            Key,
+            _document,
+            new Concepts.ReadModels.ReadModelChangeContext(
+                Concepts.ReadModels.ReadModelChangeType.Added,
+                Concepts.Events.EventSequenceNumber.First,
+                DateTimeOffset.UtcNow,
+                Cratis.Execution.CorrelationId.NotSet));
+    }
+
+    [Fact] void should_stream_the_decrypted_read_model() => JsonSerializer.Deserialize<JsonElement>(_emitted.Single(_ => !_.Subscribed).ReadModel).GetProperty("name").GetString().ShouldEqual(DecryptedName);
+    [Fact] void should_not_stamp_the_subject_marker_on_the_document_it_was_given() => _document.ContainsKey(WellKnownProperties.Subject).ShouldBeFalse();
+    [Fact] void should_leave_the_document_it_was_given_unchanged() => _document.ToJsonString().ShouldEqual(_documentBefore);
+
+    record ReadModelWithPersonalData(string Id, string Name);
+}

--- a/Source/Kernel/Core/Events/Constraints/UniqueEventTypeConstraintValidator.cs
+++ b/Source/Kernel/Core/Events/Constraints/UniqueEventTypeConstraintValidator.cs
@@ -28,7 +28,11 @@ public class UniqueEventTypeConstraintValidator(
 
         // Every covered event type is checked, not just the one being appended: the constraint allows at most
         // one event from the set, so an event source that already has a sibling type blocks this one too.
-        var (isAllowed, sequenceNumber) = await storage.IsAllowed(definition.EventTypeIds, context.EventSourceId, scopeKey);
+        //
+        // The whole definition goes to storage rather than only its covered event types, because the answer also
+        // depends on the removal event: a covered event that precedes the most recent removal belongs to a closed
+        // cycle and no longer blocks anything.
+        var (isAllowed, sequenceNumber) = await storage.IsAllowed(definition, context.EventSourceId, scopeKey);
         return isAllowed ?
             ConstraintValidationResult.Success :
             new()

--- a/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
+++ b/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
@@ -75,7 +75,16 @@ public class ReadModelsCompliance(
             return instance;
         }
 
-        return await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, instance);
+        // The subject marker is kernel bookkeeping stamped onto the document to carry the compliance identity — it is
+        // never part of the read model's own schema. The compliance manager walks every property it is handed against
+        // that schema and rejects anything the schema does not declare, so the marker has to come off first. The
+        // ExpandoObject release paths get that for free from their schema round-trip, which only carries
+        // schema-declared properties; this path has no round-trip and has to be explicit about it. Strip on a copy —
+        // the caller keeps the document it passed in, and silently removing a property from it would be a surprise.
+        var withoutSubject = (instance.DeepClone() as JsonObject)!;
+        withoutSubject.Remove(WellKnownProperties.Subject);
+
+        return await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, withoutSubject);
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
+++ b/Source/Kernel/Core/ReadModels/ReadModelsCompliance.cs
@@ -75,16 +75,27 @@ public class ReadModelsCompliance(
             return instance;
         }
 
-        // The subject marker is kernel bookkeeping stamped onto the document to carry the compliance identity — it is
-        // never part of the read model's own schema. The compliance manager walks every property it is handed against
-        // that schema and rejects anything the schema does not declare, so the marker has to come off first. The
-        // ExpandoObject release paths get that for free from their schema round-trip, which only carries
-        // schema-declared properties; this path has no round-trip and has to be explicit about it. Strip on a copy —
-        // the caller keeps the document it passed in, and silently removing a property from it would be a surprise.
-        var withoutSubject = (instance.DeepClone() as JsonObject)!;
-        withoutSubject.Remove(WellKnownProperties.Subject);
+        // Kernel bookkeeping is stamped onto the document by the kernel itself — the identity marker read above,
+        // the sink's last-handled watermark, the projection engine's initialization flag. The compliance manager
+        // walks every property it is handed against the read model schema and rejects anything the schema does not
+        // declare, so any of them left on fails the whole release. The ExpandoObject release paths get that for
+        // free from their schema round-trip, which carries only schema-declared properties; this path has no
+        // round-trip and has to be explicit. The invariant is that the manager receives exactly the schema's
+        // document, so strip the whole set — stripping only the marker this method happens to read leaves the next
+        // property stamped upstream to reintroduce the same failure.
+        //
+        // Which of them come off is decided against the schema's own flattened properties, the same lookup the
+        // compliance walk does: a read model is free to expose a bookkeeping property as its own, and several
+        // declare __lastHandledEventSequenceNumber, in which case it is a property like any other and has to
+        // survive. Strip on a copy — the caller keeps the document it passed in.
+        var declaredByTheSchema = schema.GetFlattenedProperties().Select(_ => _.Name).ToHashSet(StringComparer.Ordinal);
+        var withoutBookkeeping = (instance.DeepClone() as JsonObject)!;
+        foreach (var property in WellKnownProperties.All.Where(_ => !declaredByTheSchema.Contains(_)))
+        {
+            withoutBookkeeping.Remove(property);
+        }
 
-        return await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, withoutSubject);
+        return await complianceManager.Release(eventStore, eventStoreNamespace, schema, identifier, withoutBookkeeping);
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Services/Events/Constraints/ConstraintConverters.cs
+++ b/Source/Kernel/Core/Services/Events/Constraints/ConstraintConverters.cs
@@ -34,6 +34,7 @@ internal static class ConstraintConverters
                 new UniqueEventTypeConstraintDefinition(
                     constraint.Name,
                     constraint.Definition.Value1!.EventTypeIds.Select(_ => (EventTypeId)_).ToArray(),
+                    constraint.RemovedWith is null ? null : (EventTypeId)constraint.RemovedWith,
                     scope),
 
             _ => null!

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -792,6 +792,10 @@ internal sealed class ReadModels(
         // leaves the kernel. Sharing this between the one-shot query path and the observable (Watch) path keeps them
         // from diverging: observable queries used to skip the inference entirely and streamed a __subject-less
         // document back as ciphertext.
+        //
+        // The document handed in is never modified. On the observable path it belongs to the changeset the notifier
+        // pushed, not to this call, so stamping bookkeeping onto it would leave an internal marker on an object
+        // this method does not own.
         if (!schema.HasComplianceMetadata())
         {
             return readModel;
@@ -805,8 +809,13 @@ internal sealed class ReadModels(
             return readModel;
         }
 
-        readModel[WellKnownProperties.Subject] = resolvedSubject;
-        var released = await complianceHelper.ReleaseJson(eventStore, @namespace, schema, readModel);
+        var stamped = (readModel.DeepClone() as JsonObject)!;
+        stamped[WellKnownProperties.Subject] = resolvedSubject;
+
+        // The strip stays even though the compliance manager releases onto a clone that never carried the marker:
+        // an implementation that hands back the instance it was given returns the stamped document, and the marker
+        // must never reach the client.
+        var released = await complianceHelper.ReleaseJson(eventStore, @namespace, schema, stamped);
         released.Remove(WellKnownProperties.Subject);
         return released;
 

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/given/a_unique_event_types_constraints_storage.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/given/a_unique_event_types_constraints_storage.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Storage.InMemory.EventSequences;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.given;
+
+public class a_unique_event_types_constraints_storage : Specification
+{
+    protected const string ConstraintNameValue = "loan-open";
+    protected static readonly EventType _checkedOutEventType = new("LoanCheckedOut", EventTypeGeneration.First);
+    protected static readonly EventType _returnedEventType = new("LoanReturned", EventTypeGeneration.First);
+    protected static readonly EventSourceId _borrower = "borrower";
+    protected static readonly EventSourceId _anotherBorrower = "another-borrower";
+
+    protected EventSequenceStorage _eventSequenceStorage;
+    protected UniqueEventTypesConstraintsStorage _storage;
+
+    void Establish()
+    {
+        _eventSequenceStorage = new(
+            new EventStoreName("event-store"),
+            EventStoreNamespaceName.Default,
+            EventSequenceId.Log);
+
+        _storage = new(_eventSequenceStorage);
+    }
+
+    protected static UniqueEventTypeConstraintDefinition DefinitionReleasedByReturn =>
+        new(ConstraintNameValue, [_checkedOutEventType.Id], _returnedEventType.Id);
+
+    protected static UniqueEventTypeConstraintDefinition DefinitionWithoutRemovalEvent =>
+        new(ConstraintNameValue, [_checkedOutEventType.Id]);
+
+    protected Task Append(ulong sequenceNumber, EventType eventType, EventSourceId eventSourceId) =>
+        _eventSequenceStorage.Append(
+            sequenceNumber,
+            EventSourceType.Default,
+            eventSourceId,
+            EventStreamType.All,
+            EventStreamId.Default,
+            eventType,
+            CorrelationId.New(),
+            [],
+            [],
+            [],
+            DateTimeOffset.UtcNow,
+            new Dictionary<EventTypeGeneration, ExpandoObject> { { EventTypeGeneration.First, new ExpandoObject() } },
+            new Dictionary<EventTypeGeneration, EventHash>());
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_a_covered_event_followed_the_release.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_a_covered_event_followed_the_release.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_checking_if_allowed;
+
+/// <summary>
+/// A release opens the next cycle, it does not disable the constraint. The second checkout holds the current cycle,
+/// so a third is refused — and against that event's sequence number, not the one from the cycle already closed.
+/// Answering "has a covered event ever been appended" or "is there a release at all" would both get this wrong.
+/// </summary>
+public class and_a_covered_event_followed_the_release : given.a_unique_event_types_constraints_storage
+{
+    bool _isAllowed;
+    EventSequenceNumber _sequenceNumber;
+
+    async Task Establish()
+    {
+        await Append(0, _checkedOutEventType, _borrower);
+        await Append(1, _returnedEventType, _borrower);
+        await Append(2, _checkedOutEventType, _borrower);
+    }
+
+    async Task Because() => (_isAllowed, _sequenceNumber) = await _storage.IsAllowed(DefinitionReleasedByReturn, _borrower);
+
+    [Fact] void should_not_be_allowed() => _isAllowed.ShouldBeFalse();
+    [Fact] void should_report_the_sequence_number_from_the_current_cycle() => _sequenceNumber.ShouldEqual((EventSequenceNumber)2U);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_a_covered_event_was_already_appended.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_a_covered_event_was_already_appended.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_checking_if_allowed;
+
+/// <summary>
+/// The unchanged base case: nothing has released the constraint, so the second covered event is refused and the
+/// sequence number of the one already holding the cycle comes back for the violation to point at.
+/// </summary>
+public class and_a_covered_event_was_already_appended : given.a_unique_event_types_constraints_storage
+{
+    bool _isAllowed;
+    EventSequenceNumber _sequenceNumber;
+
+    async Task Establish() => await Append(0, _checkedOutEventType, _borrower);
+
+    async Task Because() => (_isAllowed, _sequenceNumber) = await _storage.IsAllowed(DefinitionReleasedByReturn, _borrower);
+
+    [Fact] void should_not_be_allowed() => _isAllowed.ShouldBeFalse();
+    [Fact] void should_report_the_sequence_number_of_the_event_holding_the_cycle() => _sequenceNumber.ShouldEqual((EventSequenceNumber)0U);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_another_event_source_was_released.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_another_event_source_was_released.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_checking_if_allowed;
+
+/// <summary>
+/// The constraint is per event source, so a release belongs to the event source that recorded it. Reading the most
+/// recent removal event across the whole sequence instead would let any borrower's return open everybody else's
+/// next cycle - the constraint would then be released by unrelated traffic rather than by the lifecycle it guards.
+/// </summary>
+public class and_another_event_source_was_released : given.a_unique_event_types_constraints_storage
+{
+    bool _isAllowed;
+
+    async Task Establish()
+    {
+        await Append(0, _checkedOutEventType, _borrower);
+        await Append(1, _returnedEventType, _anotherBorrower);
+    }
+
+    async Task Because() => (_isAllowed, _) = await _storage.IsAllowed(DefinitionReleasedByReturn, _borrower);
+
+    [Fact] void should_not_be_allowed() => _isAllowed.ShouldBeFalse();
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_the_constraint_was_released.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_the_constraint_was_released.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_checking_if_allowed;
+
+/// <summary>
+/// The whole point of declaring a removal event: the loan was returned, so the next one may start. Without this the
+/// constraint can only say "at most one, forever", which every lifecycle that repeats runs into exactly once and
+/// then never recovers from.
+/// </summary>
+public class and_the_constraint_was_released : given.a_unique_event_types_constraints_storage
+{
+    bool _isAllowed;
+    EventSequenceNumber _sequenceNumber;
+
+    async Task Establish()
+    {
+        await Append(0, _checkedOutEventType, _borrower);
+        await Append(1, _returnedEventType, _borrower);
+    }
+
+    async Task Because() => (_isAllowed, _sequenceNumber) = await _storage.IsAllowed(DefinitionReleasedByReturn, _borrower);
+
+    [Fact] void should_be_allowed() => _isAllowed.ShouldBeTrue();
+    [Fact] void should_have_no_sequence_number_to_report() => _sequenceNumber.ShouldEqual(EventSequenceNumber.Unavailable);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_the_definition_declares_no_removal_event.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Events/Constraints/for_UniqueEventTypesConstraintsStorage/when_checking_if_allowed/and_the_definition_declares_no_removal_event.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Events.Constraints.for_UniqueEventTypesConstraintsStorage.when_checking_if_allowed;
+
+/// <summary>
+/// Releasing is opt-in. An event that happens to end the lifecycle in the domain releases nothing unless the
+/// constraint names it, so a definition without a removal event keeps meaning "at most one, forever" — the
+/// behavior every constraint declared before this existed relies on.
+/// </summary>
+public class and_the_definition_declares_no_removal_event : given.a_unique_event_types_constraints_storage
+{
+    bool _isAllowed;
+
+    async Task Establish()
+    {
+        await Append(0, _checkedOutEventType, _borrower);
+        await Append(1, _returnedEventType, _borrower);
+    }
+
+    async Task Because() => (_isAllowed, _) = await _storage.IsAllowed(DefinitionWithoutRemovalEvent, _borrower);
+
+    [Fact] void should_not_be_allowed() => _isAllowed.ShouldBeFalse();
+}

--- a/Source/Kernel/Storage.InMemory/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using Cratis.Chronicle.Storage.InMemory.EventSequences;
 
@@ -21,15 +22,24 @@ public class UniqueEventTypesConstraintsStorage(
 {
     /// <inheritdoc/>
     public Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(
-        IEnumerable<EventTypeId> eventTypeIds,
+        UniqueEventTypeConstraintDefinition definition,
         EventSourceId eventSourceId,
         string scopeKey = "")
     {
-        var coveredEventTypeIds = eventTypeIds.ToHashSet();
-        var existing = eventSequenceStorage.Events
-            .FirstOrDefault(_ =>
-                coveredEventTypeIds.Contains(_.Context.EventType.Id) &&
-                _.Context.EventSourceId == eventSourceId);
+        var coveredEventTypeIds = definition.EventTypeIds.ToHashSet();
+        var forEventSource = eventSequenceStorage.Events
+            .Where(_ => _.Context.EventSourceId == eventSourceId)
+            .ToArray();
+
+        var latestRemoval = GetLatestRemoval(definition, forEventSource);
+
+        // Ordered so the sequence number reported back is the covered event that actually holds the cycle, rather
+        // than whichever one the sequence happened to yield first.
+        var existing = forEventSource
+            .Where(_ => coveredEventTypeIds.Contains(_.Context.EventType.Id) &&
+                        (latestRemoval is null || _.Context.SequenceNumber.Value > latestRemoval.Value))
+            .OrderBy(_ => _.Context.SequenceNumber.Value)
+            .FirstOrDefault();
 
         if (existing is not null)
         {
@@ -37,5 +47,20 @@ public class UniqueEventTypesConstraintsStorage(
         }
 
         return Task.FromResult((true, EventSequenceNumber.Unavailable));
+    }
+
+    static EventSequenceNumber? GetLatestRemoval(UniqueEventTypeConstraintDefinition definition, IEnumerable<AppendedEvent> forEventSource)
+    {
+        if (definition.RemovedWith is null)
+        {
+            return null;
+        }
+
+        var removals = forEventSource
+            .Where(_ => _.Context.EventType.Id == definition.RemovedWith)
+            .Select(_ => _.Context.SequenceNumber.Value)
+            .ToArray();
+
+        return removals.Length == 0 ? null : removals.Max();
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Events/Constraints/for_ConstraintDefinitionSerializer/when_deserializing_a_unique_event_type_constraint/and_it_declares_a_removal_event.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Events/Constraints/for_ConstraintDefinitionSerializer/when_deserializing_a_unique_event_type_constraint/and_it_declares_a_removal_event.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Events.Constraints.for_ConstraintDefinitionSerializer.when_deserializing_a_unique_event_type_constraint;
+
+/// <summary>
+/// The removal event has to survive the store. A definition that loses it on the way back in reverts to "at most one,
+/// forever" the first time the kernel reads its constraints from the collection rather than from a fresh
+/// registration — so the constraint would behave as declared until a restart and silently stop releasing after one.
+/// </summary>
+public class and_it_declares_a_removal_event : given.a_stored_constraint_definition
+{
+    static readonly EventTypeId _coveredEventTypeId = "the-event-type";
+    static readonly EventTypeId _removalEventTypeId = "the-removal-event-type";
+    static readonly UniqueEventTypeConstraintDefinition _definition = new(ConstraintNameValue, [_coveredEventTypeId], _removalEventTypeId);
+
+    IConstraintDefinition _result;
+
+    void Because() => _result = Read(Write(_definition));
+
+    [Fact] void should_read_back_the_definition_that_was_written() => _result.ShouldEqual(_definition);
+    [Fact] void should_keep_the_removal_event() => ((UniqueEventTypeConstraintDefinition)_result).RemovedWith.ShouldEqual(_removalEventTypeId);
+}

--- a/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Events/Constraints/UniqueEventTypesConstraintsStorage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using MongoDB.Driver;
@@ -18,18 +19,37 @@ public class UniqueEventTypesConstraintsStorage(IEventStoreNamespaceDatabase dat
     readonly IMongoCollection<Event> _collection = database.GetEventSequenceCollectionFor(eventSequenceId);
 
     /// <inheritdoc/>
-    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "")
+    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(UniqueEventTypeConstraintDefinition definition, EventSourceId eventSourceId, string scopeKey = "")
     {
-        var filter = Builders<Event>.Filter.In(_ => _.Type, eventTypeIds);
-        filter &= Builders<Event>.Filter.Eq(_ => _.EventSourceId, eventSourceId);
+        var forEventSource = Builders<Event>.Filter.Eq(_ => _.EventSourceId, eventSourceId);
+        var filter = forEventSource & Builders<Event>.Filter.In(_ => _.Type, definition.EventTypeIds);
 
-        using var result = await _collection.FindAsync(filter);
-        var existing = await result.FirstOrDefaultAsync();
+        var latestRemoval = await GetLatestRemoval(definition, forEventSource);
+        if (latestRemoval is not null)
+        {
+            filter &= Builders<Event>.Filter.Gt(_ => _.SequenceNumber, latestRemoval);
+        }
+
+        // Ordered so the sequence number reported back is the covered event that actually holds the cycle, rather
+        // than whichever one the collection happened to yield first.
+        var existing = await _collection.Find(filter).SortBy(_ => _.SequenceNumber).FirstOrDefaultAsync();
         if (existing is not null)
         {
             return (false, existing.SequenceNumber);
         }
 
         return (true, EventSequenceNumber.Unavailable);
+    }
+
+    async Task<EventSequenceNumber?> GetLatestRemoval(UniqueEventTypeConstraintDefinition definition, FilterDefinition<Event> forEventSource)
+    {
+        if (definition.RemovedWith is null)
+        {
+            return null;
+        }
+
+        var filter = forEventSource & Builders<Event>.Filter.Eq(_ => _.Type, definition.RemovedWith);
+        var latest = await _collection.Find(filter).SortByDescending(_ => _.SequenceNumber).FirstOrDefaultAsync();
+        return latest?.SequenceNumber;
     }
 }

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueEventTypesConstraints/UniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/UniqueEventTypesConstraints/UniqueEventTypesConstraintsStorage.cs
@@ -3,8 +3,10 @@
 
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Storage.Events.Constraints;
+using Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences;
 using Microsoft.EntityFrameworkCore;
 
 namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.UniqueEventTypesConstraints;
@@ -19,22 +21,47 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.UniqueEventTypesCo
 public class UniqueEventTypesConstraintsStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, EventSequenceId eventSequenceId, IDatabase database) : IUniqueEventTypesConstraintsStorage
 {
     /// <inheritdoc/>
-    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "")
+    public async Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(UniqueEventTypeConstraintDefinition definition, EventSourceId eventSourceId, string scopeKey = "")
     {
         await using var scope = await database.EventSequenceTable(eventStore, @namespace, eventSequenceId);
 
-        var eventTypeIdValues = eventTypeIds.Select(_ => _.Value).ToArray();
+        var eventTypeIdValues = definition.EventTypeIds.Select(_ => _.Value).ToArray();
         var eventSourceIdValue = eventSourceId.Value;
-        var existing = await scope.DbContext.Events
-            .Where(e => eventTypeIdValues.Contains(e.Type) &&
-                       e.EventSourceId == eventSourceIdValue)
-            .FirstOrDefaultAsync();
+        var latestRemoval = await GetLatestRemoval(scope.DbContext.Events, definition, eventSourceIdValue);
 
+        var query = scope.DbContext.Events
+            .Where(e => eventTypeIdValues.Contains(e.Type) &&
+                       e.EventSourceId == eventSourceIdValue);
+
+        if (latestRemoval is not null)
+        {
+            query = query.Where(e => e.SequenceNumber > latestRemoval.Value);
+        }
+
+        // Ordered so the sequence number reported back is the covered event that actually holds the cycle, rather
+        // than whichever one the table happened to yield first.
+        var existing = await query.OrderBy(e => e.SequenceNumber).FirstOrDefaultAsync();
         if (existing is not null)
         {
             return (false, (EventSequenceNumber)existing.SequenceNumber);
         }
 
         return (true, EventSequenceNumber.Unavailable);
+    }
+
+    static async Task<ulong?> GetLatestRemoval(DbSet<EventEntry> events, UniqueEventTypeConstraintDefinition definition, string eventSourceIdValue)
+    {
+        if (definition.RemovedWith is null)
+        {
+            return null;
+        }
+
+        var removalEventTypeIdValue = definition.RemovedWith.Value;
+        var latest = await events
+            .Where(e => e.Type == removalEventTypeIdValue && e.EventSourceId == eventSourceIdValue)
+            .OrderByDescending(e => e.SequenceNumber)
+            .FirstOrDefaultAsync();
+
+        return latest?.SequenceNumber;
     }
 }

--- a/Source/Kernel/Storage/Events/Constraints/IUniqueEventTypesConstraintsStorage.cs
+++ b/Source/Kernel/Storage/Events/Constraints/IUniqueEventTypesConstraintsStorage.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Events.Constraints;
 
 namespace Cratis.Chronicle.Storage.Events.Constraints;
 
@@ -13,7 +14,7 @@ public interface IUniqueEventTypesConstraintsStorage
     /// <summary>
     /// Check if a constraint value exists.
     /// </summary>
-    /// <param name="eventTypeIds">The <see cref="EventType"/> values the constraint covers.</param>
+    /// <param name="definition">The <see cref="UniqueEventTypeConstraintDefinition"/> to check against.</param>
     /// <param name="eventSourceId"><see cref="EventSourceId"/> to check.</param>
     /// <param name="scopeKey">Optional scope key for scoped constraints.</param>
     /// <returns>
@@ -21,8 +22,14 @@ public interface IUniqueEventTypesConstraintsStorage
     /// Returns <see cref="EventSequenceNumber.Unavailable"/> if it doesn't exist.
     /// </returns>
     /// <remarks>
-    /// An append is allowed only when the event source carries none of the covered event types. Passing more
-    /// than one makes them mutually exclusive: the first of them to be appended blocks all of the others.
+    /// An append is allowed only when the event source carries none of the covered event types. A definition covering
+    /// more than one makes them mutually exclusive: the first of them to be appended blocks all of the others.
+    /// <para>
+    /// A definition carrying a <see cref="UniqueEventTypeConstraintDefinition.RemovedWith"/> is answered per cycle
+    /// rather than forever — only a covered event appended after the most recent removal event on that event source
+    /// blocks the append, so an event source that has been released is free to start the next cycle. The whole
+    /// definition is passed rather than its parts so that a reader cannot answer against half of it.
+    /// </para>
     /// </remarks>
-    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(IEnumerable<EventTypeId> eventTypeIds, EventSourceId eventSourceId, string scopeKey = "");
+    Task<(bool IsAllowed, EventSequenceNumber SequenceNumber)> IsAllowed(UniqueEventTypeConstraintDefinition definition, EventSourceId eventSourceId, string scopeKey = "");
 }

--- a/Source/Kernel/Storage/WellKnownProperties.cs
+++ b/Source/Kernel/Storage/WellKnownProperties.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using Cratis.Chronicle.Changes;
 
 namespace Cratis.Chronicle.Storage;
@@ -24,4 +25,15 @@ public static class WellKnownProperties
     /// The property name for the subject (compliance identity target) of the event.
     /// </summary>
     public const string Subject = "__subject";
+
+    /// <summary>
+    /// All the kernel bookkeeping property names.
+    /// </summary>
+    /// <remarks>
+    /// The kernel stamps these onto a read model document itself — they are not read model data. Anything that
+    /// walks a document against the read model's schema has to account for them, because a read model does not
+    /// declare them unless it deliberately exposes one. Every name declared above belongs in here; leaving one
+    /// out is how such a walk ends up rejecting a property the kernel put there.
+    /// </remarks>
+    public static readonly ImmutableArray<string> All = [LastHandledEventSequenceNumber, ReadModelInstanceInitialized, Subject];
 }


### PR DESCRIPTION
## Added

- `RemovedWith<TEventType>()` on the constraint builder, so a per-event-source unique constraint can express "at most one per cycle" rather than only "at most one ever"
- `[RemoveConstraint]` now releases a unique event type constraint

## Fixed

- A `[Passive]` read model carrying a `[PII]` property can be read; every keyed read previously threw
- A watched read model carrying a `[PII]` property streams its changesets; every one was previously dropped silently