### PR TITLE
Retire unregistered projections and make projection registration failure-isolated and diagnosable

### DIFF
--- a/Documentation/projections/index.md
+++ b/Documentation/projections/index.md
@@ -58,6 +58,7 @@ read model being a moment behind.
 | [Declarative Projections](declarative/) | Build read models with the fluent `IProjectionFor<T>` API |
 | [Immediate Projections](immediate-projections.md) | Strong consistency — the read model updates before the append returns |
 | [Eventual Consistency](eventual-consistency) | The default — how and when eventual projections catch up |
+| [Registration lifecycle](registration-lifecycle.md) | What happens when projections register, change, fail, or are no longer declared |
 | [Tagging Projections](tagging-projections) | Organize and tag projections |
 | [Appended event metadata filters](../events/filtering/index.md) | How tags and metadata correlate reducers and reactors that run alongside projections |
 

--- a/Documentation/projections/registration-lifecycle.md
+++ b/Documentation/projections/registration-lifecycle.md
@@ -1,0 +1,44 @@
+# Registration lifecycle
+
+Clients register their projections on every connect — the full set of definitions the client's code
+declares. Chronicle compares each incoming definition against the registered one and only acts on
+what changed, so a re-registration from an unchanged client is near-free.
+
+## When a definition changes
+
+A changed definition — including one that *removes* a child collection — is stored, pushed to the
+engine on every silo, and the projection's observer keeps running against the new definition. The
+change also raises a **replay recommendation** ("Projection definition has changed"), because read
+models already written with the old definition may no longer match; performing the recommendation
+rebuilds them. With `ReplayOnDefinitionChange` enabled, the replay happens automatically instead.
+
+## When a registration partially fails
+
+Definitions are isolated from each other: a definition the engine rejects fails *alone*. Every other
+definition in the registration still lands — in the engine, in its projection grain, and in the
+registered state — and the failure is reported back to the client naming exactly the projections that
+did not register. A failed definition is not marked registered, so the next registration retries it.
+
+## When a projection is no longer registered — retirement
+
+A projection the client stops declaring — its read model was deleted, or renamed and thereby given a
+new identity — is **retired** when the client next registers its full set:
+
+- Its observer is unsubscribed in every namespace, so it stops consuming events.
+- Its jobs are deleted and its failed partitions are cleared.
+- Its definition is removed from the engine and from storage.
+- Its **sink container is left untouched** — data is never deleted implicitly. Drop or clean the
+  container yourself if the data is no longer wanted.
+
+Retirement only happens for a **full-set** registration: the client SDK marks the registration as the
+complete set for its owner, and only when every discovered artifact produced a definition. Partial
+registrations — such as saving a single projection from the Workbench — never retire anything, and a
+client-owned full set never retires server-owned projections (or the other way around).
+
+### Renamed read models and shared containers
+
+A renamed read model keeps its type name and thus its **container name**. Without retirement, the old
+projection and its successor would keep writing the same container with different definitions and
+overwrite each other's documents. With retirement the old projection stops, and because another
+registered projection targets the same container, Chronicle raises a replay recommendation for the
+successor so the container can be rebuilt cleanly from its definition alone.

--- a/Documentation/projections/toc.yml
+++ b/Documentation/projections/toc.yml
@@ -6,6 +6,8 @@
   href: architecture.mdx
 - name: Eventual Consistency
   href: eventual-consistency.mdx
+- name: Registration lifecycle
+  href: registration-lifecycle.md
 - name: Appended event metadata filters
   href: filtering.mdx
   items:

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/CommentAdded.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/CommentAdded.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+[EventType]
+public record CommentAdded(Guid CommentId, string Text);

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/Conversation.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/Conversation.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+public record Conversation(
+    EventSourceId Id,
+    string Name,
+    IEnumerable<ConversationComment> Comments,
+    IEnumerable<ConversationReaction> Reactions);

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationComment.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationComment.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+public class ConversationComment
+{
+    public Guid CommentId { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationProjection.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationProjection.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+public class ConversationProjection : IProjectionFor<Conversation>
+{
+    public static bool WithReactions { get; set; }
+
+    public void Define(IProjectionBuilderFor<Conversation> builder)
+    {
+        builder
+            .From<ConversationStarted>(b => b.Set(m => m.Name).To(e => e.Name))
+            .Children(m => m.Comments, c => c
+                .IdentifiedBy(m => m.CommentId)
+                .From<CommentAdded>(b => b.UsingKey(e => e.CommentId)));
+
+        if (WithReactions)
+        {
+            builder.Children(m => m.Reactions, c => c
+                .IdentifiedBy(m => m.ReactionId)
+                .From<ReactionGiven>(b => b.UsingKey(e => e.ReactionId)));
+        }
+    }
+}

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationReaction.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationReaction.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+public class ConversationReaction
+{
+    public Guid ReactionId { get; set; }
+    public string Emoji { get; set; } = string.Empty;
+}

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationStarted.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/ConversationStarted.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+[EventType]
+public record ConversationStarted(string Name);

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/ReactionGiven.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/ReactionGiven.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+[EventType]
+public record ReactionGiven(Guid ReactionId, string Emoji);

--- a/Integration/Client/Projections/Scenarios/when_removing_child_collection/and_reregistering_after_the_child_collection_was_removed.cs
+++ b/Integration/Client/Projections/Scenarios/when_removing_child_collection/and_reregistering_after_the_child_collection_was_removed.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Recommendations;
+using context = Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection.and_reregistering_after_the_child_collection_was_removed.context;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_removing_child_collection;
+
+/// <summary>
+/// Reproduces the production failure behind https://github.com/Cratis/Chronicle/issues/3722: a client first
+/// registers a projection with two child collections, a later client build re-registers it with one of the
+/// child collections removed. The stored definition must follow the change, a replay recommendation must be
+/// raised, and the observer subscriber must be able to build its pipeline and keep projecting.
+/// </summary>
+/// <param name="context">The context for the specification.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_reregistering_after_the_child_collection_was_removed(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : given.a_projection_and_events_appended_to_it<ConversationProjection, Conversation>(chronicleFixture)
+    {
+        public Conversation ResultAfterReregistration;
+        public Contracts.Projections.ProjectionDefinition StoredDefinition;
+        public IEnumerable<Recommendation> Recommendations;
+        public CommentAdded SecondComment;
+
+        public override IEnumerable<Type> EventTypes => [typeof(ConversationStarted), typeof(CommentAdded), typeof(ReactionGiven)];
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            ConversationProjection.WithReactions = true;
+            services.AddSingleton(new ConversationProjection());
+        }
+
+        void Establish()
+        {
+            EventsToAppend.Add(new ConversationStarted("The conversation"));
+            EventsToAppend.Add(new CommentAdded(Guid.NewGuid(), "First comment"));
+            EventsToAppend.Add(new ReactionGiven(Guid.NewGuid(), "thumbs-up"));
+            SecondComment = new CommentAdded(Guid.NewGuid(), "Second comment");
+        }
+
+        async Task Because()
+        {
+            // Simulate the production sequence: the projection-related grains go idle and deactivate,
+            // then a new client build re-registers the projection without the child collection.
+            await DeactivateAllGrains();
+
+            ConversationProjection.WithReactions = false;
+            await EventStore.Projections.Discover();
+            await EventStore.Projections.Register();
+
+            await Projection.WaitTillSubscribed();
+
+            var appendResult = await EventStore.EventLog.Append(EventSourceId, SecondComment);
+            await Projection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+            ResultAfterReregistration = await GetReadModel(EventSourceId);
+
+            var servicesAccessor = (IChronicleServicesAccessor)EventStore.Connection;
+            var definitions = await servicesAccessor.Services.Projections.GetAllDefinitions(new() { EventStore = EventStore.Name });
+            var projectionId = EventStore.Projections.GetProjectionIdForModel<Conversation>();
+            StoredDefinition = definitions.Single(definition => definition.Identifier == projectionId.Value);
+            Recommendations = await servicesAccessor.Services.Recommendations.GetRecommendations(new() { EventStore = EventStore.Name, Namespace = EventStore.Namespace });
+        }
+    }
+
+    [Fact] void should_keep_projecting_after_reregistration() => Context.ResultAfterReregistration.ShouldNotBeNull();
+    [Fact] void should_project_the_comment_added_after_reregistration() => Context.ResultAfterReregistration.Comments.Select(comment => comment.Text).ShouldContain(Context.SecondComment.Text);
+    [Fact] void should_store_the_definition_without_the_removed_child() => Context.StoredDefinition.Children.Keys.Any(key => key.Equals("reactions", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+    [Fact] void should_keep_the_remaining_child_in_the_stored_definition() => Context.StoredDefinition.Children.Keys.Any(key => key.Equals("comments", StringComparison.OrdinalIgnoreCase)).ShouldBeTrue();
+    [Fact] void should_recommend_replay_for_the_changed_definition() => Context.Recommendations.Any(recommendation => recommendation.Description.Contains("Projection definition has changed")).ShouldBeTrue();
+}

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/BoardNamed.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/BoardNamed.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model;
+
+[EventType]
+public record BoardNamed(string Name);

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/and_reregistering_the_full_set.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/and_reregistering_the_full_set.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts;
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Contracts.Recommendations;
+using Cratis.Chronicle.Events;
+using context = Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model.and_reregistering_the_full_set.context;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model;
+
+/// <summary>
+/// Covers the retirement behavior behind https://github.com/Cratis/Chronicle/issues/3725: a read model is renamed
+/// (moved to another namespace), keeping its type name and thus its container name. When the client re-registers
+/// its full set, the old projection must be retired - its observer stopped and its definition removed - and the
+/// successor targeting the same container must get a replay recommendation. The container itself is never dropped.
+/// </summary>
+/// <param name="context">The context for the specification.</param>
+[Collection(ChronicleCollection.Name)]
+public class and_reregistering_the_full_set(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleFixture) : Specification(chronicleFixture)
+    {
+        readonly List<Type> _projectionTypes = [typeof(original.BoardProjection)];
+
+        public EventSourceId BoardId;
+        public original.Board ResultBeforeRename;
+        public IEnumerable<string> DefinitionIdentifiers;
+        public IEnumerable<Recommendation> Recommendations;
+        public ObserverInformation OrphanObserver;
+
+        public override IEnumerable<Type> Projections => _projectionTypes;
+        public override IEnumerable<Type> EventTypes => [typeof(BoardNamed)];
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton(new original.BoardProjection());
+            services.AddSingleton(new renamed.BoardProjection());
+        }
+
+        void Establish() => BoardId = Guid.NewGuid().ToString();
+
+        async Task Because()
+        {
+            var originalProjection = EventStore.Projections.GetHandlerFor<original.BoardProjection>();
+            await originalProjection.WaitTillSubscribed();
+
+            var appendResult = await EventStore.EventLog.Append(BoardId, new BoardNamed("The board"));
+            await originalProjection.WaitTillReachesEventSequenceNumber(appendResult.SequenceNumber);
+            ResultBeforeRename = await EventStore.ReadModels.GetInstanceById<original.Board>(BoardId);
+
+            // Deploy the rename: the client now declares only the renamed read model and its projection,
+            // and re-registers its full set - read models first, then projections, like RegisterAll does.
+            _projectionTypes.Clear();
+            _projectionTypes.Add(typeof(renamed.BoardProjection));
+            await EventStore.Projections.Discover();
+            await EventStore.ReadModels.Register();
+            await EventStore.Projections.Register();
+
+            var successorProjection = EventStore.Projections.GetHandlerFor<renamed.BoardProjection>();
+            await successorProjection.WaitTillSubscribed();
+
+            var servicesAccessor = (IChronicleServicesAccessor)EventStore.Connection;
+            var definitions = await servicesAccessor.Services.Projections.GetAllDefinitions(new() { EventStore = EventStore.Name });
+            DefinitionIdentifiers = definitions.Select(definition => definition.Identifier).ToArray();
+            Recommendations = await servicesAccessor.Services.Recommendations.GetRecommendations(new() { EventStore = EventStore.Name, Namespace = EventStore.Namespace });
+            OrphanObserver = await servicesAccessor.Services.Observers.GetObserverInformation(new()
+            {
+                EventStore = EventStore.Name,
+                Namespace = EventStore.Namespace,
+                ObserverId = typeof(original.BoardProjection).FullName!,
+                EventSequenceId = EventSequences.EventSequenceId.Log
+            });
+        }
+    }
+
+    [Fact] void should_project_the_board_before_the_rename() => Context.ResultBeforeRename.Name.ShouldEqual("The board");
+    [Fact] void should_remove_the_retired_projection_definition() => Context.DefinitionIdentifiers.ShouldNotContain(typeof(original.BoardProjection).FullName);
+    [Fact] void should_keep_the_successor_projection_definition() => Context.DefinitionIdentifiers.ShouldContain(typeof(renamed.BoardProjection).FullName);
+    [Fact] void should_stop_the_retired_observer() => Context.OrphanObserver.IsSubscribed.ShouldBeFalse();
+    [Fact] void should_recommend_replaying_the_successor_sharing_the_container() => Context.Recommendations.Any(recommendation => recommendation.Description.Contains("retired") && recommendation.Description.Contains("Boards", StringComparison.OrdinalIgnoreCase)).ShouldBeTrue();
+}

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/original/Board.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/original/Board.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model.original;
+
+public record Board(EventSourceId Id, string Name);

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/original/BoardProjection.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/original/BoardProjection.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model.original;
+
+public class BoardProjection : IProjectionFor<Board>
+{
+    public void Define(IProjectionBuilderFor<Board> builder) => builder
+        .From<BoardNamed>(b => b.Set(m => m.Name).To(e => e.Name));
+}

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/renamed/Board.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/renamed/Board.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model.renamed;
+
+public record Board(EventSourceId Id, string Name);

