### PR TITLE
Add ordered event batches to unit of work

### DIFF
--- a/Documentation/client-snippets/events/transactions/ordered-exact-batch.md
+++ b/Documentation/client-snippets/events/transactions/ordered-exact-batch.md
@@ -1,0 +1,42 @@
+```csharp
+using Cratis.Chronicle;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Execution;
+
+public static class TransactionalTransferWorkflow
+{
+    public static async Task<bool> TryCommitTransfer(
+        IEventStore store,
+        EventSequenceNumber expectedAuthorizationRevision)
+    {
+        using var unitOfWork = store.UnitOfWorkManager.Begin(CorrelationId.New());
+        EventSourceId authorizationScopeLabel = "authorization-history";
+        var authorizationScope = new ConcurrencyScope(
+            expectedAuthorizationRevision,
+            EventStreamType: "authorization");
+
+        unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [
+                new EventForEventSourceId(
+                    "account-from",
+                    new TransferDebited(100m)),
+                new EventForEventSourceId(
+                    "account-to",
+                    new TransferCredited(100m))
+            ],
+            [new(authorizationScopeLabel, authorizationScope)]);
+
+        await unitOfWork.Commit();
+        return unitOfWork.IsSuccess;
+    }
+}
+
+[EventType]
+public record TransferDebited(decimal Amount);
+
+[EventType]
+public record TransferCredited(decimal Amount);
+```

--- a/Documentation/events/transactions.mdx
+++ b/Documentation/events/transactions.mdx
@@ -21,6 +21,26 @@ Create a unit of work, append through the transactional event sequence, and comm
 
 <ChronicleClientTabs snippet="events/transactions/basic" />
 
+## Commit an ordered batch with exact concurrency
+
+When a decision reads several streams, capture the exact revision it used and stage the resulting events with that scope. `AddEvents` materializes the events and scopes immediately, preserves cross-stream order, and still waits for the unit of work to commit before sending anything to Chronicle.
+
+<ChronicleClientTabs snippet="events/transactions/ordered-exact-batch" />
+
+A concurrency-scope key can be an independent label when the scope does not narrow by event-source ID. It does not need to match either event target, so one decision-wide stream-, type-, or event-type-scoped revision can protect the entire ordered batch. If a scope does narrow by event-source ID, its key must be that event-source ID.
+
+Every event target and scope label must contain a non-whitespace value; blank labels cannot survive transport and are rejected during enrollment.
+
+Chronicle resolves the configured concurrency strategy for an event target that has no supplied scope or carries `ConcurrencyScope.NotSet`. An independent non-target label has no event target from which to resolve a strategy, so Chronicle rejects `NotSet` and incomplete scopes for those labels. Give an independent label a concrete exact scope or `ConcurrencyScope.None`.
+
+`AddEvents` snapshots the event list, scope collection, and every scope's nested event-type filter before it binds or stages anything in the unit of work. When ordered enrollment first participates in a unit of work, Chronicle also snapshots effective scopes from preceding `AddEvent` calls; later `AddEvent` scopes are snapshotted as they are enrolled. Later mutations to caller-owned collections therefore cannot change the eventual commit, and a lazy collection failure is reported during enrollment.
+
+Dispose the unit of work even when enrollment validation fails, and inspect `IsSuccess` after commit. A completed `Commit` can still report a constraint or concurrency rejection rather than a successful append.
+
+Consecutive `AddEvent` calls keep their existing source-grouped order. Each `AddEvents` call creates an exact-order segment between those legacy segments. Commit flattens the segments in enrollment-call order and sends all of them through one atomic append.
+
+Legacy-only `AddEvent` calls retain their historical event-sequence behavior. Once `AddEvents` participates, every event in the unit of work must name the same event sequence; a mismatch is rejected before the ordered batch is staged.
+
 ## Roll Back
 
 Rollback discards the events staged in the unit of work. Nothing is sent to Chronicle for those staged events.

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_a_scope_for_an_event_source_different_from_its_label.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_a_scope_for_an_event_source_different_from_its_label.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
+
+public class with_a_scope_for_an_event_source_different_from_its_label : Specification
+{
+    Exception _error;
+
+    void Because()
+    {
+        var scopeLabel = EventSourceId.New();
+        var narrowedEventSourceId = EventSourceId.New();
+        _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
+            [],
+            [new(scopeLabel, new ConcurrencyScope(42UL, narrowedEventSourceId))]));
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeEventSourceIdDoesNotMatchLabel>();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_events_and_scopes.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_events_and_scopes.cs
@@ -23,7 +23,7 @@ public class with_events_and_scopes : Specification
         _firstEvent = new(EventSourceId.New(), new object());
         _secondEvent = new(EventSourceId.New(), new object());
         _firstScopeKey = EventSourceId.New();
-        _secondScopeKey = EventSourceId.New();
+        _secondScopeKey = _secondEvent.EventSourceId;
         _firstScope = new(new(42));
         _secondScope = ConcurrencyScope.NotSet;
         _events = [_firstEvent, _secondEvent];

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_incomplete_scope.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_incomplete_scope.cs
@@ -6,19 +6,13 @@ using Cratis.Chronicle.EventSequences.Concurrency;
 
 namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
 
-public class with_duplicate_scope_keys : Specification
+public class with_independent_incomplete_scope : Specification
 {
     Exception _error;
-    EventSourceId _scopeKey;
-
-    void Establish() => _scopeKey = EventSourceId.New();
 
     void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
-        [new(_scopeKey, new object())],
-        [
-            new(_scopeKey, ConcurrencyScope.None),
-            new(_scopeKey, ConcurrencyScope.NotSet)
-        ]));
+        [new(EventSourceId.New(), new object())],
+        [new(EventSourceId.New(), new ConcurrencyScope(EventSequenceNumber.Unavailable, EventTypes: [new EventType("event", 1)]))]));
 
-    [Fact] void should_fail_for_the_duplicate_key() => _error.ShouldBeOfExactType<DuplicateConcurrencyScopeForEventSourceId>();
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<IndependentConcurrencyScopeMustBeExplicit>();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_none_scope.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_none_scope.cs
@@ -6,19 +6,13 @@ using Cratis.Chronicle.EventSequences.Concurrency;
 
 namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
 
-public class with_duplicate_scope_keys : Specification
+public class with_independent_none_scope : Specification
 {
     Exception _error;
-    EventSourceId _scopeKey;
-
-    void Establish() => _scopeKey = EventSourceId.New();
 
     void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
-        [new(_scopeKey, new object())],
-        [
-            new(_scopeKey, ConcurrencyScope.None),
-            new(_scopeKey, ConcurrencyScope.NotSet)
-        ]));
+        [new(EventSourceId.New(), new object())],
+        [new(EventSourceId.New(), ConcurrencyScope.None)]));
 
-    [Fact] void should_fail_for_the_duplicate_key() => _error.ShouldBeOfExactType<DuplicateConcurrencyScopeForEventSourceId>();
+    [Fact] void should_allow_the_explicit_none_scope() => _error.ShouldBeNull();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_not_set_scope.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_independent_not_set_scope.cs
@@ -6,19 +6,13 @@ using Cratis.Chronicle.EventSequences.Concurrency;
 
 namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
 
-public class with_duplicate_scope_keys : Specification
+public class with_independent_not_set_scope : Specification
 {
     Exception _error;
-    EventSourceId _scopeKey;
-
-    void Establish() => _scopeKey = EventSourceId.New();
 
     void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
-        [new(_scopeKey, new object())],
-        [
-            new(_scopeKey, ConcurrencyScope.None),
-            new(_scopeKey, ConcurrencyScope.NotSet)
-        ]));
+        [new(EventSourceId.New(), new object())],
+        [new(EventSourceId.New(), ConcurrencyScope.NotSet)]));
 
-    [Fact] void should_fail_for_the_duplicate_key() => _error.ShouldBeOfExactType<DuplicateConcurrencyScopeForEventSourceId>();
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<IndependentConcurrencyScopeMustBeExplicit>();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_mutable_scope_event_types.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_mutable_scope_event_types.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
+
+public class with_mutable_scope_event_types : Specification
+{
+    EventsWithConcurrencyScopes _result;
+    EventType _eventType;
+    List<EventType> _eventTypes;
+
+    void Establish()
+    {
+        _eventType = new EventType("event", 1);
+        _eventTypes = [_eventType];
+        _result = new(
+            [new(EventSourceId.New(), new object())],
+            [new(EventSourceId.New(), new ConcurrencyScope(42UL, EventTypes: _eventTypes))]);
+    }
+
+    void Because() => _eventTypes.Clear();
+
+    [Fact] void should_snapshot_the_nested_event_types() => _result.ConcurrencyScopes.Single().Value.EventTypes.ShouldContainOnly(_eventType);
+    [Fact] void should_not_retain_the_mutable_collection() => ReferenceEquals(_result.ConcurrencyScopes.Single().Value.EventTypes, _eventTypes).ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_scope_event_types_that_fail_during_enumeration.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_scope_event_types_that_fail_during_enumeration.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
+
+public class with_scope_event_types_that_fail_during_enumeration : Specification
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
+        [new(EventSourceId.New(), new object())],
+        [new(EventSourceId.New(), new ConcurrencyScope(42UL, EventTypes: FailingEventTypes()))]));
+
+    [Fact] void should_surface_the_enumeration_failure_during_construction() => _error.ShouldBeOfExactType<InvalidOperationException>();
+
+    static IEnumerable<EventType> FailingEventTypes()
+    {
+        yield return new EventType("event", 1);
+        throw new InvalidOperationException("Event types could not be read");
+    }
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_unspecified_event_target.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_unspecified_event_target.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
+
+public class with_unspecified_event_target : Specification
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
+        [new(EventSourceId.Unspecified, new object())],
+        []));
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_unspecified_scope_label.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_unspecified_scope_label.cs
@@ -6,19 +6,13 @@ using Cratis.Chronicle.EventSequences.Concurrency;
 
 namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
 
-public class with_duplicate_scope_keys : Specification
+public class with_unspecified_scope_label : Specification
 {
     Exception _error;
-    EventSourceId _scopeKey;
-
-    void Establish() => _scopeKey = EventSourceId.New();
 
     void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
-        [new(_scopeKey, new object())],
-        [
-            new(_scopeKey, ConcurrencyScope.None),
-            new(_scopeKey, ConcurrencyScope.NotSet)
-        ]));
+        [new(EventSourceId.New(), new object())],
+        [new(EventSourceId.Unspecified, ConcurrencyScope.None)]));
 
-    [Fact] void should_fail_for_the_duplicate_key() => _error.ShouldBeOfExactType<DuplicateConcurrencyScopeForEventSourceId>();
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_whitespace_event_target.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_whitespace_event_target.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
+
+public class with_whitespace_event_target : Specification
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
+        [new(new EventSourceId("  "), new object())],
+        []));
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_whitespace_scope_label.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventsWithConcurrencyScopes/when_constructing/with_whitespace_scope_label.cs
@@ -6,19 +6,13 @@ using Cratis.Chronicle.EventSequences.Concurrency;
 
 namespace Cratis.Chronicle.EventSequences.for_EventsWithConcurrencyScopes.when_constructing;
 
-public class with_duplicate_scope_keys : Specification
+public class with_whitespace_scope_label : Specification
 {
     Exception _error;
-    EventSourceId _scopeKey;
-
-    void Establish() => _scopeKey = EventSourceId.New();
 
     void Because() => _error = Catch.Exception(() => _ = new EventsWithConcurrencyScopes(
-        [new(_scopeKey, new object())],
-        [
-            new(_scopeKey, ConcurrencyScope.None),
-            new(_scopeKey, ConcurrencyScope.NotSet)
-        ]));
+        [new(EventSourceId.New(), new object())],
+        [new(new EventSourceId("   "), ConcurrencyScope.None)]));
 
-    [Fact] void should_fail_for_the_duplicate_key() => _error.ShouldBeOfExactType<DuplicateConcurrencyScopeForEventSourceId>();
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
 }

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_a_blank_scope_label.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_a_blank_scope_label.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventsWithConcurrencyScopesResultHandler.when_handling;
+
+public class with_a_blank_scope_label : Specification
+{
+    Exception _error;
+    IEventLog _eventLog;
+    IEventStore _eventStore;
+
+    void Establish()
+    {
+        _eventLog = Substitute.For<IEventLog>();
+        _eventStore = Substitute.For<IEventStore>();
+        _eventStore.EventLog.Returns(_eventLog);
+    }
+
+    async Task Because() => _error = await Catch.Exception(async () => await new EventsWithConcurrencyScopesResultHandler().Handle(
+        new(Events.EventContext.Empty, new object(), ReactorContextValues.Empty),
+        _eventStore,
+        new EventsWithConcurrencyScopes(
+            [new(EventSourceId.New(), new object())],
+            [new(EventSourceId.Unspecified, ConcurrencyScope.None)])));
+
+    [Fact] void should_reject_the_invalid_reactor_result() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_not_append_any_reactor_side_effect() => _eventLog.DidNotReceiveWithAnyArgs().AppendMany(default!, default, default, default);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_independent_not_set_scope.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_independent_not_set_scope.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Reactors.SideEffects.for_EventsWithConcurrencyScopesResultHandler.when_handling;
+
+public class with_independent_not_set_scope : Specification
+{
+    Exception _error;
+    IEventLog _eventLog;
+    IEventStore _eventStore;
+
+    void Establish()
+    {
+        _eventLog = Substitute.For<IEventLog>();
+        _eventStore = Substitute.For<IEventStore>();
+        _eventStore.EventLog.Returns(_eventLog);
+    }
+
+    async Task Because() => _error = await Catch.Exception(async () => await new EventsWithConcurrencyScopesResultHandler().Handle(
+        new(Events.EventContext.Empty, new object(), ReactorContextValues.Empty),
+        _eventStore,
+        new EventsWithConcurrencyScopes(
+            [new(EventSourceId.New(), new object())],
+            [new(EventSourceId.New(), ConcurrencyScope.NotSet)])));
+
+    [Fact] void should_reject_the_invalid_reactor_result() => _error.ShouldBeOfExactType<IndependentConcurrencyScopeMustBeExplicit>();
+    [Fact] void should_not_append_any_reactor_side_effect() => _eventLog.DidNotReceiveWithAnyArgs().AppendMany(default!, default, default, default);
+}

--- a/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_success.cs
+++ b/Source/Clients/DotNET.Specs/Reactors/SideEffects/for_EventsWithConcurrencyScopesResultHandler/when_handling/with_success.cs
@@ -26,8 +26,8 @@ public class with_success : Specification
     {
         _firstEvent = new(EventSourceId.New(), new object());
         _secondEvent = new(EventSourceId.New(), new object());
-        _firstScopeKey = EventSourceId.New();
-        _secondScopeKey = EventSourceId.New();
+        _firstScopeKey = _firstEvent.EventSourceId;
+        _secondScopeKey = _secondEvent.EventSourceId;
         _firstScope = new(new(42), EventSourceId: _firstEvent.EventSourceId);
         _secondScope = ConcurrencyScope.NotSet;
 

--- a/Source/Clients/DotNET.Specs/Transcations/for_IUnitOfWork/when_enrolling_a_batch_with_legacy_implementation.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_IUnitOfWork/when_enrolling_a_batch_with_legacy_implementation.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_IUnitOfWork;
+
+public class when_enrolling_a_batch_with_legacy_implementation : Specification
+{
+    IUnitOfWork _unitOfWork;
+    Exception _error;
+
+    void Establish() => _unitOfWork = new LegacyUnitOfWork();
+
+    void Because() => _error = Catch.Exception(() => _unitOfWork.AddEvents(EventSequenceId.Log, [], []));
+
+    [Fact] void should_fail_loudly_instead_of_losing_the_batch() => _error.ShouldBeOfExactType<UnitOfWorkBatchEnrollmentNotSupported>();
+
+    sealed class LegacyUnitOfWork : IUnitOfWork
+    {
+        public bool IsCompleted => false;
+        public CorrelationId CorrelationId => CorrelationId.NotSet;
+        public bool IsSuccess => true;
+
+        public void AddEvent(
+            EventSequenceId eventSequenceId,
+            EventSourceId eventSourceId,
+            object @event,
+            Causation causation,
+            EventStreamType? eventStreamType = default,
+            EventStreamId? eventStreamId = default,
+            EventSourceType? eventSourceType = default,
+            ConcurrencyScope? concurrencyScope = default,
+            IEnumerable<string>? tags = default,
+            DateTimeOffset? occurred = default,
+            Subject? subject = default)
+        {
+        }
+
+        public IEnumerable<object> GetEvents() => [];
+        public IEnumerable<ConstraintViolation> GetConstraintViolations() => [];
+        public IEnumerable<ConcurrencyViolation> GetConcurrencyViolations() => [];
+        public IEnumerable<AppendError> GetAppendErrors() => [];
+        public Task Commit() => Task.CompletedTask;
+        public Task Rollback() => Task.CompletedTask;
+        public void OnCompleted(Action<IUnitOfWork> callback)
+        {
+        }
+
+        public bool TryGetLastCommittedEventSequenceNumber([NotNullWhen(true)] out EventSequenceNumber? eventSequenceNumber)
+        {
+            eventSequenceNumber = null;
+            return false;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_an_ordered_batch_and_independent_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_an_ordered_batch_and_independent_scope.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class with_an_ordered_batch_and_independent_scope : given.a_unit_of_work
+{
+    EventSourceId _firstEventSourceId;
+    EventSourceId _secondEventSourceId;
+    EventSourceId _scopeLabel;
+    EventForEventSourceId _firstEvent;
+    EventForEventSourceId _secondEvent;
+    EventForEventSourceId _thirdEvent;
+    ConcurrencyScope _scope;
+    List<EventForEventSourceId> _events;
+    List<KeyValuePair<EventSourceId, ConcurrencyScope>> _scopes;
+    EventForEventSourceId[] _committedEvents;
+
+    protected override AppendManyResult GetAppendResult() => new()
+    {
+        CorrelationId = _correlationId,
+    };
+
+    void Establish()
+    {
+        _firstEventSourceId = EventSourceId.New();
+        _secondEventSourceId = EventSourceId.New();
+        _scopeLabel = EventSourceId.New();
+        _firstEvent = new(_firstEventSourceId, new FirstEvent(), new Causation(DateTimeOffset.UtcNow, "first", new Dictionary<string, string>()))
+        {
+            EventStreamType = "first-stream",
+            EventStreamId = "first-stream-id",
+            EventSourceType = "first-source",
+            Tags = ["first-tag"],
+            Occurred = DateTimeOffset.UtcNow.AddMinutes(-3),
+            Subject = "first-subject"
+        };
+        _secondEvent = new(_secondEventSourceId, new SecondEvent());
+        _thirdEvent = new(_firstEventSourceId, new ThirdEvent());
+        _scope = new ConcurrencyScope(42UL, EventTypes: []);
+        _events = [_firstEvent, _secondEvent, _thirdEvent];
+        _scopes = [new(_scopeLabel, _scope)];
+
+        _unitOfWork.AddEvents(EventSequenceId.Log, _events, _scopes);
+
+        _events.Reverse();
+        _scopes.Clear();
+    }
+
+    async Task Because()
+    {
+        await _unitOfWork.Commit();
+        _committedEvents = _eventsAppended.ToArray();
+    }
+
+    [Fact] void should_commit_the_first_event_first() => _committedEvents[0].ShouldEqual(_firstEvent);
+    [Fact] void should_commit_the_second_event_second() => _committedEvents[1].ShouldEqual(_secondEvent);
+    [Fact] void should_commit_the_third_event_third() => _committedEvents[2].ShouldEqual(_thirdEvent);
+    [Fact] void should_keep_interleaved_events_for_the_first_source_in_their_global_positions() => _committedEvents.Select(_ => _.EventSourceId).ShouldContainOnly(_firstEventSourceId, _secondEventSourceId, _firstEventSourceId);
+    [Fact] void should_preserve_the_independent_scope_revision() => _concurrencyScopesAppended[_scopeLabel].SequenceNumber.ShouldEqual(_scope.SequenceNumber);
+    [Fact] void should_preserve_the_independent_scope_event_types() => _concurrencyScopesAppended[_scopeLabel].EventTypes.ShouldBeEmpty();
+    [Fact] void should_not_require_the_scope_label_to_be_an_event_target() => _committedEvents.Any(_ => _.EventSourceId == _scopeLabel).ShouldBeFalse();
+    [Fact] void should_have_materialized_the_events_before_the_caller_mutated_them() => _committedEvents.Length.ShouldEqual(3);
+    [Fact] void should_have_materialized_the_scopes_before_the_caller_mutated_them() => _concurrencyScopesAppended.Count.ShouldEqual(1);
+    [Fact] void should_append_the_batch_once() => _eventSequence.Received(1).AppendMany(Arg.Any<IEnumerable<EventForEventSourceId>>(), Arg.Any<CorrelationId?>(), Arg.Any<IEnumerable<string>>(), Arg.Any<IDictionary<EventSourceId, ConcurrencyScope>>());
+
+    record FirstEvent();
+    record SecondEvent();
+    record ThirdEvent();
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_legacy_events_for_repeated_sources.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_legacy_events_for_repeated_sources.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class with_legacy_events_for_repeated_sources : given.a_unit_of_work
+{
+    readonly Causation _causation = Causation.Unknown();
+    EventSourceId _firstSource;
+    EventSourceId _secondSource;
+    FirstEvent _firstEvent;
+    SecondEvent _secondEvent;
+    ThirdEvent _thirdEvent;
+    object[] _committedEvents;
+
+    void Establish()
+    {
+        _firstSource = EventSourceId.New();
+        _secondSource = EventSourceId.New();
+        _firstEvent = new();
+        _secondEvent = new();
+        _thirdEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, _firstSource, _firstEvent, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, _secondSource, _secondEvent, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, _firstSource, _thirdEvent, _causation);
+    }
+
+    async Task Because()
+    {
+        await _unitOfWork.Commit();
+        _committedEvents = _eventsAppended.Select(_ => _.Event).ToArray();
+    }
+
+    [Fact] void should_commit_the_first_source_first_event_first() => _committedEvents[0].ShouldEqual(_firstEvent);
+    [Fact] void should_commit_the_first_source_second_event_second() => _committedEvents[1].ShouldEqual(_thirdEvent);
+    [Fact] void should_commit_the_second_source_event_last() => _committedEvents[2].ShouldEqual(_secondEvent);
+    [Fact] void should_append_once() => _eventSequence.Received(1).AppendMany(Arg.Any<IEnumerable<EventForEventSourceId>>(), Arg.Any<CorrelationId?>(), Arg.Any<IEnumerable<string>>(), Arg.Any<IDictionary<EventSourceId, EventSequences.Concurrency.ConcurrencyScope>>());
+
+    record FirstEvent;
+    record SecondEvent;
+    record ThirdEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_mixed_legacy_and_ordered_segments.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_mixed_legacy_and_ordered_segments.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class with_mixed_legacy_and_ordered_segments : given.a_unit_of_work
+{
+    readonly Causation _causation = Causation.Unknown();
+    object[] _expectedEvents;
+    object[] _committedEvents;
+
+    void Establish()
+    {
+        var firstSource = EventSourceId.New();
+        var secondSource = EventSourceId.New();
+        var thirdSource = EventSourceId.New();
+        var first = new FirstEvent();
+        var second = new SecondEvent();
+        var third = new ThirdEvent();
+        var fourth = new FourthEvent();
+        var fifth = new FifthEvent();
+        var sixth = new SixthEvent();
+        var seventh = new SeventhEvent();
+        var eighth = new EighthEvent();
+        _expectedEvents = [first, third, second, fourth, fifth, sixth, eighth, seventh];
+
+        _unitOfWork.AddEvent(EventSequenceId.Log, firstSource, first, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, secondSource, second, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, firstSource, third, _causation);
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(secondSource, fourth), new(firstSource, fifth)], []);
+        _unitOfWork.AddEvent(EventSequenceId.Log, thirdSource, sixth, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, secondSource, seventh, _causation);
+        _unitOfWork.AddEvent(EventSequenceId.Log, thirdSource, eighth, _causation);
+    }
+
+    async Task Because()
+    {
+        await _unitOfWork.Commit();
+        _committedEvents = _eventsAppended.Select(_ => _.Event).ToArray();
+    }
+
+    [Fact] void should_keep_each_ordered_batch_between_legacy_source_grouped_segments() => _committedEvents.SequenceEqual(_expectedEvents).ShouldBeTrue();
+    [Fact] void should_append_every_segment_once() => _eventSequence.Received(1).AppendMany(Arg.Any<IEnumerable<EventForEventSourceId>>(), Arg.Any<CorrelationId?>(), Arg.Any<IEnumerable<string>>(), Arg.Any<IDictionary<EventSourceId, EventSequences.Concurrency.ConcurrencyScope>>());
+
+    record FirstEvent;
+    record SecondEvent;
+    record ThirdEvent;
+    record FourthEvent;
+    record FifthEvent;
+    record SixthEvent;
+    record SeventhEvent;
+    record EighthEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_pure_legacy_events_for_different_sequences.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_committing/with_pure_legacy_events_for_different_sequences.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_committing;
+
+public class with_pure_legacy_events_for_different_sequences : given.a_unit_of_work
+{
+    IEventSequence _secondEventSequence;
+    FirstEvent _firstEvent;
+    SecondEvent _secondEvent;
+
+    void Establish()
+    {
+        _secondEventSequence = Substitute.For<IEventSequence>();
+        _eventStore.GetEventSequence(EventSequenceId.Outbox).Returns(_secondEventSequence);
+        _firstEvent = new();
+        _secondEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, EventSourceId.New(), _firstEvent, Causation.Unknown());
+        _unitOfWork.AddEvent(EventSequenceId.Outbox, EventSourceId.New(), _secondEvent, Causation.Unknown());
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_append_both_events_to_the_first_sequence() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent, _secondEvent);
+    [Fact] void should_preserve_the_legacy_second_sequence_lookup() => _eventStore.Received(1).GetEventSequence(EventSequenceId.Outbox);
+    [Fact] void should_not_append_to_the_second_sequence() => _secondEventSequence.DidNotReceiveWithAnyArgs().AppendMany(default!, default, default, default);
+
+    record FirstEvent;
+    record SecondEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_batch_then_add_event_for_another_sequence.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_batch_then_add_event_for_another_sequence.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_batch_then_add_event_for_another_sequence : given.a_unit_of_work
+{
+    FirstEvent _firstEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _firstEvent = new();
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(EventSourceId.New(), _firstEvent)], []);
+    }
+
+    async Task Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Outbox,
+            EventSourceId.New(),
+            new RejectedEvent(),
+            Causation.Unknown()));
+        await _unitOfWork.Commit();
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<UnitOfWorkCannotSpanEventSequences>();
+    [Fact] void should_not_stage_the_rejected_event() => _unitOfWork.GetEvents().ShouldContainOnly(_firstEvent);
+    [Fact] void should_append_only_the_first_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent);
+    [Fact] void should_not_resolve_the_wrong_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Outbox);
+
+    record FirstEvent;
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_batch_event_target.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_batch_event_target.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_blank_batch_event_target : given.a_unit_of_work
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _unitOfWork.AddEvents(
+        EventSequenceId.Log,
+        [new(new EventSourceId("\t"), new RejectedEvent())],
+        []));
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_not_stage_the_event() => _unitOfWork.GetEvents().ShouldBeEmpty();
+    [Fact] void should_not_bind_the_event_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Log);
+
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_legacy_target_then_an_ordered_batch.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_legacy_target_then_an_ordered_batch.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_blank_legacy_target_then_an_ordered_batch : given.a_unit_of_work
+{
+    LegacyEvent _legacyEvent;
+    LaterLegacyEvent _laterLegacyEvent;
+    Exception _error;
+    Exception _laterLegacyError;
+
+    void Establish()
+    {
+        _legacyEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, EventSourceId.Unspecified, _legacyEvent, Causation.Unknown());
+    }
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedOrderedEvent())],
+            []));
+        _laterLegacyEvent = new();
+        _laterLegacyError = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Outbox,
+            EventSourceId.New(),
+            _laterLegacyEvent,
+            Causation.Unknown()));
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_not_stage_the_ordered_event() => _unitOfWork.GetEvents().ShouldContainOnly(_legacyEvent, _laterLegacyEvent);
+    [Fact] void should_leave_pure_legacy_sequence_behavior_active() => _laterLegacyError.ShouldBeNull();
+
+    record LegacyEvent;
+    record RejectedOrderedEvent;
+    record LaterLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_scope_label.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_blank_scope_label.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_blank_scope_label : given.a_unit_of_work
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _unitOfWork.AddEvents(
+        EventSequenceId.Log,
+        [new(EventSourceId.New(), new RejectedEvent())],
+        [new(new EventSourceId("\t"), ConcurrencyScope.None)]));
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_not_stage_the_event() => _unitOfWork.GetEvents().ShouldBeEmpty();
+    [Fact] void should_not_bind_the_event_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Log);
+
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_conflicting_exact_scope_across_legacy_and_batch_calls.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_conflicting_exact_scope_across_legacy_and_batch_calls.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_conflicting_exact_scope_across_legacy_and_batch_calls : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _originalScope;
+    FirstEvent _firstEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _originalScope = new(42UL, _eventSourceId);
+        _firstEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, _firstEvent, Causation.Unknown(), concurrencyScope: _originalScope);
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedEvent())],
+            [new(_eventSourceId, new ConcurrencyScope(43UL, _eventSourceId))]));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConflictingConcurrencyScopesForLabel>();
+    [Fact] void should_not_stage_the_rejected_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent);
+    [Fact] void should_keep_the_original_exact_scope() => ReferenceEquals(_concurrencyScopesAppended[_eventSourceId], _originalScope).ShouldBeTrue();
+
+    record FirstEvent;
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_conflicting_none_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_conflicting_none_scope.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_conflicting_none_scope : given.a_unit_of_work
+{
+    EventSourceId _scopeLabel;
+    ConcurrencyScope _originalScope;
+    FirstEvent _firstEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _scopeLabel = EventSourceId.New();
+        _originalScope = new(42UL, EventTypes: [new EventType("event", 1)]);
+        _firstEvent = new();
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(EventSourceId.New(), _firstEvent)], [new(_scopeLabel, _originalScope)]);
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedEvent())],
+            [new(_scopeLabel, ConcurrencyScope.None)]));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConflictingConcurrencyScopesForLabel>();
+    [Fact] void should_not_stage_the_rejected_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent);
+    [Fact] void should_keep_the_original_exact_revision() => _concurrencyScopesAppended[_scopeLabel].SequenceNumber.ShouldEqual(_originalScope.SequenceNumber);
+    [Fact] void should_keep_the_original_event_type_filter() => _concurrencyScopesAppended[_scopeLabel].EventTypes.ShouldContainOnly(_originalScope.EventTypes);
+
+    record FirstEvent;
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_legacy_scope_narrowed_to_another_event_source.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_legacy_scope_narrowed_to_another_event_source.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_legacy_scope_narrowed_to_another_event_source : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _scope;
+    LegacyEvent _event;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _scope = new(42UL, EventSourceId.New());
+        _event = new();
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            _eventSourceId,
+            _event,
+            Causation.Unknown(),
+            concurrencyScope: _scope);
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_preserve_the_legacy_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_event);
+    [Fact] void should_preserve_the_legacy_scope_shape() => _concurrencyScopesAppended[_eventSourceId].ShouldEqual(_scope);
+
+    record LegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_mismatched_legacy_scope_then_an_ordered_batch.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_mismatched_legacy_scope_then_an_ordered_batch.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_mismatched_legacy_scope_then_an_ordered_batch : given.a_unit_of_work
+{
+    LegacyEvent _legacyEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _legacyEvent = new();
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            EventSourceId.New(),
+            _legacyEvent,
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventSourceId.New()));
+
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedBatchEvent())],
+            []));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_reject_batch_participation_with_the_mismatched_scope() => _error.ShouldBeOfExactType<ConcurrencyScopeEventSourceIdDoesNotMatchLabel>();
+    [Fact] void should_not_stage_the_batch_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_legacyEvent);
+
+    record LegacyEvent;
+    record RejectedBatchEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_mutable_legacy_scope_then_an_ordered_batch.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_mutable_legacy_scope_then_an_ordered_batch.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_mutable_legacy_scope_then_an_ordered_batch : given.a_unit_of_work
+{
+    EventSourceId _legacyTarget;
+    EventType _eventType;
+    List<EventType> _eventTypes;
+
+    void Establish()
+    {
+        _legacyTarget = EventSourceId.New();
+        _eventType = new EventType("legacy", 1);
+        _eventTypes = [_eventType];
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            _legacyTarget,
+            new LegacyEvent(),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventTypes: _eventTypes));
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new OrderedEvent())],
+            []);
+        _eventTypes.Clear();
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_commit_the_legacy_scope_with_its_snapshotted_event_type_filter() => _concurrencyScopesAppended[_legacyTarget].EventTypes.ShouldContainOnly(_eventType);
+
+    record LegacyEvent;
+    record OrderedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_scope_narrowed_to_an_event_source_different_from_its_label.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_scope_narrowed_to_an_event_source_different_from_its_label.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_scope_narrowed_to_an_event_source_different_from_its_label : given.a_unit_of_work
+{
+    FirstEvent _firstEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _firstEvent = new();
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(EventSourceId.New(), _firstEvent)], []);
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedEvent())],
+            [new(EventSourceId.New(), new ConcurrencyScope(42UL, EventSourceId.New()))]));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeEventSourceIdDoesNotMatchLabel>();
+    [Fact] void should_not_stage_the_rejected_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent);
+    [Fact] void should_not_enroll_the_invalid_scope() => _concurrencyScopesAppended.ShouldBeEmpty();
+
+    record FirstEvent;
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_throwing_legacy_scope_then_an_ordered_batch.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_a_throwing_legacy_scope_then_an_ordered_batch.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_a_throwing_legacy_scope_then_an_ordered_batch : given.a_unit_of_work
+{
+    LegacyEvent _legacyEvent;
+    LaterLegacyEvent _laterLegacyEvent;
+    Exception _error;
+    Exception _laterLegacyError;
+
+    void Establish()
+    {
+        _legacyEvent = new();
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            EventSourceId.New(),
+            _legacyEvent,
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventTypes: FailingEventTypes()));
+    }
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedOrderedEvent())],
+            []));
+        _laterLegacyEvent = new();
+        _laterLegacyError = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Outbox,
+            EventSourceId.New(),
+            _laterLegacyEvent,
+            Causation.Unknown()));
+    }
+
+    [Fact] void should_surface_the_enumeration_failure() => _error.ShouldBeOfExactType<InvalidOperationException>();
+    [Fact] void should_not_stage_the_ordered_event() => _unitOfWork.GetEvents().ShouldContainOnly(_legacyEvent, _laterLegacyEvent);
+    [Fact] void should_leave_pure_legacy_sequence_behavior_active() => _laterLegacyError.ShouldBeNull();
+
+    static IEnumerable<EventType> FailingEventTypes()
+    {
+        yield return new EventType("legacy", 1);
+        throw new InvalidOperationException("Event types could not be read");
+    }
+
+    record LegacyEvent;
+    record RejectedOrderedEvent;
+    record LaterLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_add_event_then_a_batch_for_another_sequence.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_add_event_then_a_batch_for_another_sequence.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_add_event_then_a_batch_for_another_sequence : given.a_unit_of_work
+{
+    FirstEvent _firstEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _firstEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, EventSourceId.New(), _firstEvent, Causation.Unknown());
+    }
+
+    async Task Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Outbox,
+            [new(EventSourceId.New(), new RejectedEvent())],
+            []));
+        await _unitOfWork.Commit();
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<UnitOfWorkCannotSpanEventSequences>();
+    [Fact] void should_not_stage_the_rejected_event() => _unitOfWork.GetEvents().ShouldContainOnly(_firstEvent);
+    [Fact] void should_append_only_the_first_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstEvent);
+    [Fact] void should_not_resolve_the_wrong_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Outbox);
+
+    record FirstEvent;
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_independent_not_set_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_independent_not_set_scope.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_independent_not_set_scope : given.a_unit_of_work
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _unitOfWork.AddEvents(
+        EventSequenceId.Log,
+        [new(EventSourceId.New(), new RejectedEvent())],
+        [new(EventSourceId.New(), ConcurrencyScope.NotSet)]));
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<IndependentConcurrencyScopeMustBeExplicit>();
+    [Fact] void should_not_stage_the_event() => _unitOfWork.GetEvents().ShouldBeEmpty();
+    [Fact] void should_not_bind_the_event_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Log);
+
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_blank_legacy_target.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_blank_legacy_target.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_batch_then_a_blank_legacy_target : given.a_unit_of_work
+{
+    OrderedEvent _orderedEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _orderedEvent = new();
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), _orderedEvent)],
+            []);
+    }
+
+    async Task Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            new EventSourceId(" "),
+            new RejectedLegacyEvent(),
+            Causation.Unknown()));
+        await _unitOfWork.Commit();
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_not_stage_the_legacy_event() => _unitOfWork.GetEvents().ShouldContainOnly(_orderedEvent);
+    [Fact] void should_append_only_the_ordered_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_orderedEvent);
+
+    record OrderedEvent;
+    record RejectedLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_mismatched_legacy_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_mismatched_legacy_scope.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_batch_then_a_mismatched_legacy_scope : given.a_unit_of_work
+{
+    BatchEvent _batchEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _batchEvent = new();
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(EventSourceId.New(), _batchEvent)], []);
+        _error = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            EventSourceId.New(),
+            new RejectedLegacyEvent(),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventSourceId.New())));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_reject_the_mismatched_legacy_scope() => _error.ShouldBeOfExactType<ConcurrencyScopeEventSourceIdDoesNotMatchLabel>();
+    [Fact] void should_not_stage_the_legacy_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_batchEvent);
+
+    record BatchEvent;
+    record RejectedLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_mutable_legacy_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_mutable_legacy_scope.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_batch_then_a_mutable_legacy_scope : given.a_unit_of_work
+{
+    EventSourceId _legacyTarget;
+    EventType _eventType;
+    List<EventType> _eventTypes;
+
+    void Establish()
+    {
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new OrderedEvent())],
+            []);
+        _legacyTarget = EventSourceId.New();
+        _eventType = new EventType("legacy", 1);
+        _eventTypes = [_eventType];
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            _legacyTarget,
+            new LegacyEvent(),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventTypes: _eventTypes));
+        _eventTypes.Clear();
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_commit_the_legacy_scope_with_its_snapshotted_event_type_filter() => _concurrencyScopesAppended[_legacyTarget].EventTypes.ShouldContainOnly(_eventType);
+
+    record OrderedEvent;
+    record LegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_throwing_legacy_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_batch_then_a_throwing_legacy_scope.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_batch_then_a_throwing_legacy_scope : given.a_unit_of_work
+{
+    OrderedEvent _orderedEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _orderedEvent = new();
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), _orderedEvent)],
+            []);
+    }
+
+    async Task Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            EventSourceId.New(),
+            new RejectedLegacyEvent(),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(42UL, EventTypes: FailingEventTypes())));
+        await _unitOfWork.Commit();
+    }
+
+    [Fact] void should_surface_the_enumeration_failure() => _error.ShouldBeOfExactType<InvalidOperationException>();
+    [Fact] void should_not_stage_the_legacy_event() => _unitOfWork.GetEvents().ShouldContainOnly(_orderedEvent);
+    [Fact] void should_append_only_the_ordered_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_orderedEvent);
+
+    static IEnumerable<EventType> FailingEventTypes()
+    {
+        yield return new EventType("legacy", 1);
+        throw new InvalidOperationException("Event types could not be read");
+    }
+
+    record OrderedEvent;
+    record RejectedLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_scope_then_a_conflicting_legacy_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_scope_then_a_conflicting_legacy_scope.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_scope_then_a_conflicting_legacy_scope : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _exactScope;
+    BatchEvent _batchEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _exactScope = new(42UL, _eventSourceId);
+        _batchEvent = new();
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(_eventSourceId, _batchEvent)], [new(_eventSourceId, _exactScope)]);
+        _error = Catch.Exception(() => _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            _eventSourceId,
+            new RejectedLegacyEvent(),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(43UL, _eventSourceId)));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_reject_the_conflicting_legacy_scope() => _error.ShouldBeOfExactType<ConflictingConcurrencyScopesForLabel>();
+    [Fact] void should_not_stage_the_legacy_event() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_batchEvent);
+    [Fact] void should_keep_the_ordered_scope() => _concurrencyScopesAppended[_eventSourceId].ShouldEqual(_exactScope);
+
+    record BatchEvent;
+    record RejectedLegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_scope_then_legacy_not_set.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_an_ordered_scope_then_legacy_not_set.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_an_ordered_scope_then_legacy_not_set : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _exactScope;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _exactScope = new(42UL, _eventSourceId);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_eventSourceId, new BatchEvent())],
+            [new(_eventSourceId, _exactScope)]);
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, new LegacyEvent(), Causation.Unknown());
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_not_weaken_the_ordered_scope() => _concurrencyScopesAppended[_eventSourceId].ShouldEqual(_exactScope);
+    [Fact] void should_stage_both_events() => _eventsAppended.Count().ShouldEqual(2);
+
+    record BatchEvent;
+    record LegacyEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_legacy_events_for_two_sequences_then_a_batch_for_the_first.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_legacy_events_for_two_sequences_then_a_batch_for_the_first.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_legacy_events_for_two_sequences_then_a_batch_for_the_first : given.a_unit_of_work
+{
+    IEventSequence _secondEventSequence;
+    FirstLegacyEvent _firstLegacyEvent;
+    SecondLegacyEvent _secondLegacyEvent;
+    Exception _error;
+
+    void Establish()
+    {
+        _secondEventSequence = Substitute.For<IEventSequence>();
+        _eventStore.GetEventSequence(EventSequenceId.Outbox).Returns(_secondEventSequence);
+        _firstLegacyEvent = new();
+        _secondLegacyEvent = new();
+        _unitOfWork.AddEvent(EventSequenceId.Log, EventSourceId.New(), _firstLegacyEvent, Causation.Unknown());
+        _unitOfWork.AddEvent(EventSequenceId.Outbox, EventSourceId.New(), _secondLegacyEvent, Causation.Unknown());
+    }
+
+    async Task Because()
+    {
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new RejectedOrderedEvent())],
+            []));
+        await _unitOfWork.Commit();
+    }
+
+    [Fact] void should_fail_with_the_domain_exception() => _error.ShouldBeOfExactType<UnitOfWorkCannotSpanEventSequences>();
+    [Fact] void should_not_stage_the_ordered_event() => _unitOfWork.GetEvents().ShouldContainOnly(_firstLegacyEvent, _secondLegacyEvent);
+    [Fact] void should_append_only_the_legacy_events_to_the_first_sequence() => _eventsAppended.Select(_ => _.Event).ShouldContainOnly(_firstLegacyEvent, _secondLegacyEvent);
+    [Fact] void should_not_resolve_the_second_sequence_again() => _eventStore.Received(1).GetEventSequence(EventSequenceId.Outbox);
+    [Fact] void should_not_append_to_the_second_sequence() => _secondEventSequence.DidNotReceiveWithAnyArgs().AppendMany(default!, default, default, default);
+
+    record FirstLegacyEvent;
+    record SecondLegacyEvent;
+    record RejectedOrderedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_mutable_scope_event_types.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_mutable_scope_event_types.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_mutable_scope_event_types : given.a_unit_of_work
+{
+    EventSourceId _scopeLabel;
+    EventType _eventType;
+    List<EventType> _eventTypes;
+
+    void Establish()
+    {
+        _scopeLabel = EventSourceId.New();
+        _eventType = new EventType("event", 1);
+        _eventTypes = [_eventType];
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(EventSourceId.New(), new StagedEvent())],
+            [new(_scopeLabel, new ConcurrencyScope(42UL, EventTypes: _eventTypes))]);
+        _eventTypes.Clear();
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_commit_the_snapshotted_event_type_filter() => _concurrencyScopesAppended[_scopeLabel].EventTypes.ShouldContainOnly(_eventType);
+
+    record StagedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_not_set_after_an_explicit_scope.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_not_set_after_an_explicit_scope.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_not_set_after_an_explicit_scope : given.a_unit_of_work
+{
+    EventSourceId _scopeLabel;
+    ConcurrencyScope _originalScope;
+
+    void Establish()
+    {
+        _scopeLabel = EventSourceId.New();
+        _originalScope = new(42UL, EventTypes: [new EventType("event", 1)]);
+        _unitOfWork.AddEvents(EventSequenceId.Log, [], [new(_scopeLabel, _originalScope)]);
+        _unitOfWork.AddEvents(EventSequenceId.Log, [new(_scopeLabel, new TargetEvent())], [new(_scopeLabel, ConcurrencyScope.NotSet)]);
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_keep_the_explicit_scope_revision() => _concurrencyScopesAppended[_scopeLabel].SequenceNumber.ShouldEqual(_originalScope.SequenceNumber);
+    [Fact] void should_keep_the_explicit_scope_event_types() => _concurrencyScopesAppended[_scopeLabel].EventTypes.ShouldContainOnly(_originalScope.EventTypes);
+
+    record TargetEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_scope_event_types_that_fail_during_enumeration.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_scope_event_types_that_fail_during_enumeration.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_scope_event_types_that_fail_during_enumeration : given.a_unit_of_work
+{
+    Exception _error;
+
+    void Because() => _error = Catch.Exception(() => _unitOfWork.AddEvents(
+        EventSequenceId.Log,
+        [new(EventSourceId.New(), new RejectedEvent())],
+        [new(EventSourceId.New(), new ConcurrencyScope(42UL, EventTypes: FailingEventTypes()))]));
+
+    [Fact] void should_surface_the_enumeration_failure() => _error.ShouldBeOfExactType<InvalidOperationException>();
+    [Fact] void should_not_stage_the_event() => _unitOfWork.GetEvents().ShouldBeEmpty();
+    [Fact] void should_not_bind_the_event_sequence() => _eventStore.DidNotReceive().GetEventSequence(EventSequenceId.Log);
+
+    static IEnumerable<EventType> FailingEventTypes()
+    {
+        yield return new EventType("event", 1);
+        throw new InvalidOperationException("Event types could not be read");
+    }
+
+    record RejectedEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_semantically_identical_scopes_across_batches.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_semantically_identical_scopes_across_batches.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_semantically_identical_scopes_across_batches : given.a_unit_of_work
+{
+    EventSourceId _scopeLabel;
+    ConcurrencyScope _originalScope;
+    Exception _error;
+
+    void Establish()
+    {
+        _scopeLabel = EventSourceId.New();
+        EventType firstEventType = new("first", 1);
+        EventType secondEventType = new("second", 1);
+        _originalScope = new(42UL, EventStreamType: "stream", EventTypes: [firstEventType, secondEventType]);
+        var equivalentScope = new ConcurrencyScope(42UL, EventStreamType: "stream", EventTypes: [secondEventType, firstEventType]);
+        _unitOfWork.AddEvents(EventSequenceId.Log, [], [new(_scopeLabel, _originalScope)]);
+
+        _error = Catch.Exception(() => _unitOfWork.AddEvents(EventSequenceId.Log, [], [new(_scopeLabel, equivalentScope)]));
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_accept_the_semantically_identical_scope() => _error.ShouldBeNull();
+    [Fact] void should_keep_the_original_scope_values() => _concurrencyScopesAppended[_scopeLabel].SequenceNumber.ShouldEqual(_originalScope.SequenceNumber);
+    [Fact] void should_keep_the_original_scope_event_types() => _concurrencyScopesAppended[_scopeLabel].EventTypes.ToHashSet().SetEquals(_originalScope.EventTypes).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_two_conflicting_pure_legacy_scopes.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_enrolling/with_two_conflicting_pure_legacy_scopes.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_enrolling;
+
+public class with_two_conflicting_pure_legacy_scopes : given.a_unit_of_work
+{
+    EventSourceId _eventSourceId;
+    ConcurrencyScope _lastScope;
+
+    void Establish()
+    {
+        _eventSourceId = EventSourceId.New();
+        _lastScope = new(43UL, _eventSourceId);
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, new FirstEvent(), Causation.Unknown(), concurrencyScope: new ConcurrencyScope(42UL, _eventSourceId));
+        _unitOfWork.AddEvent(EventSequenceId.Log, _eventSourceId, new SecondEvent(), Causation.Unknown(), concurrencyScope: _lastScope);
+    }
+
+    async Task Because() => await _unitOfWork.Commit();
+
+    [Fact] void should_preserve_legacy_last_explicit_scope_semantics() => _concurrencyScopesAppended[_eventSourceId].ShouldEqual(_lastScope);
+    [Fact] void should_stage_both_legacy_events() => _eventsAppended.Count().ShouldEqual(2);
+
+    record FirstEvent;
+    record SecondEvent;
+}

--- a/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_rolling_back/with_an_ordered_batch.cs
+++ b/Source/Clients/DotNET.Specs/Transcations/for_UnitOfWork/when_rolling_back/with_an_ordered_batch.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions.for_UnitOfWork.when_rolling_back;
+
+public class with_an_ordered_batch : given.a_unit_of_work
+{
+    void Establish() => _unitOfWork.AddEvents(
+        EventSequenceId.Log,
+        [new(EventSourceId.New(), new SomeEvent())],
+        [new(EventSourceId.New(), ConcurrencyScope.None)]);
+
+    async Task Because() => await _unitOfWork.Rollback();
+
+    [Fact] void should_not_append_the_batch() => _eventSequence.DidNotReceive().AppendMany(Arg.Any<IEnumerable<EventForEventSourceId>>(), Arg.Any<CorrelationId?>(), Arg.Any<IEnumerable<string>>(), Arg.Any<IDictionary<EventSourceId, ConcurrencyScope>>());
+    [Fact] void should_not_leave_events_in_the_unit_of_work() => _unitOfWork.GetEvents().ShouldBeEmpty();
+
+    record SomeEvent();
+}

--- a/Source/Clients/DotNET/EventSequences/ConcurrencyScopeEventSourceIdDoesNotMatchLabel.cs
+++ b/Source/Clients/DotNET/EventSequences/ConcurrencyScopeEventSourceIdDoesNotMatchLabel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences;
+
+/// <summary>
+/// The exception that is thrown when a concurrency scope narrows by an event source different from its dictionary label.
+/// </summary>
+/// <param name="scopeLabel">The dictionary label for the scope.</param>
+/// <param name="scopedEventSourceId">The event source the scope narrows by.</param>
+public class ConcurrencyScopeEventSourceIdDoesNotMatchLabel(EventSourceId scopeLabel, EventSourceId scopedEventSourceId)
+    : Exception($"Concurrency scope label '{scopeLabel}' must match its narrowed event source '{scopedEventSourceId}'.");

--- a/Source/Clients/DotNET/EventSequences/ConcurrencyScopeLabelMustBeSpecified.cs
+++ b/Source/Clients/DotNET/EventSequences/ConcurrencyScopeLabelMustBeSpecified.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.EventSequences;
+
+/// <summary>
+/// The exception that is thrown when an event target or concurrency-scope label is unspecified, blank, or whitespace.
+/// </summary>
+public class ConcurrencyScopeLabelMustBeSpecified()
+    : Exception("An event target or concurrency scope label must contain a non-whitespace value.");

--- a/Source/Clients/DotNET/EventSequences/DuplicateConcurrencyScopeForEventSourceId.cs
+++ b/Source/Clients/DotNET/EventSequences/DuplicateConcurrencyScopeForEventSourceId.cs
@@ -6,8 +6,8 @@ using Cratis.Chronicle.Events;
 namespace Cratis.Chronicle.EventSequences;
 
 /// <summary>
-/// The exception that is thrown when more than one concurrency scope is supplied for the same event source id key.
+/// The exception that is thrown when more than one concurrency scope is supplied for the same event source id label.
 /// </summary>
-/// <param name="eventSourceId">The duplicate <see cref="EventSourceId"/> key.</param>
+/// <param name="eventSourceId">The duplicate <see cref="EventSourceId"/> label.</param>
 public class DuplicateConcurrencyScopeForEventSourceId(EventSourceId eventSourceId)
     : Exception($"A concurrency scope for event source id key '{eventSourceId}' has already been supplied.");

--- a/Source/Clients/DotNET/EventSequences/EventsWithConcurrencyScopes.cs
+++ b/Source/Clients/DotNET/EventSequences/EventsWithConcurrencyScopes.cs
@@ -12,10 +12,13 @@ namespace Cratis.Chronicle.EventSequences;
 /// by the same append operation.
 /// </summary>
 /// <remarks>
-/// Both inputs are materialized when this value is created. A missing scope or a
-/// <see cref="ConcurrencyScope.NotSet"/> scope retains the normal <see cref="IEventSequence.AppendMany(IEnumerable{EventForEventSourceId}, CorrelationId?, IEnumerable{string}?, IDictionary{EventSourceId, ConcurrencyScope}?)"/>
-/// behavior and is resolved by the configured concurrency strategy. Use <see cref="ConcurrencyScope.None"/> to
-/// explicitly append without a concurrency check for a key.
+/// Both inputs, including each scope's nested <see cref="ConcurrencyScope.EventTypes"/>, are materialized when this
+/// value is created. For a label that targets an event source in
+/// <see cref="Events"/>, a missing scope or <see cref="ConcurrencyScope.NotSet"/> retains the normal
+/// <see cref="IEventSequence.AppendMany(IEnumerable{EventForEventSourceId}, CorrelationId?, IEnumerable{string}?, IDictionary{EventSourceId, ConcurrencyScope}?)"/>
+/// strategy resolution. An independent non-target label must use a concrete exact scope or
+/// <see cref="ConcurrencyScope.None"/>. A scope label does not need to match an event target unless the scope narrows
+/// by <see cref="ConcurrencyScope.EventSourceId"/>; when it does, the label and narrowed event source must match.
 /// </remarks>
 public sealed class EventsWithConcurrencyScopes
 {
@@ -23,18 +26,42 @@ public sealed class EventsWithConcurrencyScopes
     /// Initializes a new instance of the <see cref="EventsWithConcurrencyScopes"/> class.
     /// </summary>
     /// <param name="events">The events to append, in append order.</param>
-    /// <param name="concurrencyScopes">The source-keyed concurrency scopes to pass to the append operation.</param>
+    /// <param name="concurrencyScopes">The independently labeled concurrency scopes to pass to the append operation.</param>
+    /// <exception cref="ConcurrencyScopeLabelMustBeSpecified">Thrown when an event target or scope label is unspecified, blank, or whitespace.</exception>
     /// <exception cref="DuplicateConcurrencyScopeForEventSourceId">Thrown when more than one scope has the same key.</exception>
+    /// <exception cref="ConcurrencyScopeEventSourceIdDoesNotMatchLabel">Thrown when a scope narrows by an event source different from its label.</exception>
+    /// <exception cref="IndependentConcurrencyScopeMustBeExplicit">Thrown when an independent non-target label has a scope that cannot be validated explicitly.</exception>
     public EventsWithConcurrencyScopes(
         IEnumerable<EventForEventSourceId> events,
         IEnumerable<KeyValuePair<EventSourceId, ConcurrencyScope>> concurrencyScopes)
     {
-        Events = Array.AsReadOnly(events.ToArray());
+        var materializedEvents = events.ToArray();
+        foreach (var @event in materializedEvents)
+        {
+            ThrowIfLabelIsNotSpecified(@event.EventSourceId);
+        }
+
+        Events = Array.AsReadOnly(materializedEvents);
+        var eventTargets = materializedEvents.Select(_ => _.EventSourceId).ToHashSet();
 
         var materializedConcurrencyScopes = new Dictionary<EventSourceId, ConcurrencyScope>();
         foreach (var (eventSourceId, concurrencyScope) in concurrencyScopes)
         {
-            if (!materializedConcurrencyScopes.TryAdd(eventSourceId, concurrencyScope))
+            ThrowIfLabelIsNotSpecified(eventSourceId);
+
+            var materializedConcurrencyScope = Materialize(concurrencyScope);
+            if (materializedConcurrencyScope.EventSourceId is not null && materializedConcurrencyScope.EventSourceId != eventSourceId)
+            {
+                throw new ConcurrencyScopeEventSourceIdDoesNotMatchLabel(eventSourceId, materializedConcurrencyScope.EventSourceId);
+            }
+
+            if (!eventTargets.Contains(eventSourceId) &&
+                (materializedConcurrencyScope == ConcurrencyScope.NotSet || materializedConcurrencyScope.IsIncomplete))
+            {
+                throw new IndependentConcurrencyScopeMustBeExplicit(eventSourceId);
+            }
+
+            if (!materializedConcurrencyScopes.TryAdd(eventSourceId, materializedConcurrencyScope))
             {
                 throw new DuplicateConcurrencyScopeForEventSourceId(eventSourceId);
             }
@@ -49,7 +76,20 @@ public sealed class EventsWithConcurrencyScopes
     public IReadOnlyList<EventForEventSourceId> Events { get; }
 
     /// <summary>
-    /// Gets the copied, source-keyed concurrency scopes.
+    /// Gets the copied, independently labeled concurrency scopes.
     /// </summary>
     public IReadOnlyDictionary<EventSourceId, ConcurrencyScope> ConcurrencyScopes { get; }
+
+    static ConcurrencyScope Materialize(ConcurrencyScope concurrencyScope) =>
+        concurrencyScope.EventTypes is null
+            ? concurrencyScope
+            : concurrencyScope with { EventTypes = concurrencyScope.EventTypes.ToArray() };
+
+    static void ThrowIfLabelIsNotSpecified(EventSourceId label)
+    {
+        if (label == EventSourceId.Unspecified || string.IsNullOrWhiteSpace(label.Value))
+        {
+            throw new ConcurrencyScopeLabelMustBeSpecified();
+        }
+    }
 }

--- a/Source/Clients/DotNET/EventSequences/IndependentConcurrencyScopeMustBeExplicit.cs
+++ b/Source/Clients/DotNET/EventSequences/IndependentConcurrencyScopeMustBeExplicit.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences;
+
+/// <summary>
+/// The exception that is thrown when an independent concurrency-scope label cannot be validated explicitly.
+/// </summary>
+/// <param name="scopeLabel">The independent label whose scope is not explicit.</param>
+public class IndependentConcurrencyScopeMustBeExplicit(EventSourceId scopeLabel)
+    : Exception($"Independent concurrency scope label '{scopeLabel}' must use a concrete exact scope or ConcurrencyScope.None.");

--- a/Source/Clients/DotNET/Transactions/ConflictingConcurrencyScopesForLabel.cs
+++ b/Source/Clients/DotNET/Transactions/ConflictingConcurrencyScopesForLabel.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences.Concurrency;
+
+namespace Cratis.Chronicle.Transactions;
+
+/// <summary>
+/// The exception that is thrown when a unit of work receives conflicting explicit concurrency scopes for one label.
+/// </summary>
+/// <param name="scopeLabel">The label that already has an explicit scope.</param>
+/// <param name="enrolledScope">The previously enrolled scope.</param>
+/// <param name="attemptedScope">The conflicting scope that was attempted.</param>
+public class ConflictingConcurrencyScopesForLabel(
+    EventSourceId scopeLabel,
+    ConcurrencyScope enrolledScope,
+    ConcurrencyScope attemptedScope)
+    : Exception($"Concurrency scope label '{scopeLabel}' is already enrolled with scope '{enrolledScope}' and cannot be changed to '{attemptedScope}'.");

--- a/Source/Clients/DotNET/Transactions/IUnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/IUnitOfWork.cs
@@ -61,6 +61,33 @@ public interface IUnitOfWork : IDisposable
         Subject? subject = default);
 
     /// <summary>
+    /// Adds an ordered batch of events and independently labeled concurrency scopes to the <see cref="IUnitOfWork"/>.
+    /// </summary>
+    /// <param name="eventSequenceId">The <see cref="EventSequenceId"/> for the events.</param>
+    /// <param name="events">The events to add, in commit order.</param>
+    /// <param name="concurrencyScopes">The concurrency scopes to validate with the batch.</param>
+    /// <remarks>
+    /// Both inputs are materialized before this method returns. Consecutive calls to <see cref="AddEvent"/> retain
+    /// their legacy source-grouped order. Each call to this method forms a globally ordered segment between those
+    /// legacy segments, and commit flattens every segment into one append operation. A concurrency-scope key can be
+    /// an independent label when its scope does not narrow by event-source ID. For event-target labels, a missing or
+    /// <see cref="ConcurrencyScope.NotSet"/> scope retains the configured strategy. An independent non-target label
+    /// must use a concrete exact scope or <see cref="ConcurrencyScope.None"/>.
+    /// </remarks>
+    /// <exception cref="ConcurrencyScopeLabelMustBeSpecified">Thrown when an event target or scope label is unspecified, blank, or whitespace.</exception>
+    /// <exception cref="ConcurrencyScopeEventSourceIdDoesNotMatchLabel">Thrown when a scope narrows by an event source different from its label.</exception>
+    /// <exception cref="DuplicateConcurrencyScopeForEventSourceId">Thrown when more than one scope has the same label in one enrollment.</exception>
+    /// <exception cref="ConflictingConcurrencyScopesForLabel">Thrown when a label already has a different explicit scope in this unit of work.</exception>
+    /// <exception cref="IndependentConcurrencyScopeMustBeExplicit">Thrown when an independent non-target label does not have a concrete exact scope or <see cref="ConcurrencyScope.None"/>.</exception>
+    /// <exception cref="UnitOfWorkCannotSpanEventSequences">Thrown when this unit of work is already bound to another event sequence.</exception>
+    /// <exception cref="UnitOfWorkBatchEnrollmentNotSupported">Thrown when an alternate unit-of-work implementation does not support ordered batch enrollment.</exception>
+    void AddEvents(
+        EventSequenceId eventSequenceId,
+        IEnumerable<EventForEventSourceId> events,
+        IEnumerable<KeyValuePair<EventSourceId, ConcurrencyScope>> concurrencyScopes) =>
+        throw new UnitOfWorkBatchEnrollmentNotSupported(GetType());
+
+    /// <summary>
     /// Get the events that have occurred in the <see cref="IUnitOfWork"/>.
     /// </summary>
     /// <returns>A collection of events.</returns>

--- a/Source/Clients/DotNET/Transactions/UnitOfWork.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWork.cs
@@ -8,7 +8,6 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventSequences.Concurrency;
-using Cratis.Chronicle.EventSequences.Operations;
 using Cratis.Traces;
 
 namespace Cratis.Chronicle.Transactions;
@@ -33,13 +32,19 @@ public class UnitOfWork(
         new ActivitySource<UnitOfWork>(new System.Diagnostics.ActivitySource(ClientActivity.SourceName));
 
     readonly IActivitySource<UnitOfWork> _activitySource = activitySource ?? DefaultActivitySource;
+    readonly List<StagedEvents> _stagedEvents = [];
+    readonly HashSet<EventSequenceId> _legacyEventSequenceIds = [];
+    Dictionary<EventSourceId, ConcurrencyScope> _concurrencyScopes = [];
 
     AppendManyResult _appendManyResult = new();
     EventSequenceNumber? _lastCommittedEventSequenceNumber = EventSequenceNumber.Unavailable;
     Action<IUnitOfWork> _onCompleted = onCompleted;
     bool _isCommitted;
     bool _isRolledBack;
-    EventSequenceOperations? _eventSequenceOperations;
+    bool _hasOrderedBatch;
+    IEventSequence? _eventSequence;
+    EventSequenceId? _eventSequenceId;
+    LegacyStagedEvents? _currentLegacyEvents;
 
     /// <inheritdoc/>
     public bool IsCompleted => _isCommitted || _isRolledBack;
@@ -64,20 +69,68 @@ public class UnitOfWork(
         DateTimeOffset? occurred = default,
         Subject? subject = default)
     {
-        var eventSequence = eventStore.GetEventSequence(eventSequenceId);
-        _eventSequenceOperations ??= new EventSequenceOperations(eventSequence);
-        _eventSequenceOperations = _eventSequenceOperations
-            .ForEventSourceId(eventSourceId, builder => builder
-            .WithConcurrencyScope(concurrencyScope ?? ConcurrencyScope.NotSet)
-            .Append(
-                @event,
-                causation,
-                eventStreamType,
-                eventStreamId,
-                eventSourceType,
-                tags,
-                occurred,
-                subject));
+        var scope = concurrencyScope ?? ConcurrencyScope.NotSet;
+        if (_hasOrderedBatch)
+        {
+            ThrowIfLabelIsNotSpecified(eventSourceId);
+            scope = MaterializeConcurrencyScope(scope);
+            EnsureEventSequenceCanBeUsed(eventSequenceId);
+            ValidateConcurrencyScope(eventSourceId, scope, _concurrencyScopes);
+            BindToEventSequence(eventSequenceId);
+        }
+        else
+        {
+            BindLegacyEventSequence(eventSequenceId);
+        }
+
+        if (_currentLegacyEvents is null)
+        {
+            _currentLegacyEvents = new LegacyStagedEvents();
+            _stagedEvents.Add(_currentLegacyEvents);
+        }
+
+        _currentLegacyEvents.Add(new EventForEventSourceId(eventSourceId, @event, causation)
+        {
+            EventStreamType = eventStreamType ?? EventStreamType.All,
+            EventStreamId = eventStreamId ?? EventStreamId.Default,
+            EventSourceType = eventSourceType ?? EventSourceType.Default,
+            Tags = tags ?? [],
+            Occurred = occurred,
+            Subject = subject
+        });
+        if (_hasOrderedBatch)
+        {
+            EnrollStrictConcurrencyScope(eventSourceId, scope);
+        }
+        else
+        {
+            SetLegacyConcurrencyScope(eventSourceId, scope);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddEvents(
+        EventSequenceId eventSequenceId,
+        IEnumerable<EventForEventSourceId> events,
+        IEnumerable<KeyValuePair<EventSourceId, ConcurrencyScope>> concurrencyScopes)
+    {
+        var batch = new EventsWithConcurrencyScopes(events, concurrencyScopes);
+        ValidateLegacyEventSequenceIdsForOrderedBatch(eventSequenceId);
+        EnsureEventSequenceCanBeUsed(eventSequenceId);
+        ValidateExistingEventTargetsForOrderedBatch();
+        var materializedConcurrencyScopes = MaterializeConcurrencyScopes(_concurrencyScopes);
+        ValidateExistingConcurrencyScopesForOrderedBatch(materializedConcurrencyScopes);
+        ValidateConcurrencyScopes(batch.ConcurrencyScopes, materializedConcurrencyScopes);
+
+        BindToEventSequence(eventSequenceId);
+        _concurrencyScopes = materializedConcurrencyScopes;
+        _hasOrderedBatch = true;
+        _currentLegacyEvents = null;
+        _stagedEvents.Add(new OrderedStagedEvents(batch.Events));
+        foreach (var (scopeLabel, concurrencyScope) in batch.ConcurrencyScopes)
+        {
+            EnrollStrictConcurrencyScope(scopeLabel, concurrencyScope);
+        }
     }
 
     /// <inheritdoc/>
@@ -87,8 +140,7 @@ public class UnitOfWork(
     public IEnumerable<ConcurrencyViolation> GetConcurrencyViolations() => _appendManyResult.ConcurrencyViolations;
 
     /// <inheritdoc/>
-    public IEnumerable<object> GetEvents() =>
-        _eventSequenceOperations?.GetAppendedEvents() ?? [];
+    public IEnumerable<object> GetEvents() => GetEventsToCommit().Select(_ => _.Event).ToArray();
 
     /// <inheritdoc/>
     public IEnumerable<AppendError> GetAppendErrors() => [.. _appendManyResult.Errors];
@@ -102,9 +154,9 @@ public class UnitOfWork(
 
         try
         {
-            if (_eventSequenceOperations is not null)
+            if (_eventSequence is not null)
             {
-                var result = await _eventSequenceOperations.Perform();
+                var result = await _eventSequence.AppendMany(GetEventsToCommit(), concurrencyScopes: _concurrencyScopes);
                 if (result.SequenceNumbers?.Any() == true)
                 {
                     _lastCommittedEventSequenceNumber = result.SequenceNumbers.MaxBy(_ => _.Value);
@@ -129,7 +181,9 @@ public class UnitOfWork(
 
         ThrowIfUnitOfWorkIsCompleted();
         _isRolledBack = true;
-        _eventSequenceOperations?.Clear();
+        _stagedEvents.Clear();
+        _currentLegacyEvents = null;
+        _concurrencyScopes.Clear();
         _appendManyResult = AppendManyResult.Success(CorrelationId.NotSet, []);
 
         _onCompleted(this);
@@ -156,9 +210,190 @@ public class UnitOfWork(
         Rollback().GetAwaiter().GetResult();
     }
 
+    static bool ConcurrencyScopesAreSemanticallyEqual(ConcurrencyScope first, ConcurrencyScope second)
+    {
+        if (first.SequenceNumber != second.SequenceNumber ||
+            first.EventSourceId != second.EventSourceId ||
+            first.EventStreamType != second.EventStreamType ||
+            first.EventStreamId != second.EventStreamId ||
+            first.EventSourceType != second.EventSourceType)
+        {
+            return false;
+        }
+
+        var firstEventTypes = first.EventTypes?.ToHashSet() ?? [];
+        var secondEventTypes = second.EventTypes?.ToHashSet() ?? [];
+        return firstEventTypes.SetEquals(secondEventTypes);
+    }
+
+    static ConcurrencyScope MaterializeConcurrencyScope(ConcurrencyScope concurrencyScope) =>
+        concurrencyScope.EventTypes is null
+            ? concurrencyScope
+            : concurrencyScope with { EventTypes = concurrencyScope.EventTypes.ToArray() };
+
+    static Dictionary<EventSourceId, ConcurrencyScope> MaterializeConcurrencyScopes(
+        IReadOnlyDictionary<EventSourceId, ConcurrencyScope> concurrencyScopes) =>
+        concurrencyScopes.ToDictionary(_ => _.Key, _ => MaterializeConcurrencyScope(_.Value));
+
+    static void ThrowIfLabelIsNotSpecified(EventSourceId label)
+    {
+        if (label == EventSourceId.Unspecified || string.IsNullOrWhiteSpace(label.Value))
+        {
+            throw new ConcurrencyScopeLabelMustBeSpecified();
+        }
+    }
+
     void ThrowIfUnitOfWorkIsCompleted()
     {
         if (_isCommitted) throw new UnitOfWorkIsAlreadyCommitted(CorrelationId);
         if (_isRolledBack) throw new UnitOfWorkIsAlreadyRolledBack(CorrelationId);
+    }
+
+    void SetLegacyConcurrencyScope(EventSourceId scopeLabel, ConcurrencyScope concurrencyScope)
+    {
+        if (concurrencyScope == ConcurrencyScope.NotSet && _concurrencyScopes.ContainsKey(scopeLabel))
+        {
+            return;
+        }
+
+        if (concurrencyScope == ConcurrencyScope.NotSet)
+        {
+            _concurrencyScopes.Remove(scopeLabel);
+            return;
+        }
+
+        _concurrencyScopes[scopeLabel] = concurrencyScope;
+    }
+
+    void EnrollStrictConcurrencyScope(EventSourceId scopeLabel, ConcurrencyScope concurrencyScope)
+    {
+        if (concurrencyScope == ConcurrencyScope.NotSet)
+        {
+            return;
+        }
+
+        _concurrencyScopes.TryAdd(scopeLabel, concurrencyScope);
+    }
+
+    void EnsureEventSequenceCanBeUsed(EventSequenceId eventSequenceId)
+    {
+        if (_eventSequenceId is not null && _eventSequenceId != eventSequenceId)
+        {
+            throw new UnitOfWorkCannotSpanEventSequences(_eventSequenceId, eventSequenceId);
+        }
+    }
+
+    void BindToEventSequence(EventSequenceId eventSequenceId)
+    {
+        if (_eventSequence is not null)
+        {
+            return;
+        }
+
+        _eventSequence = eventStore.GetEventSequence(eventSequenceId);
+        _eventSequenceId = eventSequenceId;
+    }
+
+    void BindLegacyEventSequence(EventSequenceId eventSequenceId)
+    {
+        var eventSequence = eventStore.GetEventSequence(eventSequenceId);
+        _legacyEventSequenceIds.Add(eventSequenceId);
+        if (_eventSequence is not null)
+        {
+            return;
+        }
+
+        _eventSequence = eventSequence;
+        _eventSequenceId = eventSequenceId;
+    }
+
+    void ValidateConcurrencyScopes(
+        IEnumerable<KeyValuePair<EventSourceId, ConcurrencyScope>> concurrencyScopes,
+        IReadOnlyDictionary<EventSourceId, ConcurrencyScope> enrolledConcurrencyScopes)
+    {
+        foreach (var (scopeLabel, concurrencyScope) in concurrencyScopes)
+        {
+            ValidateConcurrencyScope(scopeLabel, concurrencyScope, enrolledConcurrencyScopes);
+        }
+    }
+
+    void ValidateExistingConcurrencyScopesForOrderedBatch(IReadOnlyDictionary<EventSourceId, ConcurrencyScope> concurrencyScopes)
+    {
+        foreach (var (scopeLabel, concurrencyScope) in concurrencyScopes)
+        {
+            if (concurrencyScope.EventSourceId is not null && concurrencyScope.EventSourceId != scopeLabel)
+            {
+                throw new ConcurrencyScopeEventSourceIdDoesNotMatchLabel(scopeLabel, concurrencyScope.EventSourceId);
+            }
+        }
+    }
+
+    void ValidateConcurrencyScope(
+        EventSourceId scopeLabel,
+        ConcurrencyScope concurrencyScope,
+        IReadOnlyDictionary<EventSourceId, ConcurrencyScope> enrolledConcurrencyScopes)
+    {
+        if (concurrencyScope.EventSourceId is not null && concurrencyScope.EventSourceId != scopeLabel)
+        {
+            throw new ConcurrencyScopeEventSourceIdDoesNotMatchLabel(scopeLabel, concurrencyScope.EventSourceId);
+        }
+
+        if (concurrencyScope == ConcurrencyScope.NotSet || !enrolledConcurrencyScopes.TryGetValue(scopeLabel, out var enrolledScope))
+        {
+            return;
+        }
+
+        if (!ConcurrencyScopesAreSemanticallyEqual(enrolledScope, concurrencyScope))
+        {
+            throw new ConflictingConcurrencyScopesForLabel(scopeLabel, enrolledScope, concurrencyScope);
+        }
+    }
+
+    void ValidateExistingEventTargetsForOrderedBatch()
+    {
+        foreach (var @event in _stagedEvents.SelectMany(_ => _.GetEvents()))
+        {
+            ThrowIfLabelIsNotSpecified(@event.EventSourceId);
+        }
+    }
+
+    void ValidateLegacyEventSequenceIdsForOrderedBatch(EventSequenceId eventSequenceId)
+    {
+        var mismatchedEventSequenceId = _legacyEventSequenceIds.FirstOrDefault(_ => _ != eventSequenceId);
+        if (mismatchedEventSequenceId is not null)
+        {
+            throw new UnitOfWorkCannotSpanEventSequences(mismatchedEventSequenceId, eventSequenceId);
+        }
+    }
+
+    EventForEventSourceId[] GetEventsToCommit() =>
+        _stagedEvents.SelectMany(_ => _.GetEvents()).ToArray();
+
+    abstract class StagedEvents
+    {
+        public abstract IEnumerable<EventForEventSourceId> GetEvents();
+    }
+
+    sealed class LegacyStagedEvents : StagedEvents
+    {
+        readonly Dictionary<EventSourceId, List<EventForEventSourceId>> _eventsBySource = [];
+
+        public void Add(EventForEventSourceId @event)
+        {
+            if (!_eventsBySource.TryGetValue(@event.EventSourceId, out var events))
+            {
+                events = [];
+                _eventsBySource[@event.EventSourceId] = events;
+            }
+
+            events.Add(@event);
+        }
+
+        public override IEnumerable<EventForEventSourceId> GetEvents() => _eventsBySource.Values.SelectMany(_ => _);
+    }
+
+    sealed class OrderedStagedEvents(IReadOnlyList<EventForEventSourceId> events) : StagedEvents
+    {
+        public override IEnumerable<EventForEventSourceId> GetEvents() => events;
     }
 }

--- a/Source/Clients/DotNET/Transactions/UnitOfWorkBatchEnrollmentNotSupported.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWorkBatchEnrollmentNotSupported.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Transactions;
+
+/// <summary>
+/// The exception that is thrown when a unit-of-work implementation does not support ordered batch enrollment.
+/// </summary>
+/// <param name="unitOfWorkType">The type of unit of work that does not support ordered batch enrollment.</param>
+public class UnitOfWorkBatchEnrollmentNotSupported(Type unitOfWorkType)
+    : Exception($"The unit of work implementation '{unitOfWorkType.FullName}' does not support ordered batch enrollment.");

--- a/Source/Clients/DotNET/Transactions/UnitOfWorkCannotSpanEventSequences.cs
+++ b/Source/Clients/DotNET/Transactions/UnitOfWorkCannotSpanEventSequences.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Transactions;
+
+/// <summary>
+/// The exception that is thrown when events for different event sequences are enrolled in the same unit of work.
+/// </summary>
+/// <param name="enrolledEventSequenceId">The event sequence the unit of work is already bound to.</param>
+/// <param name="attemptedEventSequenceId">The different event sequence that was attempted.</param>
+public class UnitOfWorkCannotSpanEventSequences(EventSequenceId enrolledEventSequenceId, EventSequenceId attemptedEventSequenceId)
+    : Exception($"A unit of work bound to event sequence '{enrolledEventSequenceId}' cannot enroll events for event sequence '{attemptedEventSequenceId}'.");

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_blank_batch_target_was_rejected.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_blank_batch_target_was_rejected.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class after_a_blank_batch_target_was_rejected : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _blankTarget;
+    Exception _enrollmentError;
+    bool _blankTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _blankTarget = new EventSourceId(" ");
+    }
+
+    async Task Because()
+    {
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _enrollmentError = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_blankTarget, new TestEvent("rejected target"))],
+            []));
+
+        await _unitOfWork.Commit();
+        _blankTargetHasEvents = await _scenario.EventLog.HasEventsFor(_blankTarget);
+    }
+
+    [Fact] void should_reject_the_blank_target_at_enrollment() => _enrollmentError.ShouldBeOfExactType<ConcurrencyScopeLabelMustBeSpecified>();
+    [Fact] void should_leave_no_event_on_the_blank_target() => _blankTargetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_conflicting_scope_was_rejected.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_conflicting_scope_was_rejected.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class after_a_conflicting_scope_was_rejected : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _acceptedTarget;
+    EventSourceId _rejectedTarget;
+    Exception _enrollmentError;
+    bool _acceptedTargetHasEvents;
+    bool _rejectedTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _acceptedTarget = EventSourceId.New();
+        _rejectedTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("decision revision"));
+
+        var eventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(TestEvent));
+        var scopeLabel = EventSourceId.New();
+        var exactScope = new ConcurrencyScope(EventSequenceNumber.First, EventTypes: [eventType]);
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_acceptedTarget, new TestEvent("accepted enrollment"))],
+            [new(scopeLabel, exactScope)]);
+
+        _enrollmentError = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_rejectedTarget, new TestEvent("rejected enrollment"))],
+            [new(scopeLabel, ConcurrencyScope.None)]));
+
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("interference"));
+        await _unitOfWork.Commit();
+        _acceptedTargetHasEvents = await _scenario.EventLog.HasEventsFor(_acceptedTarget);
+        _rejectedTargetHasEvents = await _scenario.EventLog.HasEventsFor(_rejectedTarget);
+    }
+
+    [Fact] void should_reject_the_conflicting_scope_at_enrollment() => _enrollmentError.ShouldBeOfExactType<ConflictingConcurrencyScopesForLabel>();
+    [Fact] void should_keep_the_original_exact_scope_effective() => _unitOfWork.GetConcurrencyViolations().ShouldNotBeEmpty();
+    [Fact] void should_not_append_the_first_staged_event_after_its_scope_became_stale() => _acceptedTargetHasEvents.ShouldBeFalse();
+    [Fact] void should_not_partially_stage_the_rejected_event() => _rejectedTargetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_source_scoped_scope_with_a_nonmatching_label_was_rejected.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_source_scoped_scope_with_a_nonmatching_label_was_rejected.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class after_a_source_scoped_scope_with_a_nonmatching_label_was_rejected : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _acceptedTarget;
+    EventSourceId _rejectedTarget;
+    Exception _enrollmentError;
+    bool _acceptedTargetHasEvents;
+    bool _rejectedTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _acceptedTarget = EventSourceId.New();
+        _rejectedTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_acceptedTarget, new TestEvent("accepted enrollment"))],
+            []);
+
+        _enrollmentError = Catch.Exception(() => _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_rejectedTarget, new TestEvent("rejected enrollment"))],
+            [new(EventSourceId.New(), new ConcurrencyScope(EventSequenceNumber.First, _acceptedTarget))]));
+
+        await _unitOfWork.Commit();
+        _acceptedTargetHasEvents = await _scenario.EventLog.HasEventsFor(_acceptedTarget);
+        _rejectedTargetHasEvents = await _scenario.EventLog.HasEventsFor(_rejectedTarget);
+    }
+
+    [Fact] void should_reject_the_mismatched_source_scope_at_enrollment() => _enrollmentError.ShouldBeOfExactType<ConcurrencyScopeEventSourceIdDoesNotMatchLabel>();
+    [Fact] void should_commit_the_previously_staged_event() => _acceptedTargetHasEvents.ShouldBeTrue();
+    [Fact] void should_not_partially_stage_the_rejected_event() => _rejectedTargetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_strict_add_event_scope_filter_was_mutated.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/after_a_strict_add_event_scope_filter_was_mutated.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Testing.Reactors;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class after_a_strict_add_event_scope_filter_was_mutated : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _orderedTarget;
+    EventSourceId _legacyTarget;
+    bool _orderedTargetHasEvents;
+    bool _legacyTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _orderedTarget = EventSourceId.New();
+        _legacyTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("decision revision"));
+        await _scenario.EventLog.Append(EventSourceId.New(), new MemberActivityRecorded());
+
+        var testEventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(TestEvent));
+        var activityEventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(MemberActivityRecorded));
+        List<EventType> eventTypes = [testEventType, activityEventType];
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_orderedTarget, new TestEvent("ordered target"))],
+            []);
+        _unitOfWork.AddEvent(
+            EventSequenceId.Log,
+            _legacyTarget,
+            new TestEvent("legacy target"),
+            Causation.Unknown(),
+            concurrencyScope: new ConcurrencyScope(new EventSequenceNumber(1), EventTypes: eventTypes));
+
+        eventTypes.Clear();
+        eventTypes.Add(activityEventType);
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("interference"));
+        await _unitOfWork.Commit();
+
+        _orderedTargetHasEvents = await _scenario.EventLog.HasEventsFor(_orderedTarget);
+        _legacyTargetHasEvents = await _scenario.EventLog.HasEventsFor(_legacyTarget);
+    }
+
+    [Fact] void should_reject_the_stale_snapshotted_scope() => _unitOfWork.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_concurrency_violation() => _unitOfWork.GetConcurrencyViolations().ShouldNotBeEmpty();
+    [Fact] void should_leave_no_event_on_the_ordered_target() => _orderedTargetHasEvents.ShouldBeFalse();
+    [Fact] void should_leave_no_event_on_the_legacy_target() => _legacyTargetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_an_independent_exact_scope_became_stale.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_an_independent_exact_scope_became_stale.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class and_an_independent_exact_scope_became_stale : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _firstTarget;
+    EventSourceId _secondTarget;
+    bool _firstTargetHasEvents;
+    bool _secondTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _firstTarget = EventSourceId.New();
+        _secondTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("decision revision"));
+
+        var eventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(TestEvent));
+        var exactDecisionScope = new ConcurrencyScope(EventSequenceNumber.First, EventTypes: [eventType]);
+        var scopeLabel = EventSourceId.New();
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [
+                new(_firstTarget, new TestEvent("first target")),
+                new(_secondTarget, new TestEvent("second target"))
+            ],
+            [new(scopeLabel, exactDecisionScope)]);
+
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("interference"));
+        await _unitOfWork.Commit();
+
+        _firstTargetHasEvents = await _scenario.EventLog.HasEventsFor(_firstTarget);
+        _secondTargetHasEvents = await _scenario.EventLog.HasEventsFor(_secondTarget);
+    }
+
+    [Fact] void should_reject_the_stale_decision() => _unitOfWork.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_concurrency_violation() => _unitOfWork.GetConcurrencyViolations().ShouldNotBeEmpty();
+    [Fact] void should_leave_no_event_on_the_first_target() => _firstTargetHasEvents.ShouldBeFalse();
+    [Fact] void should_leave_no_event_on_the_second_target() => _secondTargetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_an_independent_exact_scope_matches.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_an_independent_exact_scope_matches.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class and_an_independent_exact_scope_matches : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _firstTarget;
+    EventSourceId _secondTarget;
+    bool _firstTargetHasEvents;
+    bool _secondTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _firstTarget = EventSourceId.New();
+        _secondTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("decision revision"));
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("known revision"));
+
+        var eventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(TestEvent));
+        var exactCurrentScope = new ConcurrencyScope(new EventSequenceNumber(1), EventTypes: [eventType]);
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [
+                new(_firstTarget, new TestEvent("first target")),
+                new(_secondTarget, new TestEvent("second target"))
+            ],
+            [new(EventSourceId.New(), exactCurrentScope)]);
+
+        await _unitOfWork.Commit();
+
+        _firstTargetHasEvents = await _scenario.EventLog.HasEventsFor(_firstTarget);
+        _secondTargetHasEvents = await _scenario.EventLog.HasEventsFor(_secondTarget);
+    }
+
+    [Fact] void should_accept_the_current_decision() => _unitOfWork.IsSuccess.ShouldBeTrue();
+    [Fact] void should_append_the_event_on_the_first_target() => _firstTargetHasEvents.ShouldBeTrue();
+    [Fact] void should_append_the_event_on_the_second_target() => _secondTargetHasEvents.ShouldBeTrue();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_one_event_violates_a_constraint.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_one_event_violates_a_constraint.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class and_one_event_violates_a_constraint : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _firstTarget;
+    EventSourceId _secondTarget;
+    AppendResult _siblingReplayResult;
+    bool _firstTargetHasEvents;
+    bool _secondTargetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _firstTarget = EventSourceId.New();
+        _secondTarget = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(EventSourceId.New())
+            .Events(new SubscriberRegistered(new("taken@cratis.io")));
+
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [
+                new(_firstTarget, new SubscriberRegistered(new("taken@cratis.io"))),
+                new(_secondTarget, new SubscriberRegistered(new("sibling@cratis.io")))
+            ],
+            []);
+
+        await _unitOfWork.Commit();
+
+        _firstTargetHasEvents = await _scenario.EventLog.HasEventsFor(_firstTarget);
+        _secondTargetHasEvents = await _scenario.EventLog.HasEventsFor(_secondTarget);
+        _siblingReplayResult = await _scenario.When
+            .ForEventSource(EventSourceId.New())
+            .Events(new SubscriberRegistered(new("sibling@cratis.io")));
+    }
+
+    [Fact] void should_reject_the_batch() => _unitOfWork.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_constraint_violation() => _unitOfWork.GetConstraintViolations().ShouldNotBeEmpty();
+    [Fact] void should_leave_no_event_on_the_first_target() => _firstTargetHasEvents.ShouldBeFalse();
+    [Fact] void should_leave_no_event_on_the_second_target() => _secondTargetHasEvents.ShouldBeFalse();
+    [Fact] void should_not_have_claimed_the_sibling_constraint_value() => _siblingReplayResult.ShouldBeSuccessful();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_one_of_two_independent_exact_scopes_became_stale.cs
+++ b/Source/Clients/Testing.Specs/Transactions/for_UnitOfWork/when_committing/and_one_of_two_independent_exact_scopes_became_stale.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Chronicle.Testing.Reactors;
+using Cratis.Chronicle.Transactions;
+
+namespace Cratis.Chronicle.Testing.Transactions.for_UnitOfWork.when_committing;
+
+public class and_one_of_two_independent_exact_scopes_became_stale : Specification, IDisposable
+{
+    EventScenario _scenario;
+    UnitOfWork _unitOfWork;
+    EventSourceId _target;
+    bool _targetHasEvents;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _target = EventSourceId.New();
+    }
+
+    async Task Because()
+    {
+        await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("decision revision"));
+        await _scenario.EventLog.Append(EventSourceId.New(), new MemberActivityRecorded());
+
+        var testEventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(TestEvent));
+        var activityEventType = Defaults.Instance.EventTypes.GetEventTypeFor(typeof(MemberActivityRecorded));
+        var eventStore = Substitute.For<IEventStore>();
+        eventStore.GetEventSequence(EventSequenceId.Log).Returns(_scenario.EventLog);
+        _unitOfWork = new(CorrelationId.New(), _ => { }, eventStore);
+        _unitOfWork.AddEvents(
+            EventSequenceId.Log,
+            [new(_target, new TestEvent("target"))],
+            [
+                new(EventSourceId.New(), new ConcurrencyScope(EventSequenceNumber.First, EventTypes: [testEventType])),
+                new(EventSourceId.New(), new ConcurrencyScope(new EventSequenceNumber(1), EventTypes: [activityEventType]))
+            ]);
+
+        await _scenario.EventLog.Append(EventSourceId.New(), new MemberActivityRecorded());
+        await _unitOfWork.Commit();
+        _targetHasEvents = await _scenario.EventLog.HasEventsFor(_target);
+    }
+
+    [Fact] void should_reject_when_either_independent_scope_is_stale() => _unitOfWork.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_stale_scope() => _unitOfWork.GetConcurrencyViolations().ShouldNotBeEmpty();
+    [Fact] void should_leave_no_target_event() => _targetHasEvents.ShouldBeFalse();
+
+    public void Dispose()
+    {
+        _unitOfWork.Dispose();
+        _scenario.Dispose();
+    }
+}


### PR DESCRIPTION
# Summary

Chronicle unit-of-work callers can now atomically enroll an already-decided, ordered cross-stream batch together with independently labelled exact concurrency scopes.

## Added

- Add `IUnitOfWork.AddEvents` for ordered cross-source events and independently labelled exact concurrency scopes in the existing transaction (#3683)

## Changed

- Materialize and validate ordered events and scope inputs before staging while preserving pure legacy `AddEvent` behavior (#3683)