### PR TITLE
Fix scoped IMongoDatabase injected into singleton security storage

### DIFF
--- a/Source/Kernel/Storage.MongoDB/Security/AuthorizationStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Security/AuthorizationStorage.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.Storage.MongoDB.Security;
 /// MongoDB implementation of <see cref="IAuthorizationStorage"/>.
 /// </summary>
 /// <param name="database">MongoDB database.</param>
-public class AuthorizationStorage(IMongoDatabase database) : IAuthorizationStorage
+public class AuthorizationStorage(IDatabase database) : IAuthorizationStorage
 {
     const string CollectionName = WellKnownCollectionNames.Authorizations;
     readonly IMongoCollection<Authorization> _collection = database.GetCollection<Authorization>(CollectionName);

--- a/Source/Kernel/Storage.MongoDB/Security/ScopeStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Security/ScopeStorage.cs
@@ -10,7 +10,7 @@ namespace Cratis.Chronicle.Storage.MongoDB.Security;
 /// MongoDB implementation of <see cref="IScopeStorage"/>.
 /// </summary>
 /// <param name="database">MongoDB database.</param>
-public class ScopeStorage(IMongoDatabase database) : IScopeStorage
+public class ScopeStorage(IDatabase database) : IScopeStorage
 {
     const string CollectionName = WellKnownCollectionNames.Scopes;
     readonly IMongoCollection<Scope> _collection = database.GetCollection<Scope>(CollectionName);

--- a/Source/Kernel/Storage.MongoDB/Security/TokenStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Security/TokenStorage.cs
@@ -10,7 +10,7 @@ namespace Cratis.Chronicle.Storage.MongoDB.Security;
 /// MongoDB implementation of <see cref="ITokenStorage"/>.
 /// </summary>
 /// <param name="database">MongoDB database.</param>
-public class TokenStorage(IMongoDatabase database) : ITokenStorage
+public class TokenStorage(IDatabase database) : ITokenStorage
 {
     const string CollectionName = WellKnownCollectionNames.Tokens;
     readonly IMongoCollection<Token> _collection = database.GetCollection<Token>(CollectionName);


### PR DESCRIPTION
## Summary
- Fixed `TokenStorage`, `AuthorizationStorage`, and `ScopeStorage` failing OAuth token issuance in production due to a singleton service constructor-injecting the scoped `IMongoDatabase`
- Switched all three to `IDatabase`, matching the existing correct pattern already used by `ApplicationStorage`

## Test plan
- [x] `dotnet build Source/Kernel/Storage.MongoDB/Storage.MongoDB.csproj -c Release` — 0 warnings, 0 errors
- [x] Verified end-to-end against a real production Chronicle deployment: OAuth token issuance succeeds, server no longer crashes after startup, and dependent application features (previously failing with 500s) work correctly

Fixes #3671