### PR TITLE
Unblock the Release build and the SSH.NET advisory restore failure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,6 +96,12 @@
     <PackageVersion Include="Cratis.Specifications.XUnit" Version="4.0.0" />
     <PackageVersion Include="EphemeralMongo" Version="3.2.0" />
     <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <!--
+        Testcontainers 4.13.0 brings in SSH.NET 2025.1.0, which GHSA-q939-rpr3-3284 covers. 2026.0.0 is the
+        patched release, so every project referencing Testcontainers also references SSH.NET directly to pull
+        the transitive dependency forward. Remove both once Testcontainers ships a version that does it itself.
+    -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />

--- a/Source/Clients/DotNET.Specs/DotNET.Specs.csproj
+++ b/Source/Clients/DotNET.Specs/DotNET.Specs.csproj
@@ -26,6 +26,8 @@
         <PackageReference Include="FluentValidation" />
         <PackageReference Include="protobuf-net.Grpc" />
         <PackageReference Include="Testcontainers" />
+        <!-- Pulls Testcontainers' vulnerable SSH.NET forward — see Directory.Packages.props. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
     <!-- Reuse the exact CoreDNS zone the Composition sample serves, so the +srv integration

--- a/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
+++ b/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
@@ -39,6 +39,8 @@
         </PackageReference>
         <PackageReference Include="mongodb.driver" />
         <PackageReference Include="Testcontainers" />
+        <!-- Pulls Testcontainers' vulnerable SSH.NET forward — see Directory.Packages.props. -->
+        <PackageReference Include="SSH.NET" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Cratis.Specifications.XUnit" />
         <PackageReference Include="Microsoft.Orleans.TestingHost" />

--- a/Source/Kernel/Contracts/Contracts.csproj
+++ b/Source/Kernel/Contracts/Contracts.csproj
@@ -6,7 +6,13 @@
         <TargetsForTfmSpecificContentInPackage></TargetsForTfmSpecificContentInPackage>
         <AssemblyName>Cratis.Chronicle.Contracts</AssemblyName>
         <RootNamespace>Cratis.Chronicle.Contracts</RootNamespace>
-        <NoWarn>$(NoWarn);CS8618;PBN2008;PBN0022</NoWarn>
+        <!--
+            PBN2013 asks for a [ProtoModel] partial class so protobuf-net generates compile-time serializers.
+            The attribute is protobuf-net 3.3+, and protobuf-net.Grpc 1.2.2 pins the runtime below that — so
+            the analyzer (BuildTools 3.3.8) is advising something this project cannot express yet. Drop this
+            once the runtime moves up and adopt compile-time serializers deliberately, on their own merits.
+        -->
+        <NoWarn>$(NoWarn);CS8618;PBN2008;PBN0022;PBN2013</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/Source/Kernel/Storage.MongoDB.Specs/Storage.MongoDB.Specs.csproj
+++ b/Source/Kernel/Storage.MongoDB.Specs/Storage.MongoDB.Specs.csproj
@@ -9,6 +9,8 @@
     <ItemGroup>
         <PackageReference Include="Cratis.Arc" />
         <PackageReference Include="Testcontainers" />
+        <!-- Pulls Testcontainers' vulnerable SSH.NET forward — see Directory.Packages.props. -->
+        <PackageReference Include="SSH.NET" />
         <ProjectReference Include="../Storage.MongoDB/Storage.MongoDB.csproj" />
         <ProjectReference Include="../Storage.InMemory/Storage.InMemory.csproj" />
         <ProjectReference Include="../Storage/Storage.csproj" />

--- a/Source/Kernel/Storage.Vault.Specs/Storage.Vault.Specs.csproj
+++ b/Source/Kernel/Storage.Vault.Specs/Storage.Vault.Specs.csproj
@@ -15,6 +15,8 @@
 
     <ItemGroup>
         <PackageReference Include="Testcontainers" />
+        <!-- Pulls Testcontainers' vulnerable SSH.NET forward — see Directory.Packages.props. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Summary
`main` cannot complete a Release build, and since the SSH.NET advisory was published no branch can complete a restore either — so every PR is red for reasons unrelated to its own changes. This unblocks both.

## Fixed
- `Source/Kernel/Contracts` builds in Release again — `protobuf-net.BuildTools` 3.3.8 asks for a `[ProtoModel]` partial class, but that attribute is protobuf-net 3.3+ and `protobuf-net.Grpc` 1.2.2 holds the runtime below it, so the diagnostic is now opted out of with a note to adopt compile-time serializers deliberately once the runtime moves up (#3696)

## Security
- SSH.NET moved to 2026.0.0 in every project that uses Testcontainers, past GHSA-q939-rpr3-3284 (arbitrary file write via server-controlled SCP filenames). Testcontainers 4.13.0 still depends on the affected 2025.1.0, so the projects using it reference SSH.NET directly to pull the transitive dependency forward
