### PR TITLE
Fix three defects shipped in v16.20.0

### DIFF
--- a/Integration/Client/for_EventSeeding/when_a_seeded_batch_is_rejected.cs
+++ b/Integration/Client/for_EventSeeding/when_a_seeded_batch_is_rejected.cs
@@ -69,7 +69,14 @@ public class when_a_seeded_batch_is_rejected(context context) : Given<context>(c
             await EventStore.EventLog.GetFromSequenceNumber(EventSequenceNumber.First);
     }
 
-    [Fact] void should_fail_the_rejected_run() => Context.FirstFailure.ShouldNotBeNull();
+    /// <summary>
+    /// The rejected run must NOT surface as an exception. Seeding happens inside <c>RegisterAll</c>, which the
+    /// client runs from <c>OnConnected</c>; a failing handler there rolls the connection back to disconnected,
+    /// the watchdog reconnects, and the same deterministic seed rejection repeats - a permanent client outage
+    /// caused by a fixable mistake in seed data. The rejection is reported by the kernel grain's Error log, and
+    /// the batch is left unseeded so a corrected run retries it, which the facts below pin.
+    /// </summary>
+    [Fact] void should_not_fail_the_rejected_run() => Context.FirstFailure.ShouldBeNull();
     [Fact] void should_append_nothing_from_the_rejected_run() => Context.EventsAfterTheRejectedRun.ShouldEqual(0);
     [Fact] void should_append_the_corrected_seed_set() => Context.EventTypesAfterTheCorrectedRun.Count().ShouldEqual(2);
     [Fact] void should_append_the_innocent_entry_that_shared_the_rejected_batch() => Context.EventTypesAfterTheCorrectedRun.ShouldContain(nameof(OfficeOpened));

--- a/Source/Clients/XUnit.Integration/Events/EventSequenceMutationExtensions.cs
+++ b/Source/Clients/XUnit.Integration/Events/EventSequenceMutationExtensions.cs
@@ -4,7 +4,6 @@
 extern alias KernelCore;
 extern alias KernelConcepts;
 using Cratis.Chronicle.Events;
-using Microsoft.Extensions.DependencyInjection;
 using KernelCorrelationId = Cratis.Execution.CorrelationId;
 using KernelEventRedactionRequested = KernelCore::Cratis.Chronicle.Events.EventSequences.EventRedactionRequested;
 using KernelEventRevised = KernelCore::Cratis.Chronicle.Events.EventSequences.EventRevised;
