### PR TITLE
Release PII on GetInstances for materialized read models

### DIFF
--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_materialized_with_compliance_data.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_getting_instances_and_it_is_materialized_with_compliance_data.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Contracts.Compliance;
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels;
+
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+public class when_getting_instances_and_it_is_materialized_with_compliance_data : given.all_dependencies
+{
+    class MyReadModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+
+    IEnumerable<MyReadModel> _result = [];
+    ICompliance _compliance = null!;
+
+    void Establish()
+    {
+        _projections.HasFor(typeof(MyReadModel)).Returns(true);
+        _reducers.HasFor(typeof(MyReadModel)).Returns(false);
+
+        var readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
+        _services.ReadModels.Returns(readModelsService);
+        readModelsService.GetAllInstances(Arg.Any<GetAllInstancesRequest>())
+            .Returns(new GetAllInstancesResponse
+            {
+                Instances =
+                [
+                    JsonSerializer.Serialize(new MyReadModel { Id = "id-1", Name = "Encrypted First" }),
+                    JsonSerializer.Serialize(new MyReadModel { Id = "id-2", Name = "Encrypted Second" })
+                ]
+            });
+
+        var schema = new JsonSchema();
+        schema.ExtensionData[ComplianceJsonSchemaExtensions.ComplianceKey] = new List<ComplianceSchemaMetadata> { new("pii", "{}") };
+        _schemaGenerator.Generate(Arg.Any<Type>()).Returns(schema);
+
+        _compliance = Substitute.For<ICompliance>();
+        _services.Compliance.Returns(_compliance);
+        _compliance.Release(Arg.Is<ReleaseRequest>(r => r.Subject == "id-1")).Returns(new ReleaseResponse { Payload = """{"Id":"id-1","Name":"Released First"}""" });
+        _compliance.Release(Arg.Is<ReleaseRequest>(r => r.Subject == "id-2")).Returns(new ReleaseResponse { Payload = """{"Id":"id-2","Name":"Released Second"}""" });
+    }
+
+    async Task Because() => _result = await _readModels.GetInstances<MyReadModel>();
+
+    [Fact] void should_call_compliance_release_for_each_instance() => _compliance.Received(2).Release(Arg.Any<ReleaseRequest>());
+    [Fact] void should_return_all_released_instances() => _result.Count().ShouldEqual(2);
+    [Fact] void should_return_first_released_instance() => _result.First().Name.ShouldEqual("Released First");
+    [Fact] void should_return_second_released_instance() => _result.Last().Name.ShouldEqual("Released Second");
+}
+#pragma warning restore CA2263 // Prefer generic overload when type is known

--- a/Source/Clients/DotNET/ReadModels/ReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModels.cs
@@ -278,8 +278,9 @@ public class ReadModels(
         };
 
         var response = await _chronicleServicesAccessor.Services.ReadModels.GetAllInstances(request);
+        var instances = response.Instances.Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!);
 
-        return response.Instances.Select(json => JsonSerializer.Deserialize<TReadModel>(json, jsonSerializerOptions)!);
+        return await Release(instances);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Fixed
- `IReadModels.GetInstances<TReadModel>()` now releases (decrypts) `[PII]`-protected values for materialized (sink-backed projection) read models, matching `GetInstanceById<TReadModel>` and the reducer/passive branch of `GetInstances`. Previously, calling `GetInstances` on a projected read model with PII properties returned ciphertext silently. (#3703)