### PR TITLE
Fix missing discriminator on polymorphic children with a single derived type

### DIFF
--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/with_a_polymorphic_child_having_a_single_derived_type.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionBuilder/when_building_model/with_children_from/with_a_polymorphic_child_having_a_single_derived_type.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionBuilder.when_building_model.with_children_from;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3571 — AutoMap only ever wires properties
+/// that exist by name on both the event and the child type, so it can never discover the
+/// <c>_derivedTypeId</c> discriminator: it is a serialization-time artifact <see cref="DerivedTypeAttribute"/>
+/// adds, not a real member of the interface or its implementation. When the child collection's item type
+/// has exactly one <see cref="DerivedTypeAttribute"/> implementation, the builder must stamp a constant
+/// discriminator mapping automatically, the same way an explicit <c>[SetValue]</c> would.
+/// </summary>
+public class with_a_polymorphic_child_having_a_single_derived_type : given.a_model_bound_projection_builder
+{
+    ProjectionDefinition _result;
+
+    void Establish()
+    {
+        event_types = new EventTypesForSpecifications([typeof(SliceUiActorUpdated)]);
+        builder = new ModelBoundProjectionBuilder(naming_policy, event_types);
+    }
+
+    void Because() => _result = builder.Build(typeof(SliceWithActors));
+
+    [Fact] void should_have_children_definition() => _result.Children.Count.ShouldEqual(1);
+
+    [Fact]
+    void should_stamp_the_derived_type_discriminator_as_a_constant_value()
+    {
+        var eventType = event_types.GetEventTypeFor(typeof(SliceUiActorUpdated)).ToContract();
+        var childrenDef = _result.Children[nameof(SliceWithActors.Actors)];
+        var fromDef = childrenDef.From.Single(kvp => kvp.Key.IsEqual(eventType)).Value;
+        fromDef.Properties["_derivedTypeId"].ShouldEqual("$value(userExperience)");
+    }
+}
+
+public interface IActor;
+
+[DerivedType("userExperience", typeof(IActor))]
+public sealed record UserExperienceActor(
+    [Key] Guid ActorId,
+    [SetFrom<SliceUiActorUpdated>(nameof(SliceUiActorUpdated.DisplayName))] string DisplayName) : IActor;
+
+[EventType]
+public record SliceUiActorUpdated(Guid SliceId, Guid ActorId, string DisplayName);
+
+[Passive]
+[FromEvent<SliceCreated>]
+public sealed record SliceWithActors(
+    [Key] Guid Id,
+    [ChildrenFrom<SliceUiActorUpdated>(key: nameof(SliceUiActorUpdated.ActorId), parentKey: nameof(SliceUiActorUpdated.SliceId))]
+    IReadOnlyList<IActor> Actors);
+
+[EventType]
+public record SliceCreated(Guid SliceId);

--- a/Source/Clients/DotNET/EventSequences/EventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/EventSequence.cs
@@ -443,6 +443,31 @@ public class EventSequence(
     }
 
     /// <inheritdoc/>
+    public async Task Revise(EventSequenceNumber sequenceNumber, object @event)
+    {
+        var eventClrType = @event.GetType();
+        ThrowIfUnknownEventType(eventTypes, eventClrType);
+
+        var eventType = eventTypes.GetEventTypeFor(eventClrType);
+        var content = await eventSerializer.Serialize(@event);
+        var causationChain = causationManager.GetCurrentChain().ToContract();
+        var identity = identityProvider.GetCurrent();
+
+        await _servicesAccessor.Services.EventSequences.Revise(new()
+        {
+            EventStore = eventStoreName,
+            Namespace = @namespace,
+            EventSequenceId = eventSequenceId,
+            SequenceNumber = sequenceNumber,
+            EventType = eventType.ToContract(),
+            Content = content.ToJsonString(),
+            CorrelationId = correlationIdAccessor.Current,
+            Causation = causationChain,
+            CausedBy = identity.ToContract()
+        });
+    }
+
+    /// <inheritdoc/>
     public async Task Redact(EventSequenceNumber sequenceNumber, RedactionReason reason)
     {
         var causationChain = causationManager.GetCurrentChain().ToContract();

--- a/Source/Clients/DotNET/EventSequences/IEventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/IEventSequence.cs
@@ -171,6 +171,18 @@ public interface IEventSequence
         IDictionary<EventSourceId, ConcurrencyScope>? concurrencyScopes = default);
 
     /// <summary>
