### PR TITLE
Key failed-partition entries by observer and partition

### DIFF
--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_registering_an_attempt_for_a_partition_loaded_from_storage.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_registering_an_attempt_for_a_partition_loaded_from_storage.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Concepts.Observation.for_FailedPartitions;
+
+public class when_registering_an_attempt_for_a_partition_loaded_from_storage : Specification
+{
+    static readonly Key _partition = new("some-partition", ArrayIndexers.NoIndexers);
+
+    FailedPartitions _failedPartitions;
+    FailedPartition _loaded;
+    FailedPartition _result;
+
+    void Establish()
+    {
+        // A partition read back from storage carries the observer identity stamped at write time,
+        // while one created in-memory does not - registering against the loaded entry must find it
+        // rather than create a second entry for the same partition.
+        _loaded = new() { Partition = _partition, ObserverId = "the-observer" };
+        _failedPartitions = new() { Partitions = [_loaded] };
+    }
+
+    void Because() => _result = _failedPartitions.RegisterAttempt(_partition, EventSequenceNumber.First, ["it failed again"], string.Empty);
+
+    [Fact] void should_register_against_the_loaded_entry() => _result.ShouldEqual(_loaded);
+    [Fact] void should_keep_a_single_entry() => _failedPartitions.Partitions.Count().ShouldEqual(1);
+    [Fact] void should_add_the_attempt() => _loaded.Attempts.Count().ShouldEqual(1);
+}

--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_removing_a_partition_registered_for_a_single_observer.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_removing_a_partition_registered_for_a_single_observer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Concepts.Observation.for_FailedPartitions;
+
+public class when_removing_a_partition_registered_for_a_single_observer : Specification
+{
+    static readonly Key _partition = new("some-partition", ArrayIndexers.NoIndexers);
+
+    FailedPartitions _failedPartitions;
+
+    void Establish()
+    {
+        _failedPartitions = new();
+        _failedPartitions.RegisterAttempt(_partition, EventSequenceNumber.First, ["something went wrong"], string.Empty);
+    }
+
+    void Because() => _failedPartitions.Remove(_partition);
+
+    [Fact] void should_no_longer_report_the_partition_as_failed() => _failedPartitions.IsFailed(_partition).ShouldBeFalse();
+    [Fact] void should_have_no_failed_partitions() => _failedPartitions.HasFailedPartitions.ShouldBeFalse();
+    [Fact] void should_track_the_partition_as_resolved() => _failedPartitions.ResolvedPartitions.Single().Partition.ShouldEqual(_partition);
+}

--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_removing_a_partition_whose_observer_was_stamped_after_registration.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_removing_a_partition_whose_observer_was_stamped_after_registration.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Concepts.Observation.for_FailedPartitions;
+
+public class when_removing_a_partition_whose_observer_was_stamped_after_registration : Specification
+{
+    static readonly Key _partition = new("some-partition", ArrayIndexers.NoIndexers);
+
+    FailedPartitions _failedPartitions;
+
+    void Establish()
+    {
+        // The grain storage provider stamps the observer identity onto an entry at write time - while
+        // the entry already sits in this collection. Removal must still find it (this exact mutation
+        // made recovery leave partitions behind when entries were keyed by observer and partition).
+        _failedPartitions = new();
+        var failure = _failedPartitions.RegisterAttempt(_partition, EventSequenceNumber.First, ["it failed"], string.Empty);
+        failure.ObserverId = "stamped-after-the-fact";
+    }
+
+    void Because() => _failedPartitions.Remove(_partition);
+
+    [Fact] void should_no_longer_report_the_partition_as_failed() => _failedPartitions.IsFailed(_partition).ShouldBeFalse();
+    [Fact] void should_have_no_failed_partitions() => _failedPartitions.HasFailedPartitions.ShouldBeFalse();
+    [Fact] void should_track_the_partition_as_resolved() => _failedPartitions.ResolvedPartitions.Single().Partition.ShouldEqual(_partition);
+}