@@ -35,7 +34,10 @@ public static class EventSequenceMutationExtensions
     /// <returns>Awaitable task.</returns>
     public static async Task ReviseEvent<TEvent>(this IChronicleSetupFixture fixture, EventSequenceNumber sequenceNumber, TEvent revision)
     {
-        var eventSerializer = fixture.Services.GetRequiredService<IEventSerializer>();
+        // Off the event store, never the root provider: IEventSerializer is scoped, so resolving it from the
+        // root either throws under ValidateScopes or hands back a serializer bound to a different event store's
+        // event types than the one being mutated here.
+        var eventSerializer = ((EventStore)fixture.EventStore).EventSerializer;
         var content = await eventSerializer.Serialize(revision!);
         var eventType = fixture.EventStore.EventTypes.GetEventTypeFor(typeof(TEvent));
         var kernelEventType = new KernelEventType(

--- a/Source/Kernel/Core.Specs/Services/Seeding/for_EventSeeding/when_seeding_a_namespace/and_the_grain_reports_incomplete_seeding.cs
+++ b/Source/Kernel/Core.Specs/Services/Seeding/for_EventSeeding/when_seeding_a_namespace/and_the_grain_reports_incomplete_seeding.cs
@@ -25,6 +25,12 @@ public class and_the_grain_reports_incomplete_seeding : given.an_event_seeding_s
 
     async Task Because() => _error = await Catch.Exception(() => _service.Seed(_request));
 
-    [Fact] void should_fail_the_external_operation() => _error.ShouldBeOfExactType<EventSeedingIncomplete>();
+    /// <summary>
+    /// Must NOT fail the operation. The client seeds inside <c>RegisterAll</c>, which runs from
+    /// <c>OnConnected</c>, and a failing handler there rolls the connection back to disconnected - so a
+    /// deterministic seed rejection would reconnect, be rejected again, and hold the client offline for good.
+    /// The grain logs the rejection and leaves the batch unseeded for a corrected run.
+    /// </summary>
+    [Fact] void should_not_fail_the_external_operation() => _error.ShouldBeNull();
     [Fact] void should_offer_the_entries_once() => _namespaceGrain.Received(1).SeedWithResult(Arg.Any<IEnumerable<SeededEntry>>());
 }

--- a/Source/Kernel/Core.Specs/Services/Seeding/for_EventSeeding/when_seeding_globally/and_the_grain_reports_incomplete_seeding.cs
+++ b/Source/Kernel/Core.Specs/Services/Seeding/for_EventSeeding/when_seeding_globally/and_the_grain_reports_incomplete_seeding.cs
@@ -26,6 +26,12 @@ public class and_the_grain_reports_incomplete_seeding : given.an_event_seeding_s
 
     async Task Because() => _error = await Catch.Exception(() => _service.Seed(_request));
 
-    [Fact] void should_fail_the_external_operation() => _error.ShouldBeOfExactType<EventSeedingIncomplete>();
+    /// <summary>
+    /// Must NOT fail the operation. The client seeds inside <c>RegisterAll</c>, which runs from
+    /// <c>OnConnected</c>, and a failing handler there rolls the connection back to disconnected - so a
+    /// deterministic seed rejection would reconnect, be rejected again, and hold the client offline for good.
+    /// The grain logs the rejection and leaves the batch unseeded for a corrected run.
+    /// </summary>
+    [Fact] void should_not_fail_the_external_operation() => _error.ShouldBeNull();
     [Fact] void should_offer_the_entries_once() => _globalGrain.Received(1).SeedWithResult(Arg.Any<IEnumerable<SeededEntry>>());
 }

--- a/Source/Kernel/Core/Seeding/EventSeeding.cs
+++ b/Source/Kernel/Core/Seeding/EventSeeding.cs
@@ -183,13 +183,16 @@ public class EventSeeding(
                 // strand the batches that did append, since their tracking is persisted below. The
                 // remaining batches are unrelated events that share nothing with the rejected one but a
                 // chunk index, so they are still worth appending.
+                // Counts and constraint names only. An event source id is the compliance subject by default, and
+                // a constraint violation message embeds it, so neither belongs in a log line that outlives the
+                // subject's erasure.
                 logger.SeededEventsRejected(
                     batch.Length,
                     _key.EventStore.Value,
                     _key.Namespace.Value,
-                    string.Join(", ", result.ConstraintViolations.Select(_ => _.Message.Value)),
-                    string.Join(", ", result.Errors.Select(_ => _.Value)),
-                    string.Join(", ", result.ConcurrencyViolations.Select(_ => _.EventSourceId.Value)));
+                    string.Join(", ", result.ConstraintViolations.Select(_ => _.ConstraintName.Value).Distinct()),
+                    result.Errors.Count(),
+                    result.ConcurrencyViolations.Count());
 
                 everyBatchAppended = false;
                 continue;

--- a/Source/Kernel/Core/Seeding/EventSeedingLogging.cs
+++ b/Source/Kernel/Core/Seeding/EventSeedingLogging.cs
@@ -23,8 +23,8 @@ internal static partial class EventSeedingLogMessages
     [LoggerMessage(LogLevel.Debug, "Applying global seeds to namespace '{Namespace}'")]
     internal static partial void ApplyingSeedsToNamespace(this ILogger<EventSeeding> logger, string @namespace);
 
