### PR TITLE
Support materialized read models through IReadModels

### DIFF
--- a/.ai/rules/reactors.md
+++ b/.ai/rules/reactors.md
@@ -65,7 +65,7 @@ public class OrderProcessing(IShippingService shipping) : IReactor
 {
     public async Task OrderPlaced(OrderPlaced @event, EventContext context, Order order, IPricingService pricing)
     {
-        // 'order' is the read model, materialized strongly consistent for this event.
+        // 'order' is the read model, resolved by Chronicle for this event's key.
         // 'pricing' is resolved from the service provider.
         await shipping.Schedule(order, pricing.PriceFor(order));
     }
@@ -75,7 +75,7 @@ public class OrderProcessing(IShippingService shipping) : IReactor
 How each parameter is resolved:
 
 - **`EventContext`** — receives the event context (position independent).
-- **A read model** — a type that has a reducer or a projection (declarative or model-bound). It is materialized on demand from that reducer or projection, making it **strongly consistent** at the point the reactor runs. Read models are resolved directly by Chronicle — they never go through the service provider.
+- **A read model** — a type that has a reducer or a projection (declarative or model-bound). Chronicle resolves it directly — read models never go through the service provider. A **materialized** read model (the default, for projections and reducers alike) is read from its sink, so it is **eventually consistent** — as current as its observer. Mark it **`[Passive]`** when the reactor needs it **strongly consistent**: a passive read model has no sink, so Chronicle computes it on demand from the events at the point the reactor runs.
 - **Any other type** — resolved from the service provider (constructor injection on the reactor itself is still preferred for collaborators used by every method).
 
 ### Resolving the read model key

--- a/Documentation/client-snippets/concepts/designing-read-models/query-ladder.md
+++ b/Documentation/client-snippets/concepts/designing-read-models/query-ladder.md
@@ -5,15 +5,15 @@ public record DesigningReadModelsCustomerListItem(Guid Id, string Name);
 
 public class DesigningReadModelsCustomerListService(IEventStore eventStore)
 {
-    public async Task<IEnumerable<DesigningReadModelsCustomerListItem>> GetAllStronglyConsistent()
+    public async Task<IEnumerable<DesigningReadModelsCustomerListItem>> GetEveryInstance()
     {
-        // Strongly consistent — Chronicle replays the read model's events on demand
+        // Every instance in one call — read from the materialized store
         return await eventStore.ReadModels.GetInstances<DesigningReadModelsCustomerListItem>();
     }
 
-    public async Task<IEnumerable<DesigningReadModelsCustomerListItem>> GetPageEventuallyConsistent()
+    public async Task<IEnumerable<DesigningReadModelsCustomerListItem>> GetPage()
     {
-        // Eventually consistent — a page of materialized instances straight from storage
+        // One page of materialized instances, with paging done by the store
         return await eventStore.ReadModels.Materialized.GetInstances<DesigningReadModelsCustomerListItem>(skip: 0, take: 20);
     }
 }

--- a/Documentation/client-snippets/concepts/designing-read-models/strongly-consistent.md
+++ b/Documentation/client-snippets/concepts/designing-read-models/strongly-consistent.md
@@ -2,6 +2,8 @@
 using Cratis.Chronicle;
 using Cratis.Chronicle.ReadModels;
 
+// Passive: no observer materializes this, so Chronicle computes it from the events on every read.
+[Passive]
 public record DesigningReadModelsCustomerDetail(Guid Id, string Name);
 
 public class DesigningReadModelsCustomerDetailService(IEventStore eventStore)

--- a/Documentation/code-analysis/CHR0032.mdx
+++ b/Documentation/code-analysis/CHR0032.mdx
@@ -18,7 +18,7 @@ Warning
 
 A reactor should express intent, not reach into the persistence layer. Injecting `IMongoCollection<T>` ties the reactor to a specific sink (the MongoDB collection backing a read model) and lets it read or write documents directly — outside the projection pipeline that owns that state. The reactor then depends on storage-layer details and can observe or corrupt read-model state that Chronicle is responsible for building.
 
-When a reactor needs current state, it reads it through the read-model abstraction: declare a read-model parameter on the handler (Chronicle materializes it strongly consistent for the event being handled) or call `IReadModels.GetInstanceById`. The read model stays the single source of derived state, and the reactor stays decoupled from where that state is persisted.
+When a reactor needs current state, it reads it through the read-model abstraction: declare a read-model parameter on the handler, or call `IReadModels.GetInstanceById`. Either way Chronicle resolves it from the materialized store, or computes it from the events when the read model is `[Passive]` — mark it passive when the reactor needs the state to be strongly consistent for the event being handled. The read model stays the single source of derived state, and the reactor stays decoupled from where that state is persisted.
 
 ## Related Rules
 

--- a/Documentation/coming-from-crud.mdx
+++ b/Documentation/coming-from-crud.mdx
@@ -60,7 +60,7 @@ Now the write and the read-back:
 
 <ChronicleClientTabs snippet="coming-from-crud/write-and-read" />
 
-`GetInstanceById` computes the card from its events on demand, so this read already reflects the append above — `TimesRelocated` included, a fact the CRUD row lost the moment `SaveChanges` ran.
+`GetInstanceById` hands back the card Chronicle derives from those events — `TimesRelocated` included, a fact the CRUD row lost the moment `SaveChanges` ran. Chronicle keeps that card up to date as events land, so a read right after an append can be a beat behind; when a read must reflect the append that preceded it, [consistency](/chronicle/read-models/consistency/) shows how.
 
 ## Not sure it's worth it?
 

--- a/Documentation/concepts/designing-read-models.mdx
+++ b/Documentation/concepts/designing-read-models.mdx
@@ -58,11 +58,11 @@ So a guard written in a read model record is not a guard. Put the intent somewhe
 
 A *materialized* read model updates *after* the event is appended, so what's stored is [eventually consistent](../read-models/consistency.md). Design with that in mind: don't read a stored model back inside a command or reactor to make a decision (use a [constraint](../constraints/) for invariants instead), and prefer [observable queries](../scenarios/real-time-query) so the UI reflects changes the moment the projection catches up.
 
-Eventual is the default, though — not a law. The `IReadModels` API can also compute a read model on demand by replaying its events, giving you a strongly consistent read that includes an event you appended a millisecond ago:
+Eventual is the default, though — not a law. Mark the read model `[Passive]` and nothing materializes it, so `IReadModels` computes it from its events on every read — a strongly consistent read that includes an event you appended a millisecond ago:
 
 <ChronicleClientTabs snippet="concepts/designing-read-models/strongly-consistent" />
 
-[Deep dive: consistency](./consistency.md) covers when each model is the right call.
+The call site is the same either way; the read model's own declaration decides where the answer comes from. [Deep dive: consistency](./consistency.md) covers when each model is the right call.
 
 ## Query it
 
@@ -70,11 +70,11 @@ When it's time to read, Chronicle gives you a ladder — trade consistency for c
 
 <ChronicleClientTabs snippet="concepts/designing-read-models/query-ladder" />
 
-- **`GetInstances<T>()`** rebuilds every instance from the event log at call time, so the result reflects everything appended so far. You can cap the work with an event count (`GetInstances<T>(eventCount)`), but a capped replay may return incomplete results. Replay cost grows with history — great for [reporting and short histories](../read-models/getting-collection-instances), not necessarily your production list view.
+- **`GetInstances<T>()`** returns every instance in one call — read from the materialized store, or rebuilt from the event log when the read model is `[Passive]`. You can force a bounded replay with an event count (`GetInstances<T>(eventCount)`), but a capped replay may return incomplete results. Good for [reporting and small populations](../read-models/getting-collection-instances), not for your production list view.
 - **`Materialized.GetInstances<T>(skip, take)`** reads what projections have already stored, with paging — cheap and fast, a moment behind. See [Materialized read models](../read-models/materialized-pagination).
 - **Need filtering, sorting, or aggregation?** Go to the sink's native query tools — `IMongoCollection<T>` or your `DbContext` — because a materialized read model is just data in a [database](../sinks/), shaped for exactly this.
 
-Kotlin and Java currently only support the strongly-consistent single-instance lookup shown above — there's no way to get all instances or page through materialized storage from those two clients yet.
+Kotlin and Java currently only support the single-instance lookup shown above — there's no way to get all instances or page through materialized storage from those two clients yet.
 
 ## Keep the read side ignorant of the write side
 

--- a/Documentation/read-models/consistency.md
+++ b/Documentation/read-models/consistency.md
@@ -32,12 +32,15 @@ Each model has distinct performance and consistency characteristics. The right c
 
 The strongest guarantee comes from computing a read model on-demand by replaying events from the event log every time you request it. This is sometimes called an *ad-hoc projection query* because no pre-materialized state is consulted — the result is built fresh from source events on each call.
 
-When you call `GetInstanceById`, Chronicle:
+You opt into this by marking the read model **passive**, which keeps any observer from materializing it and therefore leaves the event log as its only source. `GetInstanceById` then:
 
 1. Locates the projection or reducer registered for the read model type
 2. Retrieves all relevant events for the requested key from the event log
 3. Executes the projection or reducer logic in memory, event by event
 4. Returns the resulting instance that reflects the exact current state
+
+> [!IMPORTANT]
+> `GetInstanceById` only computes on-demand for a passive read model. When the read model *is* materialized — the default for both projections and reducers — Chronicle serves the stored instance from the sink instead, releasing any PII before it leaves the kernel. That read is O(1) and eventually consistent. See [Getting a Single Instance](getting-single-instance).
 
 ```mermaid
 sequenceDiagram
@@ -64,7 +67,7 @@ On-demand computation is the right choice when:
 - The read model is accessed infrequently relative to how often events are appended
 - You are validating a command against current state before appending new events
 
-For a practical guide to working with read model instances using this approach, see [Getting a Single Instance](getting-single-instance) and [Getting a Collection of Instances](getting-collection-instances).
+When those apply, mark the read model passive — see [Passive projections](../projections/declarative/passive). For a practical guide to working with read model instances, see [Getting a Single Instance](getting-single-instance) and [Getting a Collection of Instances](getting-collection-instances).
 
 ### Performance Considerations
 
@@ -149,7 +152,7 @@ Materialized projections are the right choice when:
 
 | Model | Updated | Consistency | Read Cost |
 |---|---|---|---|
-| On-demand computation | At query time | Strong | Proportional to event history length |
+| On-demand computation (passive) | At query time | Strong | Proportional to event history length |
 | Immediate projections | At event append | Strong | O(1) — stored result |
 | Materialized projections | Asynchronously | Eventual | O(1) — stored result |
 

--- a/Documentation/read-models/getting-collection-instances.mdx
+++ b/Documentation/read-models/getting-collection-instances.mdx
@@ -1,55 +1,53 @@
 ---
 title: Getting a Collection of Instances
-description: Replay every instance of a read model for small reports, diagnostics, and exact current-state analysis.
+description: Read every instance of a read model for small reports, diagnostics, and current-state analysis.
 ---
 
-Sometimes you need the exact current state of every instance of a read model: a small report, an integrity check, a back-office export, or a diagnostic script. Chronicle can rebuild the whole collection by replaying the events that feed that read model.
+Sometimes you need every instance of a read model at once: a small report, an integrity check, a back-office export, or a diagnostic script. Chronicle answers this the same way it answers a single-instance read — from the materialized store when the read model has one, and by replaying events when it does not.
 
-This is a strong-consistency operation. It is also proportional to event history, so it is not the default tool for hot list views or large data sets.
+Either way the whole result set comes back in one call, so this is not the tool for hot list views or large data sets. Reach for [materialized paging](materialized-pagination) when the caller needs a window rather than everything.
 
 ## Read all instances
 
-Use collection replay when the result set is small enough to fit comfortably in memory and the caller needs state that includes every event appended so far.
-
 <ChronicleClientTabs snippet="read-models/getting-collection-instances/basic" />
 
-Kotlin currently exposes single-instance read-model lookup only, so collection replay is not shown for that client.
+Kotlin currently exposes single-instance read-model lookup only, so collection reads are not shown for that client.
+
+For a **materialized** read model the kernel pages through the sink until it has read every stored instance, releases compliance-protected values, and returns them. For a **passive** read model it replays the events that feed the read model and returns the state that falls out, which is strongly consistent and proportional to the length of the history.
 
 ## Filter in memory
 
-Replay returns every instance. Apply language-native filtering after the read, and keep that in-memory cost in mind.
+The read returns every instance. Apply language-native filtering afterwards, and keep that in-memory cost in mind.
 
 <ChronicleClientTabs snippet="read-models/getting-collection-instances/filtering" />
 
-For large result sets, query the materialized sink directly or use a product-specific query model instead of replaying everything and filtering afterward.
+For large result sets, page the materialized read model or use a product-specific query model instead of reading everything and filtering afterward.
 
 ## Limit the replay
 
-You can cap the number of events Chronicle processes. This can make diagnostics faster, but it can also return incomplete state if the cap cuts off events that matter.
+You can cap the number of events Chronicle processes. Because a cap only means something to a replay, passing one always replays — even for a materialized read model.
 
 <ChronicleClientTabs snippet="read-models/getting-collection-instances/event-count" />
 
-Use an event-count cap for historical analysis, back-testing, or bounded diagnostics. Do not use it when the reader expects the current truth.
+This can make diagnostics faster, but it can also return incomplete state if the cap cuts off events that matter. Use an event-count cap for historical analysis, back-testing, or bounded diagnostics. Do not use it when the reader expects the current truth.
 
 ## When to use this
 
-Use collection replay when:
+Read the whole collection when:
 
-- You need a strongly consistent report over all current instances.
 - The read model population is small.
 - You are running an administrative or diagnostic task.
 - You are validating data derived from the event log.
 
-Prefer materialized or database-native reads when:
+Prefer paging or a database-native read when:
 
 - The page is user-facing and called frequently.
 - You need server-side filtering, sorting, or paging.
-- The read model has many instances or long histories.
-- Eventual consistency is acceptable.
+- The read model has many instances.
 
 ## Related topics
 
-- [Getting a Single Instance](getting-single-instance) - Replay one read model instance by key
+- [Getting a Single Instance](getting-single-instance) - Read one read model instance by key
 - [Getting Snapshots](getting-snapshots) - Inspect historical state for one instance
 - [Watching Read Models](watching-read-models) - React to read model changes
-- [Materialized Read Models](materialized-pagination) - Read sink-stored projections with paging
+- [Materialized Read Models](materialized-pagination) - Read sink-stored read models with paging

--- a/Documentation/read-models/getting-single-instance.mdx
+++ b/Documentation/read-models/getting-single-instance.mdx
@@ -1,17 +1,20 @@
 ---
 title: Getting a Single Instance
-description: Read one read model instance by key when you need the current state now, not after the materialized projection catches up.
+description: Read one read model instance by key, and understand whether the answer comes from the materialized store or from replaying events.
 ---
 
-When you need one read model and correctness matters more than query latency, read it by key from the event store. Chronicle rebuilds the instance from the events that feed that read model, so the result reflects the events that have been appended up to that call.
+When you need one read model and you have its key, ask Chronicle for it by key. You always call the same operation; what differs is where the answer comes from.
 
-Use this path for command-side decisions, read-after-write flows, and diagnostic tools. Use materialized read models when the same data is read frequently by lists, dashboards, or user interfaces that need paging.
+Chronicle knows whether the read model is **materialized** — whether an observer writes its state to a sink. If it is, the kernel reads the stored instance and releases any PII before returning it. If it is not — a passive read model has no observer and therefore no sink — the kernel rebuilds the instance from the events that feed it. You do not choose between the two at the call site; the read model's own definition decides.
 
 ## How it works
 
-When you ask Chronicle for one read model instance, the client sends the read model type and key to the kernel. Chronicle resolves the projection or reducer that owns that read model, replays the relevant events, applies compliance release rules when needed, and returns the current shape for that key.
+The client sends the read model type and key to the kernel. The kernel resolves the read model's definition and takes one of two paths:
 
-This makes the read strongly consistent. The cost is replay: longer histories take longer to rebuild than a materialized lookup.
+- **Materialized read model** — the kernel looks the instance up in the sink by key, releases compliance-protected values, and returns it. The cost is a single storage lookup regardless of how long the event history is. The instance is as current as the observer that wrote it, so it is eventually consistent.
+- **Passive read model** — the kernel replays the relevant events through the projection or reducer that owns the read model and returns the result. The instance reflects every event appended up to that call, so it is strongly consistent. The cost grows with the length of the history.
+
+The materialized path is also the only one that sees the whole picture for a projection that joins across event sources or resolves keys from other events. Replay walks one event source, so it cannot reconstruct state that was built from events belonging to a different key.
 
 ## Read by key
 
@@ -23,29 +26,32 @@ Each client names the operation in its own idiom, but the inputs are the same: t
 
 ## Missing instances
 
-If no events have produced that read model key, clients return their normal "not found" shape: `null`, `nil`, or an empty result depending on the language. Treat that as "no state exists yet," not as a projection failure.
+If no instance exists for that key, clients return their normal "not found" shape: `null`, `nil`, or an empty result depending on the language. Treat that as "no state exists yet," not as a projection failure. For a materialized read model this covers both a key that was never created and one that has been removed — the observer is authoritative, so Chronicle does not fall back to a replay that would resurrect it.
 
 If the read model type itself is unknown, that is a configuration error. Register the projection, reducer, or read model before querying it.
 
-## When to use this
+## Choosing which you get
 
-Use a single-instance replay when:
+Because the read model's definition decides the path, choose when you design the read model rather than when you query it.
+
+Leave the read model materialized — the default — when:
+
+- The same data is read often, or read from lists, dashboards, and user interfaces.
+- The event history for a key can grow long.
+- A brief lag between an append and the read reflecting it is acceptable.
+- The projection joins events across event sources.
+
+Mark the read model passive when:
 
 - A command needs the exact current state before making a decision.
 - You append an event and immediately need to read the state it creates.
-- A debugging or audit tool needs deterministic state from the event log.
-- The event history for that key is short enough that replay cost is acceptable.
-
-Prefer a materialized read model when:
-
-- The same data is read often.
-- The history for each key can grow large.
-- You need paging, sorting, or database-native filtering.
-- Eventual consistency is acceptable.
+- The event history for each key stays short.
+- The read model is queried rarely relative to how often its events are appended.
 
 ## Related topics
 
-- [Getting a Collection of Instances](getting-collection-instances) - Replay all instances for reporting or analysis
+- [Getting a Collection of Instances](getting-collection-instances) - Read or replay every instance of a read model
 - [Getting Snapshots](getting-snapshots) - Inspect how one instance evolved over time
 - [Watching Read Models](watching-read-models) - React to read model changes as they happen
 - [Materialized Read Models](materialized-pagination) - Page through sink-stored read models
+- [Passive projections](../projections/declarative/passive) - Keep a read model out of the sink so it is computed on demand

--- a/Integration/Client/for_ReadModels/given/a_projection_with_events.cs
+++ b/Integration/Client/for_ReadModels/given/a_projection_with_events.cs
@@ -23,7 +23,37 @@ public class a_projection_with_events(ChronicleFixture chronicleFixture) : Speci
 
     protected async Task AppendEvents()
     {
+        var handler = EventStore.Projections.GetHandlerFor<SomeProjection>();
+        await handler.WaitTillActive();
+
         await EventStore.EventLog.Append(EventSourceId, FirstEvent);
         await EventStore.EventLog.Append(EventSourceId, SecondEvent);
+    }
+
+    /// <summary>
+    /// Polls the materialized read model until it holds at least <paramref name="expectedCount"/>
+    /// instances, or the default timeout elapses.
+    /// </summary>
+    /// <param name="expectedCount">The minimum number of instances to wait for.</param>
+    /// <returns>The instances once the expected count is reached.</returns>
+    /// <remarks>
+    /// <see cref="SomeReadModel"/> is materialized, so <c>GetInstances</c> now reads the sink instead of
+    /// replaying — a read straight after appending can race the projection engine's catch-up unless
+    /// something polls for the result to appear, the same gap <c>GetInstanceById</c> callers close
+    /// elsewhere in this suite.
+    /// </remarks>
+    protected async Task<IEnumerable<SomeReadModel>> WaitTillInstancesAreVisible(int expectedCount)
+    {
+        using var cts = new CancellationTokenSource(TimeSpanFactory.DefaultTimeout());
+        while (true)
+        {
+            var instances = await EventStore.ReadModels.GetInstances<SomeReadModel>();
+            if (instances.Count() >= expectedCount)
+            {
+                return instances;
+            }
+
+            await Task.Delay(50, cts.Token);
+        }
     }
 }

--- a/Integration/Client/for_ReadModels/when_getting_instances/and_read_model_has_pii_property.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instances/and_read_model_has_pii_property.cs
@@ -22,8 +22,36 @@ public class and_read_model_has_pii_property(context context) : Given<context>(c
 
         async Task Because()
         {
+            var handler = EventStore.Projections.GetHandlerFor<PiiProjection>();
+            await handler.WaitTillActive();
+
             await EventStore.EventLog.Append(EventSourceId, Event);
-            Instances = await EventStore.ReadModels.GetInstances<PiiReadModel>();
+
+            Instances = await WaitTillInstancesAreVisible();
+        }
+
+        /// <summary>
+        /// Polls the materialized read model until it holds an instance, or the default timeout elapses.
+        /// </summary>
+        /// <returns>The instances once at least one is visible.</returns>
+        /// <remarks>
+        /// <see cref="PiiReadModel"/> is materialized, so <c>GetInstances</c> reads the sink instead of
+        /// replaying — a read straight after appending can race the projection engine's catch-up unless
+        /// something polls for the result to appear.
+        /// </remarks>
+        async Task<IEnumerable<PiiReadModel>> WaitTillInstancesAreVisible()
+        {
+            using var cts = new CancellationTokenSource(TimeSpanFactory.DefaultTimeout());
+            while (true)
+            {
+                var instances = await EventStore.ReadModels.GetInstances<PiiReadModel>();
+                if (instances.Any())
+                {
+                    return instances;
+                }
+
+                await Task.Delay(50, cts.Token);
+            }
         }
     }
 

--- a/Integration/Client/for_ReadModels/when_getting_instances/with_multiple_event_sources.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instances/with_multiple_event_sources.cs
@@ -28,7 +28,8 @@ public class with_multiple_event_sources(context context) : Given<context>(conte
             await AppendEvents();
             await EventStore.EventLog.Append(SecondEventSourceId, ThirdEvent);
             await EventStore.EventLog.Append(SecondEventSourceId, FourthEvent);
-            Results = await EventStore.ReadModels.GetInstances<SomeReadModel>();
+
+            Results = await WaitTillInstancesAreVisible(2);
         }
     }
 

--- a/Integration/Client/for_ReadModels/when_getting_instances/without_event_count.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instances/without_event_count.cs
@@ -15,7 +15,7 @@ public class without_event_count(context context) : Given<context>(context)
         async Task Because()
         {
             await AppendEvents();
-            Results = await EventStore.ReadModels.GetInstances<SomeReadModel>();
+            Results = await WaitTillInstancesAreVisible(1);
         }
     }
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_materialized_reducer.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_materialized_reducer.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels;
+
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+public class when_getting_instance_by_id_and_it_is_a_materialized_reducer : given.all_dependencies
+{
+    class MyReadModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    ReadModelKey _key;
+    MyReadModel _expectedModel;
+    object _result = null!;
+    Contracts.ReadModels.IReadModels _readModelsService = null!;
+    GetInstanceByKeyRequest _capturedRequest = null!;
+
+    void Establish()
+    {
+        _key = "test-key";
+        _expectedModel = new MyReadModel { Name = "FromMaterializedStore" };
+
+        _projections.HasFor(typeof(MyReadModel)).Returns(false);
+        _reducers.HasFor(typeof(MyReadModel)).Returns(true);
+
+        var handler = Substitute.For<IReducerHandler>();
+        handler.EventSequenceId.Returns(EventSequenceId.Log);
+        _reducers.GetHandlerForReadModelType(typeof(MyReadModel)).Returns(handler);
+
+        _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
+        _services.ReadModels.Returns(_readModelsService);
+        _readModelsService.GetInstanceByKey(Arg.Any<GetInstanceByKeyRequest>())
+            .Returns(new GetInstanceByKeyResponse { ReadModel = JsonSerializer.Serialize(_expectedModel) });
+        _readModelsService.When(_ => _.GetInstanceByKey(Arg.Any<GetInstanceByKeyRequest>()))
+            .Do(_ => _capturedRequest = _.Arg<GetInstanceByKeyRequest>());
+    }
+
+    async Task Because() => _result = await _readModels.GetInstanceById(typeof(MyReadModel), _key);
+
+    [Fact] void should_get_the_instance_from_the_kernel() => _readModelsService.Received(1).GetInstanceByKey(Arg.Any<GetInstanceByKeyRequest>());
+    [Fact] void should_not_reduce_in_process() => _reducers.DidNotReceive().GetInstanceById(typeof(MyReadModel), Arg.Any<ReadModelKey>());
+    [Fact] void should_ask_for_the_event_sequence_the_reducer_reduces_from() => _capturedRequest.EventSequenceId.ShouldEqual(EventSequenceId.Log.Value);
+    [Fact] void should_use_the_key() => _capturedRequest.ReadModelKey.ShouldEqual(_key.Value);
+    [Fact] void should_return_the_materialized_instance() => ((MyReadModel)_result).Name.ShouldEqual(_expectedModel.Name);
+}
+#pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_passive_reducer.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_passive_reducer.cs
@@ -6,26 +6,27 @@ using Cratis.Chronicle.Contracts.ReadModels;
 namespace Cratis.Chronicle.ReadModels.for_ReadModels;
 
 #pragma warning disable CA2263 // Prefer generic overload when type is known
-public class when_getting_instance_by_id_and_it_is_an_unseeded_reducer : given.all_dependencies
+public class when_getting_instance_by_id_and_it_is_a_passive_reducer : given.all_dependencies
 {
+    [Passive]
     class MyReadModel
     {
         public string Name { get; set; } = string.Empty;
     }
 
     ReadModelKey _key;
+    MyReadModel _expectedModel;
     object _result = null!;
     Contracts.ReadModels.IReadModels _readModelsService = null!;
 
     void Establish()
     {
         _key = "test-key";
+        _expectedModel = new MyReadModel { Name = "FromReducer" };
 
         _projections.HasFor(typeof(MyReadModel)).Returns(false);
         _reducers.HasFor(typeof(MyReadModel)).Returns(true);
-
-        // An unseeded reducer produces no state — the reducer layer returns null for the key.
-        _reducers.GetInstanceById(typeof(MyReadModel), _key).Returns((object?)null);
+        _reducers.GetInstanceById(typeof(MyReadModel), _key).Returns(_expectedModel);
 
         _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
         _services.ReadModels.Returns(_readModelsService);
@@ -33,7 +34,8 @@ public class when_getting_instance_by_id_and_it_is_an_unseeded_reducer : given.a
 
     async Task Because() => _result = await _readModels.GetInstanceById(typeof(MyReadModel), _key);
 
-    [Fact] void should_return_null_like_a_projection_backed_model() => _result.ShouldBeNull();
+    [Fact] void should_get_instance_from_reducers() => _reducers.Received(1).GetInstanceById(typeof(MyReadModel), _key);
     [Fact] void should_not_call_read_models_service() => _readModelsService.DidNotReceive().GetInstanceByKey(Arg.Any<GetInstanceByKeyRequest>());
+    [Fact] void should_return_model_from_reducer() => ((MyReadModel)_result).Name.ShouldEqual("FromReducer");
 }
 #pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_passive_reducer_with_compliance_data.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_a_passive_reducer_with_compliance_data.cs
@@ -7,8 +7,9 @@ using Cratis.Chronicle.Schemas;
 namespace Cratis.Chronicle.ReadModels.for_ReadModels;
 
 #pragma warning disable CA2263
-public class when_getting_instance_by_id_and_it_is_a_reducer_with_compliance_data : given.all_dependencies
+public class when_getting_instance_by_id_and_it_is_a_passive_reducer_with_compliance_data : given.all_dependencies
 {
+    [Passive]
     class MyReadModel
     {
         public string Id { get; set; } = string.Empty;

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_an_unseeded_passive_reducer.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instance_by_id_and_it_is_an_unseeded_passive_reducer.cs
@@ -6,26 +6,27 @@ using Cratis.Chronicle.Contracts.ReadModels;
 namespace Cratis.Chronicle.ReadModels.for_ReadModels;
 
 #pragma warning disable CA2263 // Prefer generic overload when type is known
-public class when_getting_instance_by_id_and_it_is_a_reducer : given.all_dependencies
+public class when_getting_instance_by_id_and_it_is_an_unseeded_passive_reducer : given.all_dependencies
 {
+    [Passive]
     class MyReadModel
     {
         public string Name { get; set; } = string.Empty;
     }
 
     ReadModelKey _key;
-    MyReadModel _expectedModel;
     object _result = null!;
     Contracts.ReadModels.IReadModels _readModelsService = null!;
 
     void Establish()
     {
         _key = "test-key";
-        _expectedModel = new MyReadModel { Name = "FromReducer" };
 
         _projections.HasFor(typeof(MyReadModel)).Returns(false);
         _reducers.HasFor(typeof(MyReadModel)).Returns(true);
-        _reducers.GetInstanceById(typeof(MyReadModel), _key).Returns(_expectedModel);
+
+        // An unseeded reducer produces no state — the reducer layer returns null for the key.
+        _reducers.GetInstanceById(typeof(MyReadModel), _key).Returns((object?)null);
 
         _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
         _services.ReadModels.Returns(_readModelsService);
@@ -33,8 +34,7 @@ public class when_getting_instance_by_id_and_it_is_a_reducer : given.all_depende
 
     async Task Because() => _result = await _readModels.GetInstanceById(typeof(MyReadModel), _key);
 
-    [Fact] void should_get_instance_from_reducers() => _reducers.Received(1).GetInstanceById(typeof(MyReadModel), _key);
+    [Fact] void should_return_null_like_a_projection_backed_model() => _result.ShouldBeNull();
     [Fact] void should_not_call_read_models_service() => _readModelsService.DidNotReceive().GetInstanceByKey(Arg.Any<GetInstanceByKeyRequest>());
-    [Fact] void should_return_model_from_reducer() => ((MyReadModel)_result).Name.ShouldEqual("FromReducer");
 }
 #pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_a_materialized_reducer.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_a_materialized_reducer.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Reducers;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels;
+
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+public class when_getting_instances_and_it_is_a_materialized_reducer : given.all_dependencies
+{
+    class MyReadModel
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    IEnumerable<MyReadModel> _result = [];
+    Contracts.ReadModels.IReadModels _readModelsService = null!;
+
+    void Establish()
+    {
+        _projections.HasFor(typeof(MyReadModel)).Returns(false);
+        _reducers.HasFor(typeof(MyReadModel)).Returns(true);
+
+        var handler = Substitute.For<IReducerHandler>();
+        handler.EventSequenceId.Returns(EventSequenceId.Log);
+        _reducers.GetHandlerForReadModelType(typeof(MyReadModel)).Returns(handler);
+
+        _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
+        _services.ReadModels.Returns(_readModelsService);
+        _readModelsService.GetAllInstances(Arg.Any<GetAllInstancesRequest>())
+            .Returns(new GetAllInstancesResponse
+            {
+                Instances =
+                [
+                    JsonSerializer.Serialize(new MyReadModel { Name = "First" }),
+                    JsonSerializer.Serialize(new MyReadModel { Name = "Second" })
+                ]
+            });
+    }
+
+    async Task Because() => _result = await _readModels.GetInstances<MyReadModel>();
+
+    [Fact] void should_get_the_instances_from_the_kernel() => _readModelsService.Received(1).GetAllInstances(Arg.Any<GetAllInstancesRequest>());
+    [Fact] void should_not_reduce_in_process() => _reducers.DidNotReceive().GetInstances(typeof(MyReadModel), Arg.Any<EventCount>());
+    [Fact] void should_return_all_materialized_instances() => _result.Count().ShouldEqual(2);
+    [Fact] void should_return_the_first_instance() => _result.First().Name.ShouldEqual("First");
+    [Fact] void should_return_the_second_instance() => _result.Last().Name.ShouldEqual("Second");
+}
+#pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_a_passive_reducer_with_compliance_data.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_a_passive_reducer_with_compliance_data.cs
@@ -7,8 +7,9 @@ using Cratis.Chronicle.Schemas;
 namespace Cratis.Chronicle.ReadModels.for_ReadModels;
 
 #pragma warning disable CA2263
-public class when_getting_instances_and_it_is_a_reducer_with_compliance_data : given.all_dependencies
+public class when_getting_instances_and_it_is_a_passive_reducer_with_compliance_data : given.all_dependencies
 {
+    [Passive]
     class MyReadModel
     {
         public string Id { get; set; } = string.Empty;

--- a/Source/Clients/DotNET/ReadModels/ReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModels.cs
@@ -178,7 +178,9 @@ public class ReadModels(
         var result = await GetInstanceById(readModelType, key, sessionId);
         var instance = (TReadModel)result;
 
-        if (reducers.HasFor(readModelType))
+        // Only an in-process reduce leaves PII encrypted — the Kernel releases whatever it serves from the
+        // materialized store.
+        if (IsReducedInProcess(readModelType))
         {
             return await Release(instance);
         }
@@ -195,10 +197,10 @@ public class ReadModels(
             throw new UnknownReadModel(readModelType);
         }
 
-        if (reducers.HasFor(readModelType))
+        if (IsReducedInProcess(readModelType))
         {
             // An unseeded (never-created) reducer-backed read model has no state yet. Return null — matching
-            // the projection/sink path below that returns default! for a "null" document — rather than
+            // the materialized path below that returns default! for a "null" document — rather than
             // throwing, so a nullable caller guard (state?.…) holds uniformly across both backings. A
             // throwing pre-check from a reactor on a passive reducer read model would otherwise freeze the
             // event-source partition permanently.
@@ -213,7 +215,7 @@ public class ReadModels(
             EventStore = eventStore.Name,
             Namespace = eventStore.Namespace,
             ReadModelIdentifier = readModelIdentifier,
-            EventSequenceId = EventSequenceId.Log,
+            EventSequenceId = GetEventSequenceIdFor(readModelType),
             ReadModelKey = key,
             SessionId = sessionId?.Value.ToString() ?? string.Empty
         };
@@ -255,7 +257,9 @@ public class ReadModels(
             throw new UnknownReadModel(readModelType);
         }
 
-        if (reducers.HasFor(readModelType))
+        // A bounded replay is a request to apply exactly that many events from the beginning, which the
+        // materialized store cannot answer — reduce it in-process, as for a passive read model.
+        if (reducers.HasFor(readModelType) && (readModelType.IsPassive() || eventCount is not null))
         {
             var reducerInstances = await reducers.GetInstances(readModelType, eventCount);
             return await Release(reducerInstances.Cast<TReadModel>());
@@ -269,7 +273,7 @@ public class ReadModels(
             EventStore = eventStore.Name,
             Namespace = eventStore.Namespace,
             ReadModelIdentifier = readModelIdentifier,
-            EventSequenceId = EventSequenceId.Log,
+            EventSequenceId = GetEventSequenceIdFor(readModelType),
             EventCount = eventCountValue.Value
         };
 
@@ -415,6 +419,28 @@ public class ReadModels(
 
     /// <inheritdoc/>
     public Task<IEnumerable<TReadModel>> Release<TReadModel>(IEnumerable<TReadModel> instances) => _releaser.Release(instances);
+
+    /// <summary>
+    /// Check whether a read model has to be reduced here rather than read from the Kernel's materialized store.
+    /// </summary>
+    /// <param name="readModelType">The read model type to check.</param>
+    /// <returns>True when the read model is reducer-backed and passive, false otherwise.</returns>
+    /// <remarks>
+    /// A reducer-backed read model that is not passive is observed, so the Kernel already holds its state in a
+    /// sink and serves it with PII released. A passive one has no observer and therefore no sink to read from,
+    /// so its state only exists once this client has folded the events for it.
+    /// </remarks>
+    bool IsReducedInProcess(Type readModelType) => reducers.HasFor(readModelType) && readModelType.IsPassive();
+
+    /// <summary>
+    /// Resolve the <see cref="EventSequenceId"/> a read model is built from.
+    /// </summary>
+    /// <param name="readModelType">The read model type to resolve for.</param>
+    /// <returns>The <see cref="EventSequenceId"/> to ask the Kernel for the read model on.</returns>
+    EventSequenceId GetEventSequenceIdFor(Type readModelType) =>
+        reducers.HasFor(readModelType)
+            ? reducers.GetHandlerForReadModelType(readModelType).EventSequenceId
+            : EventSequenceId.Log;
 
     async Task<IEnumerable<ReadModelSnapshot<TReadModel>>> ReleaseSnapshotInstances<TReadModel>(IEnumerable<ReadModelSnapshot<TReadModel>> snapshots)
     {

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -47,6 +47,7 @@ using KernelIdentitiesService = KernelCore::Cratis.Chronicle.Services.Identities
 using KernelJobsService = KernelCore::Cratis.Chronicle.Services.Jobs.Jobs;
 using KernelJsonComplianceManager = KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager;
 using KernelJsonCompliancePropertyValueHandler = KernelCore::Cratis.Chronicle.Compliance.IJsonCompliancePropertyValueHandler;
+using KernelMaterializedReadModelStore = KernelCore::Cratis.Chronicle.ReadModels.MaterializedReadModelStore;
 using KernelNamespacesService = KernelCore::Cratis.Chronicle.Services.Namespaces;
 using KernelObserversService = KernelCore::Cratis.Chronicle.Services.Observation.Observers;
 using KernelProjectionChangesetMediator = KernelCore::Cratis.Chronicle.Projections.ProjectionChangesetMediator;
@@ -200,6 +201,11 @@ internal sealed class TestingServices(
             new KernelEventCompliance(
                 new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
                 new ExpandoObjectConverter(new TypeFormats())),
+            new KernelMaterializedReadModelStore(
+                storage,
+                new KernelReadModelsCompliance(
+                    new KernelJsonComplianceManager(new KnownInstancesOf<KernelJsonCompliancePropertyValueHandler>(), NullLogger<KernelJsonComplianceManager>.Instance),
+                    new ExpandoObjectConverter(new TypeFormats()))),
             jsonSerializerOptions));
 
     readonly Lazy<ICompliance> _compliance = new(() =>

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/given/a_materialized_read_model.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/given/a_materialized_read_model.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.ReadModels;
+using Cratis.Chronicle.Storage.Sinks;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.given;
+
+public class a_materialized_read_model : Specification
+{
+    protected static readonly EventStoreName EventStore = "test-store";
+    protected static readonly EventStoreNamespaceName EventStoreNamespace = "test-namespace";
+
+    protected IStorage _storage;
+    protected ISink _sink;
+    protected IReadModelsCompliance _compliance;
+    protected ReadModelDefinition _definition;
+    protected MaterializedReadModelStore _store;
+
+    void Establish()
+    {
+        _sink = Substitute.For<ISink>();
+        _compliance = Substitute.For<IReadModelsCompliance>();
+
+        var sinks = Substitute.For<ISinks>();
+        sinks.GetFor(Arg.Any<ReadModelDefinition>()).Returns(_sink);
+
+        var namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        namespaceStorage.Sinks.Returns(sinks);
+
+        var eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(namespaceStorage);
+
+        _storage = Substitute.For<IStorage>();
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(eventStoreStorage);
+
+        _definition = new ReadModelDefinition(
+            "test-read-model",
+            "test-container",
+            "Test Read Model",
+            ReadModelOwner.None,
+            ReadModelSource.Unknown,
+            ReadModelObserverType.Projection,
+            "test-observer",
+            new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.InMemory),
+            new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, new JsonSchema() } },
+            []);
+
+        // The release pass is asserted on separately; by default it hands back what it was given.
+        _compliance.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<ExpandoObject>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<ExpandoObject>(3)));
+
+        _compliance.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<IEnumerable<ExpandoObject>>())
+            .Returns(callInfo => Task.FromResult(callInfo.ArgAt<IEnumerable<ExpandoObject>>(3)));
+
+        _store = new MaterializedReadModelStore(_storage, _compliance);
+    }
+
+    protected static ExpandoObject InstanceNamed(string name)
+    {
+        var instance = new ExpandoObject();
+        ((IDictionary<string, object?>)instance)["name"] = name;
+        return instance;
+    }
+
+    protected void SinkHolds(params ExpandoObject[] instances) =>
+        _sink.GetInstances(Arg.Any<ReadModelContainerName?>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(callInfo => Task.FromResult(new ReadModelInstances(
+                instances.Skip(callInfo.ArgAt<int>(1)).Take(callInfo.ArgAt<int>(2)),
+                instances.Length)));
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_checking_if_materialized/and_the_read_model_has_a_sink.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_checking_if_materialized/and_the_read_model_has_a_sink.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_checking_if_materialized;
+
+public class and_the_read_model_has_a_sink : given.a_materialized_read_model
+{
+    bool _result;
+
+    void Because() => _result = _store.IsMaterialized(_definition);
+
+    [Fact] void should_be_materialized() => _result.ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_checking_if_materialized/and_the_read_model_is_passive.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_checking_if_materialized/and_the_read_model_is_passive.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Sinks;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_checking_if_materialized;
+
+public class and_the_read_model_is_passive : given.a_materialized_read_model
+{
+    bool _result;
+
+    void Because() => _result = _store.IsMaterialized(_definition with { Sink = SinkDefinition.None });
+
+    [Fact] void should_not_be_materialized() => _result.ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_finding_by_key/and_the_sink_has_no_instance.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_finding_by_key/and_the_sink_has_no_instance.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_finding_by_key;
+
+public class and_the_sink_has_no_instance : given.a_materialized_read_model
+{
+    static readonly Key _theKey = new("read-model-key", ArrayIndexers.NoIndexers);
+
+    ExpandoObject _result;
+
+    void Establish() => _sink.FindOrDefault(_theKey).Returns((ExpandoObject?)null);
+
+    async Task Because() => _result = await _store.FindByKey(EventStore, EventStoreNamespace, _definition, _theKey);
+
+    [Fact] void should_return_nothing() => _result.ShouldBeNull();
+    [Fact] void should_not_release_anything() => _compliance.DidNotReceive().Release(
+        Arg.Any<EventStoreName>(),
+        Arg.Any<EventStoreNamespaceName>(),
+        Arg.Any<JsonSchema>(),
+        Arg.Any<ExpandoObject>());
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_finding_by_key/and_the_sink_holds_the_instance.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_finding_by_key/and_the_sink_holds_the_instance.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_finding_by_key;
+
+public class and_the_sink_holds_the_instance : given.a_materialized_read_model
+{
+    static readonly Key _theKey = new("read-model-key", ArrayIndexers.NoIndexers);
+
+    ExpandoObject _released;
+    ExpandoObject _result;
+
+    void Establish()
+    {
+        _sink.FindOrDefault(_theKey).Returns(InstanceNamed("encrypted"));
+
+        _released = InstanceNamed("released");
+        _compliance.Release(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<JsonSchema>(),
+                Arg.Any<ExpandoObject>())
+            .Returns(_released);
+    }
+
+    async Task Because() => _result = await _store.FindByKey(EventStore, EventStoreNamespace, _definition, _theKey);
+
+    [Fact] void should_return_the_released_instance() => _result.ShouldEqual(_released);
+    [Fact] void should_release_what_the_sink_held() => _compliance.Received(1).Release(
+        EventStore,
+        EventStoreNamespace,
+        Arg.Any<JsonSchema>(),
+        Arg.Any<ExpandoObject>());
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_getting_all_instances/and_the_sink_holds_more_than_one_page.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_getting_all_instances/and_the_sink_holds_more_than_one_page.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_getting_all_instances;
+
+public class and_the_sink_holds_more_than_one_page : given.a_materialized_read_model
+{
+    const int InstanceCount = 250;
+
+    ExpandoObject[] _stored;
+    IEnumerable<ExpandoObject> _result;
+
+    void Establish()
+    {
+        _stored = [.. Enumerable.Range(0, InstanceCount).Select(index => InstanceNamed($"instance-{index}"))];
+        SinkHolds(_stored);
+    }
+
+    async Task Because() => _result = await _store.GetAllInstances(EventStore, EventStoreNamespace, _definition);
+
+    [Fact] void should_page_through_every_instance() => _result.Count().ShouldEqual(InstanceCount);
+    [Fact] void should_keep_the_order_the_sink_returned_them_in() => _result.ShouldEqual(_stored);
+    [Fact] void should_release_every_page() => _compliance.Received(3).Release(
+        EventStore,
+        EventStoreNamespace,
+        Arg.Any<JsonSchema>(),
+        Arg.Any<IEnumerable<ExpandoObject>>());
+
+    [Fact] void should_stop_reading_when_the_total_is_reached() => _sink.Received(3).GetInstances(
+        Arg.Any<ReadModelContainerName?>(),
+        Arg.Any<int>(),
+        Arg.Any<int>());
+}

--- a/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_getting_all_instances/and_the_sink_is_empty.cs
+++ b/Source/Kernel/Core.Specs/ReadModels/for_MaterializedReadModelStore/when_getting_all_instances/and_the_sink_is_empty.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModelStore.when_getting_all_instances;
+
+public class and_the_sink_is_empty : given.a_materialized_read_model
+{
+    IEnumerable<ExpandoObject> _result;
+
+    void Establish() => SinkHolds();
+
+    async Task Because() => _result = await _store.GetAllInstances(EventStore, EventStoreNamespace, _definition);
+
+    [Fact] void should_return_no_instances() => _result.ShouldBeEmpty();
+    [Fact] void should_not_release_anything() => _compliance.DidNotReceive().Release(
+        Arg.Any<EventStoreName>(),
+        Arg.Any<EventStoreNamespaceName>(),
+        Arg.Any<JsonSchema>(),
+        Arg.Any<IEnumerable<ExpandoObject>>());
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/given/all_dependencies.cs
@@ -36,6 +36,7 @@ public class all_dependencies : Specification
     protected IExpandoObjectConverter _expandoObjectConverter;
     protected IJsonComplianceManager _complianceManager;
     protected IReadModelsCompliance _complianceHelper;
+    protected IMaterializedReadModelStore _materializedReadModels;
     protected IEventCompliance _eventCompliance;
     protected IReducerMediator _reducerMediator;
     protected IProjectionChangesetMediator _changesetMediator;
@@ -80,6 +81,10 @@ public class all_dependencies : Specification
         _eventCompliance = Substitute.For<IEventCompliance>();
         _complianceHelper = Substitute.For<IReadModelsCompliance>();
 
+        // The materialized store is exercised for real over the mocked sink and compliance helper — it is the
+        // sink read plus the release pass, and specs assert on both through those mocks.
+        _materializedReadModels = new MaterializedReadModelStore(_storage, _complianceHelper);
+
         _localSiloDetails = Substitute.For<ILocalSiloDetails>();
         _localSiloDetails.SiloAddress.Returns(SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 0));
 
@@ -115,6 +120,7 @@ public class all_dependencies : Specification
             _localSiloDetails,
             _complianceHelper,
             _eventCompliance,
+            _materializedReadModels,
             new JsonSerializerOptions());
     }
 }

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_all_instances/and_read_model_is_materialized.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_all_instances/and_read_model_is_materialized.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Storage.ReadModels;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_all_instances;
+
+public class and_read_model_is_materialized : given.all_dependencies
+{
+    GetAllInstancesResponse _result = null!;
+
+    void Establish()
+    {
+        _readModelDefinition = _readModelDefinition with
+        {
+            Sink = new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.InMemory)
+        };
+        _readModel.GetDefinition().Returns(_readModelDefinition);
+
+        _sink.GetInstances(Arg.Any<ReadModelContainerName?>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns(new ReadModelInstances([InstanceNamed("First"), InstanceNamed("Second")], 2));
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<Schemas.JsonSchema>())
+            .Returns(call =>
+            {
+                var jsonObject = new JsonObject();
+                foreach (var (key, value) in (IDictionary<string, object?>)call.Arg<ExpandoObject>())
+                {
+                    jsonObject[key] = value?.ToString();
+                }
+
+                return jsonObject;
+            });
+    }
+
+    async Task Because() => _result = await _service.GetAllInstances(new()
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModelIdentifier = _readModelDefinition.Identifier,
+        EventSequenceId = "event-log",
+        EventCount = ulong.MaxValue
+    });
+
+    [Fact] void should_return_every_materialized_instance() => _result.Instances.Count.ShouldEqual(2);
+    [Fact] void should_return_the_first_instance() => NameOf(_result.Instances[0]).ShouldEqual("First");
+    [Fact] void should_return_the_second_instance() => NameOf(_result.Instances[1]).ShouldEqual("Second");
+    [Fact] void should_not_process_any_events() => _result.ProcessedEventsCount.ShouldEqual(0UL);
+
+    static string? NameOf(string json) => JsonSerializer.Deserialize<JsonElement>(json).GetProperty("name").GetString();
+
+    static ExpandoObject InstanceNamed(string name)
+    {
+        var instance = new ExpandoObject();
+        ((IDictionary<string, object?>)instance)["name"] = name;
+        return instance;
+    }
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_a_materialized_reducer.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_a_materialized_reducer.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Storage;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_instance_by_key;
+
+public class and_read_model_is_a_materialized_reducer : given.all_dependencies
+{
+    GetInstanceByKeyResponse _result = null!;
+
+    void Establish()
+    {
+        _readModelDefinition = _readModelDefinition with
+        {
+            ObserverType = Concepts.ReadModels.ReadModelObserverType.Reducer,
+            ObserverIdentifier = "my-reducer",
+            Sink = new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.InMemory)
+        };
+        _readModel.GetDefinition().Returns(_readModelDefinition);
+
+        var storedState = new ExpandoObject();
+        var storedValues = (IDictionary<string, object?>)storedState;
+        storedValues["name"] = "FromMaterializedStore";
+        storedValues[WellKnownProperties.LastHandledEventSequenceNumber] = 42UL;
+        _sink.FindOrDefault(Arg.Any<Key>()).Returns(storedState);
+
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<Schemas.JsonSchema>())
+            .Returns(call =>
+            {
+                var jsonObject = new JsonObject();
+                foreach (var (key, value) in (IDictionary<string, object?>)call.Arg<ExpandoObject>())
+                {
+                    jsonObject[key] = value?.ToString();
+                }
+
+                return jsonObject;
+            });
+    }
+
+    async Task Because() => _result = await _service.GetInstanceByKey(new()
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModelIdentifier = _readModelDefinition.Identifier,
+        EventSequenceId = "event-log",
+        ReadModelKey = "read-model-key"
+    });
+
+    [Fact] void should_return_the_materialized_read_model() => JsonSerializer.Deserialize<JsonElement>(_result.ReadModel).GetProperty("name").GetString().ShouldEqual("FromMaterializedStore");
+    [Fact] void should_report_the_stored_last_handled_sequence_number() => _result.LastHandledEventSequenceNumber.ShouldEqual(42UL);
+    [Fact] void should_not_project_any_events() => _result.ProjectedEventsCount.ShouldEqual(0UL);
+    [Fact] void should_not_reduce_through_a_connected_client() => _reducerMediator.DidNotReceiveWithAnyArgs().OnNext(default!, default!, default!, default!, default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_a_projection_with_pii.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_a_projection_with_pii.cs
@@ -33,6 +33,7 @@ public class and_read_model_is_a_projection_with_pii : given.all_dependencies
 
         _readModelDefinition = _readModelDefinition with
         {
+            Sink = new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.InMemory),
             Schemas = new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, _schema } }
         };
         _readModel.GetDefinition().Returns(_readModelDefinition);

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_passive_with_a_pii_property.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_read_model_is_passive_with_a_pii_property.cs
@@ -76,6 +76,7 @@ public class and_read_model_is_passive_with_a_pii_property : given.all_dependenc
                     NullLogger<JsonComplianceManager>.Instance),
                 _expandoObjectConverter),
             _eventCompliance,
+            _materializedReadModels,
             new JsonSerializerOptions());
     }
 

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_the_materialized_read_model_has_no_instance.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_getting_instance_by_key/and_the_materialized_read_model_has_no_instance.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Contracts.ReadModels;
+
+namespace Cratis.Chronicle.Services.ReadModels.for_ReadModels.when_getting_instance_by_key;
+
+public class and_the_materialized_read_model_has_no_instance : given.all_dependencies
+{
+    GetInstanceByKeyResponse _result = null!;
+
+    void Establish()
+    {
+        _readModelDefinition = _readModelDefinition with
+        {
+            ObserverType = Concepts.ReadModels.ReadModelObserverType.Reducer,
+            ObserverIdentifier = "my-reducer",
+            Sink = new SinkDefinition(SinkConfigurationId.None, WellKnownSinkTypes.InMemory)
+        };
+        _readModel.GetDefinition().Returns(_readModelDefinition);
+
+        _sink.FindOrDefault(Arg.Any<Key>()).Returns((ExpandoObject?)null);
+    }
+
+    async Task Because() => _result = await _service.GetInstanceByKey(new()
+    {
+        EventStore = "test-store",
+        Namespace = "test-namespace",
+        ReadModelIdentifier = _readModelDefinition.Identifier,
+        EventSequenceId = "event-log",
+        ReadModelKey = "read-model-key"
+    });
+
+    [Fact] void should_answer_with_a_null_read_model() => _result.ReadModel.ShouldEqual("null");
+    [Fact] void should_report_the_sequence_number_as_unavailable() => _result.LastHandledEventSequenceNumber.ShouldEqual(EventSequenceNumber.Unavailable.Value);
+    [Fact] void should_not_fall_back_to_reducing_it() => _reducerMediator.DidNotReceiveWithAnyArgs().OnNext(default!, default!, default!, default!, default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_carries_kernel_bookkeeping.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_carries_kernel_bookkeeping.cs
@@ -79,6 +79,7 @@ public class and_document_carries_kernel_bookkeeping : given.all_dependencies
                     NullLogger<JsonComplianceManager>.Instance),
                 _expandoObjectConverter),
             _eventCompliance,
+            _materializedReadModels,
             new JsonSerializerOptions());
     }
 

--- a/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_is_owned_by_the_caller.cs
+++ b/Source/Kernel/Core.Specs/Services/ReadModels/for_ReadModels/when_watching/and_document_is_owned_by_the_caller.cs
@@ -77,6 +77,7 @@ public class and_document_is_owned_by_the_caller : given.all_dependencies
                     NullLogger<JsonComplianceManager>.Instance),
                 _expandoObjectConverter),
             _eventCompliance,
+            _materializedReadModels,
             new JsonSerializerOptions());
     }
 

--- a/Source/Kernel/Core/ReadModels/IMaterializedReadModelStore.cs
+++ b/Source/Kernel/Core/ReadModels/IMaterializedReadModelStore.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.ReadModels;
+
+/// <summary>
+/// Defines a system for reading read model instances from the materialized store.
+/// </summary>
+/// <remarks>
+/// A read model is materialized when an observer — a projection or a reducer — writes its state to a sink.
+/// The state is then already there to be read, so it does not have to be projected or reduced again, and it
+/// is released of its PII before it leaves the kernel.
+/// </remarks>
+public interface IMaterializedReadModelStore
+{
+    /// <summary>
+    /// Check whether a read model is materialized.
+    /// </summary>
+    /// <param name="definition">The <see cref="ReadModelDefinition"/> to check.</param>
+    /// <returns>True if the read model is materialized, false if not.</returns>
+    bool IsMaterialized(ReadModelDefinition definition);
+
+    /// <summary>
+    /// Find a single instance by its key.
+    /// </summary>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the read model belongs to.</param>
+    /// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> the read model belongs to.</param>
+    /// <param name="definition">The <see cref="ReadModelDefinition"/> to find the instance for.</param>
+    /// <param name="key">The <see cref="Key"/> of the instance.</param>
+    /// <returns>The released instance, or null when the store holds no instance for the key.</returns>
+    Task<ExpandoObject?> FindByKey(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        ReadModelDefinition definition,
+        Key key);
+
+    /// <summary>
+    /// Get every instance of a read model.
+    /// </summary>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the read model belongs to.</param>
+    /// <param name="eventStoreNamespace">The <see cref="EventStoreNamespaceName"/> the read model belongs to.</param>
+    /// <param name="definition">The <see cref="ReadModelDefinition"/> to get instances for.</param>
+    /// <returns>The released instances.</returns>
+    Task<IEnumerable<ExpandoObject>> GetAllInstances(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        ReadModelDefinition definition);
+}

--- a/Source/Kernel/Core/ReadModels/MaterializedReadModelStore.cs
+++ b/Source/Kernel/Core/ReadModels/MaterializedReadModelStore.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Sinks;
+
+namespace Cratis.Chronicle.ReadModels;
+
+/// <summary>
+/// Represents an implementation of <see cref="IMaterializedReadModelStore"/> that reads instances from the
+/// <see cref="ISink"/> a read model's observer writes to.
+/// </summary>
+/// <param name="storage">The <see cref="IStorage"/> to resolve sinks through.</param>
+/// <param name="compliance">The <see cref="IReadModelsCompliance"/> for releasing PII before instances leave the kernel.</param>
+public class MaterializedReadModelStore(
+    IStorage storage,
+    IReadModelsCompliance compliance) : IMaterializedReadModelStore
+{
+    /// <summary>
+    /// The number of instances read from the sink per round-trip when reading all of them.
+    /// </summary>
+    const int PageSize = 100;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A passive read model registers with <see cref="SinkTypeId.None"/> — no observer ever writes to it, so
+    /// its sink resolves to a <see cref="NullSink"/> that would answer every read with nothing.
+    /// </remarks>
+    public bool IsMaterialized(ReadModelDefinition definition) => definition.Sink.Type != SinkTypeId.None;
+
+    /// <inheritdoc/>
+    public async Task<ExpandoObject?> FindByKey(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        ReadModelDefinition definition,
+        Key key)
+    {
+        var sink = await GetSinkFor(eventStore, eventStoreNamespace, definition);
+        var instance = await sink.FindOrDefault(key);
+        if (instance is null)
+        {
+            return null;
+        }
+
+        return await compliance.Release(
+            eventStore,
+            eventStoreNamespace,
+            definition.GetSchemaForLatestGeneration(),
+            instance);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<ExpandoObject>> GetAllInstances(
+        EventStoreName eventStore,
+        EventStoreNamespaceName eventStoreNamespace,
+        ReadModelDefinition definition)
+    {
+        var sink = await GetSinkFor(eventStore, eventStoreNamespace, definition);
+        var schema = definition.GetSchemaForLatestGeneration();
+        var instances = new List<ExpandoObject>();
+        var skip = 0;
+
+        while (true)
+        {
+            var page = await sink.GetInstances(skip: skip, take: PageSize);
+            var pageInstances = page.Instances.ToList();
+            if (pageInstances.Count == 0)
+            {
+                break;
+            }
+
+            instances.AddRange(await compliance.Release(eventStore, eventStoreNamespace, schema, pageInstances));
+            skip += pageInstances.Count;
+
+            if (skip >= page.TotalCount)
+            {
+                break;
+            }
+        }
+
+        return instances;
+    }
+
+    Task<ISink> GetSinkFor(EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace, ReadModelDefinition definition) =>
+        storage.GetEventStore(eventStore).GetNamespace(eventStoreNamespace).Sinks.GetFor(definition);
+}

--- a/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
+++ b/Source/Kernel/Core/Services/ReadModels/ReadModels.cs
@@ -12,7 +12,6 @@ using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Concepts.Observation.Reducers;
 using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.ReadModels;
-using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Contracts.ReadModels;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Json;
@@ -41,6 +40,7 @@ namespace Cratis.Chronicle.Services.ReadModels;
 /// <param name="localSiloDetails">The <see cref="ILocalSiloDetails"/> for pinning the watch subscriber grain to this silo.</param>
 /// <param name="complianceHelper">The <see cref="IReadModelsCompliance"/> for decrypting PII fields.</param>
 /// <param name="eventCompliance">The <see cref="IEventCompliance"/> for decrypting PII event content.</param>
+/// <param name="materializedReadModels">The <see cref="IMaterializedReadModelStore"/> for reading instances that are already materialized.</param>
 /// <param name="jsonSerializerOptions">The JSON serializer options.</param>
 internal sealed class ReadModels(
     IGrainFactory grainFactory,
@@ -51,6 +51,7 @@ internal sealed class ReadModels(
     ILocalSiloDetails localSiloDetails,
     IReadModelsCompliance complianceHelper,
     IEventCompliance eventCompliance,
+    IMaterializedReadModelStore materializedReadModels,
     JsonSerializerOptions jsonSerializerOptions) : IReadModels
 {
     /// <inheritdoc/>
@@ -204,64 +205,21 @@ internal sealed class ReadModels(
         var readModel = grainFactory.GetReadModel(request.ReadModelIdentifier, request.EventStore);
         var definition = await readModel.GetDefinition();
 
+        // A materialized read model — projection or reducer alike — already has its state written to the sink by
+        // its observer, so read it from there rather than re-projecting or round-tripping to a connected reducer
+        // client. For a projection this is also the only path that reflects joins and custom key resolvers
+        // (UsingKey), because ImmediateProjection replays by EventSourceId alone and misses cross-source events.
+        // A session pins a projection to an in-flight state, and an unspecified key ("*") cannot be looked up by
+        // key at all, so both of those keep replaying.
+        if (materializedReadModels.IsMaterialized(definition) &&
+            string.IsNullOrEmpty(request.SessionId) &&
+            request.ReadModelKey != ReadModelKey.Unspecified.Value)
+        {
+            return await GetMaterializedInstanceByKey(request, definition);
+        }
+
         if (definition.ObserverType == Concepts.ReadModels.ReadModelObserverType.Projection)
         {
-            // When no session is active, try to read from the sink first (the stored projected value).
-            // This correctly handles joins and events with custom key resolvers (UsingKey) because
-            // the projection observer processes all events and stores the result in the sink.
-            // ImmediateProjection only replays events by EventSourceId, which misses cross-source events.
-            // Note: when ReadModelKey is unspecified ("*") we cannot look it up by key in the sink;
-            // fall through to ImmediateProjection which replays all events and returns the last state.
-            if (string.IsNullOrEmpty(request.SessionId) && request.ReadModelKey != ReadModelKey.Unspecified.Value)
-            {
-                var namespaceStorage = storage.GetEventStore(request.EventStore).GetNamespace(request.Namespace);
-                var sink = await namespaceStorage.Sinks.GetFor(definition);
-
-                // For passive projections the sink never has data; fall through to immediate projection.
-                if (sink.TypeId != SinkTypeId.None)
-                {
-                    var key = new Key(request.ReadModelKey, ArrayIndexers.NoIndexers);
-                    var storedState = await sink.FindOrDefault(key);
-
-                    if (storedState is not null)
-                    {
-                        var schema = definition.GetSchemaForLatestGeneration();
-                        var released = await complianceHelper.Release(
-                            request.EventStore,
-                            request.Namespace,
-                            schema,
-                            storedState);
-                        var jsonObject = expandoObjectConverter.ToJsonObject(released, schema);
-                        var readModelJson = jsonObject.ToJsonString(jsonSerializerOptions);
-
-                        var lastSeq = EventSequenceNumber.Unavailable;
-                        var stateDict = (IDictionary<string, object?>)released;
-                        if (stateDict.TryGetValue(WellKnownProperties.LastHandledEventSequenceNumber, out var seqObj) &&
-                            seqObj is not null)
-                        {
-                            try { lastSeq = (EventSequenceNumber)Convert.ToUInt64(seqObj); }
-                            catch { /* value not convertible to ulong; leave as Unavailable */ }
-                        }
-
-                        return new GetInstanceByKeyResponse
-                        {
-                            ReadModel = readModelJson,
-                            ProjectedEventsCount = 0,
-                            LastHandledEventSequenceNumber = lastSeq
-                        };
-                    }
-
-                    // Document not found in the sink: either it was never created or it was removed.
-                    // Return a null-model response; the projection observer is authoritative for active sinks.
-                    return new GetInstanceByKeyResponse
-                    {
-                        ReadModel = "null",
-                        ProjectedEventsCount = 0,
-                        LastHandledEventSequenceNumber = EventSequenceNumber.Unavailable
-                    };
-                }
-            }
-
             var projectionKey = !string.IsNullOrEmpty(request.SessionId)
                 ? new ImmediateProjectionKey(
                     (ProjectionId)definition.ObserverIdentifier.Value,
@@ -353,6 +311,14 @@ internal sealed class ReadModels(
     {
         var readModel = grainFactory.GetReadModel(request.ReadModelIdentifier, request.EventStore);
         var definition = await readModel.GetDefinition();
+
+        // Every instance of a materialized read model is already in the sink, so read them from there. An
+        // explicit event count is a request to re-apply exactly that many events from the beginning, which
+        // only the replay path below can answer.
+        if (materializedReadModels.IsMaterialized(definition) && request.EventCount == ulong.MaxValue)
+        {
+            return await GetAllMaterializedInstances(request, definition);
+        }
 
         if (definition.ObserverType != Concepts.ReadModels.ReadModelObserverType.Projection)
         {
@@ -466,18 +432,7 @@ internal sealed class ReadModels(
                 schema,
                 instance);
 
-            var jsonObject = expandoObjectConverter.ToJsonObject(decrypted, schema);
-
-            // Ensure __lastHandledEventSequenceNumber is included in the JSON output since
-            // ToJsonObject may drop it if it is not mapped by the schema converter.
-            var decryptedDict = (IDictionary<string, object?>)decrypted;
-            if (decryptedDict.TryGetValue(WellKnownProperties.LastHandledEventSequenceNumber, out var seqObj) && seqObj is not null)
-            {
-                try { jsonObject[WellKnownProperties.LastHandledEventSequenceNumber] = JsonValue.Create(Convert.ToUInt64(seqObj)); }
-                catch { /* leave sequence number absent if conversion fails */ }
-            }
-
-            readModels.Add(jsonObject.ToJsonString(jsonSerializerOptions));
+            readModels.Add(SerializeInstance(decrypted, schema));
         }
 
         return new GetAllInstancesResponse
@@ -588,6 +543,80 @@ internal sealed class ReadModels(
         {
             throw new NotSupportedException("Server-side reducer session dehydration is not yet supported. Reducers typically run client-side.");
         }
+    }
+
+    static EventSequenceNumber GetLastHandledEventSequenceNumber(ExpandoObject instance)
+    {
+        var values = (IDictionary<string, object?>)instance;
+        if (!values.TryGetValue(WellKnownProperties.LastHandledEventSequenceNumber, out var value) || value is null)
+        {
+            return EventSequenceNumber.Unavailable;
+        }
+
+        try
+        {
+            return (EventSequenceNumber)Convert.ToUInt64(value);
+        }
+        catch (Exception exception) when (exception is InvalidCastException or FormatException or OverflowException)
+        {
+            // The stored value is not a sequence number; report it as unavailable rather than failing the read.
+            return EventSequenceNumber.Unavailable;
+        }
+    }
+
+    async Task<GetInstanceByKeyResponse> GetMaterializedInstanceByKey(GetInstanceByKeyRequest request, Concepts.ReadModels.ReadModelDefinition definition)
+    {
+        var key = new Key(request.ReadModelKey, ArrayIndexers.NoIndexers);
+        var instance = await materializedReadModels.FindByKey(request.EventStore, request.Namespace, definition, key);
+
+        // Nothing in the sink means the instance was either never created or removed. The observer is
+        // authoritative for a materialized read model, so answer with a null model rather than falling back to
+        // a replay that would resurrect it.
+        if (instance is null)
+        {
+            return new GetInstanceByKeyResponse
+            {
+                ReadModel = "null",
+                ProjectedEventsCount = 0,
+                LastHandledEventSequenceNumber = EventSequenceNumber.Unavailable
+            };
+        }
+
+        var jsonObject = expandoObjectConverter.ToJsonObject(instance, definition.GetSchemaForLatestGeneration());
+
+        return new GetInstanceByKeyResponse
+        {
+            ReadModel = jsonObject.ToJsonString(jsonSerializerOptions),
+            ProjectedEventsCount = 0,
+            LastHandledEventSequenceNumber = GetLastHandledEventSequenceNumber(instance)
+        };
+    }
+
+    async Task<GetAllInstancesResponse> GetAllMaterializedInstances(GetAllInstancesRequest request, Concepts.ReadModels.ReadModelDefinition definition)
+    {
+        var instances = await materializedReadModels.GetAllInstances(request.EventStore, request.Namespace, definition);
+        var schema = definition.GetSchemaForLatestGeneration();
+
+        return new GetAllInstancesResponse
+        {
+            Instances = instances.Select(instance => SerializeInstance(instance, schema)).ToList(),
+            ProcessedEventsCount = 0
+        };
+    }
+
+    string SerializeInstance(ExpandoObject instance, JsonSchema schema)
+    {
+        var jsonObject = expandoObjectConverter.ToJsonObject(instance, schema);
+
+        // ToJsonObject drops the last handled event sequence number when the schema does not describe it, so
+        // put it back — clients mirror it onto the instance to tell how far it has been brought up to date.
+        var lastHandled = GetLastHandledEventSequenceNumber(instance);
+        if (lastHandled != EventSequenceNumber.Unavailable)
+        {
+            jsonObject[WellKnownProperties.LastHandledEventSequenceNumber] = JsonValue.Create(lastHandled.Value);
+        }
+
+        return jsonObject.ToJsonString(jsonSerializerOptions);
     }
 
     async Task<Concepts.ReadModels.ReadModelDefinition> WaitForReadModelDefinition(IReadModel readModel, CancellationToken cancellationToken)

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -65,6 +65,7 @@ public static class ChronicleServerSiloBuilderExtensions
         builder.Services.TryAddSingleton<IExpandoObjectConverter, ExpandoObjectConverter>();
         builder.Services.TryAddSingleton<IEventCompliance, EventCompliance>();
         builder.Services.TryAddSingleton<IReadModelsCompliance, ReadModelsCompliance>();
+        builder.Services.TryAddSingleton<IMaterializedReadModelStore, MaterializedReadModelStore>();
         builder.Services.TryAddSingleton<IEventTypeMigrations, EventTypeMigrations>();
         builder.Services.TryAddSingleton<IObserverSubscriberSelector, ObserverSubscriberSelector>();
         builder
@@ -149,7 +150,7 @@ public static class ChronicleServerSiloBuilderExtensions
                     sp.GetRequiredService<Cratis.Chronicle.Captures.Engine.DeclarationLanguage.ILanguageService>(),
                     sp.GetRequiredService<Cratis.Chronicle.Captures.Engine.ICaptureValidator>()),
                 new Cratis.Chronicle.Services.Observation.EventStoreSubscriptions.EventStoreSubscriptions(grainFactory, storage, sp.GetRequiredService<IOptions<ChronicleOptions>>()),
-                new Cratis.Chronicle.Services.ReadModels.ReadModels(grainFactory, storage, expandoObjectConverter, sp.GetRequiredService<IReducerMediator>(), sp.GetRequiredService<Cratis.Chronicle.Projections.IProjectionChangesetMediator>(), sp.GetRequiredService<Orleans.Runtime.ILocalSiloDetails>(), sp.GetRequiredService<IReadModelsCompliance>(), sp.GetRequiredService<IEventCompliance>(), jsonSerializerOptions),
+                new Cratis.Chronicle.Services.ReadModels.ReadModels(grainFactory, storage, expandoObjectConverter, sp.GetRequiredService<IReducerMediator>(), sp.GetRequiredService<Cratis.Chronicle.Projections.IProjectionChangesetMediator>(), sp.GetRequiredService<Orleans.Runtime.ILocalSiloDetails>(), sp.GetRequiredService<IReadModelsCompliance>(), sp.GetRequiredService<IEventCompliance>(), sp.GetRequiredService<IMaterializedReadModelStore>(), jsonSerializerOptions),
                 new Cratis.Chronicle.Services.ReadModels.MaterializedReadModels(grainFactory, storage, sp.GetRequiredService<IReadModelsCompliance>()),
                 new Cratis.Chronicle.Services.Jobs.Jobs(grainFactory, storage, sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Jobs.Jobs>>()),
                 new Cratis.Chronicle.Services.Seeding.EventSeeding(grainFactory),


### PR DESCRIPTION
# Summary

Reading a read model instance no longer depends on which kind of observer builds it. When a read model is materialized — the default for both projections and reducers — Chronicle now serves it from the sink and releases its PII before it leaves the kernel. Only a passive read model, which has no sink, is still computed on demand from its events.

Previously only projections read the sink. A reducer-backed read model was folded from its whole event stream on every read, and `GetInstances` replayed the entire log even for a read model whose state was already stored.

## Changed

- `IReadModels.GetInstanceById` resolves a materialized reducer-backed read model from the materialized store instead of replaying its events, with PII released server-side (#3605)
- `IReadModels.GetInstances` returns the stored instances for a materialized read model instead of replaying the event log; passing an explicit event count still replays (#3605)
- A reducer-backed read model no longer needs a connected reducer client to be read by key (#3605)
- Read model instance reads are eventually consistent unless the read model is marked `[Passive]` — mark it passive where a read must reflect an append that just happened (#3605)

## Fixed

- PII is now released on the non-generic `IReadModels.GetInstanceById(Type, ...)` for reducer-backed read models, which is how reactors resolve read model parameters — it previously returned encrypted values (#3605)
- A read model instance request for a reducer-backed read model is made against the event sequence that reducer reduces from, rather than always the event log (#3605)