--- a/Integration/Client/Projections/Scenarios/when_renaming_read_model/renamed/BoardProjection.cs
+++ b/Integration/Client/Projections/Scenarios/when_renaming_read_model/renamed/BoardProjection.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.Projections.Scenarios.when_renaming_read_model.renamed;
+
+public class BoardProjection : IProjectionFor<Board>
+{
+    public void Define(IProjectionBuilderFor<Board> builder) => builder
+        .From<BoardNamed>(b => b.Set(m => m.Name).To(e => e.Name));
+}

--- a/Source/Clients/DotNET/Projections/Projections.cs
+++ b/Source/Clients/DotNET/Projections/Projections.cs
@@ -45,6 +45,7 @@ public class Projections(
     Dictionary<Type, IProjectionHandler> _handlersByModelType = new();
     Dictionary<Type, IProjectionHandler> _modelBoundHandlers = new();
     Dictionary<Type, ProjectionDefinition> _definitionsByType = new();
+    bool _discovered;
 
     /// <summary>
     /// Gets all the <see cref="ProjectionDefinition">projection definitions</see>.
@@ -224,6 +225,7 @@ public class Projections(
                 .. modelBoundProjections.Failures.Select(kvp => new ArtifactRegistration(kvp.Key, kvp.Value))
             ]).ToImmutableList();
 
+        _discovered = true;
         return Task.CompletedTask;
     }
 
@@ -234,7 +236,13 @@ public class Projections(
         {
             EventStore = eventStore.Name,
             Owner = ProjectionOwner.Client,
-            Projections = [.. Definitions]
+            Projections = [.. Definitions],
+
+            // The registration only claims to be the client's full set when discovery has run and every discovered
+            // artifact produced a definition. An artifact whose definition could not be built is excluded from the
+            // batch, and claiming a full set then would make the kernel retire a projection that still exists in
+            // the client.
+            FullSet = _discovered && ArtifactRegistrations.All(registration => registration.IsRegistered)
         });
     }
 

--- a/Source/Kernel/Concepts/Observation/Replaying/ReplayCandidateReasonType.cs
+++ b/Source/Kernel/Concepts/Observation/Replaying/ReplayCandidateReasonType.cs
@@ -45,6 +45,11 @@ public record ReplayCandidateReasonType(string Value) : ConceptAs<string>(Value)
     public static readonly ReplayCandidateReasonType WebhookDefinitionChanged = "WebhookDefinitionChanged";
 
     /// <summary>
+    /// Gets the <see cref="ReplayCandidateReasonType"/> for when a retired projection wrote to the same read model container.
+    /// </summary>
+    public static readonly ReplayCandidateReasonType RetiredProjectionSharedContainer = "RetiredProjectionSharedContainer";
+
+    /// <summary>
     /// Implicitly convert from <see cref="string"/> to <see cref="ReplayCandidateReasonType"/>.
     /// </summary>
     /// <param name="value">String to convert from.</param>

--- a/Source/Kernel/Concepts/Observation/Replaying/RetiredProjectionSharedContainerReplayCandidateReason.cs
+++ b/Source/Kernel/Concepts/Observation/Replaying/RetiredProjectionSharedContainerReplayCandidateReason.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Observation.Replaying;
+
+/// <summary>
+/// Represents a reason for a replay candidate when a retired projection wrote to the same read model container.
+/// </summary>
+public record RetiredProjectionSharedContainerReplayCandidateReason()
+    : ReplayCandidateReason(ReplayCandidateReasonType.RetiredProjectionSharedContainer);

