### PR TITLE
Correct coverage notes for Kotlin and Java tagging and filtering

### DIFF
--- a/Documentation/concepts/subject.mdx
+++ b/Documentation/concepts/subject.mdx
@@ -37,7 +37,7 @@ an implicit conversion from `EventSourceId`, so mixing the two is painless:
 
 <ChronicleClientTabs snippet="concepts/subject/explicit" />
 
-`Subject` also converts implicitly from `string` and `Guid`. Kotlin, Java, and TypeScript don't currently expose a `subject` append option at all — only C# and Elixir do.
+`Subject` also converts implicitly from `string` and `Guid`. Kotlin and Java pass a subject through `AppendOptions`. TypeScript doesn't currently expose a `subject` append option at all.
 
 ## Implicit subject with `[Subject]`
 
@@ -47,7 +47,7 @@ explicit subject is provided:
 
 <ChronicleClientTabs snippet="concepts/subject/implicit-with-attribute" />
 
-An explicit `subject` argument always takes precedence over a `[Subject]` property. This declarative form is C#-only — Elixir requires passing `subject:` explicitly on every append (shown above); Kotlin, Java, and TypeScript don't support a subject at all yet.
+An explicit `subject` argument always takes precedence over a `[Subject]` property. This declarative form is C#-only — Elixir, Kotlin, and Java pass the subject explicitly on every append (shown above), and TypeScript doesn't support a subject at all yet.
 
 ## Compliance
 

--- a/Documentation/concepts/tagging-reactors.mdx
+++ b/Documentation/concepts/tagging-reactors.mdx
@@ -5,7 +5,7 @@ Tags provide a way to organize and categorize your reactors for better discovera
 `[Tag]` and `[Tags]` label the reactor itself. They do not filter which appended events the reactor handles. For event filtering based on appended metadata, see [Filter reducers and reactors by tag](../events/filtering/by-tag), [Filter reducers and reactors by event source type](../events/filtering/by-event-source-type), and [Filter reducers and reactors by event stream type](../events/filtering/by-event-stream-type).
 
 :::note[Client coverage]
-Tagging a reactor with `[Tag]`/`[Tags]` is currently C#-only — none of the other clients' reactor registration mechanisms (Kotlin's `@Reactor`, Elixir's `use Chronicle.Reactors.Reactor`, TypeScript's `reactor()`) expose a way to attach descriptive tags to the reactor itself.
+Kotlin and Java tag a reactor with `@Tag`, which is repeatable and takes any number of tags. Elixir's `use Chronicle.Reactors.Reactor` and TypeScript's `reactor()` expose no way to attach descriptive tags to the reactor itself.
 :::
 
 ## Adding Tags

--- a/Documentation/concepts/tagging.mdx
+++ b/Documentation/concepts/tagging.mdx
@@ -3,7 +3,7 @@
 Tags provide a flexible way to organize, categorize, and identify events and observers (reactors, reducers, projections, read models) within Chronicle. By applying the `[Tag]` or `[Tags]` attribute, you can assign one or more tags that describe the purpose, domain, or context of your artifacts.
 
 :::note[Client coverage]
-Static tags (the `[Tag]`/`[Tags]` attribute, on events, observers, or read models) and reading tags back from `EventContext` are currently C#-only. Dynamic tags supplied at append time are also supported in Elixir (shown below) — Kotlin, Java, and TypeScript don't expose a `tags` append option at all.
+Static tags on **events** or **read models** are currently C#-only. Kotlin and Java tag an **observer** with `@Tag`, supply dynamic tags at append time through `AppendOptions`, and read tags back from `EventContext` — as does Elixir for dynamic tags. TypeScript doesn't expose a `tags` append option at all.
 :::
 
 > **Note**: Both `[Tag]` and `[Tags]` attributes can be used interchangeably. Use whichever feels more natural, or mix them - all tags will be merged together.

--- a/Documentation/projections/filtering.mdx
+++ b/Documentation/projections/filtering.mdx
@@ -17,7 +17,7 @@ This projection receives every `OrderPlaced` and `OrderShipped` event regardless
 <ChronicleClientTabs snippet="projections/filtering/tagging" />
 
 :::note[Client coverage]
-Labeling a projection with `[Tag]`/`[Tags]`, and metadata-based observer filtering with `[FilterEventsByTag]`/`[EventSourceType]`/`[EventStreamType]` on a reactor or reducer, are currently C#-only. Kotlin, Elixir, and TypeScript have no equivalent tag or filter mechanism on their projection, reactor, or reducer registration APIs.
+Labeling a **projection** is currently C#-only. Kotlin and Java have the equivalents for a **reactor or reducer** — `@Tag`, `@FilterEventsByTag`, `@EventSourceType`, and `@EventStreamType` — but nothing on projection registration. Elixir and TypeScript have no tag or filter mechanism on any of the three.
 :::
 
 ## Combining a projection with metadata-based filtering

--- a/Documentation/reactors/filtering.mdx
+++ b/Documentation/reactors/filtering.mdx
@@ -15,7 +15,7 @@ These attributes correlate directly to the metadata you provide when appending a
 <ChronicleClientTabs snippet="reactors/filtering/metadata-example" />
 
 :::note[Client coverage]
-Observer-level filtering by tag, event source type, or event stream type is currently C#-only. Kotlin's `@Reactor`, Elixir's `use Chronicle.Reactors.Reactor`, and TypeScript's `reactor()` all register a reactor without a way to attach these filters.
+Kotlin and Java attach the same filters with `@FilterEventsByTag`, `@EventSourceType`, and `@EventStreamType` on the reactor class. Elixir's `use Chronicle.Reactors.Reactor` and TypeScript's `reactor()` register a reactor without a way to attach these filters.
 :::
 
 ## Filter by tag

--- a/Documentation/reducers/filtering.mdx
+++ b/Documentation/reducers/filtering.mdx
@@ -15,7 +15,7 @@ These attributes correlate directly to the metadata you provide when appending a
 <ChronicleClientTabs snippet="reducers/filtering/metadata-example" />
 
 :::note[Client coverage]
-Observer-level filtering by tag, event source type, or event stream type is currently C#-only. Kotlin's `@Reducer`, Elixir's `use Chronicle.Reducers.Reducer`, and TypeScript's `reducer()` all register a reducer without a way to attach these filters.
+Kotlin and Java attach the same filters with `@FilterEventsByTag`, `@EventSourceType`, and `@EventStreamType` on the reducer class. Elixir's `use Chronicle.Reducers.Reducer` and TypeScript's `reducer()` register a reducer without a way to attach these filters.
 :::
 
 ## Filter by tag

--- a/Documentation/reducers/tagging-reducers.mdx
+++ b/Documentation/reducers/tagging-reducers.mdx
@@ -5,7 +5,7 @@ Tags provide a way to organize and categorize your reducers for better discovera
 `[Tag]` and `[Tags]` label the reducer itself. They do not filter which appended events the reducer handles. For event filtering based on appended metadata, see [Filter reducers and reactors by tag](../events/filtering/by-tag), [Filter reducers and reactors by event source type](../events/filtering/by-event-source-type), and [Filter reducers and reactors by event stream type](../events/filtering/by-event-stream-type).
 
 :::note[Client coverage]
-Tagging a reducer with `[Tag]`/`[Tags]` is currently C#-only — none of the other clients' reducer registration mechanisms (Kotlin's `@Reducer`, Elixir's `use Chronicle.Reducers.Reducer`, TypeScript's `reducer()`) expose a way to attach descriptive tags to the reducer itself.
+Kotlin and Java tag a reducer with `@Tag`, which is repeatable and takes any number of tags. Elixir's `use Chronicle.Reducers.Reducer` and TypeScript's `reducer()` expose no way to attach descriptive tags to the reducer itself.
 :::
 
 ## Adding Tags


### PR DESCRIPTION
# Summary

Coverage notes said Kotlin and Java lacked tagging, filtering and subject support they now have.

## Changed

- Coverage notes on the subject, tagging and filtering pages now reflect that Kotlin and Java support an append-time subject and tags, `@Tag` on reactors and reducers, and observer filtering by tag, event source type and event stream type.
