### PR TITLE
Add Releasing PII page to Read Models docs

### DIFF
--- a/Documentation/client-snippets/read-models/releasing-pii/collection.md
+++ b/Documentation/client-snippets/read-models/releasing-pii/collection.md
@@ -1,0 +1,9 @@
+```csharp
+using Cratis.Chronicle;
+
+public class ReleasingPiiSupportTicketBatchService(IEventStore eventStore)
+{
+    public Task<IEnumerable<ReleasingPiiSupportTicket>> ReleaseAll(IEnumerable<ReleasingPiiSupportTicket> tickets) =>
+        eventStore.ReadModels.Release(tickets);
+}
+```

--- a/Documentation/client-snippets/read-models/releasing-pii/read-model.md
+++ b/Documentation/client-snippets/read-models/releasing-pii/read-model.md
@@ -1,0 +1,25 @@
+```csharp
+using Cratis.Chronicle;
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers;
+
+[PII]
+public record ReleasingPiiRequesterName(string Value) : ConceptAs<string>(Value)
+{
+    public static readonly ReleasingPiiRequesterName NotSet = new(string.Empty);
+    public static implicit operator string(ReleasingPiiRequesterName name) => name.Value;
+    public static implicit operator ReleasingPiiRequesterName(string value) => new(value);
+}
+
+[EventType]
+public record ReleasingPiiSupportTicketOpened(string CustomerId, ReleasingPiiRequesterName RequesterName);
+
+public record ReleasingPiiSupportTicket(string Id, [Subject] string CustomerId, [PII] string RequesterName);
+
+public class ReleasingPiiSupportTicketReducer : IReducerFor<ReleasingPiiSupportTicket>
+{
+    public ReleasingPiiSupportTicket Opened(ReleasingPiiSupportTicketOpened @event, ReleasingPiiSupportTicket? current, EventContext context) =>
+        new(context.EventSourceId.Value, @event.CustomerId, @event.RequesterName);
+}
+```

--- a/Documentation/client-snippets/read-models/releasing-pii/single-instance.md
+++ b/Documentation/client-snippets/read-models/releasing-pii/single-instance.md
@@ -1,0 +1,9 @@
+```csharp
+using Cratis.Chronicle;
+
+public class ReleasingPiiSupportTicketService(IEventStore eventStore)
+{
+    public Task<ReleasingPiiSupportTicket> Release(ReleasingPiiSupportTicket ticket) =>
+        eventStore.ReadModels.Release(ticket);
+}
+```

--- a/Documentation/client-snippets/read-models/releasing-pii/watch.md
+++ b/Documentation/client-snippets/read-models/releasing-pii/watch.md
@@ -1,0 +1,18 @@
+```csharp
+using Cratis.Chronicle;
+
+public class ReleasingPiiSupportTicketWatcher(IEventStore eventStore)
+{
+    public IDisposable Start() =>
+        eventStore.ReadModels.Watch<ReleasingPiiSupportTicket>().Subscribe(async changeset =>
+        {
+            if (changeset.Removed || changeset.ReadModel is null)
+            {
+                return;
+            }
+
+            var ticket = await eventStore.ReadModels.Release(changeset.ReadModel);
+            Console.WriteLine($"{changeset.ModelKey}: {ticket.RequesterName}");
+        });
+}
+```

--- a/Documentation/compliance/read-models.mdx
+++ b/Documentation/compliance/read-models.mdx
@@ -60,6 +60,8 @@ Read model queries are transparent to PII encryption. No changes to query code a
 
 Chronicle decrypts PII fields automatically before returning results to the caller. When the encryption key has been deleted for a subject, `Name` returns an empty string — the caller receives an `Employee` record with an empty name, never an exception or partial result.
 
+That automatic decryption covers `IReadModels`' query methods. For an instance that arrived some other way — built from raw storage, restored from a cache, or delivered through `Watch`, which streams changes without releasing them — call `IReadModels.Release` yourself; see [Releasing PII](../read-models/releasing-pii).
+
 ### One property never fails the whole read
 
 Decryption is resolved per property, and a property that cannot be read never fails the read model or the query returning it:

--- a/Documentation/read-models/index.md
+++ b/Documentation/read-models/index.md
@@ -33,6 +33,7 @@ the events:
 | [Getting a collection](./getting-collection-instances) | Retrieve all instances of a read model. |
 | [Getting snapshots](./getting-snapshots) | Retrieve historical snapshots of a read model's state. |
 | [Watching read models](./watching-read-models) | Observe a read model and react to changes in real time. |
