### PR TITLE
Fall back to read model Id for an unset subject

### DIFF
--- a/Documentation/read-models/releasing-pii.mdx
+++ b/Documentation/read-models/releasing-pii.mdx
@@ -9,7 +9,7 @@ Most of the time you never think about this. `GetInstanceById`, `GetInstances`, 
 
 <ChronicleClientTabs snippet="read-models/releasing-pii/read-model" />
 
-`RequesterName` is `[PII]`-marked explicitly on the read model — required for a reducer, since Chronicle can't infer PII lineage through arbitrary reducer logic the way it can for a model-bound projection. `CustomerId` carries `[Subject]`: the ticket's own `Id` identifies the ticket, not the person the PII belongs to, so `Release` needs to be told which property to use as the encryption key's owner.
+`RequesterName` is `[PII]`-marked explicitly on the read model — required for a reducer, since Chronicle can't infer PII lineage through arbitrary reducer logic the way it can for a model-bound projection. `CustomerId` carries `[Subject]`: the ticket's own `Id` identifies the ticket, not the person the PII belongs to, so `Release` needs to be told which property to use as the encryption key's owner. A property having the `Subject` type does not select it by itself; the attribute is what declares the role.
 
 ## Release a single instance
 
@@ -37,9 +37,13 @@ Every other read on `IReadModels` releases before returning to you. `Watch` is t
 | 2 | A constructor parameter decorated with `[Subject]` (record shorthand) |
 | 3 | A property named `Id`, case-insensitive |
 
-The first match wins. If none of the three resolve to a value — or the read model has no PII-annotated properties at all — `Release` returns the instance unchanged; there's nothing for it to do.
+The first match **with a value** wins. If an attributed property is `null`, empty or `Subject.NotSet`, `Release` continues to the `Id` fallback. This lets older rows and partially populated instances remain releasable while a newly projected `[Subject]` property is introduced.
 
-Add `[Subject]` when the identity that owns the PII differs from the read model's own key, exactly as you would on a command or event property to control which identity an append is encrypted under. When the two already match — a person's own profile, keyed by their own identity — the `Id` fallback handles it and no attribute is needed.
+If none of the three resolve to a value, `Release` returns the instance unchanged and logs a warning when the model has PII metadata. If the read model has no PII-annotated properties, it returns the instance unchanged without a warning because there is nothing to release.
+
+Add `[Subject]` when the identity that manual `Release` should use differs from the read model's own key, exactly as you would on a command or event property to control which identity an append is encrypted under. When the two already match — a person's own profile, keyed by their own identity — the `Id` fallback handles it and no attribute is needed.
+
+This attribute affects only subject discovery from the object passed to `Release`; it does not assign ownership to a managed projection document. Chronicle's projection pipeline derives ownership from the event that supplied each PII value and persists that information in its reserved `__subject` and `__subjects` fields. An explicit subject supplied while appending an event therefore controls the values originating from that event, regardless of whether the read model exposes a `Subject` property.
 
 ## When release can't recover a value
 

