### PR TITLE
Pin the read model shape guards that no spec could falsify

### DIFF
--- a/Integration/Client/for_ReadModels/when_getting_instance_with_an_unset_optional/and_the_optional_is_an_enum.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instance_with_an_unset_optional/and_the_optional_is_an_enum.cs
@@ -73,6 +73,16 @@ public class and_the_optional_is_an_enum(context context) : Given<context>(conte
     [Fact] void should_have_read_the_stored_document_when_the_backend_allows_it() => (!Context.DocumentCanBeInspected || Context.StoredDocument is not null).ShouldBeTrue();
     [Fact] void should_not_store_an_answer_the_read_model_never_gave() => (!Context.DocumentCanBeInspected || !Context.StoredDocument!.Contains(nameof(SignedContract.Outcome))).ShouldBeTrue();
     [Fact] void should_store_the_property_that_was_set() => (!Context.DocumentCanBeInspected || Context.StoredDocument!.Contains(nameof(SignedContract.Signer))).ShouldBeTrue();
+
+    /// <remarks>
+    /// This read model reaches the code under test only because it carries a <see cref="PIIAttribute"/>, which is what
+    /// sends its whole state through the registered schema on the way into the sink. That is a precondition, not a
+    /// subject, and every other assertion here is satisfied identically when it stops holding - so without this one a
+    /// regression in compliance detection would leave the spec green while it quietly stopped exercising anything.
+    /// Reading it back cannot tell the difference either, since the released value is the plaintext either way; only
+    /// the stored bytes can.
+    /// </remarks>
+    [Fact] void should_store_the_pii_property_encrypted() => (!Context.DocumentCanBeInspected || Context.StoredDocument![nameof(SignedContract.Signer)].AsString != "Ada Lovelace").ShouldBeTrue();
 }
 
 [PII]

