### PR TITLE
Correct the hosting recipes that cannot start Chronicle

### DIFF
--- a/Documentation/hosting/configuration/configuration-file.md
+++ b/Documentation/hosting/configuration/configuration-file.md
@@ -34,7 +34,20 @@ Chronicle Server loads configuration from a `chronicle.json` file in the applica
     "authentication": {
         "authority": null,
         "defaultAdminUsername": "admin",
-        "defaultAdminPassword": "admin"
+        "adminUser": {
+            "username": "admin",
+            "password": "your-secure-password",
+            "email": "admin@example.com",
+            "requirePasswordChangeOnFirstLogin": true
+        }
+    },
+    "tls": {
+        "certificatePath": "/certs/chronicle.pfx",
+        "certificatePassword": "your-password"
+    },
+    "encryptionCertificate": {
+        "certificatePath": "/certs/encryption-cert.pfx",
+        "certificatePassword": "your-password"
     },
     "identityProvider": {
         "certificate": {
@@ -46,7 +59,13 @@ Chronicle Server loads configuration from a `chronicle.json` file in the applica
 }
 ```
 
+Note that the sections are **not** wrapped in `Cratis` / `Chronicle` here — Chronicle republishes everything it reads from `chronicle.json` under the `Cratis:Chronicle:` configuration path itself. That prefix belongs on environment variables only.
+
 Environment variables can override any of these values. See [Configuration Precedence](configuration-precedence.md) for details.
+
+> [!IMPORTANT]
+> Keep passwords out of the file itself. Because every value above can be overridden by an environment variable,
+> supply secrets that way from your secret store — see [Environment Variables](environment-variables.md).
 
 | Section | Description |
 | --- | --- |
@@ -56,5 +75,7 @@ Environment variables can override any of these values. See [Configuration Prece
 | observers | Retry and timeout settings for observers |
 | readModels | Replay retention settings for replay-generated read model versions |
 | events | Event queue configuration |
-| authentication | Authentication and default admin settings |
+| authentication | Authentication, default admin username, and initial admin user bootstrap |
+| tls | TLS certificate for the main Chronicle port — required in production |
+| encryptionCertificate | Certificate protecting OAuth keys, webhook credentials, and Data Protection keys — required in production |
 | identityProvider | Optional internal identity provider certificate settings |

--- a/Documentation/hosting/configuration/environment-variables.md
+++ b/Documentation/hosting/configuration/environment-variables.md
@@ -20,10 +20,18 @@ All configuration options can be set using environment variables with the prefix
 
 ## Variables
 
+The table below covers the variables most deployments need. It is not the complete option surface — every
+property on Chronicle's options types has an environment-variable form, built by joining the section names
+with `__`. When a setting is missing here, find it on its own configuration page and translate the JSON path
+the same way (`compliance.encryption.migrateFromDefaultStorage` becomes
+`Cratis__Chronicle__Compliance__Encryption__MigrateFromDefaultStorage`).
+
 | Variable | Description |
 | --- | --- |
 | Cratis__Chronicle__Port | The single Chronicle port — gRPC (HTTP/2) and HTTP/1.1 |
 | Cratis__Chronicle__HealthCheckEndpoint | Health check endpoint path |
+| Cratis__Chronicle__Health__Port | Dedicated HTTP/1.1 port for the health endpoint |
+| Cratis__Chronicle__Health__Tls | Whether the dedicated health port uses TLS (default `true`) |
 | Cratis__Chronicle__Features__Api | Enable REST API endpoint |
 | Cratis__Chronicle__Features__Workbench | Enable Workbench UI |
 | Cratis__Chronicle__Features__ChangesetStorage | Enable changeset storage |
@@ -39,10 +47,21 @@ All configuration options can be set using environment variables with the prefix
 | Cratis__Chronicle__Events__Queues | Number of event queues |
 | Cratis__Chronicle__Authentication__Authority | External OAuth authority URL |
 | Cratis__Chronicle__Authentication__DefaultAdminUsername | Default admin username |
-| Cratis__Chronicle__Authentication__DefaultAdminPassword | Default admin password |
+| Cratis__Chronicle__Authentication__AdminUser__Username | Bootstrap admin username (falls back to the default admin username when empty) |
+| Cratis__Chronicle__Authentication__AdminUser__Password | Bootstrap admin password, hashed on first startup |
+| Cratis__Chronicle__Authentication__AdminUser__Email | Bootstrap admin email address |
+| Cratis__Chronicle__Authentication__AdminUser__RequirePasswordChangeOnFirstLogin | Force a password change on the admin's first login |
 | Cratis__Chronicle__Jobs__MaxParallelSteps | Maximum parallel job steps |
+| Cratis__Chronicle__Clustering__Type | Clustering provider — `Localhost` (default) or `MongoDB` |
+| Cratis__Chronicle__Clustering__ClusterId | Orleans cluster id, identical on every node |
+| Cratis__Chronicle__Clustering__ServiceId | Orleans service id, identical on every node |
+| Cratis__Chronicle__Clustering__SiloPort | Orleans silo port (default 11111) |
+| Cratis__Chronicle__Clustering__GatewayPort | Orleans gateway port (default 30000) |
+| Cratis__Chronicle__Clustering__AdvertisedIP | IP address this node advertises to the cluster |
 | Cratis__Chronicle__Tls__CertificatePath | TLS certificate path (PFX) |
 | Cratis__Chronicle__Tls__CertificatePassword | TLS certificate password |
+| Cratis__Chronicle__EncryptionCertificate__CertificatePath | Encryption certificate path (PFX) — OAuth keys, webhook credentials, Data Protection keys |
+| Cratis__Chronicle__EncryptionCertificate__CertificatePassword | Encryption certificate password |
 | OTEL_EXPORTER_OTLP_ENDPOINT | OTLP receiver endpoint for telemetry export |
 | OTEL_EXPORTER_OTLP_PROTOCOL | OTLP export protocol (`grpc` or `http/protobuf`) |
 | OTEL_EXPORTER_OTLP_HEADERS | Additional headers for the OTLP exporter |
@@ -132,10 +151,38 @@ Cratis__Chronicle__Authentication__Authority=https://your-oauth-provider.com
 # Default admin username (default: "admin")
 Cratis__Chronicle__Authentication__DefaultAdminUsername=admin
 
-# Default admin password (default: "admin")
-# Should be changed in production
-Cratis__Chronicle__Authentication__DefaultAdminPassword=your-secure-password
+# Bootstrap the initial admin user on first startup. The password is hashed
+# immediately on use and never retained. Supply it from your secret store.
+Cratis__Chronicle__Authentication__AdminUser__Username=admin
+Cratis__Chronicle__Authentication__AdminUser__Password=your-secure-password
+Cratis__Chronicle__Authentication__AdminUser__RequirePasswordChangeOnFirstLogin=true
 ```
+
+When `AdminUser__Password` is left empty, the admin user is created without a password and goes through the
+initial password setup flow in the Workbench. See [Authentication](authentication.md) for the full flow.
+
+## Encryption certificate
+
+```bash
+# Required in production - the internal OAuth authority refuses to start without it
+Cratis__Chronicle__EncryptionCertificate__CertificatePath=/certs/encryption-cert.pfx
+Cratis__Chronicle__EncryptionCertificate__CertificatePassword=your-certificate-password
+```
+
+See [Data Protection Key Encryption](../encryption-certificate.md) for generating and mounting the certificate.
+
+## Clustering
+
+```bash
+# Clustering provider - must be MongoDB for every multi-node deployment
+Cratis__Chronicle__Clustering__Type=MongoDB
+
+# Identical on every node so they join the same cluster
+Cratis__Chronicle__Clustering__ClusterId=chronicle
+Cratis__Chronicle__Clustering__ServiceId=chronicle
+```
+
+See [Clustering](clustering.md) for the full set of clustering properties.
 
 ## Open Telemetry
 

--- a/Documentation/hosting/configuration/index.md
+++ b/Documentation/hosting/configuration/index.md
@@ -19,12 +19,18 @@ Chronicle Server can be configured using a `chronicle.json` file or environment 
 | Root properties | Ports and health check endpoint |
 | Features | API, Workbench, and OAuth authority toggles |
 | Storage | Storage provider configuration |
+| Compliance | Dedicated storage for compliance encryption keys |
+| Clustering | Orleans clustering provider, cluster identity, and ports |
 | Observers | Retry and timeout settings |
 | Read models | Replay retention for replay-generated read model versions |
 | Events | Event queue configuration |
-| Authentication | External authority and default admin settings |
+| Jobs | Parallel job step throttling |
+| Authentication | External authority, default admin, and initial admin user bootstrap |
 | TLS | TLS certificate configuration for the Chronicle port |
+| Encryption certificate | Certificate protecting OAuth keys, webhook credentials, and Data Protection keys |
+| Health | Dedicated port for the health endpoint |
 | Identity Provider Certificate | Dedicated certificate configuration for internal OAuth authority |
+| Clients | Bootstrap client registrations created on startup |
 
 ## Topics
 
@@ -32,13 +38,17 @@ Chronicle Server can be configured using a `chronicle.json` file or environment 
 - [Root Properties](root-properties.md) - Ports and health check settings.
 - [Features](features.md) - Toggle API, Workbench, and OAuth authority.
 - [Storage](storage) - Configure the storage provider and connection details.
+- [Compliance Storage](compliance-storage.md) - Give compliance encryption keys their own storage backend.
+- [Clustering](clustering.md) - Orleans clustering provider, cluster identity, and silo/gateway ports.
 - [Observers](observers.md) - Retry and timeout settings for observer subscriptions.
 - [Read Models](read-models.md) - Configure replay retention for replay-generated read model versions.
 - [Events](events.md) - Configure event queues.
 - [Authentication](authentication.md) - External authority and default admin settings.
 - [TLS](tls.md) - Configure the TLS certificate for the Chronicle port.
+- [Data Protection Key Encryption](../encryption-certificate.md) - Configure the encryption certificate, required in production.
 - [Health Endpoint](health-endpoint.md) - Expose the health endpoint on a dedicated port with optional TLS.
 - [Identity Provider Certificate](identity-provider-certificate.md) - Configure internal OAuth authority certificates.
+- [Client Bootstrap](client-bootstrap.md) - Register client applications on startup with hashed secrets.
 - [Environment Variables](environment-variables.md) - Configure with `Cratis__Chronicle__` settings.
 - [Open Telemetry](open-telemetry.md) - Export metrics, traces, and logs via OTLP.
 - [Docker Configuration](docker.md) - Configure Chronicle in Docker.

--- a/Documentation/hosting/configuration/job-throttling.md
+++ b/Documentation/hosting/configuration/job-throttling.md
@@ -4,19 +4,21 @@ Chronicle Server's job system can be configured to limit the number of parallel 
 
 ## Configuration
 
-The maximum number of parallel job steps can be configured using the `MaxParallelSteps` option:
+The maximum number of parallel job steps can be configured using the `MaxParallelSteps` option in `chronicle.json`:
 
 ```json
 {
-  "Cratis": {
-    "Chronicle": {
-      "Jobs": {
-        "MaxParallelSteps": 4
-      }
-    }
+  "Jobs": {
+    "MaxParallelSteps": 4
   }
 }
 ```
+
+> [!IMPORTANT]
+> Do not wrap the section in `Cratis` / `Chronicle` inside `chronicle.json`. Chronicle republishes everything it
+> reads from that file under the `Cratis:Chronicle:` configuration path already, so a nested copy binds to
+> `Cratis:Chronicle:Cratis:Chronicle:Jobs` and is silently ignored. The `Cratis__Chronicle__` prefix belongs on
+> environment variables only.
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/Documentation/hosting/docker-compose.md
+++ b/Documentation/hosting/docker-compose.md
@@ -20,7 +20,6 @@ services:
     image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
     environment:
       - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true
-      - DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://chronicle:18889
       - ALLOW_UNSECURED_TRANSPORT=true
       - DOTNET_ENVIRONMENT=Development
     ports:

--- a/Documentation/hosting/encryption-certificate.md
+++ b/Documentation/hosting/encryption-certificate.md
@@ -6,7 +6,15 @@ Chronicle uses ASP.NET Core Data Protection to securely manage encryption keys f
 
 When Chronicle runs in a clustered environment, all instances need access to the same Data Protection keys to correctly encrypt and decrypt tokens. These keys are stored in MongoDB and shared across all instances using Orleans grains.
 
-In production, an encryption certificate is **required** to protect these keys at rest. In development mode, the certificate is optional for convenience.
+In production, an encryption certificate is **required**. In development builds it is optional for convenience.
+
+One PFX serves three consumers, and they fail in different ways when it is missing — worth knowing, because only one of them is loud:
+
+| Consumer | Without the certificate, in a production build |
+| --- | --- |
+| **OpenIddict** — the internal OAuth authority | **The server refuses to start.** This is the failure a production deployment hits first, before anything else can go wrong. |
+| **Webhook credentials** | Throws `EncryptionCertificateNotConfigured` **lazily**, the first time a webhook secret is encrypted or decrypted — so a server that started fine can still fail here later. |
+| **Data Protection keys** | Nothing fails. Chronicle starts, and the keys are simply written unencrypted. Data Protection never refuses to start and never generates a certificate of its own. |
 
 ## Configuration
 
@@ -138,7 +146,7 @@ In development mode (when Chronicle is built with the `DEVELOPMENT` configuratio
 
 ### Auto-Generated Certificates (Development Only)
 
-When no encryption certificate is configured **and Chronicle is compiled with DEVELOPMENT mode**, Chronicle will automatically generate a self-signed certificate for development purposes. This certificate is:
+When no encryption certificate is configured **and Chronicle is compiled with DEVELOPMENT mode**, the value-encryption subsystem — the one that protects webhook credentials — automatically generates a self-signed certificate the first time it needs one. This certificate is:
 
 - **Location**: Stored in a `certificates` folder in the current working directory
 - **Filename**: `encryption-cert.pfx`
@@ -146,9 +154,9 @@ When no encryption certificate is configured **and Chronicle is compiled with DE
 - **Validity**: 10 years from generation
 - **Reuse**: If the certificate already exists, Chronicle will use it instead of generating a new one
 
-This feature is designed to simplify local development and testing. The certificate is automatically created on first use and persisted for subsequent runs, ensuring encrypted data remains accessible across restarts.
+This feature is designed to simplify local development and testing. The certificate is created lazily on first encrypt or decrypt rather than at startup, and persisted for subsequent runs so encrypted data remains accessible across restarts. Data Protection does not take part in this — it never generates a certificate, so its keys stay unencrypted whenever none is configured.
 
-> **Important**: In **production builds** (without the DEVELOPMENT directive), Chronicle will throw an `EncryptionCertificateNotConfigured` exception if no certificate is configured. Auto-generation only occurs in development mode.
+> **Important**: In **production builds** (without the DEVELOPMENT directive) there is no auto-generation. Two things happen instead: OpenIddict makes the server **refuse to start**, and — if you get past that — the value-encryption subsystem throws `EncryptionCertificateNotConfigured` on first use.
 
 ### Running Without Configuration
 

--- a/Documentation/hosting/index.md
+++ b/Documentation/hosting/index.md
@@ -13,7 +13,7 @@ For day-to-day development, [Docker Compose](docker-compose.md) is the fastest w
 Running the Kernel in production requires two things beyond a basic Docker deployment:
 
 - **[Production](production.md)** — how to deploy the Chronicle Docker image with MongoDB, including port configuration, Docker Compose setup, health checks, and security considerations.
-- **[Data Protection Key Encryption](encryption-certificate.md)** — Chronicle uses ASP.NET Core Data Protection to protect sensitive values at rest. In production you must supply a certificate so that data protection keys are encrypted. Without this, the Kernel will either fail to start or leave keys unprotected.
+- **[Data Protection Key Encryption](encryption-certificate.md)** — Chronicle uses ASP.NET Core Data Protection to protect sensitive values at rest. In production you must supply a certificate so that data protection keys are encrypted. Without one the Kernel refuses to start, because the internal OAuth authority requires the certificate. Turn that authority off — or point Chronicle at an external one — and the Kernel starts happily while writing its data protection keys unencrypted, which is the quieter and more dangerous outcome.
 
 Both steps are required. A production deployment that skips key encryption is not secure.
 

--- a/Documentation/hosting/production.md
+++ b/Documentation/hosting/production.md
@@ -22,6 +22,26 @@ Chronicle requires configuration to define its runtime behavior. For complete co
 
 The configuration file must be mounted into the container at `/app/chronicle.json`, or you can use environment variables with the `Cratis__Chronicle__` prefix.
 
+### What makes a build a production build
+
+The production code paths are selected by the **`DEVELOPMENT` compile-time symbol**, not by `ASPNETCORE_ENVIRONMENT` or `DOTNET_ENVIRONMENT`. The symbol is defined for `Debug` builds only, so `cratis/chronicle:latest` — published from a Release build — always takes the production path, and no environment variable can switch it back. Only the `latest-development` and `latest-development-slim` images are compiled with the symbol.
+
+That matters because the production path needs all three of these before it will run — and two of them stop startup dead:
+
+| Setting | Environment variable | Why it is required |
+| --- | --- | --- |
+| Storage connection | `Cratis__Chronicle__Storage__ConnectionDetails` | Defaults to an empty string — there is no built-in fallback to connect to. Pair it with `Cratis__Chronicle__Storage__Type` when the backend is not MongoDB, which is what an unset type resolves to |
+| TLS certificate | `Cratis__Chronicle__Tls__CertificatePath` (and `__CertificatePassword`) | Port 35000 multiplexes gRPC and HTTP/1.1 over one TLS port. Without a certificate the server throws "No TLS certificate is configured" at startup |
+| Encryption certificate | `Cratis__Chronicle__EncryptionCertificate__CertificatePath` (and `__CertificatePassword`) | Protects the internal OAuth authority's signing and encryption keys. Without a certificate the server throws "An encryption certificate is required in production" at startup |
+
+The development images generate a self-signed TLS certificate and fall back to ephemeral OAuth keys instead of throwing, which is exactly why a Compose file that works against `latest-development` fails against `latest`. See [Data Protection Key Encryption](encryption-certificate.md) and [TLS Configuration](configuration/tls.md) for generating and mounting the certificates.
+
+## Storage requirements
+
+Chronicle opens MongoDB transactions when it appends events, and transactions are only served by a replica set (or a sharded cluster) — a standalone `mongod` rejects them. **Every MongoDB deployment behind Chronicle must be a replica set**, including a single-node one. The Compose recipes below initialize a single-node replica set named `rs0`; a real production deployment uses a multi-member replica set or a managed service such as MongoDB Atlas, which is already one.
+
+Chronicle's connection string carries `?directConnection=true` so the driver talks to the member it was given instead of following the replica set's advertised host name. This does not disable transactions — they keep working because MongoDB is running as a replica set.
+
 ## Port Configuration
 
 Chronicle exposes the following ports:
@@ -43,36 +63,80 @@ docker run -d \
   --name chronicle \
   -p 35000:35000 \
   -v /path/to/chronicle.json:/app/chronicle.json:ro \
+  -v /path/to/certs:/certs:ro \
+  -e Cratis__Chronicle__Storage__ConnectionDetails='mongodb://mongodb:27017/?directConnection=true' \
+  -e Cratis__Chronicle__Tls__CertificatePath=/certs/chronicle.pfx \
+  -e Cratis__Chronicle__Tls__CertificatePassword="$CHRONICLE_CERTIFICATE_PASSWORD" \
+  -e Cratis__Chronicle__EncryptionCertificate__CertificatePath=/certs/encryption-cert.pfx \
+  -e Cratis__Chronicle__EncryptionCertificate__CertificatePassword="$ENCRYPTION_CERTIFICATE_PASSWORD" \
   cratis/chronicle:latest
 ```
+
+Both certificates and the storage connection are mandatory — see [What makes a build a production build](#what-makes-a-build-a-production-build). The MongoDB instance this points at must be a replica set.
 
 ### Docker Compose
 
 ```yaml
-version: '3.8'
-
 services:
   chronicle:
     image: cratis/chronicle:latest
     ports:
       - "35000:35000"
+    environment:
+      Cratis__Chronicle__Storage__Type: "MongoDB"
+      Cratis__Chronicle__Storage__ConnectionDetails: "mongodb://mongodb:27017/?directConnection=true"
+      Cratis__Chronicle__Tls__CertificatePath: "/certs/chronicle.pfx"
+      Cratis__Chronicle__Tls__CertificatePassword: "${CHRONICLE_CERTIFICATE_PASSWORD}"
+      Cratis__Chronicle__EncryptionCertificate__CertificatePath: "/certs/encryption-cert.pfx"
+      Cratis__Chronicle__EncryptionCertificate__CertificatePassword: "${ENCRYPTION_CERTIFICATE_PASSWORD}"
     volumes:
       - ./chronicle.json:/app/chronicle.json:ro
+      - ./certs:/certs:ro
     depends_on:
       - mongodb
+      - mongodb-init
     restart: unless-stopped
 
   mongodb:
-    image: mongo:7
+    image: mongo:8
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
     restart: unless-stopped
 
+  mongodb-init:
+    image: mongo:8
+    depends_on:
+      - mongodb
+    restart: "no"
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        until mongosh --host mongodb --quiet --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
+          sleep 1
+        done
+        mongosh --host mongodb --quiet --eval "
+        try {
+          rs.status();
+        } catch (e) {
+          rs.initiate({
+            _id: 'rs0',
+            members: [{ _id: 0, host: 'localhost:27017' }]
+          });
+        }"
+
 volumes:
   mongodb_data:
 ```
+
+The `mongodb-init` service is a one-shot container: it waits for `mongod` to answer, initiates the `rs0` replica set if it is not already initiated, and exits. Advertising the member as `localhost:27017` keeps the replica set reachable from host tools such as `mongosh` and Compass, while Chronicle reaches MongoDB over the Compose network with `directConnection=true` so it does not follow that advertised host back into its own container.
+
+If an existing MongoDB data volume was initialized with a different replica-set host, wipe it (`docker compose down -v`) before starting again so `rs.initiate()` can apply the new host.
+
+The remaining settings stay in the mounted `chronicle.json`; the environment variables above override any values it holds for the same keys. Keep the certificate passwords out of the file — supply them from your secret store, as the `${...}` references do here.
 
 ## Best Practices
 
@@ -87,14 +151,36 @@ volumes:
 
 ## Health Checks
 
-Chronicle exposes a health check endpoint at `/health` by default. Add health checks to your Docker deployment:
+Chronicle exposes a health check endpoint at `/health` by default.
 
-```dockerfile
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD curl -fk https://localhost:35000/health || exit 1
+> [!IMPORTANT]
+> **Probe Chronicle from outside the container.** The production image is built on `mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled`, which ships no shell and no `curl` or `wget`. A Docker `HEALTHCHECK` — or a Compose `healthcheck:` — runs *inside* the container, so any command you give it fails immediately and the container is reported unhealthy no matter how healthy Chronicle is.
+
+Use your orchestrator's own HTTP probe instead. The main port always requires TLS, and probers that validate certificates reject a self-signed one, so publish the health endpoint on a dedicated plaintext port:
+
+```bash
+Cratis__Chronicle__Health__Port=8080
+Cratis__Chronicle__Health__Tls=false
 ```
 
-> **Note**: The health check endpoint path is configurable. See [Root Properties](configuration/root-properties.md#health-check-endpoint) for details.
+Then point the probe at it:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+    scheme: HTTP
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+    scheme: HTTP
+```
+
+Treat that port as internal — it serves the other HTTP/1.1 endpoints too, so do not expose it publicly.
+
+> **Note**: The health check endpoint path is configurable. See [Root Properties](configuration/root-properties.md#health-check-endpoint) for details, and [Health Endpoint](configuration/health-endpoint.md) for the dedicated port.
 
 ## Security Considerations
 
@@ -143,16 +229,21 @@ services:
     ports:
       - "35001:35000"
     environment:
-      Cratis__Chronicle__Storage__ConnectionDetails: "mongodb://mongodb:27017"
+      Cratis__Chronicle__Storage__ConnectionDetails: "mongodb://mongodb:27017/?directConnection=true"
       Cratis__Chronicle__Clustering__Type: "MongoDB"
       Cratis__Chronicle__Clustering__ClusterId: "chronicle"
       Cratis__Chronicle__Clustering__ServiceId: "chronicle"
       # Port 35000 requires a TLS certificate - see the TLS Configuration guide.
       Cratis__Chronicle__Tls__CertificatePath: "/certs/chronicle.pfx"
+      Cratis__Chronicle__Tls__CertificatePassword: "${CHRONICLE_CERTIFICATE_PASSWORD}"
+      # Every node must share the same encryption certificate.
+      Cratis__Chronicle__EncryptionCertificate__CertificatePath: "/certs/encryption-cert.pfx"
+      Cratis__Chronicle__EncryptionCertificate__CertificatePassword: "${ENCRYPTION_CERTIFICATE_PASSWORD}"
     volumes:
       - ./certs:/certs:ro
     depends_on:
       - mongodb
+      - mongodb-init
     restart: unless-stopped
 
   chronicle-2:
@@ -160,28 +251,59 @@ services:
     ports:
       - "35002:35000"
     environment:
-      Cratis__Chronicle__Storage__ConnectionDetails: "mongodb://mongodb:27017"
+      Cratis__Chronicle__Storage__ConnectionDetails: "mongodb://mongodb:27017/?directConnection=true"
       Cratis__Chronicle__Clustering__Type: "MongoDB"
       Cratis__Chronicle__Clustering__ClusterId: "chronicle"
       Cratis__Chronicle__Clustering__ServiceId: "chronicle"
       Cratis__Chronicle__Tls__CertificatePath: "/certs/chronicle.pfx"
+      Cratis__Chronicle__Tls__CertificatePassword: "${CHRONICLE_CERTIFICATE_PASSWORD}"
+      Cratis__Chronicle__EncryptionCertificate__CertificatePath: "/certs/encryption-cert.pfx"
+      Cratis__Chronicle__EncryptionCertificate__CertificatePassword: "${ENCRYPTION_CERTIFICATE_PASSWORD}"
     volumes:
       - ./certs:/certs:ro
     depends_on:
       - mongodb
+      - mongodb-init
     restart: unless-stopped
 
   mongodb:
-    image: mongo:7
+    image: mongo:8
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
     restart: unless-stopped
 
+  mongodb-init:
+    image: mongo:8
+    depends_on:
+      - mongodb
+    restart: "no"
+    command:
+      - /bin/bash
+      - -lc
+      - |
+        until mongosh --host mongodb --quiet --eval "db.adminCommand('ping')" >/dev/null 2>&1; do
+          sleep 1
+        done
+        mongosh --host mongodb --quiet --eval "
+        try {
+          rs.status();
+        } catch (e) {
+          rs.initiate({
+            _id: 'rs0',
+            members: [{ _id: 0, host: 'localhost:27017' }]
+          });
+        }"
+
 volumes:
   mongodb_data:
 ```
+
+Both nodes share one encryption certificate on purpose: Data Protection keys live in the shared storage, so
+every instance must be able to decrypt what any other instance wrote. See
+[Data Protection Key Encryption](encryption-certificate.md).
 
 Each container reaches the others over the Compose network by service name, so the default advertised
 address works. When you instead run multiple nodes directly on one host, set


### PR DESCRIPTION
## Added

- Environment variable reference entries for the encryption certificate, clustering and health settings

## Fixed

- The production hosting recipes now run MongoDB as a replica set, without which Chronicle cannot open the transactions it uses for event sequence storage (#3607)
- The production hosting recipes now configure the encryption certificate, without which a release build refuses to start (#3607)
- Documented that what selects the production path is the `DEVELOPMENT` compile-time symbol rather than `ASPNETCORE_ENVIRONMENT`, so the published image always takes the production branch (#3607)
- The production `HEALTHCHECK` no longer invokes `curl` inside a chiseled image that has no shell; the health endpoint and an external probe are documented instead
- `Cratis__Chronicle__Authentication__DefaultAdminPassword` is no longer documented as a production setting — it exists only in development builds; the `AdminUser` settings are documented in its place
- The job throttling example is no longer nested one level too deep to bind to anything
- The encryption certificate page no longer attributes the lazy value-encryption failure and the development certificate to Data Protection
- The Docker Compose example no longer points the dashboard's own OTLP endpoint at another host