+| [Releasing PII](./releasing-pii) | Decrypt PII in a read model instance you already have, and how the subject is resolved. |
 
 To expose a read model to a React frontend, pair it with an [Arc query](/arc/backend/queries/) — or see
 the whole loop in [Build a full-stack feature](/build-a-full-app/).

--- a/Documentation/read-models/releasing-pii.mdx
+++ b/Documentation/read-models/releasing-pii.mdx
@@ -1,0 +1,55 @@
+---
+title: Releasing PII
+description: Decrypt PII in a read model instance you already have, and how Chronicle decides whose encryption key to use.
+---
+
+Most of the time you never think about this. `GetInstanceById`, `GetInstances`, and `GetSnapshotsById` on `IReadModels` already hand you PII decrypted — a projection is decrypted by the kernel before it reaches you, and a reducer-backed instance is decrypted by the client right before it's returned. See [Read models and PII](../compliance/read-models) for how that automatic path works and what it takes to mark a property as PII in the first place.
+
+`IReadModels.Release` is the same decryption, exposed for the cases that skip that path: an instance you built from raw storage, restored from a cache or message payload, or received somewhere that doesn't release automatically. One built-in case exists today — `Watch<TReadModel>()` streams changes to you directly and does not call `Release` first.
+
+<ChronicleClientTabs snippet="read-models/releasing-pii/read-model" />
+
+`RequesterName` is `[PII]`-marked explicitly on the read model — required for a reducer, since Chronicle can't infer PII lineage through arbitrary reducer logic the way it can for a model-bound projection. `CustomerId` carries `[Subject]`: the ticket's own `Id` identifies the ticket, not the person the PII belongs to, so `Release` needs to be told which property to use as the encryption key's owner.
+
+## Release a single instance
+
+<ChronicleClientTabs snippet="read-models/releasing-pii/single-instance" />
+
+## Release a collection
+
+Releasing more than one instance at once resolves the subject for each independently, so a single batch can freely mix data belonging to different people.
+
+<ChronicleClientTabs snippet="read-models/releasing-pii/collection" />
+
+## Release while watching for changes
+
+<ChronicleClientTabs snippet="read-models/releasing-pii/watch" />
+
+Every other read on `IReadModels` releases before returning to you. `Watch` is the exception, because it's a live feed rather than one completed read — release each change yourself as it arrives, the same way you'd release any other instance.
+
+## How the subject is resolved
+
+`Release` looks at the instance you hand it to work out whose encryption key to use, in this order:
+
+| Priority | Mechanism |
+|---|---|
+| 1 | A property decorated with `[Subject]` |
+| 2 | A constructor parameter decorated with `[Subject]` (record shorthand) |
+| 3 | A property named `Id`, case-insensitive |
+
+The first match wins. If none of the three resolve to a value — or the read model has no PII-annotated properties at all — `Release` returns the instance unchanged; there's nothing for it to do.
+
+Add `[Subject]` when the identity that owns the PII differs from the read model's own key, exactly as you would on a command or event property to control which identity an append is encrypted under. When the two already match — a person's own profile, keyed by their own identity — the `Id` fallback handles it and no attribute is needed.
+
+## When release can't recover a value
+
+A property that can't be decrypted — its encryption key was deleted, or it was encrypted under a different subject entirely — degrades on its own; the rest of the instance still comes back intact. What a caller sees for each of those cases is covered in [Read models and PII](../compliance/read-models#one-property-never-fails-the-whole-read).
+
+If the release call itself can't complete — a schema mismatch, for instance — Chronicle logs the failure and returns the instance exactly as you passed it in, still encrypted. If a value you expect to read back stays ciphertext after calling `Release`, check the application logs for that failure before assuming the data is unrecoverable.
+
+## Related topics
+
+- [Read models and PII](../compliance/read-models) - How Chronicle encrypts and decrypts PII automatically, and GDPR erasure
+- [The PII attribute](../compliance/pii) - Marking event and read model properties as PII
+- [Watching Read Models](./watching-read-models) - Subscribing to read model changes
+- [Getting a Single Instance](./getting-single-instance) - The strongly consistent read path that releases for you

--- a/Documentation/read-models/toc.yml
+++ b/Documentation/read-models/toc.yml
@@ -16,6 +16,8 @@
   href: getting-snapshots.mdx
 - name: Watching Read Models
   href: watching-read-models.mdx
+- name: Releasing PII
+  href: releasing-pii.mdx
 - name: Reacting to Changes
   href: reacting-to-changes.mdx
 - name: Pagination and Observation


### PR DESCRIPTION
## Added

- Documentation for `IReadModels.Release` — decrypting PII in a read model instance obtained outside the normal query path (raw storage, a cache, or a `Watch()` subscription, which streams changes without releasing them), and how the compliance subject is resolved from the instance.