### PR TITLE
Run the production image in Aspire production mode, and let it be given certificates

### DIFF
--- a/Documentation/client-snippets/hosting/aspire/certificates.md
+++ b/Documentation/client-snippets/hosting/aspire/certificates.md
@@ -1,0 +1,18 @@
+```csharp
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+public static class HostingAspireCertificates
+{
+    public static IResourceBuilder<ChronicleResource> ConfigureAppHost(IDistributedApplicationBuilder builder)
+    {
+        var mongo = builder.AddConnectionString("chronicle-mongo");
+
+        return builder.AddCratisChronicle("chronicle", chronicle => chronicle
+            .WithMongoDB(mongo)
+            .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
+            .WithEncryptionCertificate("certs/encryption.pfx", "YourPassword"));
+    }
+}
+```

--- a/Documentation/client-snippets/hosting/aspire/complete-example.md
+++ b/Documentation/client-snippets/hosting/aspire/complete-example.md
@@ -9,8 +9,10 @@ public static class HostingAspireCompleteExample
 
         var mongo = builder.AddConnectionString("chronicle-mongo");
 
-        var chronicle = builder.AddCratisChronicle("chronicle", c =>
-            c.WithMongoDB(mongo));
+        var chronicle = builder.AddCratisChronicle("chronicle", c => c
+            .WithMongoDB(mongo)
+            .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
+            .WithEncryptionCertificate("certs/encryption.pfx", "YourPassword"));
 
         builder.AddContainer("api", "my-org/my-api")
             .WithReference(chronicle);

--- a/Documentation/get-started/choose-hosting-model.mdx
+++ b/Documentation/get-started/choose-hosting-model.mdx
@@ -294,6 +294,15 @@ MongoDB) and the `With*` method you pick sets the kernel's storage type and conn
 resource you hand it — the same two environment variables you saw in the Compose files, now derived from
 your app model instead of hand-written:
 
+<Aside type="caution" title="The production image also wants certificates">
+Passing a configure callback moves you off the development image, and the production image does not
+generate the TLS certificate it serves port 35000 with, nor the certificate that protects its OAuth keys —
+it throws at startup and stops. The snippets below show the storage wiring only, so pair them with
+`WithTlsCertificate(...)` and `WithEncryptionCertificate(...)`; the
+[Aspire integration guide](/chronicle/hosting/aspire/) shows both. If you only wanted a kernel to develop
+against, stay on `AddCratisChronicle()` above — it brings its own database *and* its own certificate.
+</Aside>
+
 <Tabs syncKey="database">
 <TabItem label="MongoDB">
 

--- a/Documentation/get-started/choose-hosting-model.mdx
+++ b/Documentation/get-started/choose-hosting-model.mdx
@@ -289,7 +289,7 @@ For development, one line gives you the same batteries-included kernel as the `d
 
 <ChronicleClientTabs snippet="get-started/choose-hosting-model/basic-apphost" />
 
-To choose a database, pass a configure callback. Aspire then switches to the slim image (no embedded
+To choose a database, pass a configure callback. Aspire then switches to the production image (no embedded
 MongoDB) and the `With*` method you pick sets the kernel's storage type and connection string from the
 resource you hand it — the same two environment variables you saw in the Compose files, now derived from
 your app model instead of hand-written:

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -29,7 +29,7 @@ For production or staging environments, use the configure callback. This switche
 |------|--------|------------|
 | A database | `WithMongoDB` / `WithPostgreSql` / `WithMsSql` / `WithSqlite` | There is no storage to connect to |
 | A TLS certificate | `WithTlsCertificate` | The server throws `No TLS certificate is configured` and exits |
-| An encryption certificate | `WithEncryptionCertificate` | The server throws `An encryption certificate is required in production` and exits |
+| An encryption certificate | `WithEncryptionCertificate` | The server throws `An encryption certificate is required in production` and exits — unless you turn the `OAuthAuthority` feature off or point `Authentication:Authority` at an external authority, which skips the internal authority that needs it |
 
 :::caution[The production image will not start without certificates]
 The development image generates a self-signed TLS certificate on the fly and falls back to ephemeral OAuth keys. The production image does neither — the production code paths are selected by a compile-time symbol, so no environment variable switches them back. A configure callback that wires up only a database therefore produces a container that starts, throws, and stops. Each storage section below shows **only** the storage wiring; add the two certificate calls from [Certificates](#certificates) to every one of them.
@@ -42,6 +42,8 @@ The development image generates a self-signed TLS certificate on the fly and fal
 <ChronicleClientTabs snippet="hosting/aspire/certificates" />
 
 Each method does two things: it bind-mounts the file read-only into the container (at `/certs/tls.pfx` and `/certs/encryption.pfx` respectively) and points the matching Chronicle setting at that in-container path. You do not add a `WithBindMount` of your own — a host path handed straight to the container names a file the container cannot see, so the mount is part of configuring the certificate rather than a separate step you have to remember. A relative path resolves against the AppHost directory, exactly like every other Aspire bind mount.
+
+Point either method at a file that is not there and the AppHost fails to start with `CertificateFileDoesNotExist`, naming both the path you gave and the absolute path it resolved to. That is deliberate: Docker happily creates a *directory* at a missing bind-mount source, and the Chronicle container would then tell you no certificate is configured — the opposite of the truth — while staying up with a dead process inside. Calling either method twice for the same certificate is last-call-wins, like every other `With…` on the builder, so a base helper's certificate can be overridden per environment.
 
 The two calls are independent, so you can point both at the same `.pfx` if one certificate serves both purposes — they are mounted at different container paths, so nothing collides. They map to configuration like this:
 

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -12,7 +12,7 @@ dotnet add package Cratis.Chronicle.Aspire
 
 ## Development Mode
 
-For local development, call `AddCratisChronicle()` without arguments. This uses the Chronicle development image (`cratis/chronicle:latest-development`), which bundles MongoDB, so no external database is required.
+For local development, call `AddCratisChronicle()` without arguments. This uses the Chronicle development image (`cratis/chronicle:latest-development`), which bundles MongoDB and generates its own self-signed TLS certificate at startup — so neither an external database nor a certificate is required.
 
 <ChronicleClientTabs snippet="hosting/aspire/dev-mode" />
 
@@ -23,7 +23,34 @@ The development image is ideal for:
 
 ## Production Mode
 
-For production or staging environments, use the configure callback. This switches to the production image (`cratis/chronicle:latest`) — no embedded MongoDB — and lets you wire up an external database resource.
+For production or staging environments, use the configure callback. This switches to the production image (`cratis/chronicle:latest`), which drops both the embedded MongoDB *and* the development conveniences — so it needs three things wired up before it will start:
+
+| What | Method | Without it |
+|------|--------|------------|
+| A database | `WithMongoDB` / `WithPostgreSql` / `WithMsSql` / `WithSqlite` | There is no storage to connect to |
+| A TLS certificate | `WithTlsCertificate` | The server throws `No TLS certificate is configured` and exits |
+| An encryption certificate | `WithEncryptionCertificate` | The server throws `An encryption certificate is required in production` and exits |
+
+:::caution[The production image will not start without certificates]
+The development image generates a self-signed TLS certificate on the fly and falls back to ephemeral OAuth keys. The production image does neither — the production code paths are selected by a compile-time symbol, so no environment variable switches them back. A configure callback that wires up only a database therefore produces a container that starts, throws, and stops. Each storage section below shows **only** the storage wiring; add the two certificate calls from [Certificates](#certificates) to every one of them.
+:::
+
+### Certificates
+
+`WithTlsCertificate` and `WithEncryptionCertificate` each take a path to a PKCS#12 (`.pfx`) file **on your machine** and the password protecting it:
+
+<ChronicleClientTabs snippet="hosting/aspire/certificates" />
+
+Each method does two things: it bind-mounts the file read-only into the container (at `/certs/tls.pfx` and `/certs/encryption.pfx` respectively) and points the matching Chronicle setting at that in-container path. You do not add a `WithBindMount` of your own — a host path handed straight to the container names a file the container cannot see, so the mount is part of configuring the certificate rather than a separate step you have to remember. A relative path resolves against the AppHost directory, exactly like every other Aspire bind mount.
+
+The two calls are independent, so you can point both at the same `.pfx` if one certificate serves both purposes — they are mounted at different container paths, so nothing collides. They map to configuration like this:
+
+| Method | Container environment variable | Chronicle setting |
+|--------|-------------------------------|-------------------|
+| `WithTlsCertificate` | `Cratis__Chronicle__Tls__CertificatePath` / `Cratis__Chronicle__Tls__CertificatePassword` | `Cratis:Chronicle:Tls:CertificatePath` / `Cratis:Chronicle:Tls:CertificatePassword` |
+| `WithEncryptionCertificate` | `Cratis__Chronicle__EncryptionCertificate__CertificatePath` / `Cratis__Chronicle__EncryptionCertificate__CertificatePassword` | `Cratis:Chronicle:EncryptionCertificate:CertificatePath` / `Cratis:Chronicle:EncryptionCertificate:CertificatePassword` |
+
+The password argument is optional, but supply it: Chronicle reads the file as PKCS#12 only when a password is present, and a TLS listener needs the private key inside that PKCS#12 container. [Local Certificate Setup](./local-certificates) shows how to generate a suitable `.pfx` with `dotnet dev-certs` or OpenSSL; [Production Hosting](./production.md) covers what a real deployment should use instead of a self-signed one.
 
 ### MongoDB
 
@@ -45,6 +72,8 @@ Aspire's `builder.AddMongoDB("mongo")` starts a **standalone** `mongod`, so it d
 For local development against the production image, `AddCratisChronicleMongoDB()` provisions this for you — a MongoDB container that initializes itself as a single-node replica set, handed back as a connection string carrying `?directConnection=true`:
 
 <ChronicleClientTabs snippet="hosting/aspire/mongo-replica-set-helper" />
+
+That solves the database half only. Running the production image locally still needs both certificates from [Certificates](#certificates) — if all you want is a Chronicle to develop against, `AddCratisChronicle()` with no configure callback is the shorter road, because the development image brings its own replica set *and* its own certificates.
 
 If you would rather define the container yourself, the same recipe written out in full is:
 
@@ -96,11 +125,11 @@ The `grpc` endpoint is registered automatically when you call `AddCratisChronicl
 
 ## Complete Example
 