-    [LoggerMessage(LogLevel.Error, "The event sequence rejected a batch of {Count} seeded events for event store '{EventStore}' in namespace '{Namespace}' - none of them were appended. Constraint violations: {ConstraintViolations}. Errors: {Errors}. Concurrency violations: {ConcurrencyViolations}. The batch has not been recorded as seeded and will be offered again on the next seeding run.")]
-    internal static partial void SeededEventsRejected(this ILogger<EventSeeding> logger, int count, string eventStore, string @namespace, string constraintViolations, string errors, string concurrencyViolations);
+    [LoggerMessage(LogLevel.Error, "The event sequence rejected a batch of {Count} seeded events for event store '{EventStore}' in namespace '{Namespace}' - none of them were appended. Violated constraints: {ConstraintNames}. Errors: {ErrorCount}. Concurrency violations: {ConcurrencyViolationCount}. The batch has not been recorded as seeded and will be offered again on the next seeding run.")]
+    internal static partial void SeededEventsRejected(this ILogger<EventSeeding> logger, int count, string eventStore, string @namespace, string constraintNames, int errorCount, int concurrencyViolationCount);
 
     [LoggerMessage(LogLevel.Error, "One or more namespaces did not seed everything they were given for event store '{EventStore}' - the global seed tracking is left uncommitted so the entries are dispatched again on the next seeding run")]
     internal static partial void NamespaceSeedingIncomplete(this ILogger<EventSeeding> logger, string eventStore);

--- a/Source/Kernel/Core/Services/Seeding/EventSeeding.cs
+++ b/Source/Kernel/Core/Services/Seeding/EventSeeding.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Seeding;
 using Cratis.Chronicle.Contracts.Seeding;
 using ProtoBuf.Grpc;
 
-using EventSeedingResult = Cratis.Chronicle.Seeding.SeedingResult;
 using ResultAwareEventSeeding = Cratis.Chronicle.Seeding.IResultAwareEventSeeding;
 
 namespace Cratis.Chronicle.Services.Seeding;
@@ -37,8 +35,14 @@ internal sealed class EventSeeding(IGrainFactory grainFactory) : IEventSeeding
                 e.Content,
                 e.Tags?.Select(t => new Concepts.Events.Tag(t)).ToArray() ?? [])).ToArray();
 
-            var result = await globalGrain.SeedWithResult(entries);
-            EnsureComplete(result, request.EventStore, EventStoreNamespaceName.NotSet);
+            // The result is deliberately not propagated to the caller. A rejected seed batch is almost always a
+            // deterministic mistake in the seed set - a constraint violation - and this call sits on the client's
+            // connected path: the client seeds inside RegisterAll, which runs from OnConnected, and a failing
+            // handler there rolls the connection back to disconnected. The watchdog reconnects, the same seed set
+            // is rejected again, and a fixable mistake in a developer's seed data becomes a permanent client
+            // outage. The grain logs the rejection at Error with the violated constraints and leaves the batch
+            // unseeded, so a corrected run retries it.
+            await globalGrain.SeedWithResult(entries);
         }
 
         // Seed namespace-specific entries
@@ -59,8 +63,8 @@ internal sealed class EventSeeding(IGrainFactory grainFactory) : IEventSeeding
                     e.Content,
                     e.Tags?.Select(t => new Concepts.Events.Tag(t)).ToArray() ?? [])).ToArray();
 
-                var result = await grain.SeedWithResult(entries);
-                EnsureComplete(result, request.EventStore, namespacedGroup.Namespace);
+                // Not propagated - see the note on the global branch above.
+                await grain.SeedWithResult(entries);
             }
         }
     }
@@ -83,14 +87,6 @@ internal sealed class EventSeeding(IGrainFactory grainFactory) : IEventSeeding
         var seeds = await grain.GetSeededEvents();
 
         return MapToResponse(seeds);
-    }
-
-    static void EnsureComplete(EventSeedingResult result, EventStoreName eventStore, EventStoreNamespaceName eventStoreNamespace)
-    {
-        if (!result.AllEntriesSeeded)
-        {
-            throw new Chronicle.Seeding.EventSeedingIncomplete(eventStore, eventStoreNamespace);
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

Three defects shipped in v16.20.0, found by a post-merge review of #3599.

## Fixed

- A rejected seed batch no longer fails the client's connection. Seeding runs inside `RegisterAll` from `OnConnected`, so the exception rolled the connection back to disconnected; because a seed rejection is deterministic, the watchdog reconnected and reproduced it indefinitely. The rejection is logged by the kernel and the batch is left unseeded for a corrected run.
- `ReviseEvent` in `Cratis.Chronicle.XUnit.Integration` no longer resolves `IEventSerializer` from the root provider. That service became scoped in 16.20.0, so the call either threw or returned a serializer bound to a different event store's event types.

## Security

- The seeding rejection log no longer writes event source ids or constraint violation messages, both of which carry the compliance subject. It names the violated constraints and reports counts instead.
