### PR TITLE
Fix broken shared Chronicle client docs

### DIFF
--- a/Documentation/client-snippets/concepts/designing-read-models/constructor-may-not-run.md
+++ b/Documentation/client-snippets/concepts/designing-read-models/constructor-may-not-run.md
@@ -1,0 +1,9 @@
+```csharp
+public record LineItem(string ProductName, int Quantity, decimal Price);
+
+// Don't rely on this. It may never execute.
+public record OrderSummary(OrderId Id, IEnumerable<LineItem> Lines)
+{
+    public IEnumerable<LineItem> Lines { get; init; } = Lines ?? [];
+}
+```

--- a/Documentation/client-snippets/testing/read-models/scenario/strict-event-subscription.md
+++ b/Documentation/client-snippets/testing/read-models/scenario/strict-event-subscription.md
@@ -1,0 +1,3 @@
+```csharp
+var scenario = new ReadModelScenario<OrderSummary>().WithStrictEventSubscription();
+```

--- a/Documentation/client-snippets/testing/read-models/scenario/strict-fidelity.md
+++ b/Documentation/client-snippets/testing/read-models/scenario/strict-fidelity.md
@@ -1,0 +1,3 @@
+```csharp
+var scenario = new ReadModelScenario<OrderSummary>().WithStrictFidelity();
+```

--- a/Documentation/client-snippets/testing/read-models/scenario/substitutions.md
+++ b/Documentation/client-snippets/testing/read-models/scenario/substitutions.md
@@ -1,0 +1,8 @@
+```csharp
+var scenario = new ReadModelScenario<OrderSummary>();
+
+foreach (var substitution in scenario.Substitutions)
+{
+    Console.WriteLine($"{substitution.Layer}: {substitution.Shape} — {substitution.Consequence}");
+}
+```

--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -38,13 +38,7 @@ You rarely write code that *updates* a read model — you declare how events map
 
 Sooner or later you'll want to put a small piece of logic in the read model record itself — a normalizer that turns a `null` collection into an empty one, a computed default, a guard that rejects a value that should never arrive:
 
-```csharp
-// Don't rely on this. It may never execute.
-public record OrderSummary(OrderId Id, IEnumerable<LineItem> Lines)
-{
-    public IEnumerable<LineItem> Lines { get; init; } = Lines ?? [];
-}
-```
+<ChronicleClientTabs snippet="concepts/designing-read-models/constructor-may-not-run" />
 
 Whether that line runs is not yours to decide. A read model instance is *materialized* by a deserializer, and a document deserializer is free to build the record without running either a constructor or the initializer. The MongoDB driver does exactly that, and it is not conditional: for a record with a primary constructor it builds no creator map at all, so it creates the instance uninitialized and assigns the members by reflection. That happens on every document — a complete one just as much as one missing a field. Read a read model through `IMongoCollection<T>` and your normalizer never runs, ever.
 

--- a/Documentation/concepts/event-type-migrations.mdx
+++ b/Documentation/concepts/event-type-migrations.mdx
@@ -22,8 +22,6 @@ To define a migration, extend the `EventTypeMigration<TUpgrade, TPrevious>` base
 
 <ChronicleClientTabs snippet="concepts/event-type-migrations/defining-migrations" />
 
-Kotlin and Java don't currently have a migration API — there's no equivalent to `EventTypeMigration<TUpgrade, TPrevious>` in the Kotlin client SDK.
-
 ## Migration Operations
 
 The migration builder supports the following operations:

--- a/Documentation/jobs/index.mdx
+++ b/Documentation/jobs/index.mdx
@@ -25,8 +25,6 @@ A job is made up of one or more steps. Get them to see fine-grained progress:
 
 <ChronicleClientTabs snippet="jobs/index/stop-resume-delete" />
 
-Kotlin and Java don't currently have a jobs API — there's no equivalent anywhere in the Kotlin client SDK yet.
-
 ## Related topics
 
 - [Webhooks](../webhooks/) — pushing observed events to external HTTP endpoints, the other kernel-managed background concern.

