### PR TITLE
Fix cross-store subscriptions never picking up newly introduced event types

### DIFF
--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_a_subscription_is_active_with_a_newly_introduced_event_type.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_a_subscription_is_active_with_a_newly_introduced_event_type.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
+using Cratis.Chronicle.Namespaces;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_source_event_store_is_added;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3591 — an observer that is already
+/// subscribed does not automatically pick up an event type added to the subscription definition
+/// after the observer first subscribed, because <c>RefreshSubscription</c> previously returned as
+/// soon as <c>IsSubscribed()</c> was true, without comparing the observer's own event types against
+/// the current definition.
+/// </summary>
+public class and_a_subscription_is_active_with_a_newly_introduced_event_type : Specification
+{
+    const string TargetEventStore = "Lobby";
+    const string SourceEventStore = "StudioAdmin";
+
+    TestKitSilo _silo;
+    EventStoreSubscriptionsManager _manager;
+    IObserver _observer;
+    EventType _existingEventType;
+    EventType _newlyIntroducedEventType;
+    EventType[] _allEventTypes;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        _silo.AddService(localSiloDetails);
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        _existingEventType = new EventType("5db7cfa2-0fcb-4791-b174-83ff2806d654", EventTypeGeneration.First);
+        _newlyIntroducedEventType = new EventType("a883c6c1-0c1a-4b9b-8b3a-6c9e2b6e6f0a", EventTypeGeneration.First);
+        _allEventTypes = [_existingEventType, _newlyIntroducedEventType];
+
+        _observer = Substitute.For<IObserver>();
+        _observer.IsSubscribed().Returns(true);
+        _observer.GetEventTypes().Returns([_existingEventType]);
+        _silo.AddProbe(_ => _observer);
+
+        _manager = await _silo.CreateGrainAsync<EventStoreSubscriptionsManager>(TargetEventStore);
+
+        await _manager.Add(
+            new EventStoreSubscriptionDefinition(
+                new EventStoreSubscriptionId(SourceEventStore),
+                new EventStoreName(SourceEventStore),
+                _allEventTypes));
+    }
+
+    async Task Because() => await _manager.SourceEventStoreAdded(new EventStoreName(SourceEventStore));
+
+    [Fact] void should_not_unsubscribe() => _observer.DidNotReceive().Unsubscribe();
+
+    [Fact]
+    void should_subscribe_again_with_the_full_event_type_list() =>
+        _observer.Received(1).Subscribe<IEventStoreSubscriptionObserverSubscriber>(
+            ObserverType.External,
+            Arg.Is<IEnumerable<EventType>>(types => types.SequenceEqual(_allEventTypes)),
+            Arg.Any<SiloAddress>(),
+            Arg.Any<object?>(),
+            Arg.Any<bool>());
+}

--- a/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_a_subscription_is_already_active_with_the_current_event_types.cs
+++ b/Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_source_event_store_is_added/and_a_subscription_is_already_active_with_the_current_event_types.cs
@@ -8,13 +8,12 @@ using Cratis.Chronicle.Concepts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Namespaces;
 using Orleans.TestKit;
 
-namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_receiving_subscription_reminder;
+namespace Cratis.Chronicle.Observation.EventStoreSubscriptions.for_EventStoreSubscriptionsManager.when_source_event_store_is_added;
 
-public class and_subscription_is_already_subscribed : Specification
+public class and_a_subscription_is_already_active_with_the_current_event_types : Specification
 {
     const string TargetEventStore = "Lobby";
     const string SourceEventStore = "StudioAdmin";
-    const string ReminderName = "event-store-subscription-subscribe:StudioAdmin";
 
     TestKitSilo _silo;
     EventStoreSubscriptionsManager _manager;
@@ -47,7 +46,7 @@ public class and_subscription_is_already_subscribed : Specification
                 [eventType]));
     }
 