-A typical Aspire AppHost `Program.cs` for a production setup with MongoDB:
+A typical Aspire AppHost `Program.cs` for a production setup with MongoDB — database plus both certificates, which is the smallest configuration the production image actually starts on:
 
 <ChronicleClientTabs snippet="hosting/aspire/complete-example" />
 
-For development, simplify further by dropping the MongoDB wiring:
+For development, drop the whole callback. The development image brings its own MongoDB replica set, generates its own TLS certificate, and uses ephemeral OAuth keys, so there is nothing left to wire:
 
 <ChronicleClientTabs snippet="hosting/aspire/complete-example-dev" />
 
@@ -108,8 +137,8 @@ For development, simplify further by dropping the MongoDB wiring:
 
 | Image tag                       | Description                                             | Selected by                                    |
 |---------------------------------|---------------------------------------------------------|------------------------------------------------|
-| `cratis/chronicle:latest`       | Production image — no embedded MongoDB                  | `AddCratisChronicle(configure: ...)`           |
-| `cratis/chronicle:latest-development` | Development image — includes embedded MongoDB | `AddCratisChronicle()`                         |
+| `cratis/chronicle:latest`       | Production image — no embedded MongoDB, no self-generated certificates | `AddCratisChronicle(configure: ...)`           |
+| `cratis/chronicle:latest-development` | Development image — includes embedded MongoDB, generates a TLS certificate and ephemeral OAuth keys | `AddCratisChronicle()`                         |
 | `cratis/chronicle:latest-development-slim` | Development slim image — no embedded MongoDB | Not selected by the Aspire integration — run it directly |
 
 See [Production Hosting](./production.md) for guidance on running Chronicle in production environments.

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -23,7 +23,7 @@ The development image is ideal for:
 
 ## Production Mode
 
-For production or staging environments, use the configure callback. This switches to the slim image (`cratis/chronicle:latest-development-slim`) — no embedded MongoDB — and lets you wire up an external database resource.
+For production or staging environments, use the configure callback. This switches to the production image (`cratis/chronicle:latest`) — no embedded MongoDB — and lets you wire up an external database resource.
 
 ### MongoDB
 
