### PR TITLE
Say where a value's subject comes from rather than what to do with it

### DIFF
--- a/Documentation/client-snippets/compliance/read-models/subject-from-two-subjects.md
+++ b/Documentation/client-snippets/compliance/read-models/subject-from-two-subjects.md
@@ -13,6 +13,6 @@ public record ComplianceReadModelsDuplicatePair(
     string ContactPointHash,
     string FirstPersonId,
     string SecondPersonId,
-    [ReleaseUnder(nameof(FirstPersonId))] ComplianceReadModelsPersonFullName FirstName,
-    [ReleaseUnder(nameof(SecondPersonId))] ComplianceReadModelsPersonFullName SecondName);
+    [SubjectFrom(nameof(FirstPersonId))] ComplianceReadModelsPersonFullName FirstName,
+    [SubjectFrom(nameof(SecondPersonId))] ComplianceReadModelsPersonFullName SecondName);
 ```

--- a/Documentation/client-snippets/compliance/read-models/subject-from.md
+++ b/Documentation/client-snippets/compliance/read-models/subject-from.md
@@ -15,12 +15,12 @@ public record ComplianceReadModelsRetentionSubject(
     ComplianceReadModelsPostponementComment Comment);
 
 // The row a query composes in memory. Its identity is not named Id and it carries no [Subject], so
-// it has no compliance subject of its own — [ReleaseUnder] says which subject the lifted comment
+// it has no compliance subject of its own — [SubjectFrom] says which subject the lifted comment
 // belongs to.
 public record ComplianceReadModelsRetentionDueSubject(
     string SubjectId,
     DateTimeOffset DueAt,
-    [ReleaseUnder(nameof(SubjectId))] ComplianceReadModelsPostponementComment Comment);
+    [SubjectFrom(nameof(SubjectId))] ComplianceReadModelsPostponementComment Comment);
 
 public class ComplianceReadModelsRetentionDueService(IEventStore eventStore)
 {

--- a/Documentation/compliance/read-models.mdx
+++ b/Documentation/compliance/read-models.mdx
@@ -80,7 +80,7 @@ The fourth row is a modeling defect rather than a transient failure: a read mode
 > [!NOTE]
 > Applying PII behaves the opposite way, and deliberately so: if encryption fails on the way *in*, the operation fails. Storing a value that was meant to be protected, unprotected, is never an acceptable degradation.
 
-## Composing a read model yourself — `[ReleaseUnder]`
+## Composing a read model yourself — `[SubjectFrom]`
 
 Everything above describes a read model Chronicle builds and stores. A query method may instead compose one in memory, from rows it fetched itself — and a row read straight out of a collection still holds ciphertext, because the release only happens on the way through the kernel.
 
@@ -91,23 +91,24 @@ Such a row has no subject of its own to release under. Chronicle resolves one fr
 | exposes a subject that is not the value's own | Released under the wrong subject: an empty value, plus an error in the kernel log. |
 | exposes no subject at all | Nothing. The release pass does not run and the ciphertext is returned as read. |
 
-`[ReleaseUnder]` on the property says which subject the value belongs to, so neither outcome is reached by accident:
+`[SubjectFrom]` on the property says where to find the subject the value belongs to, so neither outcome is reached by accident:
 
-<ChronicleClientTabs snippet="compliance/read-models/release-under" />
+<ChronicleClientTabs snippet="compliance/read-models/subject-from" />
 
 The attribute names a property of the same read model, and its value becomes the subject that one property is released under. Everything the property holds travels with it, including personal values nested inside a value object. Every property *without* the attribute keeps releasing under the read model's own subject exactly as before — including doing nothing when the row resolves none.
 
 Because each property carries its own subject, one row can hold data belonging to more than one person and release all of it — a shape a single-subject read model cannot express:
 
-<ChronicleClientTabs snippet="compliance/read-models/release-under-two-subjects" />
+<ChronicleClientTabs snippet="compliance/read-models/subject-from-two-subjects" />
 
 ### Rules
 
 - Declare it on a property of the read model itself. A declaration inside a value object or a child element names a property that type does not have, so it is reported as an error rather than ignored — move it up to the read model property that holds the value.
-- On a positional record, write it without a `[property:]` target. Both placements are read, but only the plain form puts the attribute where `nameof` can see a sibling parameter — `[property: ReleaseUnder(nameof(PersonId))]` does not compile.
+- On a positional record, write it without a `[property:]` target. Both placements are read, but only the plain form puts the attribute where `nameof` can see a sibling parameter — `[property: SubjectFrom(nameof(PersonId))]` does not compile.
 - The name must match a public instance property of the read model. One that does not fails the read, because falling back to the read model's own subject is one of the two outcomes the declaration exists to avoid.
 - If the named property is empty on a given row, that one value is returned as read and a warning names the read model, the property and the subject property. A single unreadable value never fails a query.
+- `[ReleaseUnder]` was the name this shipped under first. It still compiles and behaves identically — it is now an alias of `[SubjectFrom]` — but it is deprecated and will be removed; rename it when you next touch the read model.
 
 ### When this is the wrong fit
 
-`[ReleaseUnder]` is for a value resolved in memory at the query edge. It does not make it acceptable to store one person's personal data on another person's document: a stored read model still holds exactly one subject's data, which is what keeps that person's erasure complete and what [CHR0038](../code-analysis/CHR0038) protects. If the personal value can be resolved from its owner's own read model at render time, prefer that — it needs no declaration at all.
+`[SubjectFrom]` is for a value resolved in memory at the query edge. It does not make it acceptable to store one person's personal data on another person's document: a stored read model still holds exactly one subject's data, which is what keeps that person's erasure complete and what [CHR0038](../code-analysis/CHR0038) protects. If the personal value can be resolved from its owner's own read model at render time, prefer that — it needs no declaration at all.

--- a/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declaration_names_a_missing_property.cs
+++ b/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declaration_names_a_missing_property.cs
@@ -40,6 +40,6 @@ public class and_the_declaration_names_a_missing_property(context context) : Giv
 /// <param name="Comment">The comment lifted off that person's own stored row.</param>
 public record MisdeclaredDueSubject(
     SubjectIdentifier SubjectId,
-    [ReleaseUnder("PersonId")] PostponementComment Comment);
+    [SubjectFrom("PersonId")] PostponementComment Comment);
 
 #pragma warning restore SA1402

--- a/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declared_property_holds_a_value_object.cs
+++ b/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declared_property_holds_a_value_object.cs
@@ -49,6 +49,6 @@ public class and_the_declared_property_holds_a_value_object(context context) : G
 /// <param name="Note">The review note lifted off that person's own stored row.</param>
 public record DeclaredNestedRow(
     SubjectIdentifier SubjectId,
-    [ReleaseUnder(nameof(SubjectId))] ReviewNote Note);
+    [SubjectFrom(nameof(SubjectId))] ReviewNote Note);
 
 #pragma warning restore SA1402

--- a/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declared_value_was_never_encrypted.cs
+++ b/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_declared_value_was_never_encrypted.cs
@@ -64,7 +64,7 @@ public class and_the_declared_value_was_never_encrypted(context context) : Given
 public record ComputedRow(
     string Id,
     SubjectIdentifier SubjectId,
-    [ReleaseUnder(nameof(SubjectId))] PostponementComment Computed,
-    [ReleaseUnder(nameof(SubjectId))] PostponementComment Stored);
+    [SubjectFrom(nameof(SubjectId))] PostponementComment Computed,
+    [SubjectFrom(nameof(SubjectId))] PostponementComment Stored);
 
 #pragma warning restore SA1402

--- a/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_owning_subject_is_declared.cs
+++ b/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_owning_subject_is_declared.cs
@@ -46,6 +46,6 @@ public class and_the_owning_subject_is_declared(context context) : Given<context
 /// <param name="Comment">The comment lifted off that person's own stored row.</param>
 public record DeclaredDueSubject(
     SubjectIdentifier SubjectId,
-    [ReleaseUnder(nameof(SubjectId))] PostponementComment Comment);
+    [SubjectFrom(nameof(SubjectId))] PostponementComment Comment);
 
 #pragma warning restore SA1402

--- a/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_row_carries_two_subjects.cs
+++ b/Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/and_the_row_carries_two_subjects.cs
@@ -54,7 +54,7 @@ public class and_the_row_carries_two_subjects(context context) : Given<context>(
 public record MultiSubjectRow(
     SubjectIdentifier FirstPersonId,
     SubjectIdentifier SecondPersonId,
-    [ReleaseUnder(nameof(FirstPersonId))] PostponementComment FirstComment,
-    [ReleaseUnder(nameof(SecondPersonId))] PostponementComment SecondComment);
+    [SubjectFrom(nameof(FirstPersonId))] PostponementComment FirstComment,
+    [SubjectFrom(nameof(SecondPersonId))] PostponementComment SecondComment);
 
 #pragma warning restore SA1402

--- a/Source/Clients/DotNET.Specs/ReadModels/for_MaterializedReadModels/when_getting_instances/and_a_property_is_declared_under_another_subject.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_MaterializedReadModels/when_getting_instances/and_a_property_is_declared_under_another_subject.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.ReadModels.for_MaterializedReadModels.when_getting_in
 /// </summary>
 public class and_a_property_is_declared_under_another_subject : given.a_recording_compliance_service
 {
-    record Assignment(string Id, string PersonId, [PII][ReleaseUnder(nameof(PersonId))] string Name);
+    record Assignment(string Id, string PersonId, [PII][SubjectFrom(nameof(PersonId))] string Name);
 
     IEnumerable<Assignment> _result = [];
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_is_on_a_property.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_is_on_a_property.cs
@@ -12,7 +12,7 @@ public class and_the_declaration_is_on_a_property : Specification
         public string SubjectId { get; set; } = string.Empty;
 
         [PII]
-        [ReleaseUnder(nameof(SubjectId))]
+        [SubjectFrom(nameof(SubjectId))]
         public string Comment { get; set; } = string.Empty;
     }
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_is_on_a_record_parameter.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_is_on_a_record_parameter.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModelReleasePlan.when_building_the
 /// </summary>
 public class and_the_declaration_is_on_a_record_parameter : Specification
 {
-    record DueSubject(string SubjectId, [PII][ReleaseUnder(nameof(SubjectId))] string Comment);
+    record DueSubject(string SubjectId, [PII][SubjectFrom(nameof(SubjectId))] string Comment);
 
     ReadModelReleasePlan _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_sits_inside_a_value_object.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_sits_inside_a_value_object.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModelReleasePlan.when_building_the
 /// </summary>
 public class and_the_declaration_sits_inside_a_value_object : Specification
 {
-    record Postponement(string SubjectId, [PII][ReleaseUnder(nameof(SubjectId))] string Comment);
+    record Postponement(string SubjectId, [PII][SubjectFrom(nameof(SubjectId))] string Comment);
 
     record DueSubject(string SubjectId, Postponement Postponement);
 
@@ -23,4 +23,5 @@ public class and_the_declaration_sits_inside_a_value_object : Specification
     [Fact] void should_name_the_read_model() => ((ReleaseUnderNotSupportedBelowReadModel)_result).ReadModelType.ShouldEqual(typeof(DueSubject));
     [Fact] void should_name_the_nested_type() => ((ReleaseUnderNotSupportedBelowReadModel)_result).DeclaringType.ShouldEqual(typeof(Postponement));
     [Fact] void should_name_the_nested_property() => ((ReleaseUnderNotSupportedBelowReadModel)_result).PropertyName.ShouldEqual(nameof(Postponement.Comment));
+    [Fact] void should_name_the_attribute_that_declares_it() => _result.Message.ShouldContain("[SubjectFrom]");
 }

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_uses_the_superseded_attribute.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_declaration_uses_the_superseded_attribute.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelReleasePlan.when_building_the_plan;
+
+/// <summary>
+/// [ReleaseUnder] shipped before [SubjectFrom] renamed the idea, so a read model written against it is
+/// released source that must keep planning to exactly the same thing. It derives from [SubjectFrom], which
+/// is the whole mechanism: the plan looks for [SubjectFrom] once and finds both.
+/// </summary>
+public class and_the_declaration_uses_the_superseded_attribute : Specification
+{
+#pragma warning disable CS0618 // the superseded attribute is the subject of this specification
+    record DueSubject(string Id, string PersonId, [PII][ReleaseUnder(nameof(PersonId))] string Comment);
+
+    record NestedComment([PII][ReleaseUnder("PersonId")] string Text);
+
+    class DueSubjectWithProperties
+    {
+        public string PersonId { get; set; } = string.Empty;
+
+        [PII]
+        [ReleaseUnder(nameof(PersonId))]
+        public string Comment { get; set; } = string.Empty;
+    }
+#pragma warning restore CS0618
+
+    record Nesting(string Id, string PersonId, NestedComment Comment);
+
+    ReadModelReleasePlan _result;
+    ReadModelReleasePlan _onProperty;
+    Exception _nested;
+
+    void Because()
+    {
+        _result = ReadModelReleasePlan.For(typeof(DueSubject));
+        _onProperty = ReadModelReleasePlan.For(typeof(DueSubjectWithProperties));
+        _nested = Catch.Exception(() => ReadModelReleasePlan.For(typeof(Nesting)));
+    }
+
+    [Fact] void should_have_one_group() => _result.Groups.Count.ShouldEqual(1);
+    [Fact] void should_release_under_the_named_property() => _result.Groups[0].SubjectProperty.Name.ShouldEqual(nameof(DueSubject.PersonId));
+    [Fact] void should_group_the_declared_property() => _result.Groups[0].Properties.Select(_ => _.Name).ShouldContainOnly([nameof(DueSubject.Comment)]);
+    [Fact] void should_recognize_it_written_on_a_property() => _onProperty.Groups.Count.ShouldEqual(1);
+    [Fact] void should_release_the_property_form_under_the_named_property() => _onProperty.Groups[0].SubjectProperty.Name.ShouldEqual(nameof(DueSubjectWithProperties.PersonId));
+    [Fact] void should_group_the_property_form_declaration() => _onProperty.Groups[0].Properties.Select(_ => _.Name).ShouldContainOnly([nameof(DueSubjectWithProperties.Comment)]);
+    [Fact] void should_refuse_it_below_the_read_model_too() => _nested.ShouldBeOfExactType<ReleaseUnderNotSupportedBelowReadModel>();
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_named_property_does_not_exist.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_the_named_property_does_not_exist.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModelReleasePlan.when_building_the
 /// </summary>
 public class and_the_named_property_does_not_exist : Specification
 {
-    record DueSubject(string SubjectId, [PII][ReleaseUnder("PersonId")] string Comment);
+    record DueSubject(string SubjectId, [PII][SubjectFrom("PersonId")] string Comment);
 
     Exception _result;
 
@@ -21,4 +21,5 @@ public class and_the_named_property_does_not_exist : Specification
     [Fact] void should_name_the_read_model() => ((ReleaseUnderPropertyNotFound)_result).ReadModelType.ShouldEqual(typeof(DueSubject));
     [Fact] void should_name_the_declaring_property() => ((ReleaseUnderPropertyNotFound)_result).PropertyName.ShouldEqual(nameof(DueSubject.Comment));
     [Fact] void should_name_the_property_it_points_at() => ((ReleaseUnderPropertyNotFound)_result).SubjectPropertyName.ShouldEqual("PersonId");
+    [Fact] void should_name_the_attribute_that_declares_it() => _result.Message.ShouldContain("[SubjectFrom(\"PersonId\")]");
 }

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_two_properties_name_different_subjects.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_two_properties_name_different_subjects.cs
@@ -13,8 +13,8 @@ public class and_two_properties_name_different_subjects : Specification
     record Pairing(
         string FirstPersonId,
         string SecondPersonId,
-        [PII][ReleaseUnder(nameof(FirstPersonId))] string FirstName,
-        [PII][ReleaseUnder(nameof(SecondPersonId))] string SecondName);
+        [PII][SubjectFrom(nameof(FirstPersonId))] string FirstName,
+        [PII][SubjectFrom(nameof(SecondPersonId))] string SecondName);
 
     ReadModelReleasePlan _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_two_properties_name_the_same_subject.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelReleasePlan/when_building_the_plan/and_two_properties_name_the_same_subject.cs
@@ -9,8 +9,8 @@ public class and_two_properties_name_the_same_subject : Specification
 {
     record DueSubject(
         string SubjectId,
-        [PII][ReleaseUnder(nameof(SubjectId))] string Comment,
-        [PII][ReleaseUnder(nameof(SubjectId))] string Reason);
+        [PII][SubjectFrom(nameof(SubjectId))] string Comment,
+        [PII][SubjectFrom(nameof(SubjectId))] string Reason);
 
     ReadModelReleasePlan _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_a_declared_property_has_an_explicit_serialized_name.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_a_declared_property_has_an_explicit_serialized_name.cs
@@ -10,7 +10,7 @@ public class and_a_declared_property_has_an_explicit_serialized_name : given.a_r
 {
     record DueSubject(
         string PersonId,
-        [property: JsonPropertyName("private_note")][PII][ReleaseUnder(nameof(PersonId))] string Comment);
+        [property: JsonPropertyName("private_note")][PII][SubjectFrom(nameof(PersonId))] string Comment);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_an_explicit_serialized_name_differs_from_the_naming_policy.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_an_explicit_serialized_name_differs_from_the_naming_policy.cs
@@ -11,7 +11,7 @@ public class and_an_explicit_serialized_name_differs_from_the_naming_policy : gi
 {
     record DueSubject(
         string PersonId,
-        [property: JsonPropertyName("PrivateNote")][PII][ReleaseUnder(nameof(PersonId))] string Comment);
+        [property: JsonPropertyName("PrivateNote")][PII][SubjectFrom(nameof(PersonId))] string Comment);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_an_undeclared_property_falls_back_to_an_explicit_subject.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_an_undeclared_property_falls_back_to_an_explicit_subject.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
+
+/// <summary>
+/// The default half of the model, pinned against the [Subject] branch: a property that says nothing uses the
+/// read model's own subject, and when that subject is declared with [Subject] it is that property — not Id,
+/// which is present here precisely so a fallback to it would show.
+/// </summary>
+public class and_an_undeclared_property_falls_back_to_an_explicit_subject : given.a_recording_compliance_service
+{
+    record DueSubject(string Id, [property: Subject] string PersonId, [PII] string Advisor, [PII][SubjectFrom(nameof(Id))] string Comment);
+
+    DueSubject _result;
+
+    async Task Because() => _result = await _readModels.Release(new DueSubject(
+        "case-9",
+        "person-1",
+        Cipher("person-1", "Grace Hopper"),
+        Cipher("case-9", "Awaiting counsel")));
+
+    [Fact] void should_release_once_per_subject() => _requests.Count.ShouldEqual(2);
+    [Fact] void should_send_the_undeclared_properties_under_the_explicit_subject() => PayloadKeysFor("person-1").ShouldContainOnly([nameof(DueSubject.Id), nameof(DueSubject.PersonId), nameof(DueSubject.Advisor)]);
+    [Fact] void should_send_only_the_declared_property_under_the_named_one() => PayloadKeysFor("case-9").ShouldContainOnly([nameof(DueSubject.Comment)]);
+    [Fact] void should_release_the_undeclared_value_under_the_explicit_subject() => _result.Advisor.ShouldEqual("Grace Hopper");
+    [Fact] void should_release_the_declared_value_under_the_named_subject() => _result.Comment.ShouldEqual("Awaiting counsel");
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_no_subject_resolves_but_one_is_declared.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_no_subject_resolves_but_one_is_declared.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
 /// </summary>
 public class and_no_subject_resolves_but_one_is_declared : given.a_recording_compliance_service
 {
-    record DueSubject(string SubjectId, [PII][ReleaseUnder(nameof(SubjectId))] string Comment);
+    record DueSubject(string SubjectId, [PII][SubjectFrom(nameof(SubjectId))] string Comment);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declaration_uses_the_superseded_attribute.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declaration_uses_the_superseded_attribute.cs
@@ -6,14 +6,15 @@ using Cratis.Chronicle.Compliance.GDPR;
 namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
 
 /// <summary>
-/// The other outcome the report names: the composed row does resolve a subject, just not the one the lifted
-/// value belongs to, so the value is released under the wrong key. Declaring the value's own subject splits
-/// the release in two — the declared value under its owner, everything else under the row's own subject,
-/// which must keep working exactly as before.
+/// The compatibility guarantee, asserted where it matters — on the release itself. Every assertion here is
+/// the one and_a_declaration_overrides_the_read_models_own_subject makes with [SubjectFrom]; a read model
+/// still written against the released [ReleaseUnder] must split the release identically.
 /// </summary>
-public class and_a_declaration_overrides_the_read_models_own_subject : given.a_recording_compliance_service
+public class and_the_declaration_uses_the_superseded_attribute : given.a_recording_compliance_service
 {
-    record DueSubject(string Id, string PersonId, [PII] string Advisor, [PII][SubjectFrom(nameof(PersonId))] string Comment);
+#pragma warning disable CS0618 // the superseded attribute is the subject of this specification
+    record DueSubject(string Id, string PersonId, [PII] string Advisor, [PII][ReleaseUnder(nameof(PersonId))] string Comment);
+#pragma warning restore CS0618
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_property_holds_a_value_object.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_property_holds_a_value_object.cs
@@ -14,7 +14,7 @@ public class and_the_declared_property_holds_a_value_object : given.a_recording_
 {
     record Postponement([PII] string Comment, string RecordedBy);
 
-    record DueSubject(string PersonId, [ReleaseUnder(nameof(PersonId))] Postponement Postponement);
+    record DueSubject(string PersonId, [SubjectFrom(nameof(PersonId))] Postponement Postponement);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_subject_property_holds_nothing.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_subject_property_holds_nothing.cs
@@ -13,7 +13,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
 /// </summary>
 public class and_the_declared_subject_property_holds_nothing : given.a_recording_compliance_service
 {
-    record DueSubject(string Id, string PersonId, [PII][ReleaseUnder(nameof(PersonId))] string Comment);
+    record DueSubject(string Id, string PersonId, [PII][SubjectFrom(nameof(PersonId))] string Comment);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_value_was_never_encrypted.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_declared_value_was_never_encrypted.cs
@@ -12,7 +12,7 @@ namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
 /// </summary>
 public class and_the_declared_value_was_never_encrypted : given.a_recording_compliance_service
 {
-    record DueSubject(string PersonId, [PII][ReleaseUnder(nameof(PersonId))] string Comment);
+    record DueSubject(string PersonId, [PII][SubjectFrom(nameof(PersonId))] string Comment);
 
     DueSubject _result;
 

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_two_values_belong_to_different_subjects.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_two_values_belong_to_different_subjects.cs
@@ -15,8 +15,8 @@ public class and_two_values_belong_to_different_subjects : given.a_recording_com
         string ContactPointHash,
         string FirstPersonId,
         string SecondPersonId,
-        [PII][ReleaseUnder(nameof(FirstPersonId))] string FirstName,
-        [PII][ReleaseUnder(nameof(SecondPersonId))] string SecondName);
+        [PII][SubjectFrom(nameof(FirstPersonId))] string FirstName,
+        [PII][SubjectFrom(nameof(SecondPersonId))] string SecondName);
 
     Duplicate _result;
 

--- a/Source/Clients/DotNET/Compliance/GDPR/ReleaseUnderAttribute.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/ReleaseUnderAttribute.cs
@@ -8,45 +8,18 @@ namespace Cratis.Chronicle.Compliance.GDPR;
 /// read model's own compliance subject.
 /// </summary>
 /// <remarks>
-/// A read model normally has exactly one compliance subject — an explicit <c>[Subject]</c>, otherwise the
-/// property named <c>Id</c> — and every <see cref="PIIAttribute">[PII]</see> value on it is released under
-/// that one subject. That is the right model for a read model Chronicle builds and stores: one document,
-/// one erasable person.
+/// Superseded by <see cref="SubjectFromAttribute">[SubjectFrom]</see>, which says the same thing the way the
+/// rest of the model says it: declaratively, naming where the subject is found rather than the action taken
+/// with it. This type stays, deriving from <see cref="SubjectFromAttribute"/>, so read models written against
+/// the released name keep compiling and keep behaving identically — everything that reads a declaration reads
+/// <see cref="SubjectFromAttribute"/>, and finds this one through it.
 /// <para>
-/// It is not enough for a read model an application composes itself at the query edge, from rows it fetched
-/// on its own. Such a row can carry a value that was encrypted under a subject that is not the row's own —
-/// and until it can say so, the release pass has only two outcomes to offer it, both silent: released under
-/// the wrong subject, or not released at all because no subject resolves and the value reaches the caller as
-/// ciphertext. This attribute is how the row says which subject the value actually belongs to.
-/// </para>
-/// <code>
-/// public record RetentionDueSubject(
-///     SubjectId Person,
-///     [ReleaseUnder(nameof(Person))] PostponementComment Comment);
-/// </code>
-/// <para>
-/// The named property is looked up on the read model itself and its value is converted to a
-/// <see cref="Subject"/> the same way an unadorned read model's subject is. Everything the adorned property
-/// holds — a scalar, a value object, a collection — is released under that subject; every property without
-/// the attribute keeps releasing under the read model's own subject, unchanged.
-/// </para>
-/// <para>
-/// Declare it only on a property of the read model type itself. A declaration further down the graph, inside
-/// a value object or a child element, cannot be honored and is reported as
-/// <see cref="ReadModels.ReleaseUnderNotSupportedBelowReadModel"/> rather than ignored.
-/// </para>
-/// <para>
-/// This does not make it acceptable to store one person's data on another person's document. It applies to a
-/// value resolved in memory at the query edge; a stored read model still holds exactly one subject's personal
-/// data, which is what keeps that person's erasure complete.
+/// The deprecation sits on the constructor rather than the type, because applying the attribute is the only
+/// way to consume it — that is where the warning belongs, and it keeps the type nameable without warning by
+/// the reflection and type-discovery code that has to enumerate every attribute in the assembly.
 /// </para>
 /// </remarks>
-/// <param name="propertyName">Name of the property on the read model holding the subject to release under.</param>
+/// <param name="propertyName">Name of the property on the read model holding the subject to use.</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
-public sealed class ReleaseUnderAttribute(string propertyName) : Attribute
-{
-    /// <summary>
-    /// Gets the name of the property on the read model holding the subject to release under.
-    /// </summary>
-    public string PropertyName { get; } = propertyName;
-}
+[method: Obsolete("Use [SubjectFrom] instead. [ReleaseUnder] is kept as an alias of [SubjectFrom] and behaves identically.", false)]
+public sealed class ReleaseUnderAttribute(string propertyName) : SubjectFromAttribute(propertyName);

--- a/Source/Clients/DotNET/Compliance/GDPR/SubjectFromAttribute.cs
+++ b/Source/Clients/DotNET/Compliance/GDPR/SubjectFromAttribute.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Compliance.GDPR;
+
+/// <summary>
+/// Declares where to find the subject the personal data held by a read model property belongs to, instead of
+/// the read model's own compliance subject.
+/// </summary>
+/// <remarks>
+/// A read model normally has exactly one compliance subject — an explicit <c>[Subject]</c>, otherwise the
+/// property named <c>Id</c> — and every <see cref="PIIAttribute">[PII]</see> value on it is released under
+/// that one subject. That is the right model for a read model Chronicle builds and stores: one document,
+/// one erasable person.
+/// <para>
+/// It is not enough for a read model an application composes itself at the query edge, from rows it fetched
+/// on its own. Such a row can carry a value that was encrypted under a subject that is not the row's own —
+/// and until it can say so, the release pass has only two outcomes to offer it, both silent: released under
+/// the wrong subject, or not released at all because no subject resolves and the value reaches the caller as
+/// ciphertext. This attribute is how the row says which subject the value actually belongs to.
+/// </para>
+/// <code>
+/// public record RetentionDueSubject(
+///     SubjectId Person,
+///     [SubjectFrom(nameof(Person))] PostponementComment Comment);
+/// </code>
+/// <para>
+/// The named property is looked up on the read model itself and its value is converted to a
+/// <see cref="Subject"/> the same way an unadorned read model's subject is. Everything the adorned property
+/// holds — a scalar, a value object, a collection — is released under that subject; every property without
+/// the attribute keeps using the read model's own subject, unchanged.
+/// </para>
+/// <para>
+/// Declare it only on a property of the read model type itself. A declaration further down the graph, inside
+/// a value object or a child element, cannot be honored and is reported as
+/// <see cref="ReadModels.ReleaseUnderNotSupportedBelowReadModel"/> rather than ignored.
+/// </para>
+/// <para>
+/// This does not make it acceptable to store one person's data on another person's document. It applies to a
+/// value resolved in memory at the query edge; a stored read model still holds exactly one subject's personal
+/// data, which is what keeps that person's erasure complete.
+/// </para>
+/// </remarks>
+/// <param name="propertyName">Name of the property on the read model holding the subject to use.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
+#pragma warning disable CA1813 // deliberately unsealed: the superseded [ReleaseUnder] derives from this, so one lookup finds both
+public class SubjectFromAttribute(string propertyName) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the property on the read model holding the subject to use.
+    /// </summary>
+    public string PropertyName { get; } = propertyName;
+}
+#pragma warning restore CA1813

--- a/Source/Clients/DotNET/ReadModels/ReadModelReleaseDeclarationScanner.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelReleaseDeclarationScanner.cs
@@ -8,7 +8,7 @@ using Cratis.Chronicle.Compliance.GDPR;
 namespace Cratis.Chronicle.ReadModels;
 
 /// <summary>
-/// Finds <see cref="ReleaseUnderAttribute"/> declarations sitting below a read model's own properties, where
+/// Finds <see cref="SubjectFromAttribute"/> declarations sitting below a read model's own properties, where
 /// they cannot be honored.
 /// </summary>
 /// <remarks>
@@ -55,7 +55,7 @@ internal static class ReadModelReleaseDeclarationScanner
     }
 
     static bool IsDeclared(PropertyInfo property) =>
-        property.IsDefined(typeof(ReleaseUnderAttribute), inherit: false) ||
+        property.IsDefined(typeof(SubjectFromAttribute), inherit: false) ||
         IsDeclaredOnConstructorParameter(property);
 
     static bool IsDeclaredOnConstructorParameter(PropertyInfo property)
@@ -65,7 +65,7 @@ internal static class ReadModelReleaseDeclarationScanner
             .GetParameters()
             .Any(parameter =>
                 string.Equals(parameter.Name, property.Name, StringComparison.OrdinalIgnoreCase) &&
-                parameter.IsDefined(typeof(ReleaseUnderAttribute), inherit: false)) ?? false;
+                parameter.IsDefined(typeof(SubjectFromAttribute), inherit: false)) ?? false;
     }
 
     static Type? Candidate(Type type)

--- a/Source/Clients/DotNET/ReadModels/ReadModelReleasePlan.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelReleasePlan.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.ReadModels;
 /// The per-property release declarations a read model type carries, resolved once per type.
 /// </summary>
 /// <remarks>
-/// A read model without a single <see cref="ReleaseUnderAttribute"/> yields <see cref="Groups"/> empty and
+/// A read model without a single <see cref="SubjectFromAttribute"/> yields <see cref="Groups"/> empty and
 /// <see cref="HasDeclarations"/> false, which is what keeps the undeclared release path exactly what it was:
 /// one subject, one call, the whole payload.
 /// </remarks>
@@ -60,15 +60,15 @@ internal sealed record ReadModelReleasePlan(IReadOnlyList<ReadModelReleaseGroup>
         return new ReadModelReleasePlan(groups);
     }
 
-    static ReleaseUnderAttribute? FindDeclaration(PropertyInfo property) =>
-        property.GetCustomAttribute<ReleaseUnderAttribute>(inherit: false) ??
+    static SubjectFromAttribute? FindDeclaration(PropertyInfo property) =>
+        property.GetCustomAttributes<SubjectFromAttribute>(inherit: false).FirstOrDefault() ??
         FindDeclarationOnConstructorParameter(property);
 
-    static ReleaseUnderAttribute? FindDeclarationOnConstructorParameter(PropertyInfo property)
+    static SubjectFromAttribute? FindDeclarationOnConstructorParameter(PropertyInfo property)
     {
         // An attribute written without an explicit target on a positional record lands on the primary
         // constructor's parameter, not on the generated property — the same shape [PII] and [Subject] are
-        // both read through, so [ReleaseUnder] has to be read the same way or it silently does nothing on
+        // both read through, so [SubjectFrom] has to be read the same way or it silently does nothing on
         // the most idiomatic way to declare a read model.
         if (property.DeclaringType is null)
         {
@@ -79,7 +79,7 @@ internal sealed record ReadModelReleasePlan(IReadOnlyList<ReadModelReleaseGroup>
         return constructor?
             .GetParameters()
             .FirstOrDefault(parameter => string.Equals(parameter.Name, property.Name, StringComparison.OrdinalIgnoreCase))?
-            .GetCustomAttribute<ReleaseUnderAttribute>(inherit: false);
+            .GetCustomAttributes<SubjectFromAttribute>(inherit: false).FirstOrDefault();
     }
 
     static PropertyInfo ResolveSubjectProperty(Type readModelType, PropertyInfo[] properties, string declaringPropertyName, string subjectPropertyName) =>

--- a/Source/Clients/DotNET/ReadModels/ReadModelReleaser.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelReleaser.cs
@@ -14,7 +14,7 @@ namespace Cratis.Chronicle.ReadModels;
 
 /// <summary>
 /// Runs the compliance release pass over read model instances, honoring any per-property
-/// <see cref="Compliance.GDPR.ReleaseUnderAttribute"/> declarations the read model carries.
+/// <see cref="Compliance.GDPR.SubjectFromAttribute"/> declarations the read model carries.
 /// </summary>
 /// <param name="eventStore">The <see cref="IEventStore"/> the read models belong to.</param>
 /// <param name="schemaGenerator">The <see cref="IJsonSchemaGenerator"/> for describing the payload.</param>

--- a/Source/Clients/DotNET/ReadModels/ReadModelSubjectResolver.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelSubjectResolver.cs
@@ -48,7 +48,7 @@ public static class ReadModelSubjectResolver
     /// <param name="value">The property value to convert.</param>
     /// <returns>The <see cref="Subject"/>, or <see langword="null"/> when the value stands for none.</returns>
     /// <remarks>
-    /// Shared with the per-property <see cref="Compliance.GDPR.ReleaseUnderAttribute"/> resolution, so a
+    /// Shared with the per-property <see cref="Compliance.GDPR.SubjectFromAttribute"/> resolution, so a
     /// declared subject is read from an instance in exactly the same way the read model's own is.
     /// </remarks>
     internal static Subject? ToSubject(object? value) =>

--- a/Source/Clients/DotNET/ReadModels/ReleaseUnderNotSupportedBelowReadModel.cs
+++ b/Source/Clients/DotNET/ReadModels/ReleaseUnderNotSupportedBelowReadModel.cs
@@ -4,7 +4,7 @@
 namespace Cratis.Chronicle.ReadModels;
 
 /// <summary>
-/// The exception that is thrown when a <see cref="Compliance.GDPR.ReleaseUnderAttribute"/> is declared below
+/// The exception that is thrown when a <see cref="Compliance.GDPR.SubjectFromAttribute">[SubjectFrom]</see> is declared below
 /// the read model itself — on a member of a value object, a child element, or any other nested type.
 /// </summary>
 /// <remarks>
@@ -18,7 +18,7 @@ namespace Cratis.Chronicle.ReadModels;
 /// <param name="declaringType">The nested type carrying the declaration.</param>
 /// <param name="propertyName">The name of the nested property carrying the declaration.</param>
 public class ReleaseUnderNotSupportedBelowReadModel(Type readModelType, Type declaringType, string propertyName)
-    : Exception($"[ReleaseUnder] on '{declaringType.Name}.{propertyName}' is nested inside read model '{readModelType.Name}' and cannot be honored. Declare it on the property of '{readModelType.Name}' that holds the value instead — the whole value is released under the declared subject.")
+    : Exception($"[SubjectFrom] on '{declaringType.Name}.{propertyName}' is nested inside read model '{readModelType.Name}' and cannot be honored. Declare it on the property of '{readModelType.Name}' that holds the value instead — the whole value is released under the declared subject.")
 {
     /// <summary>
     /// Gets the read model type being released.

--- a/Source/Clients/DotNET/ReadModels/ReleaseUnderPropertyNotFound.cs
+++ b/Source/Clients/DotNET/ReadModels/ReleaseUnderPropertyNotFound.cs
@@ -4,7 +4,7 @@
 namespace Cratis.Chronicle.ReadModels;
 
 /// <summary>
-/// The exception that is thrown when a <see cref="Compliance.GDPR.ReleaseUnderAttribute"/> names a property
+/// The exception that is thrown when a <see cref="Compliance.GDPR.SubjectFromAttribute">[SubjectFrom]</see> names a property
 /// that does not exist on the read model.
 /// </summary>
 /// <remarks>
@@ -16,7 +16,7 @@ namespace Cratis.Chronicle.ReadModels;
 /// <param name="propertyName">The name of the property carrying the declaration.</param>
 /// <param name="subjectPropertyName">The name the declaration points at.</param>
 public class ReleaseUnderPropertyNotFound(Type readModelType, string propertyName, string subjectPropertyName)
-    : Exception($"[ReleaseUnder(\"{subjectPropertyName}\")] on '{readModelType.Name}.{propertyName}' names a property that does not exist on '{readModelType.Name}'. Use nameof() with a public instance property of the read model holding the subject to release under.")
+    : Exception($"[SubjectFrom(\"{subjectPropertyName}\")] on '{readModelType.Name}.{propertyName}' names a property that does not exist on '{readModelType.Name}'. Use nameof() with a public instance property of the read model holding the subject to use.")
 {
     /// <summary>
     /// Gets the read model type carrying the declaration.


### PR DESCRIPTION
## Added

- `[SubjectFrom(nameof(property))]` declares which property holds the subject a read model value's personal data belongs to (#3601)

## Deprecated

- `[ReleaseUnder]` in favor of `[SubjectFrom]`; it still compiles and behaves identically, and now warns at the point it is applied (#3601)