--- a/Integration/Client/for_ReadModels/when_getting_instance_with_an_unset_optional/and_the_optional_is_an_enum.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instance_with_an_unset_optional/and_the_optional_is_an_enum.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using MongoDB.Bson;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_with_an_unset_optional.and_the_optional_is_an_enum.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_getting_instance_with_an_unset_optional;
+
+/// <summary>
+/// The enum case of the unset optional, driven through the compliance write path and asserted on the document at
+/// rest. A read model carrying a <c>[PII]</c> value has its whole state converted through its registered schema
+/// on the way into the sink, and every schema property with no value is offered a type default there. An optional
+/// one must be offered none, so its field is simply never written - and after a projection replay, never stamped
+/// onto every stored record.
+/// </summary>
+/// <remarks>
+/// The enum declares a zero member, and that is the whole reason this spec can fail. The obvious subject - a
+/// 1-based enum, the one the defect was reported against - cannot be observed here at all: the converter encodes
+/// an enum by member name, so a value outside the declared list has no name to write and the field stays absent
+/// whether the default was withheld deliberately or refused incidentally. Both answers look identical at rest, so
+/// a spec built on that subject would be green against a kernel with the fix removed. An enum whose zero <em>is</em>
+/// declared has a name for it, and the difference between withheld and written becomes a difference in the stored
+/// document.
+/// <para>
+/// The read-back assertion is deliberately paired with the at-rest one rather than trusted alone - a round trip
+/// resolves through the same member list and cannot, on its own, separate an absent field from a stored value the
+/// schema forbids.
+/// </para>
+/// </remarks>
+/// <param name="context">The scenario context.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_the_optional_is_an_enum(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        const string CollectionName = "SignedContracts";
+
+        public EventSourceId ContractId { get; } = "unset-optional-enum-contract-1";
+        public SignedContract? Instance { get; private set; }
+        public BsonDocument? StoredDocument { get; private set; }
+
+        public bool DocumentCanBeInspected => StoredReadModelDocument.CanBeInspected(ChronicleFixture);
+
+        public override IEnumerable<Type> EventTypes => [typeof(ContractSigned), typeof(ContractRejected)];
+
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(SignedContract)];
+
+        async Task Because()
+        {
+            // Only the creating event fires. ContractRejected - the source of the optional Outcome - never does.
+            await EventStore.EventLog.Append(ContractId, new ContractSigned("Ada Lovelace"));
+
+            using var cts = new CancellationTokenSource(TimeSpanFactory.DefaultTimeout());
+            while (Instance?.Signer is null)
+            {
+                Instance = await EventStore.ReadModels.GetInstanceById<SignedContract>(ContractId.Value);
+                if (Instance?.Signer is not null) break;
+                await Task.Delay(200, cts.Token);
+            }
+
+            StoredDocument = await StoredReadModelDocument.Read(ChronicleFixture, CollectionName);
+        }
+    }
+
+    [Fact] void should_return_the_instance() => Context.Instance.ShouldNotBeNull();
+    [Fact] void should_release_the_pii_property() => Context.Instance!.Signer.Value.ShouldEqual("Ada Lovelace");
+    [Fact] void should_read_back_the_unset_optional_as_null() => Context.Instance!.Outcome.ShouldBeNull();
+    [Fact] void should_have_read_the_stored_document_when_the_backend_allows_it() => (!Context.DocumentCanBeInspected || Context.StoredDocument is not null).ShouldBeTrue();
+    [Fact] void should_not_store_an_answer_the_read_model_never_gave() => (!Context.DocumentCanBeInspected || !Context.StoredDocument!.Contains(nameof(SignedContract.Outcome))).ShouldBeTrue();
+    [Fact] void should_store_the_property_that_was_set() => (!Context.DocumentCanBeInspected || Context.StoredDocument!.Contains(nameof(SignedContract.Signer))).ShouldBeTrue();
+}
+
+[PII]
+public record SignerName(string Value) : ConceptAs<string>(Value)
+{
+    public static implicit operator SignerName(string value) => new(value);
+}
+
+public enum SigningOutcome
+{
+    NotSet = 0,
+    RejectedBySigner = 1,
+    Expired = 2,
+    Withdrawn = 3
+}
+
+[EventType]
+public record ContractSigned(SignerName Signer);
+
+[EventType]
+public record ContractRejected(SigningOutcome Outcome);
+
+[FromEvent<ContractSigned>]
+public record SignedContract(
+    string Id,
+    SignerName Signer,
+
+    [property: SetFrom<ContractRejected>(nameof(ContractRejected.Outcome))]
+    SigningOutcome? Outcome);
+
+#pragma warning restore SA1402

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/and_it_is_not_nullable.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/and_it_is_not_nullable.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator.when_generating_schema_for_a_type_with_an_enum;
+
+/// <summary>
+/// The other half of the same wire, and the half that keeps the first half honest: a nullability reading that
+/// answered true for everything would satisfy the nullable case exactly as well as a correct one, and would take
+/// the whole withheld-default decision with it - every required property would stop being written. The required
+/// enum is what makes that indistinguishable pass distinguishable.
+/// <para>
+/// It is also the subject the member-list guard is left holding on its own. Nullability does not exempt it, so
+/// what keeps <c>0</c> out of a 1-based enum here is only that <c>0</c> is not one of its declared members.
+/// </para>
+/// </summary>
+public class and_it_is_not_nullable : given.a_contract_with_an_enum
+{
+    void Because() => _result = _generator.Generate(typeof(Contract));
+
+    [Fact] void should_carry_the_declared_members() => MembersOf(nameof(Contract.Status)).ShouldContainOnly(1L, 2L, 3L);
+    [Fact] void should_not_mark_it_as_nullable() => PropertyNamed(nameof(Contract.Status)).IsNullable().ShouldBeFalse();
+    [Fact] void should_withhold_a_default_outside_its_declared_members() => PropertyNamed(nameof(Contract.Status)).GetDefaultValue(_typeFormats).ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/and_it_is_nullable.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/and_it_is_nullable.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator.when_generating_schema_for_a_type_with_an_enum;
+
+/// <summary>
+/// The converter's withheld-default behavior reads nullability off the generated schema, and an enum is the one
+/// case where the two do not obviously meet: a formatted scalar marks itself nullable with a trailing <c>?</c> on
+/// its <c>format</c>, but an enum has no format, so the marker has to be the <c>"null"</c> entry in its type. If
+/// the generator ever emitted a nullable enum some other way - a <c>oneOf</c>, a <c>$ref</c>, a bare
+/// <c>"integer"</c> - the converter would read it as required and start writing type defaults again, while every
+/// spec written against a hand-authored schema stayed green.
+/// </summary>
+/// <remarks>
+/// The <c>"null"</c> entry itself is written by the <c>System.Text.Json</c> schema exporter, so no change to this
+/// repository can make that emission stop - <see cref="should_mark_it_as_nullable"/> is a contract pin on an
+/// upstream dependency, not a fence over Chronicle code. What it buys is a failing spec on the day that
+/// dependency changes shape, which is exactly the day the fix silently stops working.
+/// <para>
+/// <see cref="should_withhold_a_default_for_it"/> is a statement of the behavior rather than a fence over it: a
+/// 1-based nullable enum is withheld by nullability and by its member list at once, so removing either reading
+/// leaves it passing. <see cref="should_withhold_a_default_for_a_declared_zero"/> is the one that can fail for a
+/// single reason, and it is the same subject the converter's own specs use to separate the two.
+/// </para>
+/// </remarks>
+public class and_it_is_nullable : given.a_contract_with_an_enum
+{
+    void Because() => _result = _generator.Generate(typeof(Contract));
+
+    [Fact] void should_carry_the_declared_members() => MembersOf(nameof(Contract.Reason)).ShouldContainOnly(1L, 2L, 3L);
+    [Fact] void should_mark_it_as_nullable() => PropertyNamed(nameof(Contract.Reason)).IsNullable().ShouldBeTrue();
+    [Fact] void should_withhold_a_default_for_it() => PropertyNamed(nameof(Contract.Reason)).GetDefaultValue(_typeFormats).ShouldBeNull();
+    [Fact] void should_mark_a_declared_zero_enum_as_nullable() => PropertyNamed(nameof(Contract.Feedback)).IsNullable().ShouldBeTrue();
+    [Fact] void should_withhold_a_default_for_a_declared_zero() => PropertyNamed(nameof(Contract.Feedback)).GetDefaultValue(_typeFormats).ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/given/a_contract_with_an_enum.cs
+++ b/Source/Clients/DotNET.Specs/Schemas/for_JsonSchemaGenerator/when_generating_schema_for_a_type_with_an_enum/given/a_contract_with_an_enum.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaGenerator.when_generating_schema_for_a_type_with_an_enum.given;
+
+/// <summary>
+/// A read model with an optional and a required enum of the same 1-based type - the shape the withheld-default
+/// behavior is decided on - plus a nullable enum that declares a zero member.
+/// </summary>
+/// <remarks>
+/// Two independent readings decide whether a default is withheld, and on a 1-based enum both of them say withhold
+/// it, so any assertion about that type alone is satisfied by either reading on its own. The enum that declares a
+/// zero is the one subject only nullability can account for, which is what makes an assertion about it able to
+/// fail for one specific reason.
+/// </remarks>
+public class a_contract_with_an_enum : for_JsonSchemaGenerator.given.a_json_schema_generator
+{
+    protected enum RejectionReason
+    {
+        RejectedBySigner = 1,
+        Expired = 2,
+        Withdrawn = 3
+    }
+
+    protected enum Sentiment
+    {
+        NotSet = 0,
+        Positive = 1,
+        Negative = 2
+    }
+
+    protected JsonSchema _result;
+
+    protected JsonSchemaProperty PropertyNamed(string name) => _result.GetFlattenedProperties().Single(_ => _.Name == name);
+
+    protected long[] MembersOf(string name) => PropertyNamed(name).Enumeration.Select(_ => Convert.ToInt64(_, CultureInfo.InvariantCulture)).ToArray();
+
+    protected sealed record Contract(Guid Id, RejectionReason? Reason, RejectionReason Status, Sentiment? Feedback);
+}

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_child_collection_has_no_children/and_it_is_declared_non_nullable.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_child_collection_has_no_children/and_it_is_declared_non_nullable.cs
@@ -15,6 +15,11 @@ namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_a_child
 /// child collection comes back empty measures nothing: it passed before the harness stopped pre-seeding and it
 /// passes after. What has to be pinned is <em>where the answer comes from</em>, and the nullable case is the only
 /// place a spec can see that.
+/// <para>
+/// The harness materializes twice - a single threaded result and one document per resolved key - and only the
+/// first was ever asserted on, so the per-instance path could have been reading with a different set of
+/// serializer options and no spec would have noticed. It is the path every multi-source spec asserts through.
+/// </para>
 /// </remarks>
 public class and_it_is_declared_non_nullable : Specification
 {
@@ -34,4 +39,6 @@ public class and_it_is_declared_non_nullable : Specification
     [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
     [Fact] void should_honour_the_declared_type_rather_than_hand_back_null() => _scenario.Instance!.Members.ShouldNotBeNull();
     [Fact] void should_be_empty() => _scenario.Instance!.Members.ShouldBeEmpty();
+    [Fact] void should_honour_the_declared_type_through_the_per_instance_view() => _scenario.InstanceForEventSourceId(_rosterId)!.Members.ShouldNotBeNull();
+    [Fact] void should_be_empty_through_the_per_instance_view() => _scenario.InstanceForEventSourceId(_rosterId)!.Members.ShouldBeEmpty();
 }

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_child_collection_has_no_children/and_it_is_declared_nullable.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_a_child_collection_has_no_children/and_it_is_declared_nullable.cs
@@ -36,4 +36,5 @@ public class and_it_is_declared_nullable : Specification
     [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
     [Fact] void should_project_the_root() => _scenario.Instance!.GroupName.ShouldEqual("Operations");
     [Fact] void should_leave_the_child_collection_absent() => _scenario.Instance!.Members.ShouldBeNull();
+    [Fact] void should_leave_it_absent_through_the_per_instance_view() => _scenario.InstanceForEventSourceId(_rosterId)!.Members.ShouldBeNull();
 }

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/given/an_expando_object_converter_with_a_read_model_schema.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/given/an_expando_object_converter_with_a_read_model_schema.cs
@@ -9,6 +9,20 @@ namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter.given;
 /// A schema shaped the way a read model's registered schema actually is - a nullable enum carrying its member
 /// list and no format suffix, beside a nullable flag, a non-nullable enum and a non-nullable number.
 /// </summary>
+/// <remarks>
+/// The four properties above are enough to observe the two guards together but not to tell them apart: every one
+/// of them is suppressed by nullability <em>and</em> by its member list, so either guard alone accounts for the
+/// whole result. <c>feedback</c> and <c>decision</c> are the two subjects that separate them - a nullable enum
+/// whose zero <em>is</em> declared, which only the nullability guard can suppress, and its non-nullable twin,
+/// which nothing may suppress because a type default that is a declared member is a legal value and must still
+/// be written.
+/// <para>
+/// The shapes are the generator's, not invented for the fixture: a real <c>enum? Reason</c> renders as
+/// <c>{"type":["integer","null"],"enum":[...],"x-enumNames":[...]}</c> and its non-nullable counterpart as the
+/// same without <c>"null"</c> - see <c>for_JsonSchemaGenerator.when_generating_schema_for_a_type_with_an_enum</c>,
+/// which pins that wire.
+/// </para>
+/// </remarks>
 public class an_expando_object_converter_with_a_read_model_schema : Specification
 {
     protected ExpandoObjectConverter converter;
@@ -33,6 +47,16 @@ public class an_expando_object_converter_with_a_read_model_schema : Specificatio
                         "x-enumNames": ["Draft", "Signed", "Terminated"]
                     },
                     "isFinalized": { "type": ["boolean", "null"] },
+                    "feedback": {
+                        "type": ["integer", "null"],
+                        "enum": [0, 1, 2],
+                        "x-enumNames": ["NotSet", "Positive", "Negative"]
+                    },
+                    "decision": {
+                        "type": "integer",
+                        "enum": [0, 1, 2],
+                        "x-enumNames": ["NotSet", "Approved", "Rejected"]
+                    },
                     "rate": { "type": "number", "format": "decimal" }
                 }
             }

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_a_schema_property_has_no_value/and_it_is_a_non_nullable_enum_with_a_zero_member.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_a_schema_property_has_no_value/and_it_is_a_non_nullable_enum_with_a_zero_member.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter.when_a_schema_property_has_no_value;
+
+/// <summary>
+/// The non-goal of withholding illegal defaults, stated as a spec. What disqualifies a synthesized value is that
+/// the property's own member list does not contain it - not that the property happens to be an enum. An enum that
+/// declares <c>NotSet = 0</c> has said that zero is a real answer, and the round trip must keep writing it: the
+/// member list is consulted, not bypassed, and it says yes.
+/// <para>
+/// Without this, the membership test is a branch every subject in the suite takes the same way. Every other enum
+/// in the fixture is 1-based, so replacing the test with a flat "not a declared member" leaves the whole suite
+/// green and quietly turns a legal default into an absent field - the mirror-image defect, in which a read model
+/// that answered <c>NotSet</c> comes back as one that did not answer at all.
+/// </para>
+/// <para>
+/// A member list that names its members is written by name, so what lands on the wire is <c>"NotSet"</c> and
+/// what comes back is the <c>0</c> behind it.
+/// </para>
+/// </summary>
+public class and_it_is_a_non_nullable_enum_with_a_zero_member : given.an_expando_object_converter_with_a_read_model_schema
+{
+    JsonObject _asJson;
+    IDictionary<string, object?> _roundTripped;
+
+    void Because()
+    {
+        var state = new ExpandoObject();
+        ((IDictionary<string, object?>)state)["id"] = "the-contract";
+        _asJson = converter.ToJsonObject(state, schema);
+        _roundTripped = converter.ToExpandoObject(_asJson, schema);
+    }
+
+    [Fact] void should_write_the_declared_zero_member() => _asJson["decision"]!.GetValue<string>().ShouldEqual("NotSet");
+    [Fact] void should_materialize_the_declared_zero_member_on_the_way_back() => _roundTripped["decision"].ShouldEqual(0);
+}

--- a/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_a_schema_property_has_no_value/and_it_is_a_nullable_enum_with_a_zero_member.cs
+++ b/Source/Infrastructure.Specs/Json/for_ExpandoObjectConverter/when_a_schema_property_has_no_value/and_it_is_a_nullable_enum_with_a_zero_member.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_ExpandoObjectConverter.when_a_schema_property_has_no_value;
+
+/// <summary>
+/// Two independent guards decide this, and every other subject in the fixture is suppressed by both of them at
+/// once - so each of those specs stays green with either guard removed, and the pair is only ever observed as a
+/// pair. This property is the one a member list cannot account for: a nullable enum that <em>does</em> declare a
+/// zero member, so <c>0</c> is a value its own schema permits. Nothing but the nullability reading keeps it out.
+/// <para>
+/// The reading in question is the type-array one. An enum carries no <c>format</c>, so the trailing <c>?</c> the
+/// converter used to test for is not where its nullability lives - it lives in <c>"type": ["integer", "null"]</c>.
+/// Drop that leg and this property, alone among the fixture's, starts materializing a <c>0</c> that reads like a
+/// deliberate <c>NotSet</c> answer on a read model that never answered.
+/// </para>
+/// </summary>
+public class and_it_is_a_nullable_enum_with_a_zero_member : given.an_expando_object_converter_with_a_read_model_schema
+{
+    JsonObject _asJson;
+    IDictionary<string, object?> _roundTripped;
+
+    void Because()
+    {
+        var state = new ExpandoObject();
+        ((IDictionary<string, object?>)state)["id"] = "the-contract";
+        _asJson = converter.ToJsonObject(state, schema);
+        _roundTripped = converter.ToExpandoObject(_asJson, schema);
+    }
+
+    [Fact] void should_not_answer_for_a_read_model_that_never_answered() => _asJson.ContainsKey("feedback").ShouldBeFalse();
+    [Fact] void should_not_materialize_it_on_the_way_back() => _roundTripped.ContainsKey("feedback").ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_handling_event_for_root_projection/and_the_projection_owns_a_children_collection.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/Steps/for_HandleEvent/when_handling_event_for_root_projection/and_the_projection_owns_a_children_collection.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines.Steps.for_HandleEvent.when_handling_event_for_root_projection;
+
+/// <summary>
+/// The step that writes the initial state is also the step that has to withhold part of it. A children-collection
+/// path belongs to <c>ChildAdded</c> and <c>ChildRemoved</c> for the read model's whole lifetime, so the diff this
+/// step produces must carry no difference for it - otherwise a replayed root event <c>$set</c>s the collection
+/// empty over children a sibling partition already added.
+/// <para>
+/// Its sibling spec asserts only that <em>some</em> change was added, which a diff that wipes the children
+/// satisfies just as well as one that does not. What has to be pinned is which properties are in the diff, and
+/// that needs a projection that actually owns a children collection - the fixture's root owns none, so the
+/// exclusion had nothing to exclude and could be removed without a single spec turning red.
+/// </para>
+/// </summary>
+public class and_the_projection_owns_a_children_collection : given.a_handle_event_step
+{
+    List<PropertiesChanged<ExpandoObject>> _changes;
+
+    void Establish()
+    {
+        dynamic initialState = _projectionInitialModelState;
+        initialState.Members = new List<ExpandoObject>();
+        initialState.Tags = new List<ExpandoObject>();
+        initialState.GroupName = "Operations";
+
+        var childProjection = Substitute.For<IProjection>();
+        childProjection.Path.Returns(new ProjectionPath("TestProjection.Members"));
+        childProjection.ChildrenPropertyPath.Returns(new PropertyPath("Members"));
+        childProjection.ChildProjections.Returns([]);
+
+        _projection.ChildrenPropertyPath.Returns(PropertyPath.Root);
+        _projection.ChildProjections.Returns([childProjection]);
+        _projection.Accepts(_event.Context.EventType).Returns(true);
+
+        _changes = [];
+        _changeset
+            .When(_ => _.Add(Arg.Any<Change>()))
+            .Do(_ => _changes.Add(_.Arg<PropertiesChanged<ExpandoObject>>()));
+
+        _context = _context with { NeedsInitialState = true };
+    }
+
+    async Task Because() => await _step.Perform(_projection, _context);
+
+    [Fact] void should_not_set_the_children_collection_from_the_initial_state() => _changes.ShouldNotContain(_ => _.Differences.Any(difference => difference.PropertyPath == "Members"));
+    [Fact] void should_still_set_a_collection_it_does_not_own() => _changes.ShouldContain(_ => _.Differences.Any(difference => difference.PropertyPath == "Tags"));
+    [Fact] void should_still_set_a_scalar_property() => _changes.ShouldContain(_ => _.Differences.Any(difference => difference.PropertyPath == "GroupName"));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ChangesetExtensions/when_adding_properties_and_a_children_path_is_excluded.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ChangesetExtensions/when_adding_properties_and_a_children_path_is_excluded.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.Pipelines;
+
+/// <summary>
+/// A children-collection path is written by <c>ChildAdded</c> and <c>ChildRemoved</c> and by nothing else, so the
+/// initial-state diff has to leave it alone even though the initial state carries an empty collection for it. Not
+/// leaving it alone is not a cosmetic difference: replay drives sibling partitions through their own events
+/// independently, so a root event's <c>Members=[]</c> can arrive after a sibling's <c>ChildAdded</c> and erase a
+/// child that was already there.
+/// <para>
+/// The exclusion argument was optional, and the one spec that exercised this method omitted it - so the branch
+/// was reachable only from production. What distinguishes an excluded path from an ordinary one is the sibling
+/// collection beside it, which is initial state of exactly the same shape and must still be written.
+/// </para>
+/// </summary>
+public class when_adding_properties_and_a_children_path_is_excluded : Specification
+{
+    IChangeset<AppendedEvent, ExpandoObject> _changeset;
+    ExpandoObject _source;
+    List<PropertiesChanged<ExpandoObject>> _changes;
+
+    void Establish()
+    {
+        _source = new ExpandoObject();
+        dynamic sourceAsDynamic = _source;
+        sourceAsDynamic.Name = "A name";
+        sourceAsDynamic.Members = new List<ExpandoObject>();
+        sourceAsDynamic.Tags = new List<ExpandoObject>();
+
+        _changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        _changeset.Changes.Returns([]);
+        _changeset.CurrentState.Returns(new ExpandoObject());
+
+        _changes = [];
+        _changeset
+            .When(_ => _.Add(Arg.Any<Change>()))
+            .Do(_ => _changes.Add(_.Arg<PropertiesChanged<ExpandoObject>>()));
+    }
+
+    void Because() => _changeset.AddPropertiesFrom(_source, [(PropertyPath)"Members"]);
+
+    [Fact] void should_not_set_the_excluded_children_collection() => _changes.ShouldNotContain(_ => _.Differences.Any(difference => difference.PropertyPath == "Members"));
+    [Fact] void should_still_set_a_sibling_collection() => _changes.ShouldContain(_ => _.Differences.Any(difference => difference.PropertyPath == "Tags"));
+    [Fact] void should_still_set_a_scalar_property() => _changes.ShouldContain(_ => _.Differences.Any(difference => difference.PropertyPath == "Name"));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionExtensions/when_collecting_children_property_paths/and_a_child_has_nested_children.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionExtensions/when_collecting_children_property_paths/and_a_child_has_nested_children.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.for_ProjectionExtensions.when_collecting_children_property_paths;
+
+/// <summary>
+/// A children collection may itself own one, and the exclusion has to reach it: the initial state a root
+/// projection carries includes the grandchild's collection just as it includes the child's, and the same replay
+/// race erases it just as readily. Walking only the immediate children collects the shallow path, which is enough
+/// to make a single-level fixture pass while the deeper path is silently re-set to empty.
+/// </summary>
+public class and_a_child_has_nested_children : Specification
+{
+    IProjection _projection;
+    PropertyPath[] _result;
+
+    void Establish()
+    {
+        var grandchild = Substitute.For<IProjection>();
+        grandchild.ChildrenPropertyPath.Returns(new PropertyPath("Members.Roles"));
+        grandchild.ChildProjections.Returns([]);
+
+        var child = Substitute.For<IProjection>();
+        child.ChildrenPropertyPath.Returns(new PropertyPath("Members"));
+        child.ChildProjections.Returns([grandchild]);
+
+        _projection = Substitute.For<IProjection>();
+        _projection.ChildrenPropertyPath.Returns(PropertyPath.Root);
+        _projection.ChildProjections.Returns([child]);
+    }
+
+    void Because() => _result = _projection.GetChildrenPropertyPaths().ToArray();
+
+    [Fact] void should_collect_the_child_path() => _result.ShouldContain(new PropertyPath("Members"));
+    [Fact] void should_collect_the_nested_child_path() => _result.ShouldContain(new PropertyPath("Members.Roles"));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionExtensions/when_collecting_children_property_paths/and_a_child_path_is_the_root.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionExtensions/when_collecting_children_property_paths/and_a_child_path_is_the_root.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine.for_ProjectionExtensions.when_collecting_children_property_paths;
+
+/// <summary>
+/// The collected paths are subtracted from the initial-state diff, so a root path among them subtracts the whole
+/// model: every property would be read as owned by a children collection and nothing would be written at all. A
+/// child sitting at the root - a nested projection rather than a collection - is exactly that case, and it has to
+/// be dropped here rather than guarded at each of the three call sites that consume this.
+/// </summary>
+public class and_a_child_path_is_the_root : Specification
+{
+    IProjection _projection;
+    PropertyPath[] _result;
+
+    void Establish()
+    {
+        var collectionChild = Substitute.For<IProjection>();
+        collectionChild.ChildrenPropertyPath.Returns(new PropertyPath("Members"));
+        collectionChild.ChildProjections.Returns([]);
+
+        var rootChild = Substitute.For<IProjection>();
+        rootChild.ChildrenPropertyPath.Returns(PropertyPath.Root);
+        rootChild.ChildProjections.Returns([]);
+
+        _projection = Substitute.For<IProjection>();
+        _projection.ChildrenPropertyPath.Returns(PropertyPath.Root);
+        _projection.ChildProjections.Returns([collectionChild, rootChild]);
+    }
+
+    void Because() => _result = _projection.GetChildrenPropertyPaths().ToArray();
+
+    [Fact] void should_collect_the_collection_path() => _result.ShouldContain(new PropertyPath("Members"));
+    [Fact] void should_not_collect_the_root_path() => _result.ShouldNotContain(PropertyPath.Root);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayRecommendationEvaluator/when_evaluating_read_model_migrations/and_added_properties_are_non_nullable_enums.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayRecommendationEvaluator/when_evaluating_read_model_migrations/and_added_properties_are_non_nullable_enums.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionReplayRecommendationEvaluator.when_evaluating_read_model_migrations;
+
+/// <summary>
+/// The recommendation is a value an operator sees and acts on, and withholding illegal defaults moved this case
+/// across the line: a required 1-based enum used to look like a property with a type default in hand, so a
+/// generation bump was reported as a plain update. It is not one. There is no value the migration may write for
+/// this property, so the rows have to be re-derived from the events that own them.
+/// <para>
+/// Every other spec here adds a text property, which never reaches the member-list decision at all - so
+/// the whole flip from update to selective replay happened without a single spec noticing.
+/// </para>
+/// </summary>
+public class and_added_properties_are_non_nullable_enums : given.a_projection_replay_recommendation_evaluator
+{
+    ProjectionReadModelMigrationRecommendation _result;
+
+    void Establish()
+    {
+        var previousSchema = JsonSchema.FromJson("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" }
+              }
+            }
+            """);
+
+        var currentSchema = JsonSchema.FromJson("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "status": {
+                  "type": "integer",
+                  "enum": [1, 2, 3],
+                  "x-enumNames": ["Draft", "Signed", "Terminated"]
+                }
+              }
+            }
+            """);
+
+        var readModelDefinition = CreateReadModelDefinition(previousSchema, currentSchema);
+
+        _result = ProjectionReplayRecommendationEvaluator.GetReadModelMigrationRecommendation(readModelDefinition);
+    }
+
+    [Fact] void should_recommend_selective_replay_available() => _result.ShouldEqual(ProjectionReadModelMigrationRecommendation.SelectiveReplayAvailable);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayRecommendationEvaluator/when_evaluating_read_model_migrations/and_added_properties_are_nullable_enums.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionReplayRecommendationEvaluator/when_evaluating_read_model_migrations/and_added_properties_are_nullable_enums.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionReplayRecommendationEvaluator.when_evaluating_read_model_migrations;
+
+/// <summary>
+/// The counterpart, and the one that keeps the recommendation from collapsing into "replay whenever an enum is
+/// added". A nullable enum has an answer for every existing row - the absence of one - so an added generation
+/// needs no events re-read, and the operator is told so.
+/// <para>
+/// Nullability here is the <c>"null"</c> entry in the property's type rather than a trailing <c>?</c> on a
+/// format, because an enum carries no format. Read only the format and this property looks required, the 1-based
+/// member list withholds its default, and the operator is sent to a replay the data never needed.
+/// </para>
+/// </summary>
+public class and_added_properties_are_nullable_enums : given.a_projection_replay_recommendation_evaluator
+{
+    ProjectionReadModelMigrationRecommendation _result;
+
+    void Establish()
+    {
+        var previousSchema = JsonSchema.FromJson("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" }
+              }
+            }
+            """);
+
+        var currentSchema = JsonSchema.FromJson("""
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "rejectionReason": {
+                  "type": ["integer", "null"],
+                  "enum": [1, 2, 3],
+                  "x-enumNames": ["RejectedBySigner", "Expired", "Withdrawn"]
+                }
+              }
+            }
+            """);
+
+        var readModelDefinition = CreateReadModelDefinition(previousSchema, currentSchema);
+
+        _result = ProjectionReplayRecommendationEvaluator.GetReadModelMigrationRecommendation(readModelDefinition);
+    }
+
+    [Fact] void should_recommend_update_available() => _result.ShouldEqual(ProjectionReadModelMigrationRecommendation.UpdateAvailable);
+}


### PR DESCRIPTION
# Summary

Makes the guards behind the read model shape fixes falsifiable. No behavior changes.
