### PR TITLE
Build against Arc 21.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,12 @@
     <!-- Cratis -->
     <PackageVersion Include="Cratis.Fundamentals" Version="7.17.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.17.1" />
-    <PackageVersion Include="Cratis.Arc" Version="21.0.2" />
-    <PackageVersion Include="Cratis.Arc.Core" Version="21.0.2" />
-    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="21.0.2" />
-    <PackageVersion Include="Cratis.Arc.MongoDB" Version="21.0.2" />
-    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="21.0.2" />
-    <PackageVersion Include="Cratis.Arc.Swagger" Version="21.0.2" />
+    <PackageVersion Include="Cratis.Arc" Version="21.0.3" />
+    <PackageVersion Include="Cratis.Arc.Core" Version="21.0.3" />
+    <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="21.0.3" />
+    <PackageVersion Include="Cratis.Arc.MongoDB" Version="21.0.3" />
+    <PackageVersion Include="Cratis.Arc.ProxyGenerator.Build" Version="21.0.3" />
+    <PackageVersion Include="Cratis.Arc.Swagger" Version="21.0.3" />
     <PackageVersion Include="Cratis.Screenplay" Version="1.8.0" />
     <!-- Microsoft -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />


### PR DESCRIPTION
## Fixed

- Applications that depend on both Chronicle and Arc can upgrade again. Arc releases up to 21.0.2 pulled in an unlisted build of SharpCompress that NuGet ordered above the listed version Chronicle pins, which failed the restore with a package downgrade error (NU1605).