--- a/Source/Kernel/Contracts/Projections/RegisterRequest.cs
+++ b/Source/Kernel/Contracts/Projections/RegisterRequest.cs
@@ -26,4 +26,14 @@ public class RegisterRequest
     /// </summary>
     [ProtoMember(3, IsRequired = true)]
     public IList<ProjectionDefinition> Projections { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets whether <see cref="Projections"/> is the complete set of projections for <see cref="Owner"/>.
+    /// When <see langword="true"/>, any registered projection with the same owner that is not in the set is retired:
+    /// its observer stops consuming events and its definition is removed, while its sink container is left untouched.
+    /// Leave <see langword="false"/> for a partial registration, which never retires anything - including when the
+    /// client could not build a definition for every discovered artifact.
+    /// </summary>
+    [ProtoMember(4)]
+    public bool FullSet { get; set; }
 }

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionFactory/when_creating/and_definition_declares_child_collection_missing_from_schema.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_ProjectionFactory/when_creating/and_definition_declares_child_collection_missing_from_schema.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections.Engine.Expressions;
+using Cratis.Chronicle.Projections.Engine.Expressions.EventValues;
+using Cratis.Chronicle.Projections.Engine.Expressions.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.EventSequences;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Projections.Engine.for_ProjectionFactory.when_creating;
+
+/// <summary>
+/// The failure shape from https://github.com/Cratis/Chronicle/issues/3722: the stored projection definition still
+/// declares a child collection the read model schema no longer has. Building the projection must fail with an
+/// exception naming the projection, the child property and the read model - not a bare KeyNotFoundException.
+/// </summary>
+public class and_definition_declares_child_collection_missing_from_schema : Specification
+{
+    static readonly EventStoreName _eventStore = "event-store";
+    static readonly EventStoreNamespaceName _namespace = "namespace";
+    static readonly EventType _conversationStarted = new("ConversationStarted", EventTypeGeneration.First);
+    static readonly EventType _reactionGiven = new("ReactionGiven", EventTypeGeneration.First);
+
+    ProjectionFactory _factory;
+    Exception _exception;
+
+    void Establish()
+    {
+        var eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+        var storage = Substitute.For<IStorage>();
+        var eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        var namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        storage.GetEventStore(_eventStore).Returns(eventStoreStorage);
+        eventStoreStorage.GetNamespace(_namespace).Returns(namespaceStorage);
+        namespaceStorage.GetEventSequence(EventSequenceId.Log).Returns(eventSequenceStorage);
+
+        var typeFormats = new TypeFormats();
+        var keyResolvers = new KeyResolvers(NullLogger<KeyResolvers>.Instance);
+        var eventValueProviderExpressionResolvers = new EventValueProviderExpressionResolvers(
+            typeFormats,
+            NullLogger<EventValueProviderExpressionResolvers>.Instance);
+        _factory = new ProjectionFactory(
+            new ReadModelPropertyExpressionResolvers(
+                eventValueProviderExpressionResolvers,
+                typeFormats,
+                NullLogger<ReadModelPropertyExpressionResolvers>.Instance),
+            eventValueProviderExpressionResolvers,
+            new KeyExpressionResolvers(
+                eventValueProviderExpressionResolvers,
+                keyResolvers,
+                NullLogger<KeyExpressionResolvers>.Instance),
+            new ExpandoObjectConverter(typeFormats),
+            keyResolvers,
+            storage,
+            NullLogger<ProjectionFactory>.Instance);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(() => _factory.Create(
+        _eventStore,
+        _namespace,
+        CreateProjectionDefinition(),
+        CreateReadModelDefinition(),
+        []));
+
+    [Fact] void should_fail_with_a_descriptive_exception() => _exception.ShouldBeOfExactType<MissingChildCollectionInReadModelSchema>();
+    [Fact] void should_name_the_projection() => _exception.Message.ShouldContain("Chat.ChatTopicConversation");
+    [Fact] void should_name_the_child_property() => _exception.Message.ShouldContain("reactions");
+    [Fact] void should_name_the_read_model() => _exception.Message.ShouldContain("Chat.ChatTopicConversationReadModel");
+
+    static ProjectionDefinition CreateProjectionDefinition()
+    {
+        var rootFrom = new Dictionary<EventType, FromDefinition>
+        {
+            [_conversationStarted] = new(
+                new Dictionary<PropertyPath, string>(),
+                WellKnownExpressions.EventSourceId,
+                null)
+        };
+
+        var reactionsFrom = new Dictionary<EventType, FromDefinition>
+        {
+            [_reactionGiven] = new(
+                new Dictionary<PropertyPath, string>(),
+                "reactionId",
+                WellKnownExpressions.EventSourceId)
+        };
+
+        return new ProjectionDefinition(
+            ProjectionOwner.Client,
+            EventSequenceId.Log,
+            "Chat.ChatTopicConversation",
+            "Chat.ChatTopicConversationReadModel",
+            true,
+            true,
+            new(),
+            rootFrom,
+            new Dictionary<EventType, JoinDefinition>(),
+            new Dictionary<PropertyPath, ChildrenDefinition>
+            {
+                ["reactions"] = new(
+                    "reactionId",
+                    reactionsFrom,
+                    new Dictionary<EventType, JoinDefinition>(),
+                    new Dictionary<PropertyPath, ChildrenDefinition>(),
+                    new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+                    new Dictionary<EventType, RemovedWithDefinition>(),
+                    new Dictionary<EventType, RemovedWithJoinDefinition>(),
+                    AutoMap: AutoMap.Disabled)
+            },
+            [],
+            new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+            new Dictionary<EventType, RemovedWithDefinition>(),
+            new Dictionary<EventType, RemovedWithJoinDefinition>(),
+            AutoMap: AutoMap.Disabled);
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "Chat.ChatTopicConversationReadModel",
+            "chatTopicConversations",
+            "ChatTopicConversation",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                [ReadModelGeneration.First] = JsonSchema.FromJson("""
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "name": { "type": "string" },
+                        "comments": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "commentId": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    """)
+            },
+            []);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/given/a_projections_manager_grain.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/given/a_projections_manager_grain.cs
@@ -31,6 +31,9 @@ public class a_projections_manager_grain : Specification
     protected IProjectionDefinitionComparer _definitionComparer;
     protected IProjection _projectionGrain;
     protected Observation.IObserver _observerGrain;
+    protected Jobs.IJobsManager _jobsManager;
+    protected Recommendations.IRecommendationsManager _recommendationsManager;
+    protected Storage.Observation.IFailedPartitionsStorage _failedPartitionsStorage;
     protected ProjectionsManagerState _state;
     protected IEnumerable<ReadModelDefinition> _readModelDefinitions = [];
 
@@ -61,7 +64,13 @@ public class a_projections_manager_grain : Specification
         _silo.AddService(Substitute.For<ILanguageService>());
 
         var storage = Substitute.For<Storage.IStorage>();
-        storage.GetEventStore(Arg.Any<EventStoreName>()).EventTypes.GetLatestForAllEventTypes().Returns([]);
+        var eventStoreStorage = Substitute.For<Storage.IEventStoreStorage>();
+        storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(eventStoreStorage);
+        eventStoreStorage.EventTypes.GetLatestForAllEventTypes().Returns([]);
+        var namespaceStorage = Substitute.For<Storage.IEventStoreNamespaceStorage>();
+        eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(namespaceStorage);
+        _failedPartitionsStorage = Substitute.For<Storage.Observation.IFailedPartitionsStorage>();
+        namespaceStorage.FailedPartitions.Returns(_failedPartitionsStorage);
         _silo.AddService(storage);
 
         _silo.AddService(Substitute.For<ILocalSiloDetails>());
@@ -79,6 +88,13 @@ public class a_projections_manager_grain : Specification
 
         _observerGrain = Substitute.For<Observation.IObserver>();
         _silo.AddProbe(_ => _observerGrain);
+
+        _jobsManager = Substitute.For<Jobs.IJobsManager>();
+        _jobsManager.GetAllJobs().Returns(System.Collections.Immutable.ImmutableList<Storage.Jobs.JobState>.Empty);
+        _silo.AddProbe(_ => _jobsManager);
+
+        _recommendationsManager = Substitute.For<Recommendations.IRecommendationsManager>();
+        _silo.AddProbe(_ => _recommendationsManager);
 
         _state = new ProjectionsManagerState();
         var stateStorage = Substitute.For<IStorage<ProjectionsManagerState>>();
@@ -104,9 +120,9 @@ public class a_projections_manager_grain : Specification
         new Dictionary<EventType, RemovedWithDefinition>(),
         new Dictionary<EventType, RemovedWithJoinDefinition>());
 
