### PR TITLE
Log the skipped concurrency check at Debug instead of Warning

### DIFF
--- a/Documentation/events/concurrency.mdx
+++ b/Documentation/events/concurrency.mdx
@@ -85,7 +85,7 @@ This strategy gets the current tail sequence number and uses it as the expected 
 
 ## The First Append Into a Scope Is Not Checked by Default
 
-A concurrency check needs something to compare against, and the optimistic strategy gets one by reading the tail *through the scope's own narrowing*. When nothing matching that narrowing has been appended yet there is no tail to read, so the strategy reports `EventSequenceNumber.Unavailable` — the same value that means "no expected sequence number was supplied at all". The kernel cannot act on that, so it skips the check, logs a warning, and lets the append through.
+A concurrency check needs something to compare against, and the optimistic strategy gets one by reading the tail *through the scope's own narrowing*. When nothing matching that narrowing has been appended yet there is no tail to read, so the strategy reports `EventSequenceNumber.Unavailable` — the same value that means "no expected sequence number was supplied at all". The kernel cannot act on that, so it skips the check, notes it in a debug-level log line, and lets the append through — the skip is the designed default, so it is not logged as a warning.
 
 ```mermaid
 flowchart TD
@@ -95,7 +95,7 @@ flowchart TD
     V -->|no| K[(Appended)]
     V -->|yes| R[Concurrency violation]
     T -->|no| C{"First-append check turned on?"}
-    C -->|no, the default| S[Check skipped, warning logged]
+    C -->|no, the default| S[Check skipped, logged at debug]
     S --> K
     C -->|yes| W{"Does anything match it now?"}
     W -->|no| K
@@ -152,7 +152,7 @@ A scope declares "I expect no matching event" in a **field of its own** on the w
 |---|---|---|
 | current | current | **Checked.** Rejected if a matching event arrived in between |
 | current | older | **Skipped**, with the `SkippingIncompleteConcurrencyScope` warning — the older behavior. The older kernel does not know the field, reads `Unavailable`, and declines to validate exactly as it always did |
-| older | current | **Skipped**, same warning. The older client never sets the field, so the kernel has no expectation to check |
+| older | current | **Skipped**, same log line — at debug level, since for a current kernel this is the designed default. The older client never sets the field, so the kernel has no expectation to check |
 
 A skew therefore degrades to the same skip you get with the check off, and says so in the log — it never produces a check that reports success without running. Both directions are pinned by specs under `for_ConcurrencyScopeConverters/when_a_client_and_kernel_version_disagree`.
 

--- a/Source/Kernel/Core/EventSequences/Concurrency/ConcurrencyValidator.cs
+++ b/Source/Kernel/Core/EventSequences/Concurrency/ConcurrencyValidator.cs
@@ -21,7 +21,7 @@ public class ConcurrencyValidator(IEventSequenceStorage eventSequenceStorage, IL
     {
         if (!scope.ShouldBeValidated)
         {
-            WarnIfIncomplete(eventSourceId, scope);
+            LogIfIncomplete(eventSourceId, scope);
             return Option<ConcurrencyViolation>.None();
         }
 
@@ -57,7 +57,7 @@ public class ConcurrencyValidator(IEventSequenceStorage eventSequenceStorage, IL
         {
             foreach (var (eventSourceId, scope) in scopes.Scopes)
             {
-                WarnIfIncomplete(eventSourceId, scope);
+                LogIfIncomplete(eventSourceId, scope);
             }
 
             return [];
@@ -79,15 +79,15 @@ public class ConcurrencyValidator(IEventSequenceStorage eventSequenceStorage, IL
     /// <param name="eventSourceId">The <see cref="EventSourceId"/> the append is for.</param>
     /// <param name="scope">The <see cref="ConcurrencyScope"/> that is being skipped.</param>
     /// <remarks>
-    /// Failing open here looks identical to never having asked for a check, so a caller that believes its writes
-    /// are serialized never finds out otherwise. The append is still allowed - rejecting it would break every
-    /// caller that already builds such a scope - but it does not pass unnoticed: the operator sees this warning,
-    /// and the caller sees it on the append result, which reports the check as not performed.
-    /// A scope a strategy resolved against an empty narrowing reaches here unless the client opted into checking
-    /// the first append into a scope; with that on it expects <see cref="EventSequenceNumber.BeforeFirst"/>
-    /// instead, which is checked.
+    /// The signal a caller acts on is the append result, which reports the check as not performed - this log line
+    /// is a diagnostic aid on top of it. It is Debug rather than Warning because the state is the shipped default,
+    /// not an anomaly: with checking the first append into a scope not opted into, the strategy resolves an empty
+    /// narrowing to a scope with no expectation, so an application creating many event sources produces this line
+    /// on every one of them. A caller that did opt in sends the expectation that no matching event exists, which
+    /// is validated rather than skipped - so a scope reaching here carries no sign that a check was wanted, and
+    /// there is nothing to warn about.
     /// </remarks>
-    void WarnIfIncomplete(EventSourceId eventSourceId, ConcurrencyScope scope)
+    void LogIfIncomplete(EventSourceId eventSourceId, ConcurrencyScope scope)
     {
         if (scope.IsIncomplete)
         {

--- a/Source/Kernel/Core/EventSequences/Concurrency/ConcurrencyValidatorLogging.cs
+++ b/Source/Kernel/Core/EventSequences/Concurrency/ConcurrencyValidatorLogging.cs
@@ -11,6 +11,6 @@ namespace Cratis.Chronicle.EventSequences.Concurrency;
 
 internal static partial class ConcurrencyValidatorLogging
 {
-    [LoggerMessage(LogLevel.Warning, "Skipping the concurrency check for event source '{EventSourceId}' - the append declared a concurrency scope that carries no expected sequence number, so there is nothing to compare against and the append proceeds unchecked")]
+    [LoggerMessage(LogLevel.Debug, "Skipping the concurrency check for event source '{EventSourceId}' - the append declared a concurrency scope that carries no expected sequence number, so there is nothing to compare against and the append proceeds unchecked")]
     internal static partial void SkippingIncompleteConcurrencyScope(this ILogger<ConcurrencyValidator> logger, EventSourceId eventSourceId);
 }


### PR DESCRIPTION
## Fixed

- The kernel logs `SkippingIncompleteConcurrencyScope` at Debug instead of Warning. With `CheckFirstAppendIntoAScope` off — the shipped default — every first append into a new event source skips the check by design, so an application creating many event sources flooded the log with warnings; a caller that opts into the check sends an expectation the kernel validates rather than skips, so the skipped case never signals a check the caller asked for, and the append result keeps reporting the check as not performed (#3724)

🤖 Generated with [Claude Code](https://claude.com/claude-code)