--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_from_two_observers_failing_on_the_same_partition.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_from_two_observers_failing_on_the_same_partition.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Concepts.Observation.for_FailedPartitions;
+
+public class when_setting_partitions_from_two_observers_failing_on_the_same_partition : Specification
+{
+    static readonly Key _partition = new("c66fa6fd-95df-43f4-882a-a4fd380a9803", ArrayIndexers.NoIndexers);
+
+    FailedPartitions _failedPartitions;
+    FailedPartition _first;
+    FailedPartition _second;
+    Exception _error;
+
+    void Establish()
+    {
+        _first = new() { Partition = _partition, ObserverId = "first-observer" };
+        _second = new() { Partition = _partition, ObserverId = "second-observer" };
+        _failedPartitions = new();
+    }
+
+    void Because() => _error = Catch.Exception(() => _failedPartitions.Partitions = [_first, _second]);
+
+    [Fact] void should_not_fail() => _error.ShouldBeNull();
+    [Fact] void should_hold_both_entries() => _failedPartitions.Partitions.Count().ShouldEqual(2);
+    [Fact] void should_report_the_partition_as_failed() => _failedPartitions.IsFailed(_partition).ShouldBeTrue();
+}

--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_with_an_exact_duplicate.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_with_an_exact_duplicate.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Concepts.Observation.for_FailedPartitions;
+
+public class when_setting_partitions_with_an_exact_duplicate : Specification
+{
+    static readonly Key _partition = new("some-partition", ArrayIndexers.NoIndexers);
+
+    FailedPartitions _failedPartitions;
+    FailedPartition _older;
+    FailedPartition _newer;
+
+    void Establish()
+    {
+        _older = new() { Partition = _partition, ObserverId = "the-observer" };
+        _newer = new() { Partition = _partition, ObserverId = "the-observer" };
+        _failedPartitions = new();
+    }
+
+    void Because() => _failedPartitions.Partitions = [_older, _newer];
+
+    [Fact] void should_collapse_to_a_single_entry() => _failedPartitions.Partitions.Count().ShouldEqual(1);
+    [Fact] void should_keep_the_last_occurrence() => _failedPartitions.Partitions.Single().ShouldEqual(_newer);
+}

--- a/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_with_an_exact_duplicate.cs
+++ b/Source/Kernel/Concepts.Specs/Observation/for_FailedPartitions/when_setting_partitions_with_an_exact_duplicate.cs
@@ -11,13 +11,16 @@ public class when_setting_partitions_with_an_exact_duplicate : Specification
     static readonly Key _partition = new("some-partition", ArrayIndexers.NoIndexers);
 
     FailedPartitions _failedPartitions;
+    FailedPartitionId _id;
     FailedPartition _older;
     FailedPartition _newer;
 
     void Establish()
     {
-        _older = new() { Partition = _partition, ObserverId = "the-observer" };
-        _newer = new() { Partition = _partition, ObserverId = "the-observer" };
+        // Same storage identity twice - the last occurrence wins rather than the whole set failing.
+        _id = FailedPartitionId.New();
+        _older = new() { Id = _id, Partition = _partition, ObserverId = "the-observer" };
+        _newer = new() { Id = _id, Partition = _partition, ObserverId = "the-observer" };
         _failedPartitions = new();
     }
 

--- a/Source/Kernel/Concepts/Observation/FailedPartitions.cs
+++ b/Source/Kernel/Concepts/Observation/FailedPartitions.cs
@@ -11,7 +11,7 @@ namespace Cratis.Chronicle.Concepts.Observation;
 /// Represents the state of failed partitions. Typically holds the failures of a single observer, but the
 /// cross-observer storage queries (all failed partitions of a namespace, or of a set of observers) return
 /// their combined result through this type as well — so the same partition key may legitimately appear