-    protected static ReadModelDefinition CreateReadModelDefinition(ReadModelIdentifier identifier) => new(
+    protected static ReadModelDefinition CreateReadModelDefinition(ReadModelIdentifier identifier, string? containerName = null) => new(
         identifier,
-        "TheReadModel",
+        containerName ?? "TheReadModel",
         "TheReadModel",
         ReadModelOwner.Client,
         ReadModelSource.Code,

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_the_engine_rejects_one_of_two_changed_definitions.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_the_engine_rejects_one_of_two_changed_definitions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+using NSubstitute.ExceptionExtensions;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+/// <summary>
+/// The failure shape behind https://github.com/Cratis/Chronicle/issues/3722: the engine rejects one definition in
+/// the changed batch. The rejection must cost that definition alone - every other changed definition still lands
+/// in the engine, in its projection grain and in the registered state, so it is not silently stale afterwards.
+/// </summary>
+public class and_the_engine_rejects_one_of_two_changed_definitions : given.a_projections_manager_grain
+{
+    ProjectionDefinition _accepted;
+    ProjectionDefinition _rejected;
+    Exception _exception;
+
+    void Establish()
+    {
+        _accepted = CreateDefinition("accepted-projection", "accepted-read-model");
+        _rejected = CreateDefinition("rejected-projection", "rejected-read-model");
+        _readModelDefinitions = [CreateReadModelDefinition("accepted-read-model"), CreateReadModelDefinition("rejected-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.New);
+
+        _projectionsServiceClient
+            .Register(
+                (EventStoreName)EventStore,
+                Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.Contains(_rejected)))
+            .ThrowsAsync(new ProjectionDefinitionRegistrationFailed(_rejected.Identifier, new InvalidOperationException("Failed to compile projection definition")));
+    }
+
+    async Task Because() => _exception = await Catch.Exception(() => _grain.Register([_accepted, _rejected]));
+
+    [Fact] void should_throw_naming_the_rejected_definition() => _exception.ShouldBeOfExactType<SomeProjectionDefinitionsFailedToRegister>();
+    [Fact] void should_report_the_failure_for_the_rejected_definition_only() => ((SomeProjectionDefinitionsFailedToRegister)_exception).Failures.Keys.ShouldContainOnly((ProjectionId)"rejected-projection");
+    [Fact] void should_register_the_accepted_definition_with_the_engine_on_its_own() => _projectionsServiceClient.Received(1).Register((EventStoreName)EventStore, Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _accepted })));
+    [Fact] void should_set_the_definition_on_the_accepted_projection_grain() => _projectionGrain.Received(1).SetDefinition(_accepted);
+    [Fact] void should_not_set_the_definition_on_the_rejected_projection_grain() => _projectionGrain.DidNotReceive().SetDefinition(_rejected);
+    [Fact] void should_keep_only_the_accepted_definition_in_the_registered_state() => _state.Projections.ShouldContainOnly(_accepted);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_the_registration_is_partial.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering/and_the_registration_is_partial.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering;
+
+/// <summary>
+/// A partial registration - saving a single projection, for example - must never retire anything: only a
+/// registration that declares itself the full set for an owner may retire what that owner no longer registers.
+/// </summary>
+public class and_the_registration_is_partial : given.a_projections_manager_grain
+{
+    ProjectionDefinition _registered;
+    ProjectionDefinition _other;
+
+    void Establish()
+    {
+        _registered = CreateDefinition("registered-projection", "registered-read-model");
+        _other = CreateDefinition("other-projection", "other-read-model");
+        _state.Projections = [_registered, _other];
+        _readModelDefinitions = [CreateReadModelDefinition("registered-read-model"), CreateReadModelDefinition("other-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because() => await _grain.Register([_registered]);
+
+    [Fact] void should_keep_every_registered_projection() => _state.Projections.ShouldContainOnly(_registered, _other);
+    [Fact] void should_not_unsubscribe_any_observer() => _observerGrain.DidNotReceive().Unsubscribe();
+    [Fact] void should_not_remove_any_projection_grain() => _projectionGrain.DidNotReceive().Remove();
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_a_registered_projection_is_no_longer_in_the_set.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_a_registered_projection_is_no_longer_in_the_set.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Observation.States;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering_full_set;
+
+/// <summary>
+/// The retirement shape behind https://github.com/Cratis/Chronicle/issues/3725: the client re-registers its full
+/// set of projections and one previously registered projection is no longer in it (its read model was deleted).
+/// The orphan is retired - observer unsubscribed, engine and storage cleaned - and since no other projection
+/// targets its container, no replay recommendation is raised.
+/// </summary>
+public class and_a_registered_projection_is_no_longer_in_the_set : given.a_projections_manager_grain
+{
+    ProjectionDefinition _remaining;
+    ProjectionDefinition _orphan;
+
+    void Establish()
+    {
+        _remaining = CreateDefinition("remaining-projection", "remaining-read-model");
+        _orphan = CreateDefinition("orphaned-projection", "orphaned-read-model");
+        _state.Projections = [_remaining, _orphan];
+        _readModelDefinitions =
+        [
+            CreateReadModelDefinition("remaining-read-model", "remainingContainer"),
+            CreateReadModelDefinition("orphaned-read-model", "orphanedContainer")
+        ];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because() => await _grain.Register([_remaining], ProjectionOwner.Client);
+
+    [Fact] void should_unsubscribe_the_orphaned_observer() => _observerGrain.Received(1).Unsubscribe();
+    [Fact] void should_unregister_the_orphan_from_the_engine() => _projectionsServiceClient.Received(1).Unregister((EventStoreName)EventStore, (ProjectionId)"orphaned-projection");
+    [Fact] void should_remove_the_orphaned_projection_grain() => _projectionGrain.Received(1).Remove();
+    [Fact] void should_clear_the_orphaned_failed_partitions() => _failedPartitionsStorage.Received(1).Save((ObserverId)_orphan.Identifier.Value, Arg.Is<FailedPartitions>(failedPartitions => !failedPartitions.HasFailedPartitions));
+    [Fact] void should_keep_only_the_remaining_projection_in_the_registered_state() => _state.Projections.ShouldContainOnly(_remaining);
+    [Fact] void should_not_recommend_replay_when_no_projection_shares_the_container() => _recommendationsManager.DidNotReceiveWithAnyArgs().Add<IReplayCandidateRecommendation, ReplayCandidateRequest>(default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_the_retired_projection_shares_container_with_a_successor.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_the_retired_projection_shares_container_with_a_successor.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Observation.Replaying;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Observation.States;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering_full_set;
+
+/// <summary>
+/// The renamed-read-model shape from https://github.com/Cratis/Chronicle/issues/3725: the read model kept its type
+/// name (thus its container name) but moved namespace, so the old projection is retired while its successor writes
+/// the same container. The successor must get a replay recommendation so its container can be rebuilt cleanly -
+/// the container itself is never dropped.
+/// </summary>
+public class and_the_retired_projection_shares_container_with_a_successor : given.a_projections_manager_grain
+{
+    const string SharedContainer = "boards";
+    ProjectionDefinition _successor;
+    ProjectionDefinition _orphan;
+
+    void Establish()
+    {
+        _successor = CreateDefinition("renamed-projection", "renamed-read-model");
+        _orphan = CreateDefinition("original-projection", "original-read-model");
+        _state.Projections = [_successor, _orphan];
+        _readModelDefinitions =
+        [
+            CreateReadModelDefinition("renamed-read-model", SharedContainer),
+            CreateReadModelDefinition("original-read-model", SharedContainer)
+        ];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because() => await _grain.Register([_successor], ProjectionOwner.Client);
+
+    [Fact] void should_retire_the_original_projection() => _state.Projections.ShouldContainOnly(_successor);
+    [Fact]
+    void should_recommend_replaying_the_successor() =>
+        _recommendationsManager.Received(1).Add<IReplayCandidateRecommendation, ReplayCandidateRequest>(
+            Arg.Is<Concepts.Recommendations.RecommendationDescription>(description => description.Value.Contains(SharedContainer)),
+            Arg.Is<ReplayCandidateRequest>(request =>
+                request.ObserverId.Value == "renamed-projection" &&
+                request.Reasons.Any(reason => reason.Type == ReplayCandidateReasonType.RetiredProjectionSharedContainer)));
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_the_stored_projection_has_a_different_owner.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ProjectionsManager/when_registering_full_set/and_the_stored_projection_has_a_different_owner.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+
+namespace Cratis.Chronicle.Projections.for_ProjectionsManager.when_registering_full_set;
+
+/// <summary>
+/// A projection defined through the server (for example saved from the Workbench) is not part of a client's full
+/// set and must survive it - retirement only applies to projections with the same owner as the registration.
+/// </summary>
+public class and_the_stored_projection_has_a_different_owner : given.a_projections_manager_grain
+{
+    ProjectionDefinition _clientProjection;
+    ProjectionDefinition _serverProjection;
+
+    void Establish()
+    {
+        _clientProjection = CreateDefinition("client-projection", "client-read-model");
+        _serverProjection = CreateDefinition("server-projection", "server-read-model") with { Owner = ProjectionOwner.Server };
+        _state.Projections = [_clientProjection, _serverProjection];
+        _readModelDefinitions = [CreateReadModelDefinition("client-read-model"), CreateReadModelDefinition("server-read-model")];
+
+        _definitionComparer
+            .Compare(Arg.Any<ProjectionKey>(), Arg.Any<ProjectionDefinition>(), Arg.Any<ProjectionDefinition>())
+            .Returns(ProjectionDefinitionCompareResult.Same);
+    }
+
+    async Task Because() => await _grain.Register([_clientProjection], ProjectionOwner.Client);
+
+    [Fact] void should_keep_the_server_owned_projection() => _state.Projections.ShouldContainOnly(_clientProjection, _serverProjection);
+    [Fact] void should_not_unsubscribe_any_observer() => _observerGrain.DidNotReceive().Unsubscribe();
+    [Fact] void should_not_remove_any_projection_grain() => _projectionGrain.DidNotReceive().Remove();
+}

--- a/Source/Kernel/Core.Specs/Services/Projections/for_Projections/when_registering/and_the_registration_is_the_full_set.cs
+++ b/Source/Kernel/Core.Specs/Services/Projections/for_Projections/when_registering/and_the_registration_is_the_full_set.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Projections;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections.Engine.DeclarationLanguage;
+
+namespace Cratis.Chronicle.Services.Projections.for_Projections.when_registering;
+
+public class and_the_registration_is_the_full_set : Specification
+{
+    Chronicle.Projections.IProjectionsManager _projectionsManager;
+    Projections _service;
+
+    void Establish()
+    {
+        var grainFactory = Substitute.For<IGrainFactory>();
+        _projectionsManager = Substitute.For<Chronicle.Projections.IProjectionsManager>();
+        grainFactory.GetGrain<Chronicle.Projections.IProjectionsManager>(Arg.Any<string>()).Returns(_projectionsManager);
+
+        _service = new Projections(
+            grainFactory,
+            Substitute.For<IExpandoObjectConverter>(),
+            Substitute.For<ILanguageService>(),
+            Substitute.For<IServiceProvider>());
+    }
+
+    async Task Because() => await _service.Register(new RegisterRequest
+    {
+        EventStore = "event-store",
+        Owner = ProjectionOwner.Client,
+        FullSet = true,
+        Projections =
+        [
+            new ProjectionDefinition
+            {
+                EventSequenceId = "default",
+                Identifier = "EmployeeListProjection",
+                ReadModel = "EmployeeList",
+                InitialModelState = "{}",
+                All = new FromEveryDefinition()
+            }
+        ]
+    });
+
+    [Fact]
+    void should_register_as_the_full_set_for_the_owner() =>
+        _projectionsManager.Received(1).Register(
+            Arg.Any<IEnumerable<Concepts.Projections.Definitions.ProjectionDefinition>>(),
+            Concepts.Projections.ProjectionOwner.Client);
+}

--- a/Source/Kernel/Core/Projections/Engine/MissingChildCollectionInReadModelSchema.cs
+++ b/Source/Kernel/Core/Projections/Engine/MissingChildCollectionInReadModelSchema.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.Projections.Engine;
+
+/// <summary>
+/// The exception that is thrown when a projection definition declares a child collection on a property
+/// that does not exist in the read model schema - typically a stale projection definition that was kept
+/// after the read model dropped the property.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MissingChildCollectionInReadModelSchema"/> class.
+/// </remarks>
+/// <param name="projectionId">The <see cref="ProjectionId"/> of the projection whose definition is inconsistent with the schema.</param>
+/// <param name="childProperty">The property path the definition declares a child collection for.</param>
+/// <param name="readModelIdentifier">The <see cref="ReadModelIdentifier"/> of the read model the projection targets.</param>
+/// <param name="availableProperties">The properties the read model schema actually has.</param>
+public class MissingChildCollectionInReadModelSchema(
+    ProjectionId projectionId,
+    string childProperty,
+    ReadModelIdentifier readModelIdentifier,
+    IEnumerable<string> availableProperties) : Exception(
+        $"Projection '{projectionId}' declares a child collection at '{childProperty}', but the schema for read model " +
+        $"'{readModelIdentifier}' has no such property (available properties: {string.Join(", ", availableProperties)}). " +
+        "The stored projection definition is stale relative to the read model schema; re-registering the projection " +
+        "with a definition that matches the read model resolves this.");

--- a/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionFactory.cs
@@ -306,6 +306,20 @@ public class ProjectionFactory(
         }
     }
 
+    static JsonSchemaProperty GetChildCollectionProperty(ProjectionId projectionId, ReadModelDefinition rootReadModel, JsonSchema currentReadModelSchema, PropertyPath childrenProperty)
+    {
+        if (!currentReadModelSchema.Properties.TryGetValue(childrenProperty.LastSegment.Value, out var schemaProperty))
+        {
+            throw new MissingChildCollectionInReadModelSchema(
+                projectionId,
+                childrenProperty.Path,
+                rootReadModel.Identifier,
+                currentReadModelSchema.Properties.Keys);
+        }
+
+        return schemaProperty;
+    }
+
     static ExpandoObject GetInitialState(IExpandoObjectConverter expandoObjectConverter, ProjectionDefinition projectionDefinition, JsonSchema readModelSchema) =>
         projectionDefinition.InitialModelState.Count == 0 ?
             CreateInitialState(readModelSchema) :
@@ -376,7 +390,7 @@ public class ProjectionFactory(
                 var childIdentifiedBy = childDefinition.IdentifiedBy.IsRoot ?
                     childProjection.IdentifiedByProperty :
                     childDefinition.IdentifiedBy;
-                var childrenProperty = currentReadModelSchema.Properties[childEntry.kvp.Key.LastSegment.Value];
+                var childrenProperty = GetChildCollectionProperty(projection.Identifier, rootReadModel, currentReadModelSchema, childEntry.kvp.Key);
                 var childSchema = childrenProperty.Item?.ActualSchema ?? currentReadModelSchema;
 
                 SetupSubscriptionsRecursively(
@@ -471,7 +485,7 @@ public class ProjectionFactory(
         // Create child projection structures first (without resolving events)
         var childProjectionTasks = projectionDefinition.Children.Select(async kvp =>
         {
-            var childrenProperty = currentReadModelSchema.Properties[kvp.Key.LastSegment.Value];
+            var childrenProperty = GetChildCollectionProperty(projectionId, rootReadModel, currentReadModelSchema, kvp.Key);
             return await CreateProjectionStructure(
                 eventSequenceStorage,
                 projectionId,

--- a/Source/Kernel/Core/Projections/IProjection.cs
+++ b/Source/Kernel/Core/Projections/IProjection.cs
@@ -28,6 +28,12 @@ public interface IProjection : IGrainWithStringKey
     Task<ProjectionDefinition> GetDefinition();
 
     /// <summary>
+    /// Remove the projection - its definition is deleted from storage and the grain is deactivated.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    Task Remove();
+
+    /// <summary>
     /// Subscribe to changes in projection or pipeline definition changes.
     /// </summary>
     /// <param name="subscriber"><see cref="INotifyProjectionDefinitionsChanged"/> to subscribe.</param>

--- a/Source/Kernel/Core/Projections/IProjectionsManager.cs
+++ b/Source/Kernel/Core/Projections/IProjectionsManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Orleans.Concurrency;
 
@@ -34,6 +35,13 @@ public interface IProjectionsManager : IGrainWithStringKey
     /// Register a set of <see cref="ProjectionDefinition"/> for the event store it belongs to.
     /// </summary>
     /// <param name="definitions">A collection of <see cref="ProjectionDefinition"/>.</param>
+    /// <param name="fullSetOwner">
+    /// When set, the registration is the complete set of projections for that <see cref="ProjectionOwner"/> and any
+    /// registered projection with the same owner that is not in the set is retired: its observer is unsubscribed in
+    /// every namespace, its jobs and failed partitions are cleared, its definition is removed from the engine and from
+    /// storage, and its sink container is left untouched. Leave unset for a partial registration (for example saving a
+    /// single projection), which must never retire anything.
+    /// </param>
     /// <returns>Awaitable task.</returns>
-    Task Register(IEnumerable<ProjectionDefinition> definitions);
+    Task Register(IEnumerable<ProjectionDefinition> definitions, ProjectionOwner? fullSetOwner = null);
 }

--- a/Source/Kernel/Core/Projections/IProjectionsService.cs
+++ b/Source/Kernel/Core/Projections/IProjectionsService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Orleans.Services;
 
@@ -19,6 +20,14 @@ public interface IProjectionsService : IGrainService
     /// <param name="definitions">A collection of <see cref="ProjectionDefinition"/>.</param>
     /// <returns>Awaitable task.</returns>
     Task Register(EventStoreName eventStore, IEnumerable<ProjectionDefinition> definitions);
+
+    /// <summary>
+    /// Unregister a projection from the engine, evicting it and its pipelines in every namespace.
+    /// </summary>
+    /// <param name="eventStore">Name of the event store.</param>
+    /// <param name="projectionId">The <see cref="ProjectionId"/> to unregister.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Unregister(EventStoreName eventStore, ProjectionId projectionId);
 
     /// <summary>
     /// Triggered when a namespace is added to an event store.

--- a/Source/Kernel/Core/Projections/Projection.cs
+++ b/Source/Kernel/Core/Projections/Projection.cs
@@ -110,6 +110,14 @@ public class Projection(
     public Task<ProjectionDefinition> GetDefinition() => Task.FromResult(State);
 
     /// <inheritdoc/>
+    public async Task Remove()
+    {
+        _projectionsByNamespace.Clear();
+        await ClearStateAsync();
+        DeactivateOnIdle();
+    }
+
+    /// <inheritdoc/>
     public Task SubscribeDefinitionsChanged(INotifyProjectionDefinitionsChanged subscriber)
     {
         _definitionObservers.Subscribe(subscriber, subscriber);

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriber.cs
@@ -15,6 +15,7 @@ using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Projections.Engine;
 using Cratis.Chronicle.Projections.Engine.Pipelines;
+using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
@@ -57,6 +58,7 @@ public class ProjectionObserverSubscriber(
     IProjectionPipeline? _pipeline;
     IProjectionChangesetNotifier? _changesetNotifier;
     JsonSchema? _schema;
+    Exception? _pipelineBuildFailure;
 
     /// <inheritdoc/>
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
@@ -122,6 +124,22 @@ public class ProjectionObserverSubscriber(
     {
         if (_pipeline is null)
         {
+            // Retry the build on every delivery: a pipeline that failed to build (e.g. from a stale definition)
+            // heals as soon as the definition is corrected, without requiring the grain to be reactivated.
+            await HandlePipeline();
+        }
+
+        if (_pipeline is null)
+        {
+            if (_pipelineBuildFailure is not null)
+            {
+                return new(
+                    ObserverSubscriberState.Failed,
+                    EventSequenceNumber.Unavailable,
+                    _pipelineBuildFailure.GetAllMessages(),
+                    _pipelineBuildFailure.StackTrace ?? string.Empty);
+            }
+
             logger.PipelineNotReady(_key);
             return new(
                 ObserverSubscriberState.Failed,
@@ -224,12 +242,26 @@ public class ProjectionObserverSubscriber(
             return;
         }
 
-        var readModel = await GrainFactory.GetGrain<IReadModel>(new ReadModelGrainKey(State.ReadModel, _key.EventStore)).GetDefinition();
-        var eventStoreStorage = storage.GetEventStore(_key.EventStore);
-        var eventTypeSchemas = await eventStoreStorage.EventTypes.GetLatestForAllEventTypes();
-        var projection = await projectionFactory.Create(_key.EventStore, _key.Namespace, State, readModel, eventTypeSchemas);
-        _pipeline = await projectionPipelineManager.GetFor(_key.EventStore, _key.Namespace, projection);
-        _schema = readModel.GetSchemaForLatestGeneration();
+        // A build failure must not fault the grain: throwing from OnActivateAsync would fail the activation
+        // itself and every partition would report the activation error over and over. Containing the failure
+        // here keeps the grain alive, lets OnNext report the actual cause on the failed partition, and lets a
+        // later definition change (or the retry in OnNext) rebuild the pipeline without a reactivation.
+        try
+        {
+            var readModel = await GrainFactory.GetGrain<IReadModel>(new ReadModelGrainKey(State.ReadModel, _key.EventStore)).GetDefinition();
+            var eventStoreStorage = storage.GetEventStore(_key.EventStore);
+            var eventTypeSchemas = await eventStoreStorage.EventTypes.GetLatestForAllEventTypes();
+            var projection = await projectionFactory.Create(_key.EventStore, _key.Namespace, State, readModel, eventTypeSchemas);
+            _pipeline = await projectionPipelineManager.GetFor(_key.EventStore, _key.Namespace, projection);
+            _schema = readModel.GetSchemaForLatestGeneration();
+            _pipelineBuildFailure = null;
+        }
+        catch (Exception exception)
+        {
+            _pipeline = null;
+            _pipelineBuildFailure = exception;
+            logger.FailedBuildingPipeline(exception, _key);
+        }
     }
 
     bool HasDefinitionChanged(ProjectionDefinition oldDefinition, ProjectionDefinition newDefinition)
@@ -242,6 +274,11 @@ public class ProjectionObserverSubscriber(
             return true;
         }
 
+        return HasProjectionRulesChanged(oldDefinition, newDefinition);
+    }
+
+    bool HasProjectionRulesChanged(ProjectionDefinition oldDefinition, ProjectionDefinition newDefinition)
+    {
         if (oldDefinition.From.Count != newDefinition.From.Count ||
             oldDefinition.Join.Count != newDefinition.Join.Count ||
             oldDefinition.RemovedWith.Count != newDefinition.RemovedWith.Count ||
@@ -273,6 +310,39 @@ public class ProjectionObserverSubscriber(
 
             if (oldJoinRule.Key != newJoinRule.Key ||
                 oldJoinRule.Properties.Count != newJoinRule.Properties.Count)
+            {
+                return true;
+            }
+        }
+
+        // A child collection that was added, removed or redefined changes the projection structure -
+        // without this, a children-only change kept the stale cached pipeline (#3722).
+        return HasChildCollectionsChanged(oldDefinition.Children, newDefinition.Children) ||
+            HasChildCollectionsChanged(oldDefinition.Nested, newDefinition.Nested);
+    }
+
+    bool HasChildCollectionsChanged(IDictionary<PropertyPath, ChildrenDefinition>? oldChildren, IDictionary<PropertyPath, ChildrenDefinition>? newChildren)
+    {
+        var oldCount = oldChildren?.Count ?? 0;
+        var newCount = newChildren?.Count ?? 0;
+        if (oldCount != newCount)
+        {
+            return true;
+        }
+
+        if (oldChildren is null || newChildren is null)
+        {
+            return false;
+        }
+
+        foreach (var (property, oldChild) in oldChildren)
+        {
+            if (!newChildren.TryGetValue(property, out var newChild))
+            {
+                return true;
+            }
+
+            if (oldChild.IdentifiedBy != newChild.IdentifiedBy || HasProjectionRulesChanged(oldChild, newChild))
             {
                 return true;
             }

--- a/Source/Kernel/Core/Projections/ProjectionObserverSubscriberLogging.cs
+++ b/Source/Kernel/Core/Projections/ProjectionObserverSubscriberLogging.cs
@@ -14,6 +14,9 @@ internal static partial class ProjectionObserverSubscriberLogging
     [LoggerMessage(LogLevel.Warning, "Projection pipeline for key {Key} is not yet ready — event will be retried as a failed partition")]
     internal static partial void PipelineNotReady(this ILogger<ProjectionObserverSubscriber> logger, ObserverSubscriberKey key);
 
+    [LoggerMessage(LogLevel.Error, "Failed building the projection pipeline for key {Key} — events will fail their partition with this cause until the projection definition is corrected")]
+    internal static partial void FailedBuildingPipeline(this ILogger<ProjectionObserverSubscriber> logger, Exception ex, ObserverSubscriberKey key);
+
     [LoggerMessage(LogLevel.Warning, "An error occurred while handling to projection pipeline for key {Key}. Last successfully observed event was {LastObservedEventSequenceNumber}")]
     internal static partial void ErrorHandling(this ILogger<ProjectionObserverSubscriber> logger, Exception ex, ObserverSubscriberKey key, ulong lastObservedEventSequenceNumber);
 

--- a/Source/Kernel/Core/Projections/ProjectionsManager.Retirement.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsManager.Retirement.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Observation.Replaying;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Namespaces;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Observation.Jobs;
+using Cratis.Chronicle.Observation.States;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Recommendations;
+
+namespace Cratis.Chronicle.Projections;
+
+/// <summary>
+/// The retirement part of <see cref="ProjectionsManager"/>: when a full-set registration no longer contains a
+/// registered projection, the projection is retired - its observer stops consuming events, its jobs and failed
+/// partitions are cleared, and its definition is removed everywhere it lives. Its sink container is deliberately
+/// left untouched: data is never deleted implicitly. When another registered projection targets the same container,
+/// a replay recommendation is raised for it so the container can be rebuilt cleanly.
+/// </summary>
+public partial class ProjectionsManager
+{
+    async Task RetireUnregisteredProjections(IReadOnlyList<ProjectionDefinition> registeredDefinitions, ProjectionOwner owner)
+    {
+        var registeredIdentifiers = registeredDefinitions.Select(definition => definition.Identifier).ToHashSet();
+        var orphans = State.Projections
+            .Where(projection => projection.Owner == owner && !registeredIdentifiers.Contains(projection.Identifier))
+            .ToList();
+        if (orphans.Count == 0)
+        {
+            return;
+        }
+
+        var namespaces = (await GrainFactory.GetGrain<INamespaces>(_eventStoreName).GetAll()).ToList();
+        var readModelDefinitions = await GrainFactory.GetGrain<IReadModelsManager>(_eventStoreName).GetDefinitions();
+
+        foreach (var orphan in orphans)
+        {
+            try
+            {
+                logger.RetiringProjection(orphan.Identifier);
+
+                foreach (var @namespace in namespaces)
+                {
+                    await StopObserverFor(orphan, @namespace);
+                }
+
+                await projectionsService.Unregister(_eventStoreName, orphan.Identifier);
+                await GrainFactory.GetGrain<IProjection>(new ProjectionKey(orphan.Identifier, _eventStoreName)).Remove();
+
+                State.Projections = State.Projections.Where(projection => projection.Identifier != orphan.Identifier).ToList();
+
+                await AddReplayRecommendationForContainerSuccessors(orphan, namespaces, readModelDefinitions);
+            }
+            catch (Exception exception)
+            {
+                // The projection stays in the registered state so the next full-set registration retries
+                // retiring it, rather than leaving it half retired and forgotten.
+                logger.FailedRetiringProjection(exception, orphan.Identifier);
+            }
+        }
+
+        await WriteStateAsync();
+    }
+
+    async Task StopObserverFor(ProjectionDefinition orphan, EventStoreNamespaceName @namespace)
+    {
+        var observer = GrainFactory.GetGrain<IObserver>(new ObserverKey(orphan.Identifier, _eventStoreName, @namespace, orphan.EventSequenceId));
+        await observer.Unsubscribe();
+
+        var jobsManager = GrainFactory.GetJobsManager(_eventStoreName, @namespace);
+        var jobs = await jobsManager.GetAllJobs();
+        var observerJobs = jobs
+            .Where(job => job.Request is IObserverJobRequest observerJobRequest &&
+                observerJobRequest.ObserverKey.ObserverId == (ObserverId)orphan.Identifier.Value)
+            .ToList();
+        foreach (var job in observerJobs)
+        {
+            await jobsManager.Delete(job.Id);
+        }
+
+        await storage.GetEventStore(_eventStoreName).GetNamespace(@namespace).FailedPartitions.Save(orphan.Identifier.Value, new FailedPartitions());
+    }
+
+    async Task AddReplayRecommendationForContainerSuccessors(
+        ProjectionDefinition orphan,
+        IEnumerable<EventStoreNamespaceName> namespaces,
+        IEnumerable<ReadModelDefinition> readModelDefinitions)
+    {
+        var orphanReadModel = readModelDefinitions.SingleOrDefault(readModel => readModel.Identifier == orphan.ReadModel);
+        if (orphanReadModel is null)
+        {
+            return;
+        }
+
+        var successors = State.Projections
+            .Select(projection => (Projection: projection, ReadModel: readModelDefinitions.SingleOrDefault(readModel => readModel.Identifier == projection.ReadModel)))
+            .Where(candidate => candidate.ReadModel is not null && candidate.ReadModel.ContainerName == orphanReadModel.ContainerName)
+            .ToList();
+
+        foreach (var (successor, readModel) in successors)
+        {
+            logger.RetiredProjectionSharedContainer(orphan.Identifier, readModel!.ContainerName, successor.Identifier);
+            foreach (var @namespace in namespaces)
+            {
+                var recommendationsManager = GrainFactory.GetGrain<IRecommendationsManager>(0, new RecommendationsManagerKey(_eventStoreName, @namespace));
+                await recommendationsManager.Add<IReplayCandidateRecommendation, ReplayCandidateRequest>(
+                    $"Projection '{orphan.Identifier}' was retired and wrote to the same container '{readModel.ContainerName}' as projection '{successor.Identifier}'. Replay the projection to rebuild the container from its definition alone.",
+                    new()
+                    {
+                        ObserverId = successor.Identifier.Value,
+                        ObserverKey = new(successor.Identifier.Value, _eventStoreName, @namespace, successor.EventSequenceId),
+                        Reasons = [new RetiredProjectionSharedContainerReplayCandidateReason()]
+                    });
+            }
+        }
+    }
+}

--- a/Source/Kernel/Core/Projections/ProjectionsManager.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsManager.cs
@@ -31,7 +31,7 @@ namespace Cratis.Chronicle.Projections;
 /// <param name="logger">The logger.</param>
 [ImplicitChannelSubscription]
 [StorageProvider(ProviderName = WellKnownGrainStorageProviders.ProjectionsManager)]
-public class ProjectionsManager(
+public partial class ProjectionsManager(
     IProjectionFactory projectionFactory,
     IProjectionsServiceClient projectionsService,
     IProjectionDefinitionComparer projectionDefinitionComparer,
@@ -55,45 +55,50 @@ public class ProjectionsManager(
     }
 
     /// <inheritdoc/>
-    public async Task Register(IEnumerable<ProjectionDefinition> definitions)
+    public async Task Register(IEnumerable<ProjectionDefinition> definitions, ProjectionOwner? fullSetOwner = null)
     {
+        var definitionList = definitions.ToList();
+
         // Same-version client replicas re-register identical definitions on every startup and reconnect. Handling
         // only what actually changed makes such a re-registration near-free, and because this grain is non-reentrant
         // it also collapses a queue of identical registrations: the first request does the work, every queued
         // duplicate compares equal against the registered state and returns immediately instead of repeating the
         // per-namespace fan-out. Without this, stacked retries kept the request queue from ever draining.
-        var changedDefinitions = await GetChangedDefinitions(definitions);
+        var changedDefinitions = await GetChangedDefinitions(definitionList);
+        var failures = new Dictionary<ProjectionId, Exception>();
+
         if (changedDefinitions.Count == 0)
         {
             logger.AllDefinitionsUnchanged();
-            return;
         }
-
-        logger.RegisteringChangedDefinitions(changedDefinitions.Count);
-        await projectionsService.Register(_eventStoreName, changedDefinitions);
-
-        // Subscribe projections immediately so that seeded events appended after registration
-        // are not missed due to the asynchronous timer-based subscription scheduling
-        await SetDefinitionAndSubscribeForProjections(changedDefinitions);
-
-        // Merge into the state only after the engine and the projection grains have accepted the definitions, so an
-        // interrupted registration is retried in full on the next attempt instead of being skipped as unchanged.
-        var existingProjections = State.Projections.ToList();
-        foreach (var newDefinition in changedDefinitions)
+        else
         {
-            var existingIndex = existingProjections.FindIndex(p => p.Identifier == newDefinition.Identifier);
-            if (existingIndex >= 0)
+            logger.RegisteringChangedDefinitions(changedDefinitions.Count);
+            var acceptedByEngine = await RegisterWithEngine(changedDefinitions, failures);
+
+            // Subscribe projections immediately so that seeded events appended after registration
+            // are not missed due to the asynchronous timer-based subscription scheduling
+            foreach (var (identifier, exception) in await SetDefinitionAndSubscribeForProjections(acceptedByEngine))
             {
-                existingProjections[existingIndex] = newDefinition;
+                failures[identifier] = exception;
             }
-            else
-            {
-                existingProjections.Add(newDefinition);
-            }
+
+            // Merge into the state only the definitions that the engine and the projection grains fully accepted.
+            // A definition that failed anywhere is left out, so the next registration sees it as changed and retries
+            // exactly the work that did not land - one bad definition can no longer leave the others silently stale.
+            MergeIntoState(changedDefinitions.Where(definition => !failures.ContainsKey(definition.Identifier)));
+            await WriteStateAsync();
         }
 
-        State.Projections = existingProjections;
-        await WriteStateAsync();
+        if (fullSetOwner is not null)
+        {
+            await RetireUnregisteredProjections(definitionList, fullSetOwner.Value);
+        }
+
+        if (failures.Count > 0)
+        {
+            throw new SomeProjectionDefinitionsFailedToRegister(_eventStoreName, failures);
+        }
     }
 
     /// <inheritdoc/>
@@ -141,17 +146,25 @@ public class ProjectionsManager(
 
         await Task.WhenAll(State.Projections.Select(async projectionDefinition =>
         {
-            var key = new ProjectionKey(projectionDefinition.Identifier, _eventStoreName);
-            var projection = GrainFactory.GetGrain<IProjection>(key);
-            await projection.SetDefinition(projectionDefinition);
-            var readModelDefinition = readModelDefinitions.SingleOrDefault(rm => rm.Identifier == projectionDefinition.ReadModel);
-            if (readModelDefinition is null)
+            try
             {
-                logger.MissingReadModelDefinitionForProjection(projectionDefinition.Identifier, projectionDefinition.ReadModel);
-                return;
-            }
+                var key = new ProjectionKey(projectionDefinition.Identifier, _eventStoreName);
+                var projection = GrainFactory.GetGrain<IProjection>(key);
+                await projection.SetDefinition(projectionDefinition);
+                var readModelDefinition = readModelDefinitions.SingleOrDefault(rm => rm.Identifier == projectionDefinition.ReadModel);
+                if (readModelDefinition is null)
+                {
+                    logger.MissingReadModelDefinitionForProjection(projectionDefinition.Identifier, projectionDefinition.ReadModel);
+                    return;
+                }
 
-            await SubscribeIfNotSubscribed(projectionDefinition, readModelDefinition, added.Namespace, eventTypeSchemas);
+                await SubscribeIfNotSubscribed(projectionDefinition, readModelDefinition, added.Namespace, eventTypeSchemas);
+            }
+            catch (Exception exception)
+            {
+                // One projection that cannot subscribe in the new namespace must not keep the others from doing so.
+                logger.FailedSettingDefinitionAndSubscribing(exception, projectionDefinition.Identifier);
+            }
         }));
     }
 
@@ -185,7 +198,7 @@ public class ProjectionsManager(
         await SetDefinitionAndSubscribeForProjections(State.Projections);
     }
 
-    async Task SetDefinitionAndSubscribeForProjections(IEnumerable<ProjectionDefinition> definitions)
+    async Task<IReadOnlyDictionary<ProjectionId, Exception>> SetDefinitionAndSubscribeForProjections(IEnumerable<ProjectionDefinition> definitions)
     {
         var namespaces = await GrainFactory.GetGrain<INamespaces>(_eventStoreName).GetAll();
         var readModelDefinitions = await GrainFactory.GetGrain<IReadModelsManager>(_eventStoreName).GetDefinitions();
@@ -195,17 +208,89 @@ public class ProjectionsManager(
         // storage reads.
         var eventTypeSchemas = await storage.GetEventStore(_eventStoreName).EventTypes.GetLatestForAllEventTypes();
 
+        // Failures are isolated per definition: one projection that cannot set its definition or subscribe must not
+        // keep the others from landing, and the caller decides whether the collected failures surface as an error
+        // (registration) or are only logged (the timer-driven resubscription pass).
+        var failures = new Dictionary<ProjectionId, Exception>();
         await Task.WhenAll(definitions.Select(async definition =>
         {
-            var readModelDefinition = readModelDefinitions.SingleOrDefault(rm => rm.Identifier == definition.ReadModel);
-            if (readModelDefinition is null)
+            try
             {
-                logger.MissingReadModelDefinitionForProjection(definition.Identifier, definition.ReadModel);
-                return;
-            }
+                var readModelDefinition = readModelDefinitions.SingleOrDefault(rm => rm.Identifier == definition.ReadModel);
+                if (readModelDefinition is null)
+                {
+                    logger.MissingReadModelDefinitionForProjection(definition.Identifier, definition.ReadModel);
+                    failures[definition.Identifier] = new ReadModelNotFound(definition.ReadModel);
+                    return;
+                }
 
-            await SetDefinitionAndSubscribeForProjection(namespaces, definition, readModelDefinition, eventTypeSchemas);
+                await SetDefinitionAndSubscribeForProjection(namespaces, definition, readModelDefinition, eventTypeSchemas);
+            }
+            catch (Exception exception)
+            {
+                failures[definition.Identifier] = exception;
+                logger.FailedSettingDefinitionAndSubscribing(exception, definition.Identifier);
+            }
         }));
+
+        return failures;
+    }
+
+    async Task<IReadOnlyList<ProjectionDefinition>> RegisterWithEngine(IReadOnlyList<ProjectionDefinition> definitions, Dictionary<ProjectionId, Exception> failures)
+    {
+        try
+        {
+            await projectionsService.Register(_eventStoreName, definitions);
+            return definitions;
+        }
+        catch (Exception exception) when (definitions.Count == 1)
+        {
+            failures[definitions[0].Identifier] = exception;
+            logger.FailedRegisteringProjectionWithEngine(exception, definitions[0].Identifier);
+            return [];
+        }
+        catch
+        {
+            // At least one definition in the batch was rejected, and the batch call only surfaces the first failure.
+            // Fall through to registering each definition on its own so one bad definition cannot leave every other
+            // changed definition silently stale.
+        }
+
+        var accepted = new List<ProjectionDefinition>();
+        foreach (var definition in definitions)
+        {
+            try
+            {
+                await projectionsService.Register(_eventStoreName, [definition]);
+                accepted.Add(definition);
+            }
+            catch (Exception exception)
+            {
+                failures[definition.Identifier] = exception;
+                logger.FailedRegisteringProjectionWithEngine(exception, definition.Identifier);
+            }
+        }
+
+        return accepted;
+    }
+
+    void MergeIntoState(IEnumerable<ProjectionDefinition> definitions)
+    {
+        var projections = State.Projections.ToList();
+        foreach (var definition in definitions)
+        {
+            var existingIndex = projections.FindIndex(p => p.Identifier == definition.Identifier);
+            if (existingIndex >= 0)
+            {
+                projections[existingIndex] = definition;
+            }
+            else
+            {
+                projections.Add(definition);
+            }
+        }
+
+        State.Projections = projections;
     }
 
     async Task SetDefinitionAndSubscribeForProjection(IEnumerable<EventStoreNamespaceName> namespaces, ProjectionDefinition definition, ReadModelDefinition readModelDefinition, IEnumerable<EventTypeSchema> eventTypeSchemas)

--- a/Source/Kernel/Core/Projections/ProjectionsManagerLogging.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsManagerLogging.cs
@@ -30,4 +30,19 @@ internal static partial class ProjectionsManagerLogging
 
     [LoggerMessage(LogLevel.Debug, "Registering {Count} changed projection definitions")]
     internal static partial void RegisteringChangedDefinitions(this ILogger<ProjectionsManager> logger, int count);
+
+    [LoggerMessage(LogLevel.Error, "The projection engine rejected the definition for projection '{Identifier}' - its previously registered definition remains in effect and registration will be retried on the next registration")]
+    internal static partial void FailedRegisteringProjectionWithEngine(this ILogger<ProjectionsManager> logger, Exception ex, ProjectionId identifier);
+
+    [LoggerMessage(LogLevel.Error, "Failed setting the definition or subscribing the observer for projection '{Identifier}'")]
+    internal static partial void FailedSettingDefinitionAndSubscribing(this ILogger<ProjectionsManager> logger, Exception ex, ProjectionId identifier);
+
+    [LoggerMessage(LogLevel.Information, "Retiring projection '{Identifier}' - it is no longer registered by its owner. Its observer is unsubscribed and its definition removed; its sink container is left untouched")]
+    internal static partial void RetiringProjection(this ILogger<ProjectionsManager> logger, ProjectionId identifier);
+
+    [LoggerMessage(LogLevel.Information, "Retired projection '{Identifier}' wrote to container '{ContainerName}' which projection '{SuccessorIdentifier}' also targets - recommending a replay of the successor to rebuild the container")]
+    internal static partial void RetiredProjectionSharedContainer(this ILogger<ProjectionsManager> logger, ProjectionId identifier, ReadModelContainerName containerName, ProjectionId successorIdentifier);
+
+    [LoggerMessage(LogLevel.Warning, "Failed retiring projection '{Identifier}' - it remains registered and retirement will be retried on the next full registration")]
+    internal static partial void FailedRetiringProjection(this ILogger<ProjectionsManager> logger, Exception ex, ProjectionId identifier);
 }

--- a/Source/Kernel/Core/Projections/ProjectionsService.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Cratis.Chronicle.Namespaces;
 using Cratis.Chronicle.Projections.Engine.Pipelines;
@@ -38,6 +39,19 @@ public class ProjectionsService(
         EvictProjections(eventStore, definitions, allNamespaces);
 
         await projections.Register(eventStore, definitions, readModelDefinitions, allNamespaces);
+    }
+
+    /// <inheritdoc/>
+    public async Task Unregister(EventStoreName eventStore, ProjectionId projectionId)
+    {
+        var namespaces = grainFactory.GetGrain<INamespaces>(eventStore);
+        var allNamespaces = await namespaces.GetAll();
+
+        projections.Evict(eventStore, projectionId);
+        foreach (var @namespace in allNamespaces)
+        {
+            projectionPipelines.EvictFor(eventStore, @namespace, projectionId);
+        }
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Core/Projections/ProjectionsServiceClient.cs
+++ b/Source/Kernel/Core/Projections/ProjectionsServiceClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Orleans.Runtime.Services;
 
@@ -23,6 +24,16 @@ public class ProjectionsServiceClient(IGrainFactory grainFactory, IServiceProvid
         foreach (var host in hosts.Keys)
         {
             await GetGrainService(host).Register(eventStore, definitions);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task Unregister(EventStoreName eventStore, ProjectionId projectionId)
+    {
+        var hosts = await _managementGrain.GetHosts(true);
+        foreach (var host in hosts.Keys)
+        {
+            await GetGrainService(host).Unregister(eventStore, projectionId);
         }
     }
 

--- a/Source/Kernel/Core/Projections/SomeProjectionDefinitionsFailedToRegister.cs
+++ b/Source/Kernel/Core/Projections/SomeProjectionDefinitionsFailedToRegister.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Projections;
+
+namespace Cratis.Chronicle.Projections;
+
+/// <summary>
+/// The exception that is thrown when one or more projection definitions in a registration failed to register,
+/// while the rest of the registration was applied.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="SomeProjectionDefinitionsFailedToRegister"/> class.
+/// </remarks>
+/// <param name="eventStore">The <see cref="EventStoreName"/> the registration was for.</param>
+/// <param name="failures">The failure per <see cref="ProjectionId"/> that did not register.</param>
+public class SomeProjectionDefinitionsFailedToRegister(
+    EventStoreName eventStore,
+    IReadOnlyDictionary<ProjectionId, Exception> failures) : Exception(
+        $"Failed to register projection(s) {string.Join(", ", failures.Keys.Select(id => $"'{id}'"))} for event store " +
+        $"'{eventStore}'. Every other projection in the registration was applied. First failure: {failures.Values.First().Message}",
+        failures.Values.First())
+{
+    /// <summary>
+    /// Gets the failure per <see cref="ProjectionId"/> that did not register.
+    /// </summary>
+    public IReadOnlyDictionary<ProjectionId, Exception> Failures { get; } = failures;
+}

--- a/Source/Kernel/Core/Services/Projections/Projections.cs
+++ b/Source/Kernel/Core/Services/Projections/Projections.cs
@@ -42,10 +42,11 @@ internal sealed class Projections(
     public async Task Register(RegisterRequest request, CallContext context = default)
     {
         var projectionsManager = grainFactory.GetGrain<IProjectionsManager>(request.EventStore);
-        var projections = request.Projections.Select(_ => _.ToChronicle((Concepts.Projections.ProjectionOwner)(int)request.Owner)).ToArray();
+        var owner = (Concepts.Projections.ProjectionOwner)(int)request.Owner;
+        var projections = request.Projections.Select(_ => _.ToChronicle(owner)).ToArray();
         try
         {
-            await projectionsManager.Register(projections);
+            await projectionsManager.Register(projections, request.FullSet ? owner : null);
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
## Changed

- Projections a client no longer registers are retired when the client registers its full set: the observer is unsubscribed in every namespace, jobs and failed partitions are cleared, and the definition is removed from the engine and storage. The sink container is never dropped (#3725)
- When a retired projection wrote to the same container as another registered projection - a renamed read model keeps its container name - a replay recommendation is raised for the successor so the container can be rebuilt cleanly (#3725)
- Partial projection registrations (such as saving a single projection from the Workbench) never retire anything, and the client SDK only declares a full set when every discovered artifact produced a definition (#3725)

## Fixed

- One rejected projection definition no longer aborts the whole registration: failures are isolated per definition, every other definition still lands, and the failed ones are reported and retried on the next registration instead of being left silently stale (#3722)
- A projection whose pipeline cannot be built - for example a stale definition referencing a child collection the read model schema no longer has - no longer fails its grain activation and retries blindly forever; the failed partition now carries a descriptive error naming the projection, the child property and the read model, and the pipeline heals as soon as the definition is corrected (#3722)
- Re-registering a projection with only a child collection changed now correctly evicts the cached pipeline in the observer subscriber (#3722)