--- a/Integration/Client/for_ReadModels/when_projecting_the_event_subject/and_the_read_model_declares_a_subject_property.cs
+++ b/Integration/Client/for_ReadModels/when_projecting_the_event_subject/and_the_read_model_declares_a_subject_property.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable SA1402
+
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Projections.ModelBound;
+using MongoDB.Bson;
+using context = Cratis.Chronicle.Integration.for_ReadModels.when_projecting_the_event_subject.and_the_read_model_declares_a_subject_property.context;
+
+namespace Cratis.Chronicle.Integration.for_ReadModels.when_projecting_the_event_subject;
+
+/// <summary>
+/// Verifies that a subject explicitly carried by event context can also be projected into an ordinary
+/// read-model property while Chronicle retains its internal per-property ownership metadata.
+/// </summary>
+/// <param name="context">The test context.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_the_read_model_declares_a_subject_property(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture fixture) : Specification(fixture)
+    {
+        public EventSourceId SignupId { get; } = "subject-property-signup";
+        public Subject UserId { get; } = "subject-property-user";
+        public string Email { get; } = "user@example.com";
+
+        public SubjectSignup Result { get; private set; } = default!;
+        public BsonDocument? StoredDocument { get; private set; }
+
+        public bool DocumentCanBeInspected => StoredReadModelDocument.CanBeInspected(ChronicleFixture);
+
+        public override IEnumerable<Type> EventTypes => [typeof(SubjectSignupRegistered)];
+        public override IEnumerable<Type> ModelBoundProjections => [typeof(SubjectSignup)];
+
+        async Task Because()
+        {
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<SubjectSignup>();
+            var handler = EventStore.Projections.GetAllHandlers().Single(_ => _.Id == projectionId);
+            await handler.WaitTillActive();
+
+            var appendResult = await EventStore.EventLog.Append(SignupId, new SubjectSignupRegistered(Email), subject: UserId);
+            await handler.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+
+            Result = await EventStore.ReadModels.GetInstanceById<SubjectSignup>(SignupId.Value);
+            StoredDocument = await StoredReadModelDocument.Read(ChronicleFixture, "SubjectSignups");
+        }
+    }
+
+    [Fact] void should_return_the_read_model() => Context.Result.ShouldNotBeNull();
+    [Fact] void should_materialize_the_event_subject() => Context.Result.Subject.ShouldEqual(Context.UserId);
+    [Fact] void should_release_the_pii_value() => Context.Result.Email.ShouldEqual(Context.Email);
+    [Fact] void should_have_read_the_stored_document_when_the_backend_allows_it() => (!Context.DocumentCanBeInspected || Context.StoredDocument is not null).ShouldBeTrue();
+    [Fact]
+    void should_store_the_projected_subject_property_when_the_backend_allows_it()
+    {
+        if (Context.DocumentCanBeInspected)
+        {
+            Context.StoredDocument![nameof(SubjectSignup.Subject)].AsString.ShouldEqual(Context.UserId.Value);
+        }
+    }
+}
+
+/// <summary>
+/// A signup was registered for a user.
+/// </summary>
+/// <param name="Email">The user's email address.</param>
+[EventType]
+public record SubjectSignupRegistered([property: PII] string Email);
+
+/// <summary>
+/// A signup carrying the user that owns its personal data.
+/// </summary>
+/// <param name="Id">The signup identifier.</param>
+/// <param name="Subject">The user that owns the personal data.</param>
+/// <param name="Email">The user's email address.</param>
+[FromEvent<SubjectSignupRegistered>]
+public record SubjectSignup(
+    string Id,
+    [property: Subject]
+    [SetFromContext<SubjectSignupRegistered>(nameof(EventContext.Subject))]
+    Subject Subject,
+    string Email);
+
+#pragma warning restore SA1402

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_constructor_parameter_subject_has_no_value.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_constructor_parameter_subject_has_no_value.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelSubjectResolver;
+
+public class when_the_constructor_parameter_subject_has_no_value : Specification
+{
+    record ReadModelWithUnsetSubject(string Id, [Subject] Subject? UserId);
+
+    Subject? _result;
+
+    void Because() => _result = ReadModelSubjectResolver.ResolveFrom(new ReadModelWithUnsetSubject("signup-42", null));
+
+    [Fact] void should_resolve_a_subject() => _result.ShouldNotBeNull();
+    [Fact] void should_fall_back_to_the_id() => _result.Value.ShouldEqual("signup-42");
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_explicit_subject_has_no_value.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_explicit_subject_has_no_value.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelSubjectResolver;
+
+public class when_the_explicit_subject_has_no_value : Specification
+{
+    record ReadModelWithUnsetSubject(string Id, [property: Subject] Subject? UserId);
+
+    Subject? _result;
+
+    void Because() => _result = ReadModelSubjectResolver.ResolveFrom(new ReadModelWithUnsetSubject("signup-42", null));
+
+    [Fact] void should_resolve_a_subject() => _result.ShouldNotBeNull();
+    [Fact] void should_fall_back_to_the_id() => _result.Value.ShouldEqual("signup-42");
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_explicit_subject_is_not_set.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModelSubjectResolver/when_the_explicit_subject_is_not_set.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModelSubjectResolver;
+
+public class when_the_explicit_subject_is_not_set : Specification
+{
+    record ReadModelWithUnsetSubject(string Id, [property: Subject] Subject UserId);
+
+    Subject? _result;
+
+    void Because() => _result = ReadModelSubjectResolver.ResolveFrom(new ReadModelWithUnsetSubject("signup-42", Subject.NotSet));
+
+    [Fact] void should_resolve_a_subject() => _result.ShouldNotBeNull();
+    [Fact] void should_fall_back_to_the_id() => _result.Value.ShouldEqual("signup-42");
+}

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/given/all_dependencies.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/given/all_dependencies.cs
@@ -42,6 +42,7 @@ public class all_dependencies : Specification
         _eventTypes = Substitute.For<IEventTypes>();
         _additionalReadModels = [];
         _schemaGenerator = Substitute.For<IJsonSchemaGenerator>();
+        _schemaGenerator.Generate(Arg.Any<Type>()).Returns(new JsonSchema());
         _readModelWatcherManager = Substitute.For<IReadModelWatcherManager>();
         _reducerObservers = Substitute.For<IReducerObservers>();
         _jsonSerializerOptions = new();

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_explicit_subject_has_no_value.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_releasing/and_the_explicit_subject_has_no_value.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_releasing;
+
+public class and_the_explicit_subject_has_no_value : given.a_recording_compliance_service
+{
+    record SubjectSignup(string Id, [property: Subject] Subject? UserId, [PII] string Email);
+
+    SubjectSignup _result;
+
+    async Task Because() => _result = await _readModels.Release(new SubjectSignup("signup-42", null, Cipher("signup-42", "user@example.com")));
+
+    [Fact] void should_release_under_the_read_model_id() => _requests.Single().Subject.ShouldEqual("signup-42");
+    [Fact] void should_return_the_released_value() => _result.Email.ShouldEqual("user@example.com");
+}

--- a/Source/Clients/DotNET/ReadModels/IReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/IReadModels.cs
@@ -91,9 +91,10 @@ public interface IReadModels
     /// Release (decrypt) PII-annotated properties in a read model instance by deriving the subject from the instance itself.
     /// </summary>
     /// <remarks>
-    /// The subject is resolved by looking for a property or constructor parameter decorated with <see cref="SubjectAttribute"/>,
-    /// falling back to a property named <c>Id</c>. If no subject can be derived, or the read model has no compliance-annotated
-    /// properties, the original instance is returned unchanged.
+    /// The subject is resolved by looking for a property or constructor parameter decorated with <see cref="SubjectAttribute"/> that has a value,
+    /// falling back to a property named <c>Id</c> when the decorated value is null or otherwise not set. If no subject can be derived,
+    /// or the read model has no compliance-annotated properties, the original instance is returned unchanged.
+    /// A warning is logged when compliance metadata exists but no subject can be resolved.
     /// If decryption fails (e.g. the encryption key has been permanently deleted), the original instance is returned and
     /// the failure is logged.
     /// </remarks>

--- a/Source/Clients/DotNET/ReadModels/ReadModelReleaser.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelReleaser.cs
@@ -37,8 +37,20 @@ internal class ReadModelReleaser(
             return instance;
         }
 
+        var schema = schemaGenerator.Generate(typeof(TReadModel));
+        if (!schema.HasComplianceMetadata())
+        {
+            return instance;
+        }
+
         var subject = ReadModelSubjectResolver.ResolveFrom(instance);
-        return subject is null ? instance : await ReleaseWhole(subject, instance);
+        if (subject is null)
+        {
+            logger.NoSubjectForRelease(typeof(TReadModel).Name);
+            return instance;
+        }
+
+        return await ReleaseWhole(subject, instance, schema);
     }
 
     /// <summary>
@@ -58,14 +70,8 @@ internal class ReadModelReleaser(
         return result;
     }
 
-    async Task<TReadModel> ReleaseWhole<TReadModel>(Subject subject, TReadModel instance)
+    async Task<TReadModel> ReleaseWhole<TReadModel>(Subject subject, TReadModel instance, JsonSchema schema)
     {
-        var schema = schemaGenerator.Generate(typeof(TReadModel));
-        if (!schema.HasComplianceMetadata())
-        {
-            return instance;
-        }
-
         var payload = JsonSerializer.Serialize(instance, jsonSerializerOptions);
         var released = await ReleasePayload<TReadModel>(subject, schema.ToJson(), payload);
 

--- a/Source/Clients/DotNET/ReadModels/ReadModelReleaserLogMessages.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelReleaserLogMessages.cs
@@ -10,6 +10,9 @@ namespace Cratis.Chronicle.ReadModels;
 /// </summary>
 internal static partial class ReadModelReleaserLogMessages
 {
+    [LoggerMessage(LogLevel.Warning, "Read model '{ReadModelType}' has compliance metadata but no subject could be resolved; returning its values without releasing them")]
+    internal static partial void NoSubjectForRelease(this ILogger logger, string readModelType);
+
     [LoggerMessage(LogLevel.Error, "Failed to release compliance for read model '{ReadModelType}' with subject '{Subject}': {Error}")]
     internal static partial void FailedToRelease(this ILogger logger, string readModelType, string subject, string error);
 }

--- a/Source/Clients/DotNET/ReadModels/ReadModelSubjectResolver.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModelSubjectResolver.cs
@@ -8,20 +8,22 @@ namespace Cratis.Chronicle.ReadModels;
 
 /// <summary>
 /// Resolves a <see cref="Subject"/> from a read model instance by checking for a property or constructor
-/// parameter decorated with <see cref="SubjectAttribute"/>, falling back to a property named <c>Id</c>.
+/// parameter decorated with <see cref="SubjectAttribute"/> that has a value, falling back to a property named <c>Id</c>.
 /// </summary>
 public static class ReadModelSubjectResolver
 {
-    static readonly ConcurrentDictionary<Type, PropertyInfo?> _cache = new();
+    static readonly ConcurrentDictionary<Type, SubjectProperties> _cache = new();
 
     /// <summary>
     /// Attempt to derive a <see cref="Subject"/> from a read model instance.
     /// <para>Resolution order:</para>
     /// <list type="number">
-    ///   <item><description>Property decorated with <see cref="SubjectAttribute"/>.</description></item>
-    ///   <item><description>Constructor parameter decorated with <see cref="SubjectAttribute"/> (record shorthand).</description></item>
+    ///   <item><description>A property decorated with <see cref="SubjectAttribute"/> that has a value.</description></item>
+    ///   <item><description>A constructor parameter decorated with <see cref="SubjectAttribute"/> that has a value (record shorthand).</description></item>
     ///   <item><description>Property named <c>Id</c> (case-insensitive).</description></item>
     /// </list>
+    /// An attributed property that is null, empty, or <see cref="Subject.NotSet"/> does not stop resolution;
+    /// the <c>Id</c> fallback is attempted next.
     /// </summary>
     /// <param name="instance">The read model instance to inspect, or <see langword="null"/> for a read model that does not exist (never created or removed).</param>
     /// <returns>The resolved <see cref="Subject"/>, or <see langword="null"/> when no subject can be derived (including when <paramref name="instance"/> is <see langword="null"/>).</returns>
@@ -32,14 +34,9 @@ public static class ReadModelSubjectResolver
             return null;
         }
 
-        var property = _cache.GetOrAdd(instance.GetType(), FindSubjectProperty);
-
-        if (property is null)
-        {
-            return null;
-        }
-
-        return ToSubject(property.GetValue(instance));
+        var properties = _cache.GetOrAdd(instance.GetType(), FindSubjectProperties);
+        return ToSubject(properties.Explicit?.GetValue(instance)) ??
+               ToSubject(properties.Id?.GetValue(instance));
     }
 
     /// <summary>
@@ -51,36 +48,38 @@ public static class ReadModelSubjectResolver
         value switch
         {
             null => null,
-            Subject s => s,
+            Subject s when s.IsSet => s,
             string str when !string.IsNullOrEmpty(str) => str,
             Guid g when g != Guid.Empty => g,
             _ => value.ToString() is { } str and not "" ? new Subject(str) : null
         };
 
-    static PropertyInfo? FindSubjectProperty(Type t)
+    static SubjectProperties FindSubjectProperties(Type type)
     {
-        var properties = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var idProperty = properties.FirstOrDefault(property =>
+            string.Equals(property.Name, "Id", StringComparison.OrdinalIgnoreCase));
 
         // 1. Explicit [Subject] on property
-        var prop = properties.FirstOrDefault(p => p.IsDefined(typeof(SubjectAttribute), inherit: false));
-        if (prop is not null)
-        {
-            return prop;
-        }
+        var explicitProperty = properties.FirstOrDefault(property =>
+            property.IsDefined(typeof(SubjectAttribute), inherit: false));
 
         // 2. [Subject] on constructor parameter (record shorthand, without [property:])
-        var primaryCtor = t.GetConstructors().MaxBy(c => c.GetParameters().Length);
-        var subjectParam = primaryCtor?.GetParameters()
-            .FirstOrDefault(p => p.IsDefined(typeof(SubjectAttribute), inherit: false));
-
-        if (subjectParam is not null)
+        if (explicitProperty is null)
         {
-            return properties.FirstOrDefault(p =>
-                string.Equals(p.Name, subjectParam.Name, StringComparison.OrdinalIgnoreCase));
+            var primaryConstructor = type.GetConstructors().MaxBy(constructor => constructor.GetParameters().Length);
+            var subjectParameter = primaryConstructor?.GetParameters()
+                .FirstOrDefault(parameter => parameter.IsDefined(typeof(SubjectAttribute), inherit: false));
+
+            if (subjectParameter is not null)
+            {
+                explicitProperty = properties.FirstOrDefault(property =>
+                    string.Equals(property.Name, subjectParameter.Name, StringComparison.OrdinalIgnoreCase));
+            }
         }
 
-        // 3. Fallback: property named "Id"
-        return properties.FirstOrDefault(p =>
-            string.Equals(p.Name, "Id", StringComparison.OrdinalIgnoreCase));
+        return new(explicitProperty, idProperty == explicitProperty ? null : idProperty);
     }
+
+    readonly record struct SubjectProperties(PropertyInfo? Explicit, PropertyInfo? Id);
 }

--- a/Source/Clients/DotNET/SubjectAttribute.cs
+++ b/Source/Clients/DotNET/SubjectAttribute.cs
@@ -4,13 +4,12 @@
 namespace Cratis.Chronicle;
 
 /// <summary>
-/// Marks a property or record parameter as the <see cref="Subject"/> of an event — the identity used to
-/// key per-subject compliance material such as PII encryption keys.
+/// Marks a property or record parameter as the <see cref="Subject"/> used for compliance operations.
 /// </summary>
 /// <remarks>
-/// When this attribute is present on a property or record constructor parameter of an event type,
-/// Chronicle will automatically derive the subject from that value when the caller does not supply
-/// an explicit <see cref="Subject"/> to <c>IEventSequence.Append</c>.
+/// On an event type, Chronicle derives the append subject from this value when the caller does not supply
+/// an explicit <see cref="Subject"/>. On a read model, <see cref="ReadModels.IReadModels.Release{TReadModel}(TReadModel)"/>
+/// uses this value to select the encryption key for an instance that needs manual release.
 ///
 /// <code>
 /// [EventType]
@@ -22,7 +21,8 @@ namespace Cratis.Chronicle;
 ///
 /// Appending without an explicit subject automatically uses the <c>Customer</c> property as the
 /// subject, so PII fields are encrypted under the customer's key rather than the order's key.
+/// A read model's attribute does not override the ownership metadata maintained by Chronicle's projection
+/// pipeline; managed projection reads use the provenance of each projected value.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
 public sealed class SubjectAttribute : Attribute;
-


### PR DESCRIPTION
# Summary

Manual read-model release now follows the complete subject resolution order instead of silently stopping on an unset annotated member.

## Changed

- Subject guidance now distinguishes managed projection ownership from manual `IReadModels.Release` subject selection. (#3708)

## Fixed

- Manual PII release falls back to the read model `Id` when its `[Subject]` member is null or `NotSet`, and warns when no usable subject exists. (#3708)