@@ -34,7 +34,7 @@ The `WithMongoDB` method sets the `Cratis__Chronicle__Storage__Type` and `Cratis
 :::caution[Chronicle needs a MongoDB replica set]
 Chronicle uses MongoDB transactions, and its observers, projections, and observable queries rely on change streams — **both require MongoDB to run as a replica set**, not a standalone `mongod`. Against a standalone server the change-stream watch never opens, so observable read-model queries silently return their empty seed and it looks like a projection bug rather than a storage-topology problem.
 
-Aspire's `builder.AddMongoDB("mongo")` starts a **standalone** `mongod`, so it does not work with the slim image on its own — point `WithMongoDB` at a replica set instead.
+Aspire's `builder.AddMongoDB("mongo")` starts a **standalone** `mongod`, so it does not work with the production image on its own — point `WithMongoDB` at a replica set instead.
 :::
 
 `mongo` can be any `IResourceBuilder<IResourceWithConnectionString>` that resolves to a replica set, including:
@@ -42,7 +42,7 @@ Aspire's `builder.AddMongoDB("mongo")` starts a **standalone** `mongod`, so it d
 - A MongoDB Atlas connection string (`builder.AddConnectionString("...")`) — Atlas clusters are always replica sets.
 - Any self-hosted or cloud MongoDB cluster reached through a connection string.
 
-For local development against the slim image, `AddCratisChronicleMongoDB()` provisions this for you — a MongoDB container that initializes itself as a single-node replica set, handed back as a connection string carrying `?directConnection=true`:
+For local development against the production image, `AddCratisChronicleMongoDB()` provisions this for you — a MongoDB container that initializes itself as a single-node replica set, handed back as a connection string carrying `?directConnection=true`:
 
 <ChronicleClientTabs snippet="hosting/aspire/mongo-replica-set-helper" />
 
@@ -50,7 +50,7 @@ If you would rather define the container yourself, the same recipe written out i
 
 <ChronicleClientTabs snippet="hosting/aspire/mongo-replica-set" />
 
-`directConnection=true` keeps the driver from following the advertised replica-set member host — `localhost:27017`, only reachable inside the container — back out and hanging. This is the same single-node-replica-set recipe Chronicle's own integration tests use. The embedded development image (`AddCratisChronicle()` with no configure callback) bundles a ready replica set, which is why the development path just works; the requirement only surfaces once you move to the slim image with an external database.
+`directConnection=true` keeps the driver from following the advertised replica-set member host — `localhost:27017`, only reachable inside the container — back out and hanging. This is the same single-node-replica-set recipe Chronicle's own integration tests use. The embedded development image (`AddCratisChronicle()` with no configure callback) bundles a ready replica set, which is why the development path just works; the requirement only surfaces once you move to the production image with an external database.
 
 ### PostgreSQL
 
@@ -106,10 +106,10 @@ For development, simplify further by dropping the MongoDB wiring:
 
 ## Docker Images
 
-| Image tag                       | Description                                             |
-|---------------------------------|---------------------------------------------------------|
-| `cratis/chronicle:latest`       | Production image — no embedded MongoDB                  |
-| `cratis/chronicle:latest-development` | Development image — includes embedded MongoDB |
-| `cratis/chronicle:latest-development-slim` | Development slim image — no embedded MongoDB |
+| Image tag                       | Description                                             | Selected by                                    |
+|---------------------------------|---------------------------------------------------------|------------------------------------------------|
+| `cratis/chronicle:latest`       | Production image — no embedded MongoDB                  | `AddCratisChronicle(configure: ...)`           |
+| `cratis/chronicle:latest-development` | Development image — includes embedded MongoDB | `AddCratisChronicle()`                         |
+| `cratis/chronicle:latest-development-slim` | Development slim image — no embedded MongoDB | Not selected by the Aspire integration — run it directly |
 
 See [Production Hosting](./production.md) for guidance on running Chronicle in production environments.

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/given/a_distributed_application_builder.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/given/a_distributed_application_builder.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.given;
+
+public class a_distributed_application_builder : Specification
+{
+    protected IDistributedApplicationBuilder _builder;
+
+    void Establish() => _builder = DistributedApplication.CreateBuilder([]);
+
+    protected static async Task<Dictionary<string, object>> EnvironmentFor(IResource resource)
+    {
+        var context = new EnvironmentCallbackContext(
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
+            new Dictionary<string, object>());
+        foreach (var annotation in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
+        {
+            await annotation.Callback(context);
+        }
+        return context.EnvironmentVariables;
+    }
+
+    protected static IEnumerable<ContainerMountAnnotation> MountsFor(IResource resource) =>
+        resource.Annotations.OfType<ContainerMountAnnotation>();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/given/a_distributed_application_builder.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/given/a_distributed_application_builder.cs
@@ -9,8 +9,26 @@ namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.given;
 public class a_distributed_application_builder : Specification
 {
     protected IDistributedApplicationBuilder _builder;
+    protected string _appHostDirectory;
 
-    void Establish() => _builder = DistributedApplication.CreateBuilder([]);
+    void Establish()
+    {
+        _appHostDirectory = Path.Combine(Path.GetTempPath(), $"chronicle-apphost-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_appHostDirectory);
+        _builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = [],
+            ProjectDirectory = _appHostDirectory
+        });
+    }
+
+    void Destroy()
+    {
+        if (Directory.Exists(_appHostDirectory))
+        {
+            Directory.Delete(_appHostDirectory, recursive: true);
+        }
+    }
 
     protected static async Task<Dictionary<string, object>> EnvironmentFor(IResource resource)
     {
@@ -26,4 +44,17 @@ public class a_distributed_application_builder : Specification
 
     protected static IEnumerable<ContainerMountAnnotation> MountsFor(IResource resource) =>
         resource.Annotations.OfType<ContainerMountAnnotation>();
+
+    protected static ContainerMountAnnotation[] MountsFor(IResource resource, string containerPath) =>
+        [.. MountsFor(resource).Where(_ => _.Target == containerPath)];
+
+    protected string CertificateFileIn(string relativePath)
+    {
+        var path = InAppHostDirectory(relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "The AppHost only checks that this file is there - it never reads it.");
+        return relativePath;
+    }
+
+    protected string InAppHostDirectory(string relativePath) => Path.GetFullPath(relativePath, _appHostDirectory);
 }

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_both_certificates_are_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_both_certificates_are_configured.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_both_certificates_are_configured : given.a_distributed_application_builder
+{
+    const string TlsCertificatePath = "certs/chronicle.pfx";
+    const string TlsCertificatePassword = "the-tls-password";
+    const string EncryptionCertificatePath = "certs/encryption.pfx";
+    const string EncryptionCertificatePassword = "the-encryption-password";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    ContainerMountAnnotation _tlsMount;
+    ContainerMountAnnotation _encryptionMount;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
+            .WithTlsCertificate(TlsCertificatePath, TlsCertificatePassword)
+            .WithEncryptionCertificate(EncryptionCertificatePath, EncryptionCertificatePassword));
+        _environment = await EnvironmentFor(_result.Resource);
+        _tlsMount = MountsFor(_result.Resource).Single(_ => _.Target == ChronicleContainerImageTags.TlsCertificateContainerPath);
+        _encryptionMount = MountsFor(_result.Resource).Single(_ => _.Target == ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+    }
+
+    [Fact] void should_mount_one_file_per_certificate() => MountsFor(_result.Resource).Count().ShouldEqual(2);
+    [Fact] void should_mount_the_tls_certificate_from_its_host_path() => _tlsMount.Source.ShouldEqual(Path.GetFullPath(TlsCertificatePath));
+    [Fact] void should_mount_the_encryption_certificate_from_its_host_path() => _encryptionMount.Source.ShouldEqual(Path.GetFullPath(EncryptionCertificatePath));
+    [Fact] void should_point_the_tls_certificate_path_at_its_mounted_file() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(_tlsMount.Target);
+    [Fact] void should_point_the_encryption_certificate_path_at_its_mounted_file() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(_encryptionMount.Target);
+    [Fact] void should_configure_the_tls_certificate_password() => _environment[ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable].ShouldEqual(TlsCertificatePassword);
+    [Fact] void should_configure_the_encryption_certificate_password() => _environment[ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable].ShouldEqual(EncryptionCertificatePassword);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_both_certificates_are_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_both_certificates_are_configured.cs
@@ -18,6 +18,12 @@ public class and_both_certificates_are_configured : given.a_distributed_applicat
     ContainerMountAnnotation _tlsMount;
     ContainerMountAnnotation _encryptionMount;
 
+    void Establish()
+    {
+        CertificateFileIn(TlsCertificatePath);
+        CertificateFileIn(EncryptionCertificatePath);
+    }
+
     async Task Because()
     {
         _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
@@ -29,8 +35,8 @@ public class and_both_certificates_are_configured : given.a_distributed_applicat
     }
 
     [Fact] void should_mount_one_file_per_certificate() => MountsFor(_result.Resource).Count().ShouldEqual(2);
-    [Fact] void should_mount_the_tls_certificate_from_its_host_path() => _tlsMount.Source.ShouldEqual(Path.GetFullPath(TlsCertificatePath));
-    [Fact] void should_mount_the_encryption_certificate_from_its_host_path() => _encryptionMount.Source.ShouldEqual(Path.GetFullPath(EncryptionCertificatePath));
+    [Fact] void should_mount_the_tls_certificate_from_its_host_path() => _tlsMount.Source.ShouldEqual(InAppHostDirectory(TlsCertificatePath));
+    [Fact] void should_mount_the_encryption_certificate_from_its_host_path() => _encryptionMount.Source.ShouldEqual(InAppHostDirectory(EncryptionCertificatePath));
     [Fact] void should_point_the_tls_certificate_path_at_its_mounted_file() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(_tlsMount.Target);
     [Fact] void should_point_the_encryption_certificate_path_at_its_mounted_file() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(_encryptionMount.Target);
     [Fact] void should_configure_the_tls_certificate_password() => _environment[ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable].ShouldEqual(TlsCertificatePassword);

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_certificate_is_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_certificate_is_configured.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_no_certificate_is_configured : given.a_distributed_application_builder
+{
+    const string ConnectionString = "Data Source=/data/chronicle.db";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    IEnumerable<ContainerMountAnnotation> _mounts;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithSqlite(ConnectionString));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mounts = MountsFor(_result.Resource);
+    }
+
+    [Fact] void should_still_configure_the_storage() => _environment[ChronicleContainerImageTags.StorageConnectionDetailsEnvironmentVariable].ShouldEqual(ConnectionString);
+    [Fact] void should_not_configure_a_tls_certificate_path() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_a_tls_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_an_encryption_certificate_path() => _environment.ContainsKey(ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_an_encryption_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_mount_anything_into_the_container() => _mounts.ShouldBeEmpty();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_passwords_are_given.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_passwords_are_given.cs
@@ -14,6 +14,12 @@ public class and_no_passwords_are_given : given.a_distributed_application_builde
     IResourceBuilder<ChronicleResource> _result;
     Dictionary<string, object> _environment;
 
+    void Establish()
+    {
+        CertificateFileIn(TlsCertificatePath);
+        CertificateFileIn(EncryptionCertificatePath);
+    }
+
     async Task Because()
     {
         _result = _builder.AddCratisChronicle(configure: chronicle => chronicle

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_passwords_are_given.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_no_passwords_are_given.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_no_passwords_are_given : given.a_distributed_application_builder
+{
+    const string TlsCertificatePath = "certs/chronicle.pfx";
+    const string EncryptionCertificatePath = "certs/encryption.pfx";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
+            .WithTlsCertificate(TlsCertificatePath)
+            .WithEncryptionCertificate(EncryptionCertificatePath));
+        _environment = await EnvironmentFor(_result.Resource);
+    }
+
+    [Fact] void should_configure_the_tls_certificate_path() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
+    [Fact] void should_configure_the_encryption_certificate_path() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+    [Fact] void should_not_configure_a_tls_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_an_encryption_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_one_file_serves_both_certificates.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_one_file_serves_both_certificates.cs
@@ -15,6 +15,8 @@ public class and_one_file_serves_both_certificates : given.a_distributed_applica
     Dictionary<string, object> _environment;
     IEnumerable<ContainerMountAnnotation> _mounts;
 
+    void Establish() => CertificateFileIn(CertificatePath);
+
     async Task Because()
     {
         _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
@@ -24,7 +26,7 @@ public class and_one_file_serves_both_certificates : given.a_distributed_applica
         _mounts = MountsFor(_result.Resource);
     }
 
-    [Fact] void should_mount_the_same_host_file_twice() => _mounts.Select(_ => _.Source).ShouldContainOnly(Path.GetFullPath(CertificatePath), Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_same_host_file_twice() => _mounts.Select(_ => _.Source).ShouldContainOnly(InAppHostDirectory(CertificatePath), InAppHostDirectory(CertificatePath));
     [Fact] void should_mount_the_two_certificates_at_distinct_container_paths() => _mounts.Select(_ => _.Target).Distinct().Count().ShouldEqual(2);
     [Fact] void should_configure_the_tls_certificate_path() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
     [Fact] void should_configure_the_encryption_certificate_path() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_one_file_serves_both_certificates.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_one_file_serves_both_certificates.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_one_file_serves_both_certificates : given.a_distributed_application_builder
+{
+    const string CertificatePath = "certs/chronicle.pfx";
+    const string CertificatePassword = "the-shared-password";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    IEnumerable<ContainerMountAnnotation> _mounts;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
+            .WithTlsCertificate(CertificatePath, CertificatePassword)
+            .WithEncryptionCertificate(CertificatePath, CertificatePassword));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mounts = MountsFor(_result.Resource);
+    }
+
+    [Fact] void should_mount_the_same_host_file_twice() => _mounts.Select(_ => _.Source).ShouldContainOnly(Path.GetFullPath(CertificatePath), Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_two_certificates_at_distinct_container_paths() => _mounts.Select(_ => _.Target).Distinct().Count().ShouldEqual(2);
+    [Fact] void should_configure_the_tls_certificate_path() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
+    [Fact] void should_configure_the_encryption_certificate_path() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_a_tls_certificate_is_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_a_tls_certificate_is_configured.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_only_a_tls_certificate_is_configured : given.a_distributed_application_builder
+{
+    const string CertificatePath = "certs/chronicle.pfx";
+    const string CertificatePassword = "the-tls-password";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    ContainerMountAnnotation _mount;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithTlsCertificate(CertificatePath, CertificatePassword));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mount = MountsFor(_result.Resource).Single();
+    }
+
+    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_certificate_at_the_tls_certificate_container_path() => _mount.Target.ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
+    [Fact] void should_mount_the_certificate_as_read_only() => _mount.IsReadOnly.ShouldBeTrue();
+    [Fact] void should_mount_the_certificate_as_a_bind_mount() => _mount.Type.ShouldEqual(ContainerMountType.BindMount);
+    [Fact] void should_point_the_configured_certificate_path_at_the_mounted_file() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(_mount.Target);
+    [Fact] void should_configure_the_certificate_password() => _environment[ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable].ShouldEqual(CertificatePassword);
+    [Fact] void should_not_configure_an_encryption_certificate_path() => _environment.ContainsKey(ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_an_encryption_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_a_tls_certificate_is_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_a_tls_certificate_is_configured.cs
@@ -15,6 +15,8 @@ public class and_only_a_tls_certificate_is_configured : given.a_distributed_appl
     Dictionary<string, object> _environment;
     ContainerMountAnnotation _mount;
 
+    void Establish() => CertificateFileIn(CertificatePath);
+
     async Task Because()
     {
         _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithTlsCertificate(CertificatePath, CertificatePassword));
@@ -22,7 +24,7 @@ public class and_only_a_tls_certificate_is_configured : given.a_distributed_appl
         _mount = MountsFor(_result.Resource).Single();
     }
 
-    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(InAppHostDirectory(CertificatePath));
     [Fact] void should_mount_the_certificate_at_the_tls_certificate_container_path() => _mount.Target.ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
     [Fact] void should_mount_the_certificate_as_read_only() => _mount.IsReadOnly.ShouldBeTrue();
     [Fact] void should_mount_the_certificate_as_a_bind_mount() => _mount.Type.ShouldEqual(ContainerMountType.BindMount);

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_an_encryption_certificate_is_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_an_encryption_certificate_is_configured.cs
@@ -15,6 +15,8 @@ public class and_only_an_encryption_certificate_is_configured : given.a_distribu
     Dictionary<string, object> _environment;
     ContainerMountAnnotation _mount;
 
+    void Establish() => CertificateFileIn(CertificatePath);
+
     async Task Because()
     {
         _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithEncryptionCertificate(CertificatePath, CertificatePassword));
@@ -22,7 +24,7 @@ public class and_only_an_encryption_certificate_is_configured : given.a_distribu
         _mount = MountsFor(_result.Resource).Single();
     }
 
-    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(InAppHostDirectory(CertificatePath));
     [Fact] void should_mount_the_certificate_at_the_encryption_certificate_container_path() => _mount.Target.ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);
     [Fact] void should_mount_the_certificate_as_read_only() => _mount.IsReadOnly.ShouldBeTrue();
     [Fact] void should_mount_the_certificate_as_a_bind_mount() => _mount.Type.ShouldEqual(ContainerMountType.BindMount);

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_an_encryption_certificate_is_configured.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_only_an_encryption_certificate_is_configured.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_only_an_encryption_certificate_is_configured : given.a_distributed_application_builder
+{
+    const string CertificatePath = "certs/encryption.pfx";
+    const string CertificatePassword = "the-encryption-password";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    ContainerMountAnnotation _mount;
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithEncryptionCertificate(CertificatePath, CertificatePassword));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mount = MountsFor(_result.Resource).Single();
+    }
+
+    [Fact] void should_mount_the_certificate_from_the_given_host_path() => _mount.Source.ShouldEqual(Path.GetFullPath(CertificatePath));
+    [Fact] void should_mount_the_certificate_at_the_encryption_certificate_container_path() => _mount.Target.ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+    [Fact] void should_mount_the_certificate_as_read_only() => _mount.IsReadOnly.ShouldBeTrue();
+    [Fact] void should_mount_the_certificate_as_a_bind_mount() => _mount.Type.ShouldEqual(ContainerMountType.BindMount);
+    [Fact] void should_point_the_configured_certificate_path_at_the_mounted_file() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(_mount.Target);
+    [Fact] void should_configure_the_certificate_password() => _environment[ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable].ShouldEqual(CertificatePassword);
+    [Fact] void should_not_configure_a_tls_certificate_path() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable).ShouldBeFalse();
+    [Fact] void should_not_configure_a_tls_certificate_password() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_certificate_path_is_absolute.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_certificate_path_is_absolute.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_the_certificate_path_is_absolute : given.a_distributed_application_builder
+{
+    string _certificatePath;
+    IResourceBuilder<ChronicleResource> _result;
+    ContainerMountAnnotation _mount;
+
+    void Establish()
+    {
+        _certificatePath = Path.Combine(Path.GetTempPath(), $"chronicle-absolute-{Guid.NewGuid():N}.pfx");
+        File.WriteAllText(_certificatePath, "A certificate outside the AppHost directory.");
+    }
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithTlsCertificate(_certificatePath));
+        _mount = MountsFor(_result.Resource).Single();
+    }
+
+    void Destroy() => File.Delete(_certificatePath);
+
+    [Fact] void should_mount_the_certificate_from_the_absolute_path_as_given() => _mount.Source.ShouldEqual(_certificatePath);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_certificate_path_is_relative.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_certificate_path_is_relative.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+/// <summary>
+/// A decoy file with the same relative path sits in the process working directory, so the mount can only land on
+/// the AppHost directory copy by resolving against the AppHost directory rather than the working directory.
+/// </summary>
+public class and_the_certificate_path_is_relative : given.a_distributed_application_builder
+{
+    const string CertificatePath = "certs-relative-probe/chronicle.pfx";
+
+    IResourceBuilder<ChronicleResource> _result;
+    ContainerMountAnnotation _mount;
+
+    void Establish()
+    {
+        CertificateFileIn(CertificatePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(CertificatePath))!);
+        File.WriteAllText(Path.GetFullPath(CertificatePath), "The decoy in the working directory - the mount must not land here.");
+    }
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle.WithTlsCertificate(CertificatePath));
+        _mount = MountsFor(_result.Resource).Single();
+    }
+
+    void Destroy() => Directory.Delete(Path.GetDirectoryName(Path.GetFullPath(CertificatePath))!, recursive: true);
+
+    [Fact] void should_resolve_the_path_against_the_app_host_directory() => _mount.Source.ShouldEqual(InAppHostDirectory(CertificatePath));
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_encryption_certificate_file_does_not_exist.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_encryption_certificate_file_does_not_exist.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_the_encryption_certificate_file_does_not_exist : given.a_distributed_application_builder
+{
+    const string MissingCertificatePath = "certs/missing-encryption.pfx";
+
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() =>
+        _builder.AddCratisChronicle(configure: chronicle => chronicle.WithEncryptionCertificate(MissingCertificatePath)));
+
+    [Fact] void should_fail_the_app_host() => _exception.ShouldBeOfExactType<CertificateFileDoesNotExist>();
+    [Fact] void should_name_the_configured_path() => _exception.Message.ShouldContain(MissingCertificatePath);
+    [Fact] void should_name_the_path_it_resolved_to() => _exception.Message.ShouldContain(InAppHostDirectory(MissingCertificatePath));
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_encryption_certificate_is_configured_twice.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_encryption_certificate_is_configured_twice.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_the_encryption_certificate_is_configured_twice : given.a_distributed_application_builder
+{
+    const string FirstCertificatePath = "certs/shared.pfx";
+    const string SecondCertificatePath = "certs/environment.pfx";
+    const string SecondCertificatePassword = "the-environment-password";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    ContainerMountAnnotation[] _mounts;
+
+    void Establish()
+    {
+        CertificateFileIn(FirstCertificatePath);
+        CertificateFileIn(SecondCertificatePath);
+    }
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
+            .WithEncryptionCertificate(FirstCertificatePath)
+            .WithEncryptionCertificate(SecondCertificatePath, SecondCertificatePassword));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mounts = MountsFor(_result.Resource, ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+    }
+
+    [Fact] void should_mount_only_one_certificate_on_the_container_path() => _mounts.Length.ShouldEqual(1);
+    [Fact] void should_mount_the_certificate_from_the_last_call() => _mounts.Single().Source.ShouldEqual(InAppHostDirectory(SecondCertificatePath));
+    [Fact] void should_still_configure_the_certificate_path() => _environment[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.EncryptionCertificateContainerPath);
+    [Fact] void should_configure_the_password_from_the_last_call() => _environment[ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable].ShouldEqual(SecondCertificatePassword);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_tls_certificate_file_does_not_exist.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_tls_certificate_file_does_not_exist.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_the_tls_certificate_file_does_not_exist : given.a_distributed_application_builder
+{
+    const string MissingCertificatePath = "certs/missing-tls.pfx";
+
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() =>
+        _builder.AddCratisChronicle(configure: chronicle => chronicle.WithTlsCertificate(MissingCertificatePath)));
+
+    [Fact] void should_fail_the_app_host() => _exception.ShouldBeOfExactType<CertificateFileDoesNotExist>();
+    [Fact] void should_name_the_configured_path() => _exception.Message.ShouldContain(MissingCertificatePath);
+    [Fact] void should_name_the_path_it_resolved_to() => _exception.Message.ShouldContain(InAppHostDirectory(MissingCertificatePath));
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_tls_certificate_is_configured_twice.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleAspireBuilderExtensions/when_configuring_certificates/and_the_tls_certificate_is_configured_twice.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleAspireBuilderExtensions.when_configuring_certificates;
+
+public class and_the_tls_certificate_is_configured_twice : given.a_distributed_application_builder
+{
+    const string FirstCertificatePath = "certs/shared.pfx";
+    const string FirstCertificatePassword = "the-shared-password";
+    const string SecondCertificatePath = "certs/environment.pfx";
+
+    IResourceBuilder<ChronicleResource> _result;
+    Dictionary<string, object> _environment;
+    ContainerMountAnnotation[] _mounts;
+
+    void Establish()
+    {
+        CertificateFileIn(FirstCertificatePath);
+        CertificateFileIn(SecondCertificatePath);
+    }
+
+    async Task Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => chronicle
+            .WithTlsCertificate(FirstCertificatePath, FirstCertificatePassword)
+            .WithTlsCertificate(SecondCertificatePath));
+        _environment = await EnvironmentFor(_result.Resource);
+        _mounts = MountsFor(_result.Resource, ChronicleContainerImageTags.TlsCertificateContainerPath);
+    }
+
+    [Fact] void should_mount_only_one_certificate_on_the_container_path() => _mounts.Length.ShouldEqual(1);
+    [Fact] void should_mount_the_certificate_from_the_last_call() => _mounts.Single().Source.ShouldEqual(InAppHostDirectory(SecondCertificatePath));
+    [Fact] void should_still_configure_the_certificate_path() => _environment[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable].ShouldEqual(ChronicleContainerImageTags.TlsCertificateContainerPath);
+    [Fact] void should_not_keep_the_password_from_the_overridden_call() => _environment.ContainsKey(ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable).ShouldBeFalse();
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleContainerImageTags/when_referencing_the_configuration_keys.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleContainerImageTags/when_referencing_the_configuration_keys.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleContainerImageTags;
+
+/// <summary>
+/// Pins the container environment variable keys as literals. The Chronicle server binds them through the
+/// <c>Cratis__Chronicle__</c> prefix onto <c>ChronicleOptions</c>, so a renamed constant would leave every
+/// other spec green while the server silently ignored the configuration.
+/// </summary>
+public class when_referencing_the_configuration_keys : Specification
+{
+    [Fact] void should_configure_the_storage_type() => ChronicleContainerImageTags.StorageTypeEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Storage__Type");
+    [Fact] void should_configure_the_storage_connection_details() => ChronicleContainerImageTags.StorageConnectionDetailsEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Storage__ConnectionDetails");
+    [Fact] void should_configure_the_compliance_encryption_storage_type() => ChronicleContainerImageTags.ComplianceEncryptionStorageTypeEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Compliance__Encryption__Storage__Type");
+    [Fact] void should_configure_the_compliance_encryption_storage_connection_details() => ChronicleContainerImageTags.ComplianceEncryptionStorageConnectionDetailsEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Compliance__Encryption__Storage__ConnectionDetails");
+    [Fact] void should_configure_the_vault_token() => ChronicleContainerImageTags.VaultTokenEnvironmentVariable.ShouldEqual("VAULT_TOKEN");
+    [Fact] void should_configure_the_tls_certificate_path() => ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Tls__CertificatePath");
+    [Fact] void should_configure_the_tls_certificate_password() => ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable.ShouldEqual("Cratis__Chronicle__Tls__CertificatePassword");
+    [Fact] void should_configure_the_encryption_certificate_path() => ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable.ShouldEqual("Cratis__Chronicle__EncryptionCertificate__CertificatePath");
+    [Fact] void should_configure_the_encryption_certificate_password() => ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable.ShouldEqual("Cratis__Chronicle__EncryptionCertificate__CertificatePassword");
+    [Fact] void should_mount_the_tls_certificate_below_certs() => ChronicleContainerImageTags.TlsCertificateContainerPath.ShouldEqual("/certs/tls.pfx");
+    [Fact] void should_mount_the_encryption_certificate_below_certs() => ChronicleContainerImageTags.EncryptionCertificateContainerPath.ShouldEqual("/certs/encryption.pfx");
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleContainerImageTags/when_referencing_the_published_images.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleContainerImageTags/when_referencing_the_published_images.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleContainerImageTags;
+
+/// <summary>
+/// Pins the published image coordinates as literals. Every other spec compares against these constants, so
+/// without this a changed constant would rename the image the Aspire integration pulls while leaving the
+/// whole suite green.
+/// </summary>
+public class when_referencing_the_published_images : Specification
+{
+    [Fact] void should_pull_from_docker_hub() => ChronicleContainerImageTags.Registry.ShouldEqual("docker.io");
+    [Fact] void should_pull_the_cratis_chronicle_image() => ChronicleContainerImageTags.Image.ShouldEqual("cratis/chronicle");
+    [Fact] void should_publish_the_production_image_as_latest() => ChronicleContainerImageTags.Tag.ShouldEqual("latest");
+    [Fact] void should_publish_the_development_image_as_latest_development() => ChronicleContainerImageTags.DevelopmentTag.ShouldEqual("latest-development");
+    [Fact] void should_publish_the_slim_development_image_as_latest_development_slim() => ChronicleContainerImageTags.DevelopmentSlimTag.ShouldEqual("latest-development-slim");
+    [Fact] void should_pull_the_mongo_db_image() => ChronicleContainerImageTags.MongoDBImage.ShouldEqual("mongo");
+    [Fact] void should_pull_the_pinned_mongo_db_tag() => ChronicleContainerImageTags.MongoDBTag.ShouldEqual("8.0");
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/given/a_distributed_application_builder.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleDistributedApplicationBuilderExtensions.given;
+
+public class a_distributed_application_builder : Specification
+{
+    protected IDistributedApplicationBuilder _builder;
+
+    void Establish() => _builder = DistributedApplication.CreateBuilder([]);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_configuring_for_production.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_configuring_for_production.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleDistributedApplicationBuilderExtensions.when_adding_chronicle;
+
+public class and_configuring_for_production : given.a_distributed_application_builder
+{
+    IResourceBuilder<ChronicleResource> _result;
+    IChronicleAspireBuilder _configured;
+    ContainerImageAnnotation _image;
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicle(configure: chronicle => _configured = chronicle);
+        _image = _result.Resource.Annotations.OfType<ContainerImageAnnotation>().Single();
+    }
+
+    [Fact] void should_use_the_production_image_tag() => _image.Tag.ShouldEqual(ChronicleContainerImageTags.Tag);
+    [Fact] void should_not_use_the_development_slim_image_tag() => _image.Tag.ShouldNotEqual(ChronicleContainerImageTags.DevelopmentSlimTag);
+    [Fact] void should_use_the_chronicle_image() => _image.Image.ShouldEqual(ChronicleContainerImageTags.Image);
+    [Fact] void should_invoke_the_configure_callback() => _configured.ShouldNotBeNull();
+    [Fact] void should_hand_the_chronicle_resource_to_the_callback() => _configured.ResourceBuilder.Resource.ShouldEqual(_result.Resource);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_specifying_a_name.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_specifying_a_name.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleDistributedApplicationBuilderExtensions.when_adding_chronicle;
+
+public class and_specifying_a_name : given.a_distributed_application_builder
+{
+    const string Name = "event-store";
+
+    IResourceBuilder<ChronicleResource> _result;
+
+    void Because() => _result = _builder.AddCratisChronicle(Name);
+
+    [Fact] void should_name_the_resource_as_specified() => _result.Resource.Name.ShouldEqual(Name);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_specifying_a_name_and_configuring_for_production.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_specifying_a_name_and_configuring_for_production.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleDistributedApplicationBuilderExtensions.when_adding_chronicle;
+
+public class and_specifying_a_name_and_configuring_for_production : given.a_distributed_application_builder
+{
+    const string Name = "event-store";
+
+    IResourceBuilder<ChronicleResource> _result;
+    IChronicleAspireBuilder _configured;
+    ContainerImageAnnotation _image;
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicle(Name, chronicle => _configured = chronicle);
+        _image = _result.Resource.Annotations.OfType<ContainerImageAnnotation>().Single();
+    }
+
+    [Fact] void should_name_the_resource_as_specified() => _result.Resource.Name.ShouldEqual(Name);
+    [Fact] void should_use_the_production_image_tag() => _image.Tag.ShouldEqual(ChronicleContainerImageTags.Tag);
+    [Fact] void should_hand_the_named_chronicle_resource_to_the_callback() => _configured.ResourceBuilder.Resource.Name.ShouldEqual(Name);
+}

--- a/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_using_the_defaults.cs
+++ b/Source/Clients/Aspire.Specs/for_ChronicleDistributedApplicationBuilderExtensions/when_adding_chronicle/and_using_the_defaults.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Cratis.Chronicle.Aspire.for_ChronicleDistributedApplicationBuilderExtensions.when_adding_chronicle;
+
+public class and_using_the_defaults : given.a_distributed_application_builder
+{
+    IResourceBuilder<ChronicleResource> _result;
+    ContainerImageAnnotation _image;
+    EndpointAnnotation _endpoint;
+
+    void Because()
+    {
+        _result = _builder.AddCratisChronicle();
+        _image = _result.Resource.Annotations.OfType<ContainerImageAnnotation>().Single();
+        _endpoint = _result.Resource.Annotations.OfType<EndpointAnnotation>().Single();
+    }
+
+    [Fact] void should_name_the_resource_by_convention() => _result.Resource.Name.ShouldEqual("chronicle");
+    [Fact] void should_use_the_chronicle_image() => _image.Image.ShouldEqual(ChronicleContainerImageTags.Image);
+    [Fact] void should_use_the_development_image_tag() => _image.Tag.ShouldEqual(ChronicleContainerImageTags.DevelopmentTag);
+    [Fact] void should_use_the_docker_hub_registry() => _image.Registry.ShouldEqual(ChronicleContainerImageTags.Registry);
+    [Fact] void should_name_the_endpoint_by_convention() => _endpoint.Name.ShouldEqual(ChronicleContainerImageTags.GrpcEndpointName);
+    [Fact] void should_target_the_chronicle_port() => _endpoint.TargetPort.ShouldEqual(ChronicleResource.DefaultGrpcPort);
+    [Fact] void should_expose_the_grpc_endpoint_as_the_connection_string() => _result.Resource.ConnectionStringExpression.ValueExpression.ShouldEqual($"chronicle://{{{_result.Resource.Name}.bindings.{ChronicleContainerImageTags.GrpcEndpointName}.host}}:{{{_result.Resource.Name}.bindings.{ChronicleContainerImageTags.GrpcEndpointName}.port}}");
+}

--- a/Source/Clients/Aspire/CertificateFileDoesNotExist.cs
+++ b/Source/Clients/Aspire/CertificateFileDoesNotExist.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Aspire;
+
+/// <summary>
+/// The exception that is thrown when a certificate file configured for the Chronicle resource does not exist on the host.
+/// </summary>
+/// <param name="certificatePath">The certificate path as configured.</param>
+/// <param name="resolvedPath">The absolute path the configured path resolved to.</param>
+public class CertificateFileDoesNotExist(string certificatePath, string resolvedPath)
+    : Exception($"The certificate file '{certificatePath}' does not exist. It resolved to '{resolvedPath}' - a relative path resolves against the AppHost directory. Docker would create a directory at that path and the Chronicle container would then report that no certificate is configured.");

--- a/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
@@ -186,4 +186,113 @@ public static class ChronicleAspireBuilderExtensions
         });
         return builder;
     }
+
+    /// <summary>
+    /// Configures the Chronicle resource to serve its port with the TLS certificate at the given path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The production image cannot start without this. The Chronicle port serves gRPC (HTTP/2) and the
+    /// Workbench, API and OAuth flows (HTTP/1.1) multiplexed through ALPN on a single TLS port, so a
+    /// certificate is mandatory — the server throws <c>No TLS certificate is configured</c> at startup
+    /// without one. Only the development images generate a self-signed certificate instead of throwing,
+    /// which is why the development path works with no certificate at all.
+    /// </para>
+    /// <para>
+    /// Bind-mounts <paramref name="certificatePath"/> read-only into the container at
+    /// <see cref="ChronicleContainerImageTags.TlsCertificateContainerPath"/> and sets the
+    /// <c>Cratis__Chronicle__Tls__CertificatePath</c> container environment variable to that in-container
+    /// path — a path on the host means nothing to the container, so the mount is part of configuring the
+    /// certificate rather than something to remember separately. When a
+    /// <paramref name="certificatePassword"/> is given, <c>Cratis__Chronicle__Tls__CertificatePassword</c>
+    /// is set to it. These map to <c>Cratis:Chronicle:Tls:CertificatePath</c> and
+    /// <c>Cratis:Chronicle:Tls:CertificatePassword</c> in the Chronicle server configuration respectively.
+    /// </para>
+    /// <para>
+    /// The certificate must be a PKCS#12 (<c>.pfx</c>) file carrying its private key, and Chronicle reads it
+    /// as PKCS#12 only when a password is supplied — pass the password the file was protected with.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IChronicleAspireBuilder"/> to configure.</param>
+    /// <param name="certificatePath">Path on the host to the PKCS#12 certificate file. A relative path resolves against the AppHost directory.</param>
+    /// <param name="certificatePassword">Optional password protecting the certificate file.</param>
+    /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    /// <example>
+    /// <code>
+    /// builder.AddCratisChronicle("chronicle", chronicle => chronicle
+    ///     .WithMongoDB(mongo)
+    ///     .WithTlsCertificate("certs/chronicle.pfx", "YourPassword"));
+    /// </code>
+    /// </example>
+    public static IChronicleAspireBuilder WithTlsCertificate(
+        this IChronicleAspireBuilder builder,
+        string certificatePath,
+        string? certificatePassword = default)
+    {
+        builder.ResourceBuilder.WithBindMount(certificatePath, ChronicleContainerImageTags.TlsCertificateContainerPath, isReadOnly: true);
+        builder.ResourceBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable] = ChronicleContainerImageTags.TlsCertificateContainerPath;
+
+            if (!string.IsNullOrEmpty(certificatePassword))
+            {
+                context.EnvironmentVariables[ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable] = certificatePassword;
+            }
+        });
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the Chronicle resource to protect its Data Protection and OAuth keys with the certificate at the given path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The production image cannot start without this either. The certificate signs and encrypts the internal
+    /// OAuth authority's keys, and the server throws <c>An encryption certificate is required in production</c>
+    /// at startup when it is missing. The development images fall back to ephemeral keys instead.
+    /// </para>
+    /// <para>
+    /// Bind-mounts <paramref name="certificatePath"/> read-only into the container at
+    /// <see cref="ChronicleContainerImageTags.EncryptionCertificateContainerPath"/> and sets the
+    /// <c>Cratis__Chronicle__EncryptionCertificate__CertificatePath</c> container environment variable to that
+    /// in-container path. When a <paramref name="certificatePassword"/> is given,
+    /// <c>Cratis__Chronicle__EncryptionCertificate__CertificatePassword</c> is set to it. These map to
+    /// <c>Cratis:Chronicle:EncryptionCertificate:CertificatePath</c> and
+    /// <c>Cratis:Chronicle:EncryptionCertificate:CertificatePassword</c> in the Chronicle server configuration
+    /// respectively.
+    /// </para>
+    /// <para>
+    /// The certificate must be a PKCS#12 (<c>.pfx</c>) file carrying its private key. It may be the same file
+    /// passed to <see cref="WithTlsCertificate"/> — the two are mounted separately, so pointing both at one
+    /// file works.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The <see cref="IChronicleAspireBuilder"/> to configure.</param>
+    /// <param name="certificatePath">Path on the host to the PKCS#12 certificate file. A relative path resolves against the AppHost directory.</param>
+    /// <param name="certificatePassword">Optional password protecting the certificate file.</param>
+    /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    /// <example>
+    /// <code>
+    /// builder.AddCratisChronicle("chronicle", chronicle => chronicle
+    ///     .WithMongoDB(mongo)
+    ///     .WithEncryptionCertificate("certs/encryption.pfx", "YourPassword"));
+    /// </code>
+    /// </example>
+    public static IChronicleAspireBuilder WithEncryptionCertificate(
+        this IChronicleAspireBuilder builder,
+        string certificatePath,
+        string? certificatePassword = default)
+    {
+        builder.ResourceBuilder.WithBindMount(certificatePath, ChronicleContainerImageTags.EncryptionCertificateContainerPath, isReadOnly: true);
+        builder.ResourceBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable] = ChronicleContainerImageTags.EncryptionCertificateContainerPath;
+
+            if (!string.IsNullOrEmpty(certificatePassword))
+            {
+                context.EnvironmentVariables[ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable] = certificatePassword;
+            }
+        });
+        return builder;
+    }
 }

--- a/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleAspireBuilderExtensions.cs
@@ -217,6 +217,7 @@ public static class ChronicleAspireBuilderExtensions
     /// <param name="certificatePath">Path on the host to the PKCS#12 certificate file. A relative path resolves against the AppHost directory.</param>
     /// <param name="certificatePassword">Optional password protecting the certificate file.</param>
     /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    /// <exception cref="CertificateFileDoesNotExist">Thrown when there is no file at <paramref name="certificatePath"/> on the host.</exception>
     /// <example>
     /// <code>
     /// builder.AddCratisChronicle("chronicle", chronicle => chronicle
@@ -229,16 +230,13 @@ public static class ChronicleAspireBuilderExtensions
         string certificatePath,
         string? certificatePassword = default)
     {
-        builder.ResourceBuilder.WithBindMount(certificatePath, ChronicleContainerImageTags.TlsCertificateContainerPath, isReadOnly: true);
-        builder.ResourceBuilder.WithEnvironment(context =>
-        {
-            context.EnvironmentVariables[ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable] = ChronicleContainerImageTags.TlsCertificateContainerPath;
-
-            if (!string.IsNullOrEmpty(certificatePassword))
-            {
-                context.EnvironmentVariables[ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable] = certificatePassword;
-            }
-        });
+        ConfigureCertificate(
+            builder,
+            certificatePath,
+            certificatePassword,
+            ChronicleContainerImageTags.TlsCertificateContainerPath,
+            ChronicleContainerImageTags.TlsCertificatePathEnvironmentVariable,
+            ChronicleContainerImageTags.TlsCertificatePasswordEnvironmentVariable);
         return builder;
     }
 
@@ -247,9 +245,12 @@ public static class ChronicleAspireBuilderExtensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The production image cannot start without this either. The certificate signs and encrypts the internal
-    /// OAuth authority's keys, and the server throws <c>An encryption certificate is required in production</c>
-    /// at startup when it is missing. The development images fall back to ephemeral keys instead.
+    /// The production image needs this whenever it runs its own OAuth authority, which is the default. The
+    /// certificate signs and encrypts the internal OAuth authority's keys, and the server throws
+    /// <c>An encryption certificate is required in production</c> at startup when it is missing. Turning the
+    /// <c>OAuthAuthority</c> feature off, or pointing <c>Authentication:Authority</c> at an external authority,
+    /// skips that setup entirely and with it the requirement. The development images fall back to ephemeral
+    /// keys instead.
     /// </para>
     /// <para>
     /// Bind-mounts <paramref name="certificatePath"/> read-only into the container at
@@ -271,6 +272,7 @@ public static class ChronicleAspireBuilderExtensions
     /// <param name="certificatePath">Path on the host to the PKCS#12 certificate file. A relative path resolves against the AppHost directory.</param>
     /// <param name="certificatePassword">Optional password protecting the certificate file.</param>
     /// <returns>The same <see cref="IChronicleAspireBuilder"/> for continuation.</returns>
+    /// <exception cref="CertificateFileDoesNotExist">Thrown when there is no file at <paramref name="certificatePath"/> on the host.</exception>
     /// <example>
     /// <code>
     /// builder.AddCratisChronicle("chronicle", chronicle => chronicle
@@ -283,16 +285,74 @@ public static class ChronicleAspireBuilderExtensions
         string certificatePath,
         string? certificatePassword = default)
     {
-        builder.ResourceBuilder.WithBindMount(certificatePath, ChronicleContainerImageTags.EncryptionCertificateContainerPath, isReadOnly: true);
-        builder.ResourceBuilder.WithEnvironment(context =>
+        ConfigureCertificate(
+            builder,
+            certificatePath,
+            certificatePassword,
+            ChronicleContainerImageTags.EncryptionCertificateContainerPath,
+            ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable,
+            ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable);
+        return builder;
+    }
+
+    /// <summary>
+    /// Bind-mounts a certificate file from the host into the container and points the matching Chronicle
+    /// configuration environment variables at the mounted file.
+    /// </summary>
+    /// <param name="builder">The <see cref="IChronicleAspireBuilder"/> to configure.</param>
+    /// <param name="certificatePath">Path on the host to the certificate file, relative to the AppHost directory or absolute.</param>
+    /// <param name="certificatePassword">Optional password protecting the certificate file.</param>
+    /// <param name="containerPath">Path inside the container to mount the certificate at.</param>
+    /// <param name="pathEnvironmentVariable">Environment variable holding the in-container certificate path.</param>
+    /// <param name="passwordEnvironmentVariable">Environment variable holding the certificate password.</param>
+    /// <exception cref="CertificateFileDoesNotExist">Thrown when there is no file at <paramref name="certificatePath"/> on the host.</exception>
+    /// <remarks>
+    /// The existence check fails the AppHost at start rather than at container start: Docker creates a
+    /// <em>directory</em> at a missing bind-mount source, and the Chronicle container then reports that no
+    /// certificate is configured at all — the opposite of what happened. Calling this for the same container
+    /// path more than once replaces the earlier mount instead of adding a second one, so the certificate
+    /// methods are last-call-wins like every other configuration method on the builder; a second mount on the
+    /// same target makes <c>docker run</c> refuse to start the container with a duplicate mount point.
+    /// </remarks>
+    static void ConfigureCertificate(
+        IChronicleAspireBuilder builder,
+        string certificatePath,
+        string? certificatePassword,
+        string containerPath,
+        string pathEnvironmentVariable,
+        string passwordEnvironmentVariable)
+    {
+        var resourceBuilder = builder.ResourceBuilder;
+        var resolvedPath = Path.GetFullPath(certificatePath, resourceBuilder.ApplicationBuilder.AppHostDirectory);
+
+        if (!File.Exists(resolvedPath))
         {
-            context.EnvironmentVariables[ChronicleContainerImageTags.EncryptionCertificatePathEnvironmentVariable] = ChronicleContainerImageTags.EncryptionCertificateContainerPath;
+            throw new CertificateFileDoesNotExist(certificatePath, resolvedPath);
+        }
+
+        var existingMounts = resourceBuilder.Resource.Annotations
+            .OfType<ContainerMountAnnotation>()
+            .Where(_ => _.Target == containerPath)
+            .ToArray();
+
+        foreach (var existingMount in existingMounts)
+        {
+            resourceBuilder.Resource.Annotations.Remove(existingMount);
+        }
+
+        resourceBuilder.WithBindMount(resolvedPath, containerPath, isReadOnly: true);
+        resourceBuilder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[pathEnvironmentVariable] = containerPath;
 
             if (!string.IsNullOrEmpty(certificatePassword))
             {
-                context.EnvironmentVariables[ChronicleContainerImageTags.EncryptionCertificatePasswordEnvironmentVariable] = certificatePassword;
+                context.EnvironmentVariables[passwordEnvironmentVariable] = certificatePassword;
+            }
+            else
+            {
+                context.EnvironmentVariables.Remove(passwordEnvironmentVariable);
             }
         });
-        return builder;
     }
 }

--- a/Source/Clients/Aspire/ChronicleContainerImageTags.cs
+++ b/Source/Clients/Aspire/ChronicleContainerImageTags.cs
@@ -87,4 +87,38 @@ public static class ChronicleContainerImageTags
     /// Chronicle reads this variable directly; the value must be a valid Vault token.
     /// </summary>
     public const string VaultTokenEnvironmentVariable = "VAULT_TOKEN";
+
+    /// <summary>
+    /// Environment variable key for the path to the TLS certificate the Chronicle port is served with.
+    /// Maps to <c>Cratis:Chronicle:Tls:CertificatePath</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string TlsCertificatePathEnvironmentVariable = "Cratis__Chronicle__Tls__CertificatePath";
+
+    /// <summary>
+    /// Environment variable key for the password protecting the TLS certificate.
+    /// Maps to <c>Cratis:Chronicle:Tls:CertificatePassword</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string TlsCertificatePasswordEnvironmentVariable = "Cratis__Chronicle__Tls__CertificatePassword";
+
+    /// <summary>
+    /// Environment variable key for the path to the certificate protecting the Data Protection and OAuth keys.
+    /// Maps to <c>Cratis:Chronicle:EncryptionCertificate:CertificatePath</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string EncryptionCertificatePathEnvironmentVariable = "Cratis__Chronicle__EncryptionCertificate__CertificatePath";
+
+    /// <summary>
+    /// Environment variable key for the password protecting the encryption certificate.
+    /// Maps to <c>Cratis:Chronicle:EncryptionCertificate:CertificatePassword</c> in the Chronicle server configuration.
+    /// </summary>
+    public const string EncryptionCertificatePasswordEnvironmentVariable = "Cratis__Chronicle__EncryptionCertificate__CertificatePassword";
+
+    /// <summary>
+    /// Path inside the Chronicle container that <c>WithTlsCertificate</c> mounts the TLS certificate at.
+    /// </summary>
+    public const string TlsCertificateContainerPath = "/certs/tls.pfx";
+
+    /// <summary>
+    /// Path inside the Chronicle container that <c>WithEncryptionCertificate</c> mounts the encryption certificate at.
+    /// </summary>
+    public const string EncryptionCertificateContainerPath = "/certs/encryption.pfx";
 }

--- a/Source/Clients/Aspire/ChronicleDistributedApplicationBuilderExtensions.cs
+++ b/Source/Clients/Aspire/ChronicleDistributedApplicationBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class ChronicleDistributedApplicationBuilderExtensions
         var resource = new ChronicleResource(name);
         var imageTag = configure is null
             ? ChronicleContainerImageTags.DevelopmentTag
-            : ChronicleContainerImageTags.DevelopmentSlimTag;
+            : ChronicleContainerImageTags.Tag;
 
         var resourceBuilder = builder
             .AddResource(resource)

--- a/Source/Kernel/Server.Specs/for_CertificateLoader/given/a_certificate_file.cs
+++ b/Source/Kernel/Server.Specs/for_CertificateLoader/given/a_certificate_file.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cratis.Chronicle.Server.for_CertificateLoader.given;
+
+public class a_certificate_file : Specification
+{
+    protected string _certificatePath;
+    protected X509Certificate2 _sourceCertificate;
+
+    void Establish()
+    {
+        _certificatePath = Path.Combine(Path.GetTempPath(), $"chronicle-certificate-{Guid.NewGuid():N}.pfx");
+        using var key = RSA.Create(2048);
+        var request = new CertificateRequest("CN=chronicle-specs", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        _sourceCertificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    void Destroy()
+    {
+        _sourceCertificate?.Dispose();
+
+        if (File.Exists(_certificatePath))
+        {
+            File.Delete(_certificatePath);
+        }
+    }
+
+    protected void WritePkcs12(string? password) =>
+        File.WriteAllBytes(_certificatePath, _sourceCertificate.Export(X509ContentType.Pkcs12, password));
+
+    protected Configuration.ChronicleOptions OptionsWithTls(string? password, bool enabled = true) =>
+        new()
+        {
+            Tls = new Configuration.Tls
+            {
+                Enabled = enabled,
+                CertificatePath = _certificatePath,
+                CertificatePassword = password
+            }
+        };
+}

--- a/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_configured_file_does_not_exist.cs
+++ b/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_configured_file_does_not_exist.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cratis.Chronicle.Server.for_CertificateLoader.when_loading_the_certificate;
+
+public class and_the_configured_file_does_not_exist : given.a_certificate_file
+{
+    X509Certificate2 _result;
+    Exception _exception;
+
+    void Because() => _exception = Catch.Exception(() => _result = CertificateLoader.LoadCertificate(OptionsWithTls(password: null)));
+
+    [Fact] void should_not_load_a_certificate() => _result.ShouldBeNull();
+    [Fact] void should_leave_it_to_the_caller_to_decide_what_a_missing_certificate_means() => _exception.ShouldBeNull();
+}

--- a/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_pkcs12_file_has_a_password.cs
+++ b/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_pkcs12_file_has_a_password.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cratis.Chronicle.Server.for_CertificateLoader.when_loading_the_certificate;
+
+public class and_the_pkcs12_file_has_a_password : given.a_certificate_file
+{
+    const string Password = "the-certificate-password";
+
+    X509Certificate2 _result;
+    Exception _exception;
+
+    void Establish() => WritePkcs12(Password);
+
+    void Because() => _exception = Catch.Exception(() => _result = CertificateLoader.LoadCertificate(OptionsWithTls(Password)));
+
+    void Destroy() => _result?.Dispose();
+
+    [Fact] void should_load_the_certificate() => _exception.ShouldBeNull();
+    [Fact] void should_load_the_configured_certificate() => _result.Thumbprint.ShouldEqual(_sourceCertificate.Thumbprint);
+    [Fact] void should_load_the_private_key_the_tls_listener_needs() => _result.HasPrivateKey.ShouldBeTrue();
+}

--- a/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_pkcs12_file_has_no_password.cs
+++ b/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_the_pkcs12_file_has_no_password.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cratis.Chronicle.Server.for_CertificateLoader.when_loading_the_certificate;
+
+public class and_the_pkcs12_file_has_no_password : given.a_certificate_file
+{
+    X509Certificate2 _result;
+    Exception _exception;
+
+    void Establish() => WritePkcs12(password: null);
+
+    void Because() => _exception = Catch.Exception(() => _result = CertificateLoader.LoadCertificate(OptionsWithTls(password: null)));
+
+    void Destroy() => _result?.Dispose();
+
+    [Fact] void should_load_the_certificate() => _exception.ShouldBeNull();
+    [Fact] void should_load_the_configured_certificate() => _result.Thumbprint.ShouldEqual(_sourceCertificate.Thumbprint);
+    [Fact] void should_load_the_private_key_the_tls_listener_needs() => _result.HasPrivateKey.ShouldBeTrue();
+}

--- a/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_tls_is_disabled.cs
+++ b/Source/Kernel/Server.Specs/for_CertificateLoader/when_loading_the_certificate/and_tls_is_disabled.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Cratis.Chronicle.Server.for_CertificateLoader.when_loading_the_certificate;
+
+public class and_tls_is_disabled : given.a_certificate_file
+{
+    X509Certificate2 _result;
+
+    void Establish() => WritePkcs12(password: null);
+
+    void Because() => _result = CertificateLoader.LoadCertificate(OptionsWithTls(password: null, enabled: false));
+
+    [Fact] void should_not_load_the_configured_certificate() => _result.ShouldBeNull();
+}

--- a/Source/Kernel/Server/CertificateLoader.cs
+++ b/Source/Kernel/Server/CertificateLoader.cs
@@ -15,6 +15,11 @@ public static class CertificateLoader
     /// </summary>
     /// <param name="options">The Chronicle options.</param>
     /// <returns>The loaded certificate or null if no certificate is available.</returns>
+    /// <remarks>
+    /// The configured file is read as PKCS#12 whether or not a password is configured, since the TLS listener
+    /// needs the private key the PKCS#12 container carries.
+    /// </remarks>
+    /// <exception cref="System.Security.Cryptography.CryptographicException">Thrown when the configured file is not a PKCS#12 file or the configured password is wrong.</exception>
     public static X509Certificate2? LoadCertificate(Configuration.ChronicleOptions options)
     {
         return LoadFromTls(options.Tls);
@@ -29,26 +34,13 @@ public static class CertificateLoader
 
         if (!string.IsNullOrEmpty(tls.CertificatePath) && File.Exists(tls.CertificatePath))
         {
-            return LoadCertificateFromPath(tls.CertificatePath, tls.CertificatePassword);
+            // The certificate is always read as PKCS#12, with or without a password. The TLS listener needs the
+            // private key, which only PKCS#12 carries, and X509CertificateLoader.LoadCertificateFromFile reads
+            // DER/PEM only — handing it a password-less .pfx fails with "ASN1 corrupted data" rather than
+            // loading it. LoadPkcs12FromFile takes a nullable password, so it covers both cases.
+            return X509CertificateLoader.LoadPkcs12FromFile(tls.CertificatePath, tls.CertificatePassword);
         }
 
         return null;
-    }
-
-    static X509Certificate2 LoadCertificateFromPath(string path, string? password)
-    {
-        if (string.IsNullOrEmpty(password))
-        {
-#if NET8_0
-            return new X509Certificate2(path);
-#else
-            return X509CertificateLoader.LoadCertificateFromFile(path);
-#endif
-        }
-#if NET8_0
-        return new X509Certificate2(path, password);
-#else
-        return X509CertificateLoader.LoadPkcs12FromFile(path, password);
-#endif
     }
 }


### PR DESCRIPTION
## Added

- `WithTlsCertificate` and `WithEncryptionCertificate` on the Aspire builder, which mount a certificate into the Chronicle container read-only and point the configuration at it (#3607)

## Changed

- An Aspire AppHost configured for production must now supply a TLS certificate, and an encryption certificate when the internal OAuth authority is enabled — without them the production image does not start (#3607)

## Fixed

- An Aspire AppHost that configures Chronicle for production now runs the production image, instead of the development image that ships development credentials and an anonymous state-reset endpoint (#3607)
- A TLS certificate without a password now loads, instead of failing the server's startup with a cryptographic error
- A certificate path that does not exist now fails the AppHost immediately, instead of producing a container that reports itself running while its process has died (#3607)
- Configuring either certificate twice now replaces the earlier call, instead of producing a container Docker refuses to start (#3607)

## Security

- An Aspire AppHost configured for production no longer runs a development-compiled Chronicle, which seeds a documented default administrator password and a fixed OAuth client secret, and exposes an unauthenticated endpoint that erases the event store (#3607)
