### PR TITLE
Ship a documentation-only pull request without a label or a wait

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -144,7 +144,7 @@ Tagged **[contract]** (framework-enforced) or **[convention]** (house default). 
 | Frontend | test | zero failures when frontend specs/behavior changed |
 | Frontend | build | zero errors |
 
-All gates pass before merging, opening a PR, or marking a slice complete. After pushing to a PR, monitor CI with the GitHub MCP tools (`pull_request_read` → `get_check_runs`, `get_job_logs`); investigate and fix any failure, then push again — the task is not done until CI is green or the only remaining failures are confirmed pre-existing flakes unrelated to the change.
+All gates pass before merging, opening a PR, or marking a slice complete — except for a **documentation-only** pull request, which waits for nothing and carries no version label (see [pull-requests.md](./pull-requests.md)). After pushing to a PR, monitor CI with the GitHub MCP tools (`pull_request_read` → `get_check_runs`, `get_job_logs`); investigate and fix any failure, then push again — the task is not done until CI is green or the only remaining failures are confirmed pre-existing flakes unrelated to the change.
 
 ---
 

--- a/.ai/rules/pull-requests.md
+++ b/.ai/rules/pull-requests.md
@@ -30,11 +30,17 @@ Quick reminders:
 - Label the PR according to semantic versioning impact:
   - **major** — breaking changes to public APIs
   - **minor** — new features, new slices, non-breaking additions
-  - **patch** — bug fixes, docs, refactoring with identical behavior
+  - **patch** — bug fixes, refactoring with identical behavior
+
+### Documentation-only pull requests carry no label
+
+**If every changed file is documentation, do not label the PR at all** — not `patch`, not anything. No label means the Publish run skips every publish step, which is exactly right: a docs change should not cut a release. A `verify`-style job that fails because the label is missing is the expected outcome for this kind of PR, not a problem to fix.
 
 ## Quality Gates
 
-Before marking a PR ready for review:
+**A documentation-only pull request skips this section entirely.** Nothing it changes can break a build, a spec or a lint, so there is nothing to wait for: open it and merge it. Do not monitor its checks, do not wait for green, and do not treat a red `verify` from the deliberately absent version label as a failure. Verify the content instead — links resolve, anchors exist, every code example matches real source.
+
+Before marking any other PR ready for review:
 - `dotnet build` — zero errors, zero warnings
 - `dotnet test` — all specs pass
 - `yarn lint` — zero errors

--- a/.ai/skills/ship-changes/SKILL.md
+++ b/.ai/skills/ship-changes/SKILL.md
@@ -174,17 +174,23 @@ instead.
 
 Skip this step entirely if the user said no label or did not provide one.
 
+**Skip it unconditionally when every changed file is documentation** — a docs-only PR carries no version label, so that no release is cut for it. See [pull-requests.md](../../rules/pull-requests.md).
+
 Otherwise use `gh pr edit <number> --add-label "<label>"` with one of:
 
 | Label | When |
 |-------|------|
-| `patch` | bug fixes, docs, refactoring with identical behavior |
+| `patch` | bug fixes, refactoring with identical behavior |
 | `minor` | new features, new slices, non-breaking additions |
 | `major` | breaking changes to public APIs |
 
+If `gh pr edit` fails on the Projects-classic GraphQL deprecation, add the label with the REST API instead: `gh api -X POST repos/<owner>/<repo>/issues/<number>/labels -f "labels[]=<label>"`. Label **before** the PR's first `verify` run where you can — a run that starts before the label lands sees no label and fails, and needs re-running.
+
 ## Step 7 — Wait for CI to pass
 
-Before merging, poll the PR checks with `pull_request_read`:
+**Skip this step entirely for a documentation-only PR** — merge as soon as it is open. Its `verify` will be red for the deliberately absent version label, and that is the expected outcome, not a failure to chase.
+
+Otherwise, before merging, poll the PR checks with `pull_request_read`:
 
 - Use `method: get_check_runs` (and `get_job_logs` on any failure).
 - Merge **only** when all required checks are green. If a check fails, investigate, fix, and push again.


### PR DESCRIPTION
# Summary

AI instruction corpus only — no user-facing change.
