### PR TITLE
Prevent projection registration storms

### DIFF
--- a/Source/Clients/DotNET.Specs/Registrations/for_RegistrationBackoff/when_computing_the_next_delay.cs
+++ b/Source/Clients/DotNET.Specs/Registrations/for_RegistrationBackoff/when_computing_the_next_delay.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations.for_RegistrationBackoff;
+
+public class when_computing_the_next_delay : Specification
+{
+    RegistrationBackoff _backoff;
+
+    void Establish() => _backoff = new RegistrationBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(8), () => 1);
+
+    [Fact] void should_not_delay_when_nothing_has_failed() => _backoff.NextDelay(0).ShouldEqual(TimeSpan.Zero);
+    [Fact] void should_start_at_the_initial_delay_after_the_first_failure() => _backoff.NextDelay(1).ShouldEqual(TimeSpan.FromSeconds(1));
+    [Fact] void should_grow_exponentially_with_consecutive_failures() => _backoff.NextDelay(3).ShouldEqual(TimeSpan.FromSeconds(4));
+    [Fact] void should_cap_at_the_maximum_delay() => _backoff.NextDelay(10).ShouldEqual(TimeSpan.FromSeconds(8));
+}

--- a/Source/Clients/DotNET.Specs/Registrations/for_RegistrationBackoff/when_computing_the_next_delay_with_jitter.cs
+++ b/Source/Clients/DotNET.Specs/Registrations/for_RegistrationBackoff/when_computing_the_next_delay_with_jitter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations.for_RegistrationBackoff;
+
+public class when_computing_the_next_delay_with_jitter : Specification
+{
+    RegistrationBackoff _floorBackoff;
+    RegistrationBackoff _midBackoff;
+
+    void Establish()
+    {
+        _floorBackoff = new RegistrationBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(8), () => 0);
+        _midBackoff = new RegistrationBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(8), () => 0.5);
+    }
+
+    [Fact] void should_never_drop_below_half_the_exponential_delay() => _floorBackoff.NextDelay(1).ShouldEqual(TimeSpan.FromMilliseconds(500));
+    [Fact] void should_scale_the_exponential_delay_by_the_jitter() => _midBackoff.NextDelay(1).ShouldEqual(TimeSpan.FromMilliseconds(750));
+    [Fact] void should_jitter_the_capped_delay_as_well() => _floorBackoff.NextDelay(10).ShouldEqual(TimeSpan.FromSeconds(4));
+}

--- a/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_after_a_failed_run.cs
+++ b/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_after_a_failed_run.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations.for_SingleFlightRegistration;
+
+public class when_running_after_a_failed_run : Specification
+{
+    SingleFlightRegistration _runner;
+    List<TimeSpan> _requestedDelays;
+    int _invocations;
+    Exception _firstRunFailure;
+
+    void Establish()
+    {
+        _requestedDelays = [];
+        _runner = new SingleFlightRegistration(
+            () => _invocations++ == 0 ? Task.FromException(new FirstRunFailed()) : Task.CompletedTask,
+            new RegistrationBackoff(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(8), () => 1),
+            toWait =>
+            {
+                _requestedDelays.Add(toWait);
+                return Task.CompletedTask;
+            });
+    }
+
+    async Task Because()
+    {
+        _firstRunFailure = await Catch.Exception(_runner.Run);
+        await _runner.Run();
+        await _runner.Run();
+    }
+
+    [Fact] void should_surface_the_failure_to_the_caller() => _firstRunFailure.ShouldBeOfExactType<FirstRunFailed>();
+    [Fact] void should_back_off_before_the_run_that_follows_the_failure() => _requestedDelays.ShouldContainOnly(TimeSpan.FromSeconds(1));
+    [Fact] void should_stop_backing_off_once_a_run_succeeded() => _requestedDelays.Count.ShouldEqual(1);
+
+    /// <summary>
+    /// The exception the first run fails with in this specification.
+    /// </summary>
+    public class FirstRunFailed() : Exception("The first run failed");
+}