-    async Task Because() => await _manager.ReceiveReminder(ReminderName, default);
+    async Task Because() => await _manager.SourceEventStoreAdded(new EventStoreName(SourceEventStore));
 
     [Fact] void should_not_unsubscribe() => _observer.DidNotReceive().Unsubscribe();
 

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManager.cs
@@ -249,13 +249,20 @@ public class EventStoreSubscriptionsManager(
             var subscribed = await observer.IsSubscribed();
             if (subscribed)
             {
-                // Already subscribed - no need to unsubscribe and re-subscribe
-                // This eliminates the event loss gap that occurs every 60 seconds
-                logger.SubscriptionAlreadyActive(definition.Identifier, namespaceName);
-                return;
+                if (await IsSubscribedToCurrentEventTypes(observer, definition))
+                {
+                    // Already subscribed with the current event types - no need to unsubscribe and re-subscribe
+                    // This eliminates the event loss gap that occurs every 60 seconds
+                    logger.SubscriptionAlreadyActive(definition.Identifier, namespaceName);
+                    return;
+                }
+
+                // Subscribed, but the definition's event types have changed since - re-subscribing overwrites
+                // the observer's event type list in place, so there is no unsubscribe/gap in between.
+                logger.SubscriptionEventTypesChanged(definition.Identifier, namespaceName);
             }
 
-            // Not subscribed yet, subscribe now
+            // Not subscribed yet, or subscribed with a stale event type list - (re)subscribe now
             logger.Subscribing(definition.Identifier, namespaceName);
             await observer.Subscribe<IEventStoreSubscriptionObserverSubscriber>(
                 ObserverType.External,
@@ -268,6 +275,12 @@ public class EventStoreSubscriptionsManager(
             logger.ErrorRefreshingSubscription(ex, definition.Identifier, namespaceName);
             throw;
         }
+    }
+
+    async Task<bool> IsSubscribedToCurrentEventTypes(IObserver observer, EventStoreSubscriptionDefinition definition)
+    {
+        var subscribedEventTypeIds = (await observer.GetEventTypes()).Select(eventType => eventType.Id).ToHashSet();
+        return subscribedEventTypeIds.SetEquals(definition.EventTypes.Select(eventType => eventType.Id));
     }
 
     async Task<bool> CheckSubscriptionForNamespace(EventStoreSubscriptionDefinition definition, EventStoreNamespaceName namespaceName)

--- a/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManagerLogging.cs
+++ b/Source/Kernel/Core/Observation/EventStoreSubscriptions/EventStoreSubscriptionsManagerLogging.cs
@@ -30,6 +30,9 @@ internal static partial class EventStoreSubscriptionsManagerLogging
     [LoggerMessage(LogLevel.Debug, "Event store subscription '{SubscriptionId}' in namespace '{Namespace}' is already active - skipping unnecessary re-subscription")]
     internal static partial void SubscriptionAlreadyActive(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId, EventStoreNamespaceName @namespace);
 
+    [LoggerMessage(LogLevel.Information, "Event store subscription '{SubscriptionId}' in namespace '{Namespace}' is active but its event types have changed - re-subscribing")]
+    internal static partial void SubscriptionEventTypesChanged(this ILogger<EventStoreSubscriptionsManager> logger, EventStoreSubscriptionId subscriptionId, EventStoreNamespaceName @namespace);
+
     [LoggerMessage(LogLevel.Error, "Error refreshing event store subscription '{SubscriptionId}' in namespace '{Namespace}'")]
     internal static partial void ErrorRefreshingSubscription(this ILogger<EventStoreSubscriptionsManager> logger, Exception exception, EventStoreSubscriptionId subscriptionId, EventStoreNamespaceName @namespace);
 


### PR DESCRIPTION
## Fixed

- An event-store subscription (outbox → inbox) that is already active now picks up an event type added to its definition after the subscription was first established, instead of silently continuing to deliver only the original event types indefinitely. (#3591)