+    /// Revise a specific event in the event sequence with new content.
+    /// </summary>
+    /// <param name="sequenceNumber"><see cref="EventSequenceNumber"/> of the event to revise.</param>
+    /// <param name="event">The event holding the revised content.</param>
+    /// <returns>Awaitable <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The type of <paramref name="event"/> has to be the same as the original event at the sequence number.
+    /// Its generational information is taken into account when revising.
+    /// </remarks>
+    Task Revise(EventSequenceNumber sequenceNumber, object @event);
+
+    /// <summary>
     /// Redact an event at a specific sequence number.
     /// </summary>
     /// <param name="sequenceNumber"><see cref="EventSequenceNumber"/> to redact.</param>

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -150,7 +150,7 @@ static class ChildrenDefinitionExtensions
         var discoveredParentKey = explicitParentKey is null ? DiscoverEventPropertyForParentId(eventType, parentModelType, key, namingPolicy) : null;
         var parentKey = explicitParentKey ?? discoveredParentKey ?? WellKnownExpressions.EventSourceId;
 
-        var childType = GetChildType(memberType);
+        var childType = ResolveConcreteChildType(GetChildType(memberType));
         var identifiedBy = identifiedByProperty?.GetValue(attr) as string;
         if (string.IsNullOrEmpty(identifiedBy))
         {
@@ -199,7 +199,11 @@ static class ChildrenDefinitionExtensions
 
         if (childType is not null)
         {
+            AddDerivedTypeDiscriminatorMapping(childrenDef.From, getOrCreateEventType, eventType, childType);
+
             // For records, process constructor parameters to pick up attributes
+            // (childType is resolved to the concrete DerivedType implementation when unambiguous,
+            // above, so [SetFrom]/[SetValue]/[SetFromContext] declared on it are discovered here too)
             var primaryConstructor = childType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
                 .OrderByDescending(c => c.GetParameters().Length)
                 .FirstOrDefault();
@@ -687,6 +691,60 @@ static class ChildrenDefinitionExtensions
             .SelectMany(property => property.GetAttributesOfGenericType<ChildrenFromAttribute<object>>().Select(pair => pair.EventType));
 
         return fromConstructor.Concat(fromProperties);
+    }
+
+    /// <summary>
+    /// Resolves a children collection's declared item type to its single concrete <see cref="DerivedTypeAttribute"/>
+    /// implementation, when it is a <see cref="DerivedTypeAttribute"/> base (an interface or abstract class) with
+    /// exactly one registered implementation. Reflection-based discovery (constructor parameters for
+    /// <c>[SetFrom]</c>/<c>[SetValue]</c>/<c>[SetFromContext]</c>, and the <c>[Key]</c> property for identity)
+    /// finds nothing on an interface or abstract type, so without this resolution a polymorphic children
+    /// collection silently loses those mappings. When the base type has zero or more than one implementation,
+    /// the concrete type for this collection cannot be inferred safely, so the declared type is kept as-is.
+    /// </summary>
+    /// <param name="childType">The declared item type of the children collection.</param>
+    /// <returns>The concrete implementation when unambiguous; otherwise <paramref name="childType"/> unchanged.</returns>
+    static Type? ResolveConcreteChildType(Type? childType)
+    {
+        if (childType is null || (!childType.IsInterface && !childType.IsAbstract))
+        {
+            return childType;
+        }
+
+        var implementations = Types.Types.Instance.All
+            .Where(type => !type.IsAbstract && !type.IsInterface &&
+                           childType.IsAssignableFrom(type) &&
+                           Attribute.IsDefined(type, typeof(DerivedTypeAttribute)))
+            .ToArray();
+
+        return implementations.Length == 1 ? implementations[0] : childType;
+    }
+
+    /// <summary>
+    /// Stamps a constant discriminator mapping for a children collection whose resolved item type is
+    /// adorned with <see cref="DerivedTypeAttribute"/>. AutoMap only ever wires properties that exist by
+    /// name on both the event and the child type, so it can never discover <c>_derivedTypeId</c> — that
+    /// property is a serialization-time artifact added by <see cref="DerivedTypeJsonConverter{T}"/>, not a
+    /// real member on the type. Without this, a newly created child of a polymorphic collection is
+    /// persisted without its discriminator and cannot be resolved back to its concrete type on read.
+    /// </summary>
+    /// <param name="targetFrom">The From dictionary for the children definition to add the mapping to.</param>
+    /// <param name="getOrCreateEventType">Function to get or create a cached EventType instance.</param>
+    /// <param name="eventType">The event type creating the child.</param>
+    /// <param name="childType">The resolved item type of the children collection.</param>
+    static void AddDerivedTypeDiscriminatorMapping(
+        IDictionary<EventType, FromDefinition> targetFrom,
+        Func<Type, EventType> getOrCreateEventType,
+        Type eventType,
+        Type childType)
+    {
+        var derivedTypeAttribute = childType.GetCustomAttribute<DerivedTypeAttribute>();
+        if (derivedTypeAttribute is null)
+        {
+            return;
+        }
+
+        targetFrom.AddSetValueMapping(getOrCreateEventType, eventType, DerivedTypeJsonConverter<object>.DerivedTypeIdProperty, derivedTypeAttribute.Identifier);
     }
 
     static Type? GetChildType(Type propertyType)

--- a/Source/Clients/Testing.Specs/ReadModels/IActor.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/IActor.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Marker interface for a polymorphic actor on a <see cref="SliceWithActors"/>, with a single
+/// <see cref="UserExperienceActor"/> implementation.
+/// </summary>
+public interface IActor;

--- a/Source/Clients/Testing.Specs/ReadModels/SliceCreated.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SliceCreated.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for creating a <see cref="SliceWithActors"/>.
+/// </summary>
+/// <param name="SliceId">The slice identifier.</param>
+[EventType]
+public record SliceCreated(Guid SliceId);

--- a/Source/Clients/Testing.Specs/ReadModels/SliceUiActorUpdated.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SliceUiActorUpdated.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event for adding or updating a <see cref="UserExperienceActor"/> on a <see cref="SliceWithActors"/>.
+/// </summary>
+/// <param name="SliceId">The parent slice identifier.</param>
+/// <param name="ActorId">The actor identifier.</param>
+/// <param name="DisplayName">Display name of the actor.</param>
+[EventType]
+public record SliceUiActorUpdated(Guid SliceId, Guid ActorId, string DisplayName);

--- a/Source/Clients/Testing.Specs/ReadModels/SliceWithActors.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/SliceWithActors.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model with a polymorphic children collection projected from an event that does not itself
+/// carry any discriminator information — the discriminator must be inferred from
+/// <see cref="UserExperienceActor"/> being the only implementation of <see cref="IActor"/>.
+/// </summary>
+/// <param name="Id">The slice identifier used as the key.</param>
+/// <param name="Actors">The actors on the slice.</param>
+[Passive]
+[FromEvent<SliceCreated>]
+public sealed record SliceWithActors(
+    [Key] Guid Id,
+    [ChildrenFrom<SliceUiActorUpdated>(key: nameof(SliceUiActorUpdated.ActorId), parentKey: nameof(SliceUiActorUpdated.SliceId))]
+    IReadOnlyList<IActor> Actors);

--- a/Source/Clients/Testing.Specs/ReadModels/UserExperienceActor.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/UserExperienceActor.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Keys;
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// The only implementation of <see cref="IActor"/> — a discriminator for it must be inferred
+/// automatically since there is no <see cref="SetValueAttribute{TEvent}"/> to set one explicitly.
+/// </summary>
+/// <param name="ActorId">The actor identifier used as the key.</param>
+/// <param name="DisplayName">Display name of the actor.</param>
+[DerivedType("userExperience", typeof(IActor))]
+public sealed record UserExperienceActor(
+    [Key] Guid ActorId,
+    [SetFrom<SliceUiActorUpdated>(nameof(SliceUiActorUpdated.DisplayName))] string DisplayName) : IActor;

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_is_polymorphic_with_a_single_derived_type.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_child_is_polymorphic_with_a_single_derived_type.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3571 — a child collection typed as a
+/// <see cref="DerivedTypeAttribute"/> base with a single implementation must round-trip through the
+/// correct concrete type without an explicit <c>[SetValue]</c> discriminator.
+/// </summary>
+public class and_child_is_polymorphic_with_a_single_derived_type : Specification
+{
+    ReadModelScenario<SliceWithActors> _scenario;
+    EventSourceId _sliceId;
+    Guid _sliceGuid;
+    Guid _actorGuid;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SliceWithActors>();
+        _sliceGuid = Guid.NewGuid();
+        _actorGuid = Guid.NewGuid();
+        _sliceId = new EventSourceId(_sliceGuid);
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_sliceId)
+            .Events(new SliceCreated(_sliceGuid));
+
+        await _scenario.Given
+            .ForEventSource(new EventSourceId(_actorGuid))
+            .Events(new SliceUiActorUpdated(_sliceGuid, _actorGuid, "Jane"));
+    }
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_have_one_actor() => _scenario.Instance.Actors.Count.ShouldEqual(1);
+    [Fact] void should_resolve_the_actor_to_its_concrete_derived_type() => _scenario.Instance.Actors[0].ShouldBeOfExactType<UserExperienceActor>();
+    [Fact] void should_preserve_the_actor_display_name() => ((UserExperienceActor)_scenario.Instance.Actors[0]).DisplayName.ShouldEqual("Jane");
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionDerivedType/when_a_projection_persists_a_polymorphic_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionDerivedType/when_a_projection_persists_a_polymorphic_child.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ReadModelChildCollectionDerivedType;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3571 — a child of a polymorphic
+/// (<c>[DerivedType]</c>) collection carrying a <c>_derivedTypeId</c> discriminator must round-trip
+/// through the real MongoDB sink unchanged. The read model's item schema is an open object (no fixed
+/// "properties", as <c>JsonSchemaGenerator</c> emits for a type with registered derivatives), so the
+/// sink must preserve every property it does not recognize rather than dropping it.
+/// </summary>
+/// <param name="ctx">The shared fixture holding the stored child document.</param>
+[Collection(MongoDBCollection.Name)]
+public class when_a_projection_persists_a_polymorphic_child(when_a_projection_persists_a_polymorphic_child.context ctx)
+    : IClassFixture<when_a_projection_persists_a_polymorphic_child.context>
+{
+    public class context(MongoDBFixture fixture) : IAsyncLifetime
+    {
+        const string Identifier = "slice-1";
+
+        IMongoClient _client = default!;
+        string _databaseName = default!;
+
+        public BsonDocument? StoredChild { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            var schema = await JsonSchema.FromJsonAsync(
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "actors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+                """);
+
+            var typeFormats = new TypeFormats();
+            var sinkConverter = new ExpandoObjectConverter(typeFormats);
+
+            _databaseName = $"chronicle_polymorphic_child_{Guid.NewGuid():N}";
+            _client = new MongoClient(fixture.ConnectionString);
+            var database = _client.GetDatabase(_databaseName);
+
+            var readModel = new ReadModelDefinition(
+                "polymorphic-child-read-model",
+                $"slices_{Guid.NewGuid():N}",
+                "PolymorphicChildReadModel",
+                ReadModelOwner.Client,
+                ReadModelSource.Code,
+                ReadModelObserverType.Projection,
+                ReadModelObserverIdentifier.Unspecified,
+                SinkDefinition.None,
+                new Dictionary<ReadModelGeneration, JsonSchema> { { ReadModelGeneration.First, schema } },
+                []);
+
+            var collections = new SinkCollections(readModel, database);
+            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+            var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, sinkConverter);
+            var sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, sinkConverter);
+
+            var key = new Key(Identifier, ArrayIndexers.NoIndexers);
+
+            var actor = new ExpandoObject();
+            var actorValues = (IDictionary<string, object?>)actor;
+            actorValues["_derivedTypeId"] = "userExperience";
+            actorValues["actorId"] = "actor-1";
+            actorValues["displayName"] = "Jane";
+
+            var objectComparer = new ObjectComparer();
+            var @event = new AppendedEvent(
+                EventContext.From(
+                    "test-store",
+                    "test-namespace",
+                    EventType.Unknown,
+                    EventSourceType.Default,
+                    Identifier,
+                    EventStreamType.All,
+                    EventStreamId.Default,
+                    EventSequenceNumber.First,
+                    CorrelationId.NotSet),
+                new ExpandoObject());
+            var changeset = new Changeset<AppendedEvent, ExpandoObject>(objectComparer, @event, new ExpandoObject());
+            changeset.AddChild("actors", actor);
+
+            await sink.ApplyChanges(key, changeset, EventSequenceNumber.First);
+
+            var storedDocument = await collections.GetCollection()
+                .Find(Builders<BsonDocument>.Filter.Empty)
+                .FirstAsync();
+            StoredChild = storedDocument["actors"].AsBsonArray[0].AsBsonDocument;
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_databaseName is not null)
+            {
+                await _client.DropDatabaseAsync(_databaseName);
+            }
+        }
+    }
+
+    [Fact] void should_preserve_the_derived_type_discriminator() => ctx.StoredChild!.Contains("_derivedTypeId").ShouldBeTrue();
+    [Fact] void should_preserve_other_actor_fields() => ctx.StoredChild!["displayName"].AsString.ShouldEqual("Jane");
+}


### PR DESCRIPTION
## Added

- `IEventSequence.Revise` on the .NET client, exposing the kernel's existing revise-event capability.

## Fixed

- Model-bound `[ChildrenFrom]` projections now stamp the `_derivedTypeId` discriminator for a children collection whose declared item type is a `[DerivedType]` base with exactly one implementation, so a newly created child of a polymorphic collection round-trips through the sink correctly instead of losing its discriminator. (#3571)