--- a/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_again_after_a_completed_run.cs
+++ b/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_again_after_a_completed_run.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations.for_SingleFlightRegistration;
+
+public class when_running_again_after_a_completed_run : Specification
+{
+    SingleFlightRegistration _runner;
+    List<TimeSpan> _requestedDelays;
+    int _invocations;
+
+    void Establish()
+    {
+        _requestedDelays = [];
+        _runner = new SingleFlightRegistration(
+            () =>
+            {
+                _invocations++;
+                return Task.CompletedTask;
+            },
+            new RegistrationBackoff(jitterSource: () => 1),
+            toWait =>
+            {
+                _requestedDelays.Add(toWait);
+                return Task.CompletedTask;
+            });
+    }
+
+    async Task Because()
+    {
+        await _runner.Run();
+        await _runner.Run();
+    }
+
+    [Fact] void should_invoke_the_action_for_each_run() => _invocations.ShouldEqual(2);
+    [Fact] void should_never_wait_when_no_run_has_failed() => _requestedDelays.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_while_a_run_is_in_flight.cs
+++ b/Source/Clients/DotNET.Specs/Registrations/for_SingleFlightRegistration/when_running_while_a_run_is_in_flight.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations.for_SingleFlightRegistration;
+
+public class when_running_while_a_run_is_in_flight : Specification
+{
+    SingleFlightRegistration _runner;
+    TaskCompletionSource _actionGate;
+    int _invocations;
+    Task _first;
+    Task _second;
+
+    void Establish()
+    {
+        _actionGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _runner = new SingleFlightRegistration(() =>
+        {
+            Interlocked.Increment(ref _invocations);
+            return _actionGate.Task;
+        });
+    }
+
+    async Task Because()
+    {
+        _first = _runner.Run();
+        _second = _runner.Run();
+        _actionGate.SetResult();
+        await Task.WhenAll(_first, _second);
+    }
+
+    [Fact] void should_share_the_in_flight_run() => _second.ShouldEqual(_first);
+    [Fact] void should_only_invoke_the_action_once() => _invocations.ShouldEqual(1);
+}

--- a/Source/Clients/DotNET.Specs/for_EventStore/when_registering_all/and_a_second_call_arrives_while_one_is_in_flight.cs
+++ b/Source/Clients/DotNET.Specs/for_EventStore/when_registering_all/and_a_second_call_arrives_while_one_is_in_flight.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts;
+
+namespace Cratis.Chronicle.for_EventStore.when_registering_all;
+
+/// <summary>
+/// The client half of a registration storm: a re-trigger - a reconnect, or any operation re-running connect after a
+/// failed registration - arrives while a registration is still on the wire. It must join the in-flight run rather
+/// than send the kernel a second copy of the same registration to queue behind the first.
+/// </summary>
+public class and_a_second_call_arrives_while_one_is_in_flight : given.an_event_store_with_a_projection_that_cannot_be_built
+{
+    TaskCompletionSource _kernelGate;
+    Task _first;
+    Task _second;
+
+    void Establish()
+    {
+        _clientArtifacts.Projections.Returns([typeof(BuildableProjection)]);
+        _kernelGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _servicesAccessor.Services.EventStores.Ensure(Arg.Any<EnsureEventStore>()).Returns(_ => _kernelGate.Task);
+    }
+
+    async Task Because()
+    {
+        await _projections.Discover();
+        _first = _eventStore.RegisterAll();
+        _second = _eventStore.RegisterAll();
+        _kernelGate.SetResult();
+        await Task.WhenAll(_first, _second);
+    }
+
+    [Fact] void should_share_the_in_flight_run() => _second.ShouldEqual(_first);
+    [Fact] void should_only_send_one_registration_to_the_kernel() => _servicesAccessor.Services.EventStores.Received(1).Ensure(Arg.Any<EnsureEventStore>());
+    [Fact] void should_report_the_shared_run_as_successful() => _eventStore.Registration.IsSuccess.ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/for_EventStore/when_registering_all/given/an_event_store_with_a_projection_that_cannot_be_built.cs
+++ b/Source/Clients/DotNET.Specs/for_EventStore/when_registering_all/given/an_event_store_with_a_projection_that_cannot_be_built.cs
@@ -30,6 +30,7 @@ public class an_event_store_with_a_projection_that_cannot_be_built : Specificati
     protected EventStore _eventStore;
     protected IProjections _projections;
     protected IClientArtifactsProvider _clientArtifacts;
+    protected IChronicleServicesAccessor _servicesAccessor;
 
     void Establish()
     {
@@ -64,10 +65,11 @@ public class an_event_store_with_a_projection_that_cannot_be_built : Specificati
         projections.Discover().GetAwaiter().GetResult();
         _projections = projections;
 
+        _servicesAccessor = Substitute.For<IChronicleServicesAccessor>();
         _eventStore = (EventStore)RuntimeHelpers.GetUninitializedObject(typeof(EventStore));
         SetField("_eventStoreName", new EventStoreName("Testing"));
         SetField("_clientArtifactsProvider", clientArtifacts);
-        SetField("_servicesAccessor", Substitute.For<IChronicleServicesAccessor>());
+        SetField("_servicesAccessor", _servicesAccessor);
         SetField("_logger", Substitute.For<ILogger<EventStore>>());
         SetField("_projections", projections);
         SetAutoProperty("Registration", Registrations.RegistrationOutcome.NotRun);

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -54,6 +54,7 @@ public class EventStore : IEventStore
     readonly IActivitySource<EventSequence> _activitySource;
     readonly ConcurrentDictionary<EventSequenceId, IEventSequence> _sequences = new();
     readonly Projections.Projections _projections;
+    SingleFlightRegistration? _registerAllFlight;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStore"/> class.
@@ -339,7 +340,51 @@ public class EventStore : IEventStore
     }
 
     /// <inheritdoc/>
-    public async Task RegisterAll()
+    /// <remarks>
+    /// Runs as a single flight per event store: a call that arrives while a run is in flight - a reconnect firing
+    /// while startup registration is still on the wire, or any operation re-triggering connect after a failed run -
+    /// joins that run instead of sending the kernel a second copy of the same registration. A run that follows a
+    /// failed one waits an exponentially growing, jittered backoff first, so a kernel that is too slow to accept the
+    /// registration sees the retry pressure back off instead of pile up. The flight is created lazily so an instance
+    /// materialized without its constructor - as specification harnesses do - still registers correctly.
+    /// </remarks>
+    public Task RegisterAll()
+    {
+        var flight = LazyInitializer.EnsureInitialized(
+            ref _registerAllFlight,
+            () => new SingleFlightRegistration(RegisterAllCore));
+        return flight.Run();
+    }
+
+    /// <inheritdoc/>
+    public IEventSequence GetEventSequence(EventSequenceId id) =>
+        _sequences.GetOrAdd(
+            id,
+            static (key, state) => new EventSequence(
+                state._eventStoreName,
+                state.Namespace,
+                key,
+                state.Connection,
+                state.EventTypes,
+                state.Constraints,
+                state.EventSerializer,
+                state._correlationIdAccessor,
+                state._concurrencyScopeStrategies,
+                state._causationManager,
+                state.UnitOfWorkManager,
+                state._identityProvider,
+                state._jsonSerializerOptions,
+                state._activitySource),
+            this);
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<EventStoreNamespaceName>> GetNamespaces(CancellationToken cancellationToken = default)
+    {
+        var namespaces = await _servicesAccessor.Services.Namespaces.GetNamespaces(new() { EventStore = _eventStoreName });
+        return namespaces.Select(_ => (EventStoreNamespaceName)_).ToArray();
+    }
+
+    async Task RegisterAllCore()
     {
         _logger.RegisterAllArtifacts();
 
@@ -386,34 +431,6 @@ public class EventStore : IEventStore
             Registration = new RegistrationOutcome(true, _projections.ArtifactRegistrations, exception);
             throw;
         }
-    }
-
-    /// <inheritdoc/>
-    public IEventSequence GetEventSequence(EventSequenceId id) =>
-        _sequences.GetOrAdd(
-            id,
-            static (key, state) => new EventSequence(
-                state._eventStoreName,
-                state.Namespace,
-                key,
-                state.Connection,
-                state.EventTypes,
-                state.Constraints,
-                state.EventSerializer,
-                state._correlationIdAccessor,
-                state._concurrencyScopeStrategies,
-                state._causationManager,
-                state.UnitOfWorkManager,
-                state._identityProvider,
-                state._jsonSerializerOptions,
-                state._activitySource),
-            this);
-
-    /// <inheritdoc/>
-    public async Task<IEnumerable<EventStoreNamespaceName>> GetNamespaces(CancellationToken cancellationToken = default)
-    {
-        var namespaces = await _servicesAccessor.Services.Namespaces.GetNamespaces(new() { EventStore = _eventStoreName });
-        return namespaces.Select(_ => (EventStoreNamespaceName)_).ToArray();
     }
 
     async Task RegisterExternalEventStoreSubscriptionsAsync()

--- a/Source/Clients/DotNET/Registrations/RegistrationBackoff.cs
+++ b/Source/Clients/DotNET/Registrations/RegistrationBackoff.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations;
+
+/// <summary>
+/// Computes how long a registration run should wait before hitting the wire again after failed runs.
+/// </summary>
+/// <remarks>
+/// The delay grows exponentially with the number of consecutive failures and is capped, so a kernel that is slow to
+/// accept a large registration sees the pressure back off instead of build up. The delay is jittered to between half
+/// and the full exponential value, so replicas that failed together do not retry together.
+/// </remarks>
+/// <param name="initialDelay">Delay after the first failure. Defaults to one second.</param>
+/// <param name="maximumDelay">Upper bound for the delay. Defaults to one minute.</param>
+/// <param name="jitterSource">Source of jitter values in [0, 1). Defaults to <see cref="Random.Shared"/>.</param>
+internal sealed class RegistrationBackoff(TimeSpan? initialDelay = null, TimeSpan? maximumDelay = null, Func<double>? jitterSource = null)
+{
+    readonly TimeSpan _initialDelay = initialDelay ?? TimeSpan.FromSeconds(1);
+    readonly TimeSpan _maximumDelay = maximumDelay ?? TimeSpan.FromMinutes(1);
+    readonly Func<double> _jitterSource = jitterSource ?? Random.Shared.NextDouble;
+
+    /// <summary>
+    /// Get the delay to wait before the next run.
+    /// </summary>
+    /// <param name="consecutiveFailures">Number of runs that have failed in a row. Zero means the previous run succeeded or there has been none.</param>
+    /// <returns>The <see cref="TimeSpan"/> to wait; <see cref="TimeSpan.Zero"/> when there is nothing to back off from.</returns>
+    public TimeSpan NextDelay(int consecutiveFailures)
+    {
+        if (consecutiveFailures <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var exponential = _initialDelay * Math.Pow(2, consecutiveFailures - 1);
+        if (exponential > _maximumDelay)
+        {
+            exponential = _maximumDelay;
+        }
+
+        return exponential * (0.5 + (0.5 * _jitterSource()));
+    }
+}

--- a/Source/Clients/DotNET/Registrations/SingleFlightRegistration.cs
+++ b/Source/Clients/DotNET/Registrations/SingleFlightRegistration.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Registrations;
+
+/// <summary>
+/// Runs a registration action as a single flight: callers that arrive while a run is in flight await that same run
+/// instead of starting another, and a run that follows a failed one waits a backoff delay before hitting the wire.
+/// </summary>
+/// <remarks>
+/// Registration requests are heavy on the kernel side and idempotent from the caller's point of view, so there is
+/// never a reason to have two of them from the same client in flight at once. Stacking them is actively harmful: a
+/// request that timed out client-side is usually still queued kernel-side, and every immediate retry adds the same
+/// workload to a queue that is already too slow to answer - the feedback loop behind a registration storm. Sharing
+/// the in-flight run and pacing the next one with <see cref="RegistrationBackoff"/> breaks that loop at the client.
+/// </remarks>
+/// <param name="action">The registration action to run.</param>
+/// <param name="backoff">Optional <see cref="RegistrationBackoff"/> deciding the delay after failed runs.</param>
+/// <param name="delay">Optional delay implementation, for deciding how to wait. Defaults to <see cref="Task.Delay(TimeSpan)"/>.</param>
+internal sealed class SingleFlightRegistration(Func<Task> action, RegistrationBackoff? backoff = null, Func<TimeSpan, Task>? delay = null)
+{
+    readonly RegistrationBackoff _backoff = backoff ?? new();
+    readonly Func<TimeSpan, Task> _delay = delay ?? (toWait => Task.Delay(toWait));
+    readonly object _gate = new();
+    Task? _inFlight;
+    int _consecutiveFailures;
+
+    /// <summary>
+    /// Run the registration action, or join the run that is already in flight.
+    /// </summary>
+    /// <returns>The task representing the shared run; it faults when the action does.</returns>
+    public Task Run()
+    {
+        lock (_gate)
+        {
+            _inFlight ??= RunSingleFlight();
+            return _inFlight;
+        }
+    }
+
+    async Task RunSingleFlight()
+    {
+        // Leave the caller's lock before doing any work, so the action never runs while the gate is held.
+        await Task.Yield();
+
+        try
+        {
+            var toWait = _backoff.NextDelay(_consecutiveFailures);
+            if (toWait > TimeSpan.Zero)
+            {
+                await _delay(toWait);
+            }
+
+            await action();
+            _consecutiveFailures = 0;
+        }
+        catch
+        {
+            _consecutiveFailures++;
+            throw;
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _inFlight = null;
+            }
+        }
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/given/a_projections_manager_grain.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/given/a_projections_manager_grain.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventTypes;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Namespaces;
+using Cratis.Chronicle.Projections.Engine;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Schemas;
+using Orleans.Core;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.given;
+
+public class a_projections_manager_grain : Specification
+{
+    protected const string EventStore = "the-event-store";
+
+    protected ProjectionsManager _grain;
+    protected TestKitSilo _silo;
+    protected IProjectionsServiceClient _projectionsServiceClient;
+    protected IProjectionDefinitionComparer _definitionComparer;
+    protected IProjection _projectionGrain;
+    protected Observation.IObserver _observerGrain;
+    protected ProjectionsManagerState _state;
+    protected IEnumerable<ReadModelDefinition> _readModelDefinitions = [];
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+
+        _definitionComparer = Substitute.For<IProjectionDefinitionComparer>();
+        _silo.AddService(_definitionComparer);
+
+        var engineProjection = Substitute.For<Engine.IProjection>();
+        engineProjection.EventTypes.Returns([]);
+        engineProjection.IsEventSourceKeyed.Returns(true);
+        var projectionFactory = Substitute.For<IProjectionFactory>();
+        projectionFactory
+            .Create(
+                Arg.Any<EventStoreName>(),
+                Arg.Any<EventStoreNamespaceName>(),
+                Arg.Any<ProjectionDefinition>(),
+                Arg.Any<ReadModelDefinition>(),
+                Arg.Any<IEnumerable<EventTypeSchema>>())
+            .Returns(engineProjection);
+        _silo.AddService(projectionFactory);
+
+        _projectionsServiceClient = Substitute.For<IProjectionsServiceClient>();
+        _silo.AddService(_projectionsServiceClient);
+
+        _silo.AddService(Substitute.For<ILanguageService>());
+
+        var storage = Substitute.For<Storage.IStorage>();
+        storage.GetEventStore(Arg.Any<EventStoreName>()).EventTypes.GetLatestForAllEventTypes().Returns([]);
+        _silo.AddService(storage);
+
+        _silo.AddService(Substitute.For<ILocalSiloDetails>());
+
+        var namespaces = Substitute.For<INamespaces>();
+        namespaces.GetAll().Returns([EventStoreNamespaceName.Default]);
+        _silo.AddProbe(_ => namespaces);
+
+        var readModelsManager = Substitute.For<IReadModelsManager>();
+        readModelsManager.GetDefinitions().Returns(_ => Task.FromResult(_readModelDefinitions));
+        _silo.AddProbe(_ => readModelsManager);
+
+        _projectionGrain = Substitute.For<IProjection>();
+        _silo.AddProbe(_ => _projectionGrain);
+
+        _observerGrain = Substitute.For<Observation.IObserver>();
+        _silo.AddProbe(_ => _observerGrain);
+
+        _state = new ProjectionsManagerState();
+        var stateStorage = Substitute.For<IStorage<ProjectionsManagerState>>();
+        stateStorage.State = _state;
+        _silo.Options.StorageFactory = _ => stateStorage;
+
+        _grain = await _silo.CreateGrainAsync<ProjectionsManager>(EventStore);
+    }
+
+    protected static ProjectionDefinition CreateDefinition(ProjectionId identifier, ReadModelIdentifier readModel) => new(
+        ProjectionOwner.Client,
+        EventSequenceId.Log,
+        identifier,
+        readModel,
+        true,
+        true,
+        new JsonObject(),
+        new Dictionary<EventType, FromDefinition>(),
+        new Dictionary<EventType, JoinDefinition>(),
+        new Dictionary<PropertyPath, ChildrenDefinition>(),
+        [],
+        new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+        new Dictionary<EventType, RemovedWithDefinition>(),
+        new Dictionary<EventType, RemovedWithJoinDefinition>());
+
+    protected static ReadModelDefinition CreateReadModelDefinition(ReadModelIdentifier identifier) => new(
+        identifier,
+        "TheReadModel",
+        "TheReadModel",
+        ReadModelOwner.Client,
+        ReadModelSource.Code,
+        ReadModelObserverType.Projection,
+        ReadModelObserverIdentifier.Unspecified,
+        SinkDefinition.None,
+        new Dictionary<ReadModelGeneration, JsonSchema>(),
+        []);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_a_definition_has_changed.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_a_definition_has_changed.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+public class and_a_definition_has_changed : given.a_projections_manager_grain
+{
+    ProjectionDefinition _existing;
+    ProjectionDefinition _incoming;
+
+    void Establish()
+    {
+        _existing = CreateDefinition("the-projection", "the-read-model");
+        _incoming = _existing with { IsRewindable = false };
+        _state.Projections = [_existing];
+        _readModelDefinitions = [CreateReadModelDefinition("the-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Different);
+    }
+
+    async Task Because() => await _grain.Register([_incoming]);
+
+    [Fact]
+    void should_register_the_changed_definition_with_the_engine() =>
+        _projectionsServiceClient.Received(1).Register(
+            (EventStoreName)EventStore,
+            Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _incoming })));
+
+    [Fact] void should_set_the_definition_on_the_projection_grain() => _projectionGrain.Received(1).SetDefinition(_incoming);
+
+    [Fact]
+    void should_subscribe_the_observer() =>
+        _observerGrain.Received(1).Subscribe<IProjectionObserverSubscriber>(
+            ObserverType.Projection,
+            Arg.Any<IEnumerable<EventType>>(),
+            Arg.Any<SiloAddress>());
+
+    [Fact] void should_replace_the_registered_definition() => _state.Projections.ShouldContainOnly(_incoming);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_a_definition_is_new.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_a_definition_is_new.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+public class and_a_definition_is_new : given.a_projections_manager_grain
+{
+    ProjectionDefinition _incoming;
+
+    void Establish()
+    {
+        _incoming = CreateDefinition("the-projection", "the-read-model");
+        _readModelDefinitions = [CreateReadModelDefinition("the-read-model")];
+    }
+
+    async Task Because() => await _grain.Register([_incoming]);
+
+    [Fact] void should_not_consult_the_comparer() => _definitionComparer.DidNotReceiveWithAnyArgs().Compare(default!, default!, default!);
+
+    [Fact]
+    void should_register_the_definition_with_the_engine() =>
+        _projectionsServiceClient.Received(1).Register(
+            (EventStoreName)EventStore,
+            Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _incoming })));
+
+    [Fact] void should_set_the_definition_on_the_projection_grain() => _projectionGrain.Received(1).SetDefinition(_incoming);
+    [Fact] void should_add_the_definition_to_the_registered_ones() => _state.Projections.ShouldContainOnly(_incoming);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_all_definitions_are_unchanged.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_all_definitions_are_unchanged.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+public class and_all_definitions_are_unchanged : given.a_projections_manager_grain
+{
+    ProjectionDefinition _existing;
+    ProjectionDefinition _incoming;
+
+    void Establish()
+    {
+        _existing = CreateDefinition("the-projection", "the-read-model");
+        _incoming = CreateDefinition("the-projection", "the-read-model");
+        _state.Projections = [_existing];
+        _readModelDefinitions = [CreateReadModelDefinition("the-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because() => await _grain.Register([_incoming]);
+
+    [Fact] void should_not_register_with_the_engine() => _projectionsServiceClient.DidNotReceiveWithAnyArgs().Register(default!, default!);
+    [Fact] void should_not_set_any_projection_definition() => _projectionGrain.DidNotReceiveWithAnyArgs().SetDefinition(default!);
+    [Fact] void should_not_touch_any_observer() => _observerGrain.ReceivedCalls().ShouldBeEmpty();
+    [Fact] void should_leave_the_registered_definitions_untouched() => _state.Projections.ShouldContainOnly(_existing);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_only_some_definitions_have_changed.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_only_some_definitions_have_changed.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+public class and_only_some_definitions_have_changed : given.a_projections_manager_grain
+{
+    ProjectionDefinition _unchangedExisting;
+    ProjectionDefinition _unchangedIncoming;
+    ProjectionDefinition _changedExisting;
+    ProjectionDefinition _changedIncoming;
+
+    void Establish()
+    {
+        _unchangedExisting = CreateDefinition("unchanged-projection", "the-read-model");
+        _unchangedIncoming = CreateDefinition("unchanged-projection", "the-read-model");
+        _changedExisting = CreateDefinition("changed-projection", "the-read-model");
+        _changedIncoming = _changedExisting with { IsRewindable = false };
+        _state.Projections = [_unchangedExisting, _changedExisting];
+        _readModelDefinitions = [CreateReadModelDefinition("the-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), _unchangedExisting, _unchangedIncoming)
+            .Returns(ProjectionDefinitionCompareResult.Same);
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), _changedExisting, _changedIncoming)
+            .Returns(ProjectionDefinitionCompareResult.Different);
+    }
+
+    async Task Because() => await _grain.Register([_unchangedIncoming, _changedIncoming]);
+
+    [Fact]
+    void should_only_register_the_changed_definition_with_the_engine() =>
+        _projectionsServiceClient.Received(1).Register(
+            (EventStoreName)EventStore,
+            Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _changedIncoming })));
+
+    [Fact] void should_only_set_the_changed_definition_on_its_projection_grain() => _projectionGrain.Received(1).SetDefinition(_changedIncoming);
+
+    [Fact]
+    void should_keep_the_unchanged_definition_and_replace_the_changed_one() =>
+        _state.Projections.ShouldContainOnly(_unchangedExisting, _changedIncoming);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_registering_identical_definitions_a_second_time.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_registering_identical_definitions_a_second_time.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+/// <summary>
+/// The registration-storm shape: the same registration arrives again - a retry, another replica of the same client
+/// version, or a request that was still queued when its sender gave up. The first request does the work; because the
+/// grain is non-reentrant every duplicate runs after it, compares equal against the registered state and returns
+/// without repeating the per-namespace fan-out.
+/// </summary>
+public class and_registering_identical_definitions_a_second_time : given.a_projections_manager_grain
+{
+    ProjectionDefinition _definition;
+    ProjectionDefinition _identicalDefinition;
+
+    void Establish()
+    {
+        _definition = CreateDefinition("the-projection", "the-read-model");
+        _identicalDefinition = CreateDefinition("the-projection", "the-read-model");
+        _readModelDefinitions = [CreateReadModelDefinition("the-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because()
+    {
+        await _grain.Register([_definition]);
+        await _grain.Register([_identicalDefinition]);
+    }
+
+    [Fact] void should_only_register_with_the_engine_once() => _projectionsServiceClient.ReceivedWithAnyArgs(1).Register(default!, default!);
+    [Fact] void should_only_set_the_projection_definition_once() => _projectionGrain.ReceivedWithAnyArgs(1).SetDefinition(default!);
+    [Fact] void should_keep_the_first_registration_as_the_registered_state() => _state.Projections.ShouldContainOnly(_definition);
+}

--- a/Source/Kernel/Core/Projections/ProjectionsManager.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.EventTypes;
 using Cratis.Chronicle.Concepts.Observation;
 using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
@@ -23,6 +24,7 @@ namespace Cratis.Chronicle.Projections;
 /// </summary>
 /// <param name="projectionFactory"><see cref="IProjectionFactory"/> for creating projections.</param>
 /// <param name="projectionsService"><see cref="IProjectionsServiceClient"/> for managing projections.</param>
+/// <param name="projectionDefinitionComparer"><see cref="IProjectionDefinitionComparer"/> for comparing incoming definitions against the registered ones.</param>
 /// <param name="languageService"><see cref="Generator"/> for generating projection declaration language strings.</param>
 /// <param name="storage"><see cref="IStorage"/> for accessing storage.</param>
 /// <param name="localSiloDetails"><see cref="ILocalSiloDetails"/> for getting the local silo details.</param>
@@ -32,6 +34,7 @@ namespace Cratis.Chronicle.Projections;
 public class ProjectionsManager(
     IProjectionFactory projectionFactory,
     IProjectionsServiceClient projectionsService,
+    IProjectionDefinitionComparer projectionDefinitionComparer,
     ILanguageService languageService,
     IStorage storage,
     ILocalSiloDetails localSiloDetails,
@@ -54,12 +57,29 @@ public class ProjectionsManager(
     /// <inheritdoc/>
     public async Task Register(IEnumerable<ProjectionDefinition> definitions)
     {
-        var definitionsToRegister = definitions.ToList();
-        await projectionsService.Register(_eventStoreName, definitionsToRegister);
+        // Same-version client replicas re-register identical definitions on every startup and reconnect. Handling
+        // only what actually changed makes such a re-registration near-free, and because this grain is non-reentrant
+        // it also collapses a queue of identical registrations: the first request does the work, every queued
+        // duplicate compares equal against the registered state and returns immediately instead of repeating the
+        // per-namespace fan-out. Without this, stacked retries kept the request queue from ever draining.
+        var changedDefinitions = await GetChangedDefinitions(definitions);
+        if (changedDefinitions.Count == 0)
+        {
+            logger.AllDefinitionsUnchanged();
+            return;
+        }
 
-        // Merge new definitions with existing ones, replacing any with the same identifier
+        logger.RegisteringChangedDefinitions(changedDefinitions.Count);
+        await projectionsService.Register(_eventStoreName, changedDefinitions);
+
+        // Subscribe projections immediately so that seeded events appended after registration
+        // are not missed due to the asynchronous timer-based subscription scheduling
+        await SetDefinitionAndSubscribeForProjections(changedDefinitions);
+
+        // Merge into the state only after the engine and the projection grains have accepted the definitions, so an
+        // interrupted registration is retried in full on the next attempt instead of being skipped as unchanged.
         var existingProjections = State.Projections.ToList();
-        foreach (var newDefinition in definitions)
+        foreach (var newDefinition in changedDefinitions)
         {
             var existingIndex = existingProjections.FindIndex(p => p.Identifier == newDefinition.Identifier);
             if (existingIndex >= 0)
@@ -74,10 +94,6 @@ public class ProjectionsManager(
 
         State.Projections = existingProjections;
         await WriteStateAsync();
-
-        // Subscribe projections immediately so that seeded events appended after registration
-        // are not missed due to the asynchronous timer-based subscription scheduling
-        await SetDefinitionAndSubscribeForAllProjections();
     }
 
     /// <inheritdoc/>
@@ -121,6 +137,7 @@ public class ProjectionsManager(
     {
         await projectionsService.NamespaceAdded(_eventStoreName, added.Namespace);
         var readModelDefinitions = await GrainFactory.GetGrain<IReadModelsManager>(_eventStoreName).GetDefinitions();
+        var eventTypeSchemas = await storage.GetEventStore(_eventStoreName).EventTypes.GetLatestForAllEventTypes();
 
         await Task.WhenAll(State.Projections.Select(async projectionDefinition =>
         {
@@ -134,8 +151,33 @@ public class ProjectionsManager(
                 return;
             }
 
-            await SubscribeIfNotSubscribed(projectionDefinition, readModelDefinition, added.Namespace);
+            await SubscribeIfNotSubscribed(projectionDefinition, readModelDefinition, added.Namespace, eventTypeSchemas);
         }));
+    }
+
+    async Task<IReadOnlyList<ProjectionDefinition>> GetChangedDefinitions(IEnumerable<ProjectionDefinition> definitions)
+    {
+        var changed = new List<ProjectionDefinition>();
+        foreach (var definition in definitions)
+        {
+            var existing = State.Projections.FirstOrDefault(p => p.Identifier == definition.Identifier);
+            if (existing is null)
+            {
+                changed.Add(definition);
+                continue;
+            }
+
+            var compareResult = await projectionDefinitionComparer.Compare(
+                new ProjectionKey(definition.Identifier, _eventStoreName),
+                existing,
+                definition);
+            if (compareResult != ProjectionDefinitionCompareResult.Same)
+            {
+                changed.Add(definition);
+            }
+        }
+
+        return changed;
     }
 
     async Task SetDefinitionAndSubscribeForAllProjections()
@@ -148,6 +190,11 @@ public class ProjectionsManager(
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_eventStoreName).GetAll();
         var readModelDefinitions = await GrainFactory.GetGrain<IReadModelsManager>(_eventStoreName).GetDefinitions();
 
+        // The event type schemas are the same for every definition and namespace in this pass; fetching them once
+        // here instead of per subscription keeps a registration from fanning out into definitions × namespaces
+        // storage reads.
+        var eventTypeSchemas = await storage.GetEventStore(_eventStoreName).EventTypes.GetLatestForAllEventTypes();
+
         await Task.WhenAll(definitions.Select(async definition =>
         {
             var readModelDefinition = readModelDefinitions.SingleOrDefault(rm => rm.Identifier == definition.ReadModel);
@@ -157,11 +204,11 @@ public class ProjectionsManager(
                 return;
             }
 
-            await SetDefinitionAndSubscribeForProjection(namespaces, definition, readModelDefinition);
+            await SetDefinitionAndSubscribeForProjection(namespaces, definition, readModelDefinition, eventTypeSchemas);
         }));
     }
 
-    async Task SetDefinitionAndSubscribeForProjection(IEnumerable<EventStoreNamespaceName> namespaces, ProjectionDefinition definition, ReadModelDefinition readModelDefinition)
+    async Task SetDefinitionAndSubscribeForProjection(IEnumerable<EventStoreNamespaceName> namespaces, ProjectionDefinition definition, ReadModelDefinition readModelDefinition, IEnumerable<EventTypeSchema> eventTypeSchemas)
     {
         logger.SettingDefinition(definition.Identifier);
         var key = new ProjectionKey(definition.Identifier, _eventStoreName);
@@ -173,10 +220,10 @@ public class ProjectionsManager(
             return;
         }
 
-        await Task.WhenAll(namespaces.Select(namespaceName => SubscribeIfNotSubscribed(definition, readModelDefinition, namespaceName)));
+        await Task.WhenAll(namespaces.Select(namespaceName => SubscribeIfNotSubscribed(definition, readModelDefinition, namespaceName, eventTypeSchemas)));
     }
 
-    async Task SubscribeIfNotSubscribed(ProjectionDefinition definition, ReadModelDefinition readModelDefinition, EventStoreNamespaceName namespaceName)
+    async Task SubscribeIfNotSubscribed(ProjectionDefinition definition, ReadModelDefinition readModelDefinition, EventStoreNamespaceName namespaceName, IEnumerable<EventTypeSchema> eventTypeSchemas)
     {
         if (!definition.IsActive)
         {
@@ -186,8 +233,6 @@ public class ProjectionsManager(
         var observer = GrainFactory.GetGrain<IObserver>(new ObserverKey(definition.Identifier, _eventStoreName, namespaceName, definition.EventSequenceId));
 
         logger.Subscribing(definition.Identifier, namespaceName);
-        var eventStoreStorage = storage.GetEventStore(_eventStoreName);
-        var eventTypeSchemas = await eventStoreStorage.EventTypes.GetLatestForAllEventTypes();
         var projection = await projectionFactory.Create(_eventStoreName, namespaceName, definition, readModelDefinition, eventTypeSchemas);
 
         logger.SubscribingWithEventTypes(

--- a/Source/Kernel/Core/Projections/ProjectionsManagerLogging.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsManagerLogging.cs
@@ -24,4 +24,10 @@ internal static partial class ProjectionsManagerLogging
 
     [LoggerMessage(LogLevel.Warning, "Read model definition '{ReadModel}' not found for projection '{Identifier}'")]
     internal static partial void MissingReadModelDefinitionForProjection(this ILogger<ProjectionsManager> logger, ProjectionId identifier, ReadModelIdentifier readModel);
+
+    [LoggerMessage(LogLevel.Debug, "All projection definitions in the registration are identical to the registered ones - skipping registration work")]
+    internal static partial void AllDefinitionsUnchanged(this ILogger<ProjectionsManager> logger);
+
+    [LoggerMessage(LogLevel.Debug, "Registering {Count} changed projection definitions")]
+    internal static partial void RegisteringChangedDefinitions(this ILogger<ProjectionsManager> logger, int count);
 }


### PR DESCRIPTION
# Summary

A rolling redeploy of client services could turn projection registration into a self-sustaining storm: every replica re-registered the same definitions on startup, the kernel processed the full fan-out every time, callers timed out while their request was still queued, and their retries enqueued the same workload again - so the queue never drained. This makes an identical re-registration near-free on the kernel and stops the client from stacking retries.

## Fixed

- Registering projection definitions that are identical to the ones already registered no longer repeats the registration fan-out - the kernel only processes definitions that are new or changed, so restarting or reconnecting clients of the same version register near-instantly and queued duplicate registrations collapse instead of piling up
- The .NET client no longer stacks registration retries: `RegisterAll` runs as a single flight per event store - a call arriving while a registration is in flight joins that run instead of sending a duplicate - and a run that follows a failure waits an exponentially growing, jittered backoff before hitting the kernel again
- An interrupted registration is retried in full on the next attempt instead of being skipped as already registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)