-/// once per observer, and entries are identified by observer and partition together.
+/// once per observer, and entries are identified by their own identity rather than their partition.
 /// </summary>
 public class FailedPartitions
 {
@@ -22,7 +22,7 @@ public class FailedPartitions
     const int MaxResolvedPartitions = 100;
 
     readonly List<FailedPartition> _resolvedPartitions = [];
-    Dictionary<FailedPartitionKey, FailedPartition> _partitions = [];
+    Dictionary<FailedPartitionId, FailedPartition> _partitions = [];
 
     /// <summary>
     /// Gets or sets the failed partitions.
@@ -32,13 +32,15 @@ public class FailedPartitions
         get => _partitions.Values;
         set
         {
-            // Built with the indexer rather than ToDictionary: this setter is fed straight from storage,
-            // and reporting the data must never throw on it — an exact duplicate (same observer and
-            // partition) collapses to the last occurrence instead of failing the whole collection.
-            var partitions = new Dictionary<FailedPartitionKey, FailedPartition>();
+            // Keyed by the entry identity rather than the partition: a partition is only unique within
+            // one observer, and the cross-observer queries feed this setter with several observers'
+            // failures at once. The identity is also immutable, unlike the observer — which the grain
+            // storage provider stamps onto an entry while it already sits in this dictionary. Built with
+            // the indexer rather than ToDictionary so reporting stored data can never throw on it.
+            var partitions = new Dictionary<FailedPartitionId, FailedPartition>();
             foreach (var partition in value)
             {
-                partitions[FailedPartitionKey.For(partition)] = partition;
+                partitions[partition.Id] = partition;
             }
 
             _partitions = partitions;
@@ -123,7 +125,7 @@ public class FailedPartitions
         {
             _resolvedPartitions.RemoveAt(0);
         }
-        _partitions.Remove(FailedPartitionKey.For(failedPartition));
+        _partitions.Remove(failedPartition.Id);
     }
 
     /// <summary>
@@ -138,16 +140,5 @@ public class FailedPartitions
         }
     }
 
-    void Add(FailedPartition failedPartition) => _partitions[FailedPartitionKey.For(failedPartition)] = failedPartition;
-
-    /// <summary>
-    /// The identity of an entry: a partition is only unique within one observer, so the observer is part
-    /// of the key — two observers failing on the same partition are two distinct entries.
-    /// </summary>
-    /// <param name="ObserverId">The observer the failure belongs to.</param>
-    /// <param name="Partition">The failed partition.</param>
-    readonly record struct FailedPartitionKey(ObserverId ObserverId, Key Partition)
-    {
-        public static FailedPartitionKey For(FailedPartition failedPartition) => new(failedPartition.ObserverId, failedPartition.Partition);
-    }
+    void Add(FailedPartition failedPartition) => _partitions[failedPartition.Id] = failedPartition;
 }

--- a/Source/Kernel/Concepts/Observation/FailedPartitions.cs
+++ b/Source/Kernel/Concepts/Observation/FailedPartitions.cs
@@ -8,7 +8,10 @@ using Cratis.Chronicle.Concepts.Keys;
 namespace Cratis.Chronicle.Concepts.Observation;
 
 /// <summary>
-/// Represents the state of all failed partitions within an observer.
+/// Represents the state of failed partitions. Typically holds the failures of a single observer, but the
+/// cross-observer storage queries (all failed partitions of a namespace, or of a set of observers) return
+/// their combined result through this type as well — so the same partition key may legitimately appear
+/// once per observer, and entries are identified by observer and partition together.
 /// </summary>
 public class FailedPartitions
 {
@@ -19,22 +22,31 @@ public class FailedPartitions
     const int MaxResolvedPartitions = 100;
 
     readonly List<FailedPartition> _resolvedPartitions = [];
-    Dictionary<Key, FailedPartition> _partitions = [];
+    Dictionary<FailedPartitionKey, FailedPartition> _partitions = [];
 
     /// <summary>
-    /// Gets or sets the failed partitions for the observer.
+    /// Gets or sets the failed partitions.
     /// </summary>
     public IEnumerable<FailedPartition> Partitions
     {
         get => _partitions.Values;
         set
         {
-            _partitions = value.ToDictionary(_ => _.Partition, _ => _);
+            // Built with the indexer rather than ToDictionary: this setter is fed straight from storage,
+            // and reporting the data must never throw on it — an exact duplicate (same observer and
+            // partition) collapses to the last occurrence instead of failing the whole collection.
+            var partitions = new Dictionary<FailedPartitionKey, FailedPartition>();
+            foreach (var partition in value)
+            {
+                partitions[FailedPartitionKey.For(partition)] = partition;
+            }
+
+            _partitions = partitions;
         }
     }
 
     /// <summary>
-    /// Gets the resolved partitions for the observer.
+    /// Gets the resolved partitions.
     /// </summary>
     public IEnumerable<FailedPartition> ResolvedPartitions => _resolvedPartitions;
 
@@ -44,19 +56,24 @@ public class FailedPartitions
     public bool HasFailedPartitions => _partitions.Count > 0;
 
     /// <summary>
-    /// Check whether a partition is failed.
+    /// Check whether a partition is failed, for any observer represented in this instance.
     /// </summary>
     /// <param name="partition">Partition to check.</param>
     /// <returns>True if failed, false if not.</returns>
-    public bool IsFailed(Key partition) => _partitions.ContainsKey(partition);
+    public bool IsFailed(Key partition) => TryGet(partition, out _);
 
     /// <summary>
-    /// Try to get a failed partition by its partition identifier.
+    /// Try to get a failed partition by its partition identifier. When this instance holds the failures
+    /// of several observers, the first entry for the partition is returned.
     /// </summary>
     /// <param name="partition">Partition to get.</param>
     /// <param name="failedPartition">The optional failed partition.</param>
     /// <returns>True when failed partition exists, false if not.</returns>
-    public bool TryGet(Key partition, [NotNullWhen(true)] out FailedPartition? failedPartition) => _partitions.TryGetValue(partition, out failedPartition);
+    public bool TryGet(Key partition, [NotNullWhen(true)] out FailedPartition? failedPartition)
+    {
+        failedPartition = _partitions.Values.FirstOrDefault(candidate => candidate.Partition == partition);
+        return failedPartition is not null;
+    }
 
     /// <summary>
     /// Register an attempt for a partition.
@@ -106,7 +123,7 @@ public class FailedPartitions
         {
             _resolvedPartitions.RemoveAt(0);
         }
-        _partitions.Remove(partition);
+        _partitions.Remove(FailedPartitionKey.For(failedPartition));
     }
 
     /// <summary>
@@ -121,5 +138,16 @@ public class FailedPartitions
         }
     }
 
-    void Add(FailedPartition failedPartition) => _partitions.Add(failedPartition.Partition, failedPartition);
+    void Add(FailedPartition failedPartition) => _partitions[FailedPartitionKey.For(failedPartition)] = failedPartition;
+
+    /// <summary>
+    /// The identity of an entry: a partition is only unique within one observer, so the observer is part
+    /// of the key — two observers failing on the same partition are two distinct entries.
+    /// </summary>
+    /// <param name="ObserverId">The observer the failure belongs to.</param>
+    /// <param name="Partition">The failed partition.</param>
+    readonly record struct FailedPartitionKey(ObserverId ObserverId, Key Partition)
+    {
+        public static FailedPartitionKey For(FailedPartition failedPartition) => new(failedPartition.ObserverId, failedPartition.Partition);
+    }
 }


### PR DESCRIPTION
## Fixed

- Listing failed partitions across observers no longer crashes with a duplicate-key error when two observers have failed on the same partition (#3727)