--- a/Documentation/migrations/validation.mdx
+++ b/Documentation/migrations/validation.mdx
@@ -3,7 +3,7 @@
 Chronicle enforces rules about how event type generations and their migration chains must be structured. These rules exist to keep your event history consistent and to prevent silent data loss caused by incomplete migration definitions.
 
 :::note[Client coverage]
-These validation rules are enforced by the kernel regardless of client. Elixir has a real `MigrationBuilder.default_value/3` for the "default values for new properties" example below — Kotlin and Java have no migration API at all (see [Event Type Migrations](../concepts/event-type-migrations)). The `EnableEventTypeGenerationValidation` toggle further down is a .NET-hosting-specific configuration option with no equivalent found in the other clients.
+These validation rules are enforced by the kernel regardless of client. Elixir has a real `MigrationBuilder.default_value/3` for the "default values for new properties" example below, and Kotlin/Java have the equivalent `EventTypeMigrationBuilder.defaultValue` (see [Event Type Migrations](../concepts/event-type-migrations)). The `EnableEventTypeGenerationValidation` toggle further down is a .NET-hosting-specific configuration option with no equivalent found in the other clients.
 :::
 
 ## The rules

--- a/Documentation/subscriptions/explicit-subscriptions.mdx
+++ b/Documentation/subscriptions/explicit-subscriptions.mdx
@@ -17,7 +17,7 @@ Explicit subscriptions are ideal when:
 - Events come from a legacy or external system
 
 :::note[Client coverage]
-Explicit subscriptions are real in Elixir (`Chronicle.subscribe_to_event_store/3,4`, `Chronicle.unsubscribe_from_event_store/1,2`) and TypeScript (`store.subscriptions.subscribe`/`.unsubscribe`) too — both map closely onto C#'s `Subscriptions` API. Kotlin and Java have no event-store-subscription support at all yet — nothing in the Kotlin SDK source corresponds to this API. The host-builder-specific registration patterns further down this page (ASP.NET Core startup) aren't ported — see each client's own startup/registration conventions for the equivalent.
+Explicit subscriptions are real in Elixir (`Chronicle.subscribe_to_event_store/3,4`, `Chronicle.unsubscribe_from_event_store/1,2`), TypeScript (`store.subscriptions.subscribe`/`.unsubscribe`), and Kotlin/Java (`store.eventStoreSubscriptions.subscribe`) too — all map closely onto C#'s `Subscriptions` API. The host-builder-specific registration patterns further down this page (ASP.NET Core startup) aren't ported — see each client's own startup/registration conventions for the equivalent.
 :::
 
 ## Setting Up an Explicit Subscription

--- a/Documentation/subscriptions/implicit-subscriptions.mdx
+++ b/Documentation/subscriptions/implicit-subscriptions.mdx
@@ -7,7 +7,7 @@ uid: implicit-subscriptions
 Chronicle supports **implicit subscriptions** — automatic routing of events from a source event store's outbox to the correct inbox sequence, driven entirely by `[EventStore]` attributes on event types.
 
 :::note[Client coverage]
-This entire page is C#-only. It depends on the `[EventStore]` attribute (already confirmed absent from Kotlin, Elixir, and TypeScript throughout this docs effort) plus .NET-specific packaging and build mechanics (NuGet packages, `AssemblyInfo.cs`/`GlobalUsings.cs`/`<AssemblyAttribute>` in a `.csproj`) that have no equivalent in the other ecosystems. Use [explicit subscriptions](./explicit-subscriptions) instead for Kotlin, Elixir, or TypeScript — Elixir and TypeScript support them; Kotlin/Java don't have subscription support at all yet.
+This entire page is C#-only. It depends on the `[EventStore]` attribute (already confirmed absent from Kotlin, Elixir, and TypeScript throughout this docs effort) plus .NET-specific packaging and build mechanics (NuGet packages, `AssemblyInfo.cs`/`GlobalUsings.cs`/`<AssemblyAttribute>` in a `.csproj`) that have no equivalent in the other ecosystems. Use [explicit subscriptions](./explicit-subscriptions) instead for Kotlin, Elixir, or TypeScript — all three support them.
 :::
 
 Implicit subscriptions are ideal when:

--- a/Documentation/testing/read-models/scenario.mdx
+++ b/Documentation/testing/read-models/scenario.mdx
@@ -92,9 +92,7 @@ same instance.
 
 By default the scenario mirrors the production projection engine, which filters an event source's stream down to the types the projection subscribes to — so seeding an unrelated audit or marker event is silently ignored. When you would rather be told, `WithStrictEventSubscription()` turns that silent skip into an `UnsubscribedEventSeeded` naming the offending event type:
 
-```csharp
-var scenario = new ReadModelScenario<OrderSummary>().WithStrictEventSubscription();
-```
+<ChronicleClientTabs snippet="testing/read-models/scenario/strict-event-subscription" />
 
 This applies to projection-backed read models. A reducer only invokes the handlers it declares, so an unsubscribed seeded event is inherently a no-op there, exactly as at runtime.
 
@@ -156,14 +154,7 @@ Three more are substituted only for certain shapes — and because the harness c
 
 `Substitutions` reports the substituted layers your read model's own shape reaches. It is derived from the read model and its projection alone, so you can read it before seeding anything:
 
-```csharp
-var scenario = new ReadModelScenario<OrderSummary>();
-
-foreach (var substitution in scenario.Substitutions)
-{
-    Console.WriteLine($"{substitution.Layer}: {substitution.Shape} — {substitution.Consequence}");
-}
-```
+<ChronicleClientTabs snippet="testing/read-models/scenario/substitutions" />
 
 | `Layer` | Reported when |
 |---------|---------------|
@@ -175,9 +166,7 @@ An empty list means nothing shape-dependent is being stood in for. Anything in t
 
 To make that binding rather than advisory, opt in to strict fidelity. A read model that reaches a substituted layer then raises `ReadModelDependsOnSubstitutedLayer` instead of returning a result, so a suite can turn it on everywhere and have only the shapes that genuinely need a second tier change color:
 
-```csharp
-var scenario = new ReadModelScenario<OrderSummary>().WithStrictFidelity();
-```
+<ChronicleClientTabs snippet="testing/read-models/scenario/strict-fidelity" />
 
 ## Notes
 

--- a/Documentation/validate-client-snippets.py
+++ b/Documentation/validate-client-snippets.py
@@ -81,6 +81,10 @@ BODY_SNIPPETS = {
     "hosting/configuration/storage/in-memory": """
         ISiloBuilder siloBuilder = default!;
     """,
+    # OrderSummary is declared globally by concepts/designing-read-models/constructor-may-not-run.
+    "testing/read-models/scenario/strict-event-subscription": "",
+    "testing/read-models/scenario/substitutions": "",
+    "testing/read-models/scenario/strict-fidelity": "",
 }
 
 # Declaration-style snippets that need a namespace wrapper with aliases for Kernel-only

--- a/Documentation/webhooks/index.mdx
+++ b/Documentation/webhooks/index.mdx
@@ -15,8 +15,6 @@ If no event types are configured, the webhook forwards every event type register
 
 <ChronicleClientTabs snippet="webhooks/index/query" />
 
-Kotlin and Java don't currently have a webhooks API — there's no equivalent anywhere in the Kotlin client SDK yet.
-
 ## Related topics
 
 - [Jobs](../jobs/) — inspecting and controlling long-running Kernel operations, the other kernel-managed background concern.


### PR DESCRIPTION
## Fixed

- Two shared read-model docs pages had raw C# code fences instead of the `<ChronicleClientTabs>` convention used elsewhere on those pages; they now render properly for all clients
- Removed outdated "Kotlin and Java don't have this API" notes on the webhooks, jobs, event type migrations, and event store subscriptions pages — those clients gained real support and the pages already rendered working Kotlin/Java examples next to the stale disclaimer