### PR TITLE
Fix System event type re-registration after kernel reset and ReadModelScenario child isolation

### DIFF
--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_event_sources_each_have_their_own_children.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_two_event_sources_each_have_their_own_children.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Two roots seeded in one scenario, each with a child of its own on its own event source and no explicit
+/// <c>parentKey</c> — so the event source id is the only thing routing a child to its parent. Each instance
+/// must carry only its own child, exactly as the kernel does; the harness previously let the later document
+/// accumulate the earlier one's children because every event shared one threaded state.
+/// </summary>
+public class and_two_event_sources_each_have_their_own_children : Specification
+{
+    ReadModelScenario<SameSourceTicketLedger> _scenario;
+    EventSourceId _firstLedgerId;
+    EventSourceId _secondLedgerId;
+    Guid _firstTicket;
+    Guid _secondTicket;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<SameSourceTicketLedger>();
+        _firstLedgerId = new EventSourceId(Guid.NewGuid());
+        _secondLedgerId = new EventSourceId(Guid.NewGuid());
+        _firstTicket = Guid.NewGuid();
+        _secondTicket = Guid.NewGuid();
+    }
+
+    async Task Because()
+    {
+        await _scenario.Given
+            .ForEventSource(_firstLedgerId)
+            .Events(new LedgerOpened("First"), new TicketLogged(_firstTicket, 100m));
+
+        await _scenario.Given
+            .ForEventSource(_secondLedgerId)
+            .Events(new LedgerOpened("Second"), new TicketLogged(_secondTicket, 200m));
+    }
+
+    [Fact] void should_materialize_both_ledgers() => _scenario.Instances.Count.ShouldEqual(2);
+    [Fact] void should_name_the_first_ledger() => _scenario.InstanceForEventSourceId(_firstLedgerId)!.Name.ShouldEqual("First");
+    [Fact] void should_name_the_second_ledger() => _scenario.InstanceForEventSourceId(_secondLedgerId)!.Name.ShouldEqual("Second");
+    [Fact] void should_give_the_first_ledger_only_its_own_ticket() => _scenario.InstanceForEventSourceId(_firstLedgerId)!.Tickets.Select(_ => _.Ticket).ShouldContainOnly(_firstTicket);
+    [Fact] void should_give_the_second_ledger_only_its_own_ticket() => _scenario.InstanceForEventSourceId(_secondLedgerId)!.Tickets.Select(_ => _.Ticket).ShouldContainOnly(_secondTicket);
+}

--- a/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
+++ b/Source/Clients/Testing/ReadModels/ProjectionReadModelProcessor.cs
@@ -95,10 +95,11 @@ internal static class ProjectionReadModelProcessor
     /// <see cref="UnsubscribedEventSeeded"/> instead.
     /// </param>
     /// <returns>
-    /// A tuple of the primary projected read model (the threaded result exposed as <c>Instance</c>, or
-    /// <see langword="null"/> if the projection did not apply any changes) and a dictionary of every
-    /// materialized instance keyed by its event source id (read per-key from the sink, so a multi-source
-    /// projection such as a join can be asserted against the intended instance deterministically).
+    /// A tuple of the primary projected read model (the instance for the first key resolved, exposed as
+    /// <c>Instance</c>, or <see langword="null"/> if the projection did not apply any changes) and a
+    /// dictionary of every materialized instance keyed by its event source id (read per-key from the sink,
+    /// so a multi-source projection such as a join can be asserted against the intended instance
+    /// deterministically).
     /// </returns>
     /// <exception cref="InvalidOperationException">Thrown when a deferred key cannot be resolved after retrying all events.</exception>
     /// <exception cref="UnsubscribedEventSeeded">Thrown when strict mode is enabled and a seeded event is not subscribed to.</exception>
@@ -189,9 +190,15 @@ internal static class ProjectionReadModelProcessor
             kernelReadModelDefinition,
             eventTypeSchemas);
 
-        var state = initialState is not null
+        // The state every read model instance starts from, produced fresh per instance. The live pipeline
+        // clones the projection's initial model state for each key it has not seen (SetInitialState), so a
+        // second event source starts from an empty model rather than inheriting the first one's values —
+        // which is what a shared, threaded state silently did, carrying one root's children onto the next.
+        ExpandoObject CreateSeedState() => initialState is not null
             ? initialState.AsExpandoObject(true)
             : CreateInitialStateFromSchema(schema, engineProjection);
+
+        var statesByKey = new Dictionary<object, ExpandoObject>();
 
         // Capture the first non-deferred key resolved for the root projection. In production, MongoDB
         // upserts each read model document with `_id` = this key value, and the BSON deserializer maps
@@ -208,8 +215,7 @@ internal static class ProjectionReadModelProcessor
         var deferredEvents = new Queue<KernelAppendedEvent>();
         foreach (var @event in appendedEvents)
         {
-            var (newState, eventKey, eventRemoved) = await ProcessSingleEvent(engineProjection, kernelProjectionDefinition, inMemoryEventSequenceStorage, inMemorySink, @event, state, deferredEvents, strictEventSubscription);
-            state = newState;
+            var (eventKey, eventRemoved) = await ProcessSingleEvent(engineProjection, kernelProjectionDefinition, inMemoryEventSequenceStorage, inMemorySink, @event, statesByKey, CreateSeedState, deferredEvents, strictEventSubscription);
             rootKey ??= eventKey;
             if (eventRemoved)
             {
@@ -220,7 +226,6 @@ internal static class ProjectionReadModelProcessor
         // Retry deferred events once; if still deferred, throw a descriptive exception.
         foreach (var @event in new List<KernelAppendedEvent>(deferredEvents))
         {
-            var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
             var keyResolver = engineProjection.GetKeyResolverFor(@event.Context.EventType);
             var keyResult = await keyResolver(inMemoryEventSequenceStorage, inMemorySink, @event);
 
@@ -233,35 +238,14 @@ internal static class ProjectionReadModelProcessor
 
             var key = (keyResult as KernelProjectionEngine::ResolvedKey)!.Key;
             rootKey ??= key;
-            var context = new KernelProjectionEngine::ProjectionEventContext(
-                key,
-                @event,
-                changeset,
-                engineProjection.GetOperationTypeFor(@event.Context.EventType),
-                false);
 
-            HandleEventFor(engineProjection, context);
-
-            // Apply to the sink before mutating the threaded state — the sink clones the changeset's
-            // InitialState (the same object as `state`), so mutating it first would double an additive change.
-            if (changeset.HasChanges)
+            if (await ApplyResolvedEvent(engineProjection, inMemorySink, @event, key, statesByKey, CreateSeedState))
             {
-                await inMemorySink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
-            }
-
-            if (changeset.Changes.Any(change => change is Removed))
-            {
-                state = new ExpandoObject();
                 explicitInitialStateIsPresent = false;
-            }
-            else if (changeset.HasChanges)
-            {
-                state = ApplyActualChanges(key, changeset.Changes, state);
             }
         }
 
-        // Read every materialized instance per-key from the sink. Unlike the single threaded `state`
-        // (which blends events across sources into one object), the sink keeps one document per resolved
+        // Read every materialized instance per-key from the sink, which keeps one document per resolved
         // root key — so a multi-source projection (e.g. a join whose join-source event was seeded first)
         // can be asserted against the intended instance via InstanceForEventSourceId.
         var instances = BuildInstancesFromSink<TReadModel>(inMemorySink);
@@ -275,6 +259,10 @@ internal static class ProjectionReadModelProcessor
         {
             return (null, instances);
         }
+
+        var state = rootKey is not null && statesByKey.TryGetValue(inMemorySink.GetKeyValue(rootKey), out var rootState)
+            ? rootState
+            : CreateSeedState();
 
         InjectIdentifierFromKey<TReadModel>(state, rootKey);
 
@@ -290,7 +278,7 @@ internal static class ProjectionReadModelProcessor
 
     /// <summary>
     /// Deserializes every per-key document held by the in-memory sink into a <typeparamref name="TReadModel"/>,
-    /// keyed by its event source id — the faithful per-instance view the single threaded state cannot provide.
+    /// keyed by its event source id.
     /// </summary>
     /// <typeparam name="TReadModel">The read model type being projected.</typeparam>
     /// <param name="sink">The in-memory sink populated during processing.</param>
@@ -426,13 +414,14 @@ internal static class ProjectionReadModelProcessor
         return schemas;
     }
 
-    static async Task<(ExpandoObject State, KernelKey? Key, bool Removed)> ProcessSingleEvent(
+    static async Task<(KernelKey? Key, bool Removed)> ProcessSingleEvent(
         KernelProjectionEngine::IProjection projection,
         KernelConceptsNs::Projections.Definitions.ProjectionDefinition kernelProjectionDefinition,
         InMemoryEventSequenceStorage eventSequenceStorage,
         InMemorySink sink,
         KernelAppendedEvent @event,
-        ExpandoObject state,
+        Dictionary<object, ExpandoObject> statesByKey,
+        Func<ExpandoObject> createSeedState,
         Queue<KernelAppendedEvent> deferredEvents,
         bool strictEventSubscription)
     {
@@ -451,10 +440,8 @@ internal static class ProjectionReadModelProcessor
                 throw new UnsubscribedEventSeeded(@event.Context.EventType.Id.ToString());
             }
 
-            return (state, null, false);
+            return (null, false);
         }
-
-        var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
 
         KernelProjectionEngine::KeyResolverResult keyResult;
 
@@ -466,7 +453,7 @@ internal static class ProjectionReadModelProcessor
         {
             if (resolvedRootKey is null)
             {
-                return (state, null, false);
+                return (null, false);
             }
 
             keyResult = KernelProjectionEngine::KeyResolverResult.Resolved(resolvedRootKey);
@@ -481,14 +468,14 @@ internal static class ProjectionReadModelProcessor
             {
                 // Defensive fallback for a nested/child [Join] whose join key can't be force-converted to the
                 // identifier type: skip rather than crash the scenario (root joins are handled above).
-                return (state, null, false);
+                return (null, false);
             }
         }
 
         if (keyResult is KernelProjectionEngine::DeferredKey)
         {
             deferredEvents.Enqueue(@event);
-            return (state, null, false);
+            return (null, false);
         }
 
         var key = (keyResult as KernelProjectionEngine::ResolvedKey)!.Key;
@@ -501,12 +488,48 @@ internal static class ProjectionReadModelProcessor
         {
             if (childJoinRootKey is null)
             {
-                return (state, null, false);
+                return (null, false);
             }
 
             key = key with { Value = childJoinRootKey.Value };
         }
 
+        var removed = await ApplyResolvedEvent(projection, sink, @event, key, statesByKey, createSeedState);
+        return (key, removed);
+    }
+
+    /// <summary>
+    /// Applies an event whose key is resolved to the state of the instance that key addresses, and to the sink.
+    /// </summary>
+    /// <param name="projection">The <see cref="KernelProjectionEngine::IProjection"/> being applied.</param>
+    /// <param name="sink">The <see cref="InMemorySink"/> holding one document per resolved root key.</param>
+    /// <param name="event">The event to apply.</param>
+    /// <param name="key">The resolved <see cref="KernelKey"/> the event projects onto.</param>
+    /// <param name="statesByKey">The state of each instance materialized so far, keyed as the sink keys its documents.</param>
+    /// <param name="createSeedState">Produces the state a not-yet-seen instance starts from.</param>
+    /// <returns>True when the event removed the root instance.</returns>
+    /// <remarks>
+    /// State is held per instance rather than threaded across every seeded event, mirroring the live pipeline's
+    /// <c>SetInitialState</c>: an event only ever sees the state of the instance its own key addresses. The key
+    /// comes from <see cref="InMemorySink.GetKeyValue"/> so that "the same instance" means the same thing here
+    /// as it does to the sink — a concept key and its underlying primitive address one document, not two.
+    /// </remarks>
+    static async Task<bool> ApplyResolvedEvent(
+        KernelProjectionEngine::IProjection projection,
+        InMemorySink sink,
+        KernelAppendedEvent @event,
+        KernelKey key,
+        Dictionary<object, ExpandoObject> statesByKey,
+        Func<ExpandoObject> createSeedState)
+    {
+        var stateKey = sink.GetKeyValue(key);
+        if (!statesByKey.TryGetValue(stateKey, out var state))
+        {
+            state = createSeedState();
+            statesByKey[stateKey] = state;
+        }
+
+        var changeset = new Changeset<KernelAppendedEvent, ExpandoObject>(_objectComparer, @event, state);
         var context = new KernelProjectionEngine::ProjectionEventContext(
             key,
             @event,
@@ -517,19 +540,19 @@ internal static class ProjectionReadModelProcessor
         HandleEventFor(projection, context);
 
         // A root-level removal yields a Removed change, which the real sink applies by deleting the
-        // document. Mirror that by resetting the threaded state so any subsequent re-create starts clean.
+        // document. Mirror that by resetting the instance state so any subsequent re-create starts clean.
         var removed = changeset.Changes.Any(change => change is Removed);
 
-        // Apply to the sink BEFORE mutating the threaded state. The sink clones the changeset's InitialState —
-        // which is the SAME object as the threaded `state` — so mutating the threaded state first would let the
-        // sink re-apply an additive change (e.g. a child add) on top of an already-advanced base, duplicating it.
+        // Apply to the sink BEFORE mutating the instance state. The sink clones the changeset's InitialState —
+        // which is the SAME object as `state` — so mutating the state first would let the sink re-apply an
+        // additive change (e.g. a child add) on top of an already-advanced base, duplicating it.
         if (changeset.HasChanges)
         {
             await sink.ApplyChanges(key, changeset, @event.Context.SequenceNumber);
         }
 
-        var updatedState = removed ? new ExpandoObject() : ApplyActualChanges(key, changeset.Changes, state);
-        return (updatedState, key, removed);
+        statesByKey[stateKey] = removed ? new ExpandoObject() : ApplyActualChanges(key, changeset.Changes, state);
+        return removed;
     }
 
     static KernelReadModels::ReadModelDefinition BuildKernelReadModelDefinition(Type readModelType, JsonSchema schema)

--- a/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
+++ b/Source/Clients/Testing/ReadModels/ReadModelScenario.cs
@@ -122,12 +122,13 @@ public class ReadModelScenario<TReadModel>(TReadModel? initialState, Defaults de
     /// Gets every materialized read model instance, keyed by its event source id.
     /// </summary>
     /// <remarks>
-    /// Unlike <see cref="Instance"/> — which returns a single threaded result and blends events across
-    /// sources into one object — this reads one document per resolved root key from the sink. Use it (or
-    /// <see cref="InstanceForEventSourceId"/>) for multi-source projections, such as a join whose
-    /// join-source event was seeded before the entity under test, to assert against the intended instance
-    /// deterministically. It is populated for projections; reducers are single-instance and expose their
-    /// result through <see cref="Instance"/> only.
+    /// Where <see cref="Instance"/> returns the single instance under test, this reads one document per
+    /// resolved root key from the sink. Use it (or <see cref="InstanceForEventSourceId"/>) for multi-source
+    /// projections, such as a join whose join-source event was seeded before the entity under test, to
+    /// assert against the intended instance deterministically. Each instance carries only what was
+    /// projected onto its own key — seeding a second event source never adds to the first. It is populated
+    /// for projections; reducers are single-instance and expose their result through <see cref="Instance"/>
+    /// only.
     /// </remarks>
     public IReadOnlyDictionary<EventSourceId, TReadModel> Instances
     {

--- a/Source/Kernel/Core.Specs/Setup/for_KernelBootstrapResetHandler/given/a_bootstrap_reset_handler.cs
+++ b/Source/Kernel/Core.Specs/Setup/for_KernelBootstrapResetHandler/given/a_bootstrap_reset_handler.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.EventTypes;
+using Cratis.Chronicle.Namespaces;
+using Cratis.Chronicle.Observation.Reactors.Kernel;
+using Cratis.Chronicle.Setup.Authentication;
+
+namespace Cratis.Chronicle.Setup.for_KernelBootstrapResetHandler.given;
+
+public class a_bootstrap_reset_handler : Specification
+{
+    KernelBootstrapResetHandler _handler = null!;
+    TestAuthenticationService _authenticationService = null!;
+    protected IGrainFactory _grainFactory = null!;
+    protected IEventTypes _eventTypes = null!;
+    protected IReactors _reactors = null!;
+    protected INamespaces _systemNamespaces = null!;
+
+    protected int EnsureDefaultAdminUserCount => _authenticationService.EnsureDefaultAdminUserCount;
+
+    protected int EnsureBootstrapClientsCount => _authenticationService.EnsureBootstrapClientsCount;
+
+    void Establish()
+    {
+        _grainFactory = Substitute.For<IGrainFactory>();
+        _eventTypes = Substitute.For<IEventTypes>();
+        _reactors = Substitute.For<IReactors>();
+        _authenticationService = new TestAuthenticationService();
+        _systemNamespaces = Substitute.For<INamespaces>();
+
+        _grainFactory.GetGrain<INamespaces>(EventStoreName.System).Returns(_systemNamespaces);
+        _systemNamespaces.EnsureDefault().Returns(Task.CompletedTask);
+        _eventTypes.DiscoverAndRegister(EventStoreName.System).Returns(Task.CompletedTask);
+        _reactors.DiscoverAndRegister(EventStoreName.System, EventStoreNamespaceName.Default).Returns(Task.CompletedTask);
+
+        _handler = new(_grainFactory, _eventTypes, _reactors, _authenticationService);
+    }
+
+    protected Task Bootstrap() => _handler.Bootstrap();
+
+    class TestAuthenticationService : IAuthenticationService
+    {
+        public int EnsureDefaultAdminUserCount { get; private set; }
+
+        public int EnsureBootstrapClientsCount { get; private set; }
+
+        public Task<Storage.Security.User?> AuthenticateUser(
+            Concepts.Security.Username username,
+            Concepts.Security.Password password) => Task.FromResult<Storage.Security.User?>(null);
+
+        public Task EnsureDefaultAdminUser()
+        {
+            EnsureDefaultAdminUserCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureBootstrapClients()
+        {
+            EnsureBootstrapClientsCount++;
+            return Task.CompletedTask;
+        }
+#if DEVELOPMENT
+        public Task EnsureDefaultClientCredentials() => Task.CompletedTask;
+#endif
+    }
+}

--- a/Source/Kernel/Core.Specs/Setup/for_KernelBootstrapResetHandler/when_bootstrapping.cs
+++ b/Source/Kernel/Core.Specs/Setup/for_KernelBootstrapResetHandler/when_bootstrapping.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+
+namespace Cratis.Chronicle.Setup.for_KernelBootstrapResetHandler;
+
+/// <summary>
+/// The reset drops the System event store's database along with the event type schemas registered into it.
+/// Nothing else re-registers them — every other store gets them back through <c>EventStores.Ensure</c> when a
+/// client reconnects — so bootstrap has to, or the kernel's own events cannot be appended afterwards.
+/// </summary>
+public class when_bootstrapping : given.a_bootstrap_reset_handler
+{
+    Task Because() => Bootstrap();
+
+    [Fact] void should_ensure_the_default_system_namespace() => _systemNamespaces.Received(1).EnsureDefault();
+    [Fact] void should_register_the_system_event_store_event_types() => _eventTypes.Received(1).DiscoverAndRegister(EventStoreName.System);
+    [Fact] void should_register_the_kernel_reactors() => _reactors.Received(1).DiscoverAndRegister(EventStoreName.System, EventStoreNamespaceName.Default);
+    [Fact] void should_ensure_the_default_admin_user() => EnsureDefaultAdminUserCount.ShouldEqual(1);
+    [Fact] void should_ensure_the_bootstrap_clients() => EnsureBootstrapClientsCount.ShouldEqual(1);
+}

--- a/Source/Kernel/Core/Setup/KernelBootstrapResetHandler.cs
+++ b/Source/Kernel/Core/Setup/KernelBootstrapResetHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.EventTypes;
 using Cratis.Chronicle.Namespaces;
 using Cratis.Chronicle.Observation.Reactors.Kernel;
 using Cratis.Chronicle.Setup.Authentication;
@@ -17,22 +18,32 @@ namespace Cratis.Chronicle.Setup;
 /// methods are no-ops when their target data already exists.
 /// </summary>
 /// <param name="grainFactory">The <see cref="IGrainFactory"/> used to look up grains.</param>
+/// <param name="eventTypes">The kernel event types registry.</param>
 /// <param name="reactors">The kernel reactors registry.</param>
 /// <param name="authenticationService">The authentication bootstrap service.</param>
 [Singleton]
 internal sealed class KernelBootstrapResetHandler(
     IGrainFactory grainFactory,
+    IEventTypes eventTypes,
     IReactors reactors,
     IAuthenticationService authenticationService)
 {
     /// <summary>
-    /// Re-bootstrap the system event store, kernel reactors, and default identity data.
+    /// Re-bootstrap the system event store, its event types, kernel reactors, and default identity data.
     /// </summary>
     /// <returns>Awaitable task.</returns>
     public async Task Bootstrap()
     {
         await grainFactory.GetGrain<INamespaces>(EventStoreName.System).EnsureDefault();
         await reactors.DiscoverAndRegister(EventStoreName.System, EventStoreNamespaceName.Default);
+
+        // The System event store's event type schemas live in its own database, which the reset drops.
+        // Every other store re-registers them through EventStores.Ensure when a client reconnects, but
+        // nothing re-registers the System store's — so without this the kernel's own events (e.g.
+        // ApplicationAuthenticated) fail to append with MissingEventSchemaForEventType for the rest of
+        // the kernel's lifetime.
+        await eventTypes.DiscoverAndRegister(EventStoreName.System);
+
         await authenticationService.EnsureDefaultAdminUser();
         await authenticationService.EnsureBootstrapClients();
 #if DEVELOPMENT

--- a/Source/Kernel/Storage.InMemory/Sinks/InMemorySink.cs
+++ b/Source/Kernel/Storage.InMemory/Sinks/InMemorySink.cs
@@ -62,12 +62,54 @@ public class InMemorySink(
         _isReplaying ? _rewindLastHandledEventSequenceNumbers : _lastHandledEventSequenceNumbers;
 
     /// <summary>
+    /// Gets the value this sink addresses a document by for a given <see cref="Key"/>.
+    /// </summary>
+    /// <param name="key">The <see cref="Key"/> to resolve.</param>
+    /// <returns>The value the document for <paramref name="key"/> is stored under in <see cref="Collection"/>.</returns>
+    /// <remarks>
+    /// Two <see cref="Key"/> instances addressing the same document — a concept and its underlying primitive,
+    /// say — resolve to the same value here. Callers that keep per-document state beside the sink must derive
+    /// it from this rather than from <see cref="Key.Value"/>, or the two disagree on what "the same document" is.
+    /// </remarks>
+    public object GetKeyValue(Key key)
+    {
+        if (key.Value is ExpandoObject expandoKey)
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (var (_, value) in expandoKey.GetKeyValuePairs().OrderBy(_ => _.Key))
+            {
+                if (stringBuilder.Length > 0) stringBuilder.Append('_');
+                stringBuilder.Append(value);
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        if (_keyTargetType is not null)
+        {
+            return TypeConversion.Convert(_keyTargetType, key.Value);
+        }
+
+        if (key.Value.IsConcept())
+        {
+            return key.Value.GetConceptValue();
+        }
+
+        if (!key.Value.GetType().IsAPrimitiveType())
+        {
+            return key.Value.AsExpandoObject(true);
+        }
+
+        return key.Value;
+    }
+
+    /// <summary>
     /// Remove any existing read model by the given key.
     /// </summary>
     /// <param name="key"><see cref="Key"/> for the read model to remove.</param>
     public void RemoveAnyExisting(Key key)
     {
-        var keyValue = GetActualKeyValue(key);
+        var keyValue = GetKeyValue(key);
         lock (_collectionLock)
         {
             Collection.Remove(keyValue);
@@ -78,7 +120,7 @@ public class InMemorySink(
     /// <inheritdoc/>
     public Task<ExpandoObject?> FindOrDefault(Key key)
     {
-        var keyValue = GetActualKeyValue(key);
+        var keyValue = GetKeyValue(key);
         lock (_collectionLock)
         {
             if (Collection.TryGetValue(keyValue, out var value)) return Task.FromResult<ExpandoObject?>(value);
@@ -95,7 +137,7 @@ public class InMemorySink(
     public Task<IEnumerable<FailedPartition>> ApplyChanges(Key key, IChangeset<AppendedEvent, ExpandoObject> changeset, EventSequenceNumber eventSequenceNumber, SinkWriteMode mode)
     {
         var state = changeset.InitialState.Clone();
-        var keyValue = GetActualKeyValue(key);
+        var keyValue = GetKeyValue(key);
 
         if (changeset.HasBeenRemoved())
         {
@@ -274,38 +316,6 @@ public class InMemorySink(
 
         return !LastHandledEventSequenceNumbers.TryGetValue(keyValue, out var lastHandled) ||
                lastHandled < eventSequenceNumber.Value;
-    }
-
-    object GetActualKeyValue(Key key)
-    {
-        if (key.Value is ExpandoObject expandoKey)
-        {
-            var stringBuilder = new StringBuilder();
-            foreach (var (_, value) in expandoKey.GetKeyValuePairs().OrderBy(_ => _.Key))
-            {
-                if (stringBuilder.Length > 0) stringBuilder.Append('_');
-                stringBuilder.Append(value);
-            }
-
-            return stringBuilder.ToString();
-        }
-
-        if (_keyTargetType is not null)
-        {
-            return TypeConversion.Convert(_keyTargetType, key.Value);
-        }
-
-        if (key.Value.IsConcept())
-        {
-            return key.Value.GetConceptValue();
-        }
-
-        if (!key.Value.GetType().IsAPrimitiveType())
-        {
-            return key.Value.AsExpandoObject(true);
-        }
-
-        return key.Value;
     }
 
     ExpandoObject ApplyActualChanges(Key key, IEnumerable<Change> changes, ExpandoObject state)


### PR DESCRIPTION
## Fixed
- Kernel event types are re-registered for the `System` event store after `ResetKernelState()`, so the kernel's own events — such as `ApplicationAuthenticated` on every authentication — keep appending instead of failing with `MissingEventSchemaForEventType` for the rest of the kernel's lifetime (#3687)
- `ReadModelScenario<T>` isolates each read model instance's state by event source, so `[ChildrenFrom]` children no longer accumulate onto a document seeded later in the same scenario (#3688)
