### PR TITLE
Stop FromParentHierarchy re-resolving the child creation event on every later event

### DIFF
--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_child_event_without_parent_key.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_child_event_without_parent_key.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Dynamic;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.Sinks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers;
+
+/// <summary>
+/// When the configured parent key expression resolves to no value — the event does not carry the
+/// property named as <c>parent</c> in the projection definition — the resolution must fail with a
+/// descriptive exception naming the projection and the event, not a bare
+/// <see cref="ArgumentNullException"/> from deep inside the event-sequence lookup (issue #3725).
+/// </summary>
+public class when_identifying_read_model_key_for_child_event_without_parent_key : Specification
+{
+    const string ChildKey = "child-key-789";
+    const string BoardEventSource = "board-event-source";
+    static readonly EventType _childEventType = new("02405794-91e7-4e4f-8ad1-f043070ca297", 1);
+    static readonly EventType _rootEventType = new("5f4f4368-6989-4d9d-a84e-7393e0b41cfd", 1);
+
+    AppendedEvent _event;
+    IProjection _rootProjection;
+    IProjection _childProjection;
+    IEventSequenceStorage _storage;
+    ISink _sink;
+    KeyResolvers _keyResolvers;
+    Exception _error;
+
+    void Establish()
+    {
+        _keyResolvers = new KeyResolvers(NullLogger<KeyResolvers>.Instance);
+
+        _event = new(
+            new(
+                _childEventType,
+                EventSourceType.Default,
+                BoardEventSource,
+                EventStreamType.All,
+                EventStreamId.Default,
+                3,
+                DateTimeOffset.UtcNow,
+                "123b8935-a1a4-410d-aace-e340d48f0aa0",
+                "41f18595-4748-4b01-88f7-4c0d0907aa90",
+                CorrelationId.New(),
+                [],
+                Identity.System,
+                [],
+                EventHash.NotSet),
+            new
+            {
+                childId = ChildKey
+            }.AsExpandoObject());
+
+        _rootProjection = Substitute.For<IProjection>();
+        _rootProjection.HasParent.Returns(false);
+        _rootProjection.Parent.Returns((IProjection)null);
+        _rootProjection.ChildrenPropertyPath.Returns(PropertyPath.NotSet);
+        _rootProjection.IdentifiedByProperty.Returns((PropertyPath)"id");
+        _rootProjection.Path.Returns((ProjectionPath)"root");
+        _rootProjection.OwnEventTypes.Returns([_rootEventType]);
+        _rootProjection.EventTypes.Returns([_rootEventType]);
+
+        _childProjection = Substitute.For<IProjection>();
+        _childProjection.Identifier.Returns((ProjectionId)"my-projection");
+        _childProjection.HasParent.Returns(true);
+        _childProjection.Parent.Returns(_rootProjection);
+        _childProjection.ChildrenPropertyPath.Returns((PropertyPath)"children");
+        _childProjection.IdentifiedByProperty.Returns((PropertyPath)"childId");
+        _childProjection.Path.Returns((ProjectionPath)"root -> children");
+        _childProjection.OwnEventTypes.Returns([_childEventType]);
+        _childProjection.EventTypes.Returns([_childEventType]);
+
+        _storage = Substitute.For<IEventSequenceStorage>();
+        _sink = Substitute.For<ISink>();
+    }
+
+    async Task Because() => _error = await Catch.Exception(async () => await _keyResolvers.FromParentHierarchy(
+        _childProjection,
+        _keyResolvers.FromEventValueProvider(EventValueProviders.EventContent("childId")),
+        _keyResolvers.FromEventValueProvider(EventValueProviders.EventContent("parentId")),
+        "childId")(_storage, _sink, _event));
+
+    [Fact] void should_throw_missing_parent_key_for_child_event() => _error.ShouldBeOfExactType<MissingParentKeyForChildEvent>();
+    [Fact] void should_carry_the_projection_identifier() => ((MissingParentKeyForChildEvent)_error).ProjectionIdentifier.ShouldEqual((ProjectionId)"my-projection");
+    [Fact] void should_carry_the_projection_path() => ((MissingParentKeyForChildEvent)_error).ProjectionPath.ShouldEqual((ProjectionPath)"root -> children");
+    [Fact] void should_carry_the_children_property_path() => ((MissingParentKeyForChildEvent)_error).ChildrenPropertyPath.ShouldEqual((PropertyPath)"children");
+    [Fact] void should_carry_the_event_type() => ((MissingParentKeyForChildEvent)_error).EventTypeId.ShouldEqual(_childEventType.Id);
+    [Fact] void should_carry_the_sequence_number() => ((MissingParentKeyForChildEvent)_error).SequenceNumber.ShouldEqual(new EventSequenceNumber(3));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_already_exists_in_sink.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_already_exists_in_sink.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_keyed_child_update;
+
+/// <summary>
+/// A keyed update event for a child that was already projected under the document identified by the
+/// resolved parent key must resolve its placement directly from the sink — without looking up parent
+/// events or scanning for the child's creation event in the event sequence on every subsequent event
+/// of the stream. This is the production scenario from issue #3723: one parent-event lookup, one
+/// creation-event scan and one rejection per unrelated move/rename event, forever.
+/// </summary>
+public class and_child_already_exists_in_sink : given.a_flat_child_projection_with_keyed_events
+{
+    KeyResolverResult _result;
+    PropertyPath _queriedChildPropertyPath;
+
+    void Establish()
+    {
+        // The parent's own event type never occurs on this stream — the resolution used to fall
+        // through to re-resolving the child's creation event on every update.
+        Storage.TryGetLastInstanceOfAny(Arg.Any<EventSourceId>(), Arg.Any<IEnumerable<EventTypeId>>())
+            .Returns(Option<AppendedEvent>.None());
+        Storage.GetHeadSequenceNumber(Arg.Any<IEnumerable<EventType>>(), (EventSourceId)ChildKey)
+            .Returns(EventSequenceNumber.Unavailable);
+        Storage.GetHeadSequenceNumber(Arg.Any<IEnumerable<EventType>>(), (EventSourceId)BoardKey)
+            .Returns(new EventSequenceNumber(5));
+        var cursor = CreateCursorWith(ChildAddedEvent);
+        Storage.GetRange(
+                Arg.Any<EventSequenceNumber>(),
+                Arg.Any<EventSequenceNumber>(),
+                (EventSourceId)BoardKey,
+                Arg.Any<IEnumerable<EventType>>(),
+                Arg.Any<IEnumerable<Tag>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(cursor);
+
+        Sink.When(x => x.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey))
+            .Do(callInfo => _queriedChildPropertyPath = callInfo.ArgAt<PropertyPath>(0));
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(new Option<Key>(new Key(BoardKey, ArrayIndexers.NoIndexers)));
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), BoardKey)
+            .Returns(Option<Key>.None());
+    }
+
+    async Task Because() => _result = await CreateResolverUnderTest()(Storage, Sink, ChildMovedEvent);
+
+    [Fact] void should_resolve_to_the_board_key() => (_result as ResolvedKey).Key.Value.ShouldEqual(BoardKey);
+    [Fact] void should_have_array_indexer_for_the_child() => (_result as ResolvedKey).Key.ArrayIndexers.All.Single(_ => _.ArrayProperty == "children").Identifier.ShouldEqual(ChildKey);
+    [Fact] void should_query_the_sink_by_the_child_key_path() => _queriedChildPropertyPath.ShouldEqual((PropertyPath)"children.childId");
+    [Fact] void should_not_look_up_parent_events_in_the_event_sequence() => Storage.DidNotReceive().TryGetLastInstanceOfAny(Arg.Any<EventSourceId>(), Arg.Any<IEnumerable<EventTypeId>>());
+    [Fact] void should_not_scan_the_event_sequence_for_creation_events() => Storage.DidNotReceive().GetHeadSequenceNumber(Arg.Any<IEnumerable<EventType>>(), Arg.Any<EventSourceId>());
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_is_not_yet_in_sink.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_is_not_yet_in_sink.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_keyed_child_update;
+
+/// <summary>
+/// When the child is not in the sink yet — such as when the current event is the child's creation
+/// event — the resolution must fall through to the event-sequence strategies and resolve via the
+/// parent's creation event as before.
+/// </summary>
+public class and_child_is_not_yet_in_sink : given.a_flat_child_projection_with_keyed_events
+{
+    KeyResolverResult _result;
+
+    void Establish()
+    {
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(Option<Key>.None());
+
+        Storage.TryGetLastInstanceOfAny(BoardKey, Arg.Is<IEnumerable<EventTypeId>>(x => x.Contains(RootCreatedEventType.Id)))
+            .Returns(new Option<AppendedEvent>(RootCreatedEvent));
+    }
+
+    async Task Because() => _result = await CreateResolverUnderTest()(Storage, Sink, ChildAddedEvent);
+
+    [Fact] void should_resolve_to_the_board_key() => (_result as ResolvedKey).Key.Value.ShouldEqual(BoardKey);
+    [Fact] void should_have_array_indexer_for_the_child() => (_result as ResolvedKey).Key.ArrayIndexers.All.Single(_ => _.ArrayProperty == "children").Identifier.ShouldEqual(ChildKey);
+    [Fact] void should_look_up_the_parent_event_in_the_event_sequence() => Storage.Received(1).TryGetLastInstanceOfAny(BoardKey, Arg.Is<IEnumerable<EventTypeId>>(x => x.Contains(RootCreatedEventType.Id)));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_with_same_key_exists_under_a_different_root.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/and_child_with_same_key_exists_under_a_different_root.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Properties;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_keyed_child_update;
+
+/// <summary>
+/// The same child key can exist under multiple roots — the child key alone never decides the
+/// placement. When the sink locates the child under a root that does not match the resolved parent
+/// key, the direct resolution must be rejected and the event-sequence strategies must decide, so the
+/// update lands under the parent the event belongs to and not under whichever root the sink returned.
+/// </summary>
+public class and_child_with_same_key_exists_under_a_different_root : given.a_flat_child_projection_with_keyed_events
+{
+    const string OtherRootKey = "other-root-key";
+
+    KeyResolverResult _result;
+
+    void Establish()
+    {
+        Sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(new Option<Key>(new Key(OtherRootKey, ArrayIndexers.NoIndexers)));
+
+        Storage.TryGetLastInstanceOfAny(BoardKey, Arg.Is<IEnumerable<EventTypeId>>(x => x.Contains(RootCreatedEventType.Id)))
+            .Returns(new Option<AppendedEvent>(RootCreatedEvent));
+    }
+
+    async Task Because() => _result = await CreateResolverUnderTest()(Storage, Sink, ChildMovedEvent);
+
+    [Fact] void should_resolve_to_the_board_key() => (_result as ResolvedKey).Key.Value.ShouldEqual(BoardKey);
+    [Fact] void should_not_resolve_to_the_other_root() => (_result as ResolvedKey).Key.Value.ShouldNotEqual(OtherRootKey);
+    [Fact] void should_fall_back_to_the_event_sequence() => Storage.Received(1).TryGetLastInstanceOfAny(BoardKey, Arg.Is<IEnumerable<EventTypeId>>(x => x.Contains(RootCreatedEventType.Id)));
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/given/a_flat_child_projection_with_keyed_events.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_for_keyed_child_update/given/a_flat_child_projection_with_keyed_events.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Dynamic;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.Sinks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers.when_identifying_read_model_key_for_keyed_child_update.given;
+
+/// <summary>
+/// Sets up a flat two-level projection hierarchy: Root → Child, where all child events are appended
+/// to the root's event source and carry the child's key in their content. The child is created by
+/// one event type and updated by another — the shape that produced per-event re-resolution of the
+/// child's creation event for every subsequent event on the same event source.
+/// </summary>
+public class a_flat_child_projection_with_keyed_events : Specification
+{
+    protected const string BoardKey = "board-key";
+    protected const string ChildKey = "child-key";
+
+    protected static readonly EventType RootCreatedEventType = new("root-created-event-type", 1);
+    protected static readonly EventType ChildAddedEventType = new("child-added-event-type", 1);
+    protected static readonly EventType ChildMovedEventType = new("child-moved-event-type", 1);
+
+    protected AppendedEvent RootCreatedEvent;
+    protected AppendedEvent ChildAddedEvent;
+    protected AppendedEvent ChildMovedEvent;
+
+    protected IProjection RootProjection;
+    protected IProjection ChildProjection;
+
+    protected IEventSequenceStorage Storage;
+    protected ISink Sink;
+    protected KeyResolvers KeyResolvers;
+
+    void Establish()
+    {
+        Storage = Substitute.For<IEventSequenceStorage>();
+        Sink = Substitute.For<ISink>();
+        KeyResolvers = new KeyResolvers(NullLogger<KeyResolvers>.Instance);
+
+        RootCreatedEvent = CreateEvent(0, RootCreatedEventType, BoardKey, new ExpandoObject());
+        ChildAddedEvent = CreateEvent(5, ChildAddedEventType, BoardKey, new { childId = ChildKey }.AsExpandoObject());
+        ChildMovedEvent = CreateEvent(7, ChildMovedEventType, BoardKey, new { childId = ChildKey }.AsExpandoObject());
+
+        RootProjection = Substitute.For<IProjection>();
+        RootProjection.HasParent.Returns(false);
+        RootProjection.Parent.Returns((IProjection)null);
+        RootProjection.ChildrenPropertyPath.Returns(PropertyPath.NotSet);
+        RootProjection.IdentifiedByProperty.Returns((PropertyPath)"id");
+        RootProjection.Path.Returns((ProjectionPath)"root");
+        RootProjection.OwnEventTypes.Returns([RootCreatedEventType]);
+        RootProjection.EventTypes.Returns([RootCreatedEventType]);
+        RootProjection.GetKeyResolverFor(RootCreatedEventType).Returns((_, _, _) =>
+            Task.FromResult(KeyResolverResult.Resolved(new Key(BoardKey, ArrayIndexers.NoIndexers))));
+
+        ChildProjection = Substitute.For<IProjection>();
+        ChildProjection.HasParent.Returns(true);
+        ChildProjection.Parent.Returns(RootProjection);
+        ChildProjection.ChildrenPropertyPath.Returns((PropertyPath)"children");
+        ChildProjection.IdentifiedByProperty.Returns((PropertyPath)"childId");
+        ChildProjection.Path.Returns((ProjectionPath)"children");
+        ChildProjection.OwnEventTypes.Returns([ChildAddedEventType, ChildMovedEventType]);
+        ChildProjection.EventTypes.Returns([ChildAddedEventType, ChildMovedEventType]);
+
+        // Wire the real resolvers so any re-resolution of the child's creation event runs the
+        // full chain, exactly as it does in production.
+        var childAddedKeyResolver = CreateResolverUnderTest();
+        ChildProjection.GetKeyResolverFor(ChildAddedEventType).Returns(childAddedKeyResolver);
+        var childMovedKeyResolver = CreateResolverUnderTest();
+        ChildProjection.GetKeyResolverFor(ChildMovedEventType).Returns(childMovedKeyResolver);
+    }
+
+    protected KeyResolver CreateResolverUnderTest() =>
+        KeyResolvers.FromParentHierarchy(
+            ChildProjection,
+            KeyResolvers.FromEventValueProvider(EventValueProviders.EventContent("childId")),
+            KeyResolvers.FromEventSourceId,
+            "childId");
+
+    protected static AppendedEvent CreateEvent(ulong sequenceNumber, EventType eventType, EventSourceId eventSourceId, ExpandoObject content) =>
+        new(
+            new(
+                eventType,
+                EventSourceType.Default,
+                eventSourceId,
+                EventStreamType.All,
+                EventStreamId.Default,
+                sequenceNumber,
+                DateTimeOffset.UtcNow,
+                "123b8935-a1a4-410d-aace-e340d48f0aa0",
+                "41f18595-4748-4b01-88f7-4c0d0907aa90",
+                CorrelationId.New(),
+                [],
+                Identity.System,
+                [],
+                EventHash.NotSet),
+            content);
+
+    protected IEventCursor CreateCursorWith(params AppendedEvent[] events)
+    {
+        var cursor = Substitute.For<IEventCursor>();
+        cursor.Current.Returns(events);
+        var callCount = 0;
+        cursor.MoveNext().Returns(_ => Task.FromResult(callCount++ == 0));
+        return cursor;
+    }
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_using_sink_lookup.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_using_sink_lookup.cs
@@ -87,6 +87,11 @@ public class when_identifying_read_model_key_from_parent_hierarchy_using_sink_lo
         _storage.TryGetLastInstanceOfAny(ParentKey, Arg.Any<IEnumerable<EventTypeId>>())
             .Returns(Option<AppendedEvent>.None());
 
+        // The child is not in the sink yet — the direct child-key lookup misses and the
+        // resolution falls through to the parent-key strategies under test.
+        _sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(Option<Key>.None());
+
         // Sink lookup returns the root key
         // Capture the property path used in the query to verify it's correct
         _sink.When(x => x.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ParentKey))

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_with_empty_string_children_property_path.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_with_empty_string_children_property_path.cs
@@ -86,6 +86,11 @@ public class when_identifying_read_model_key_from_parent_hierarchy_with_empty_st
         _storage.TryGetLastInstanceOfAny(ParentKey, Arg.Any<IEnumerable<EventTypeId>>())
             .Returns(Option<AppendedEvent>.None());
 
+        // The child is not in the sink yet — the direct child-key lookup misses and the
+        // resolution falls through to the parent-key strategies under test.
+        _sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(Option<Key>.None());
+
         // Sink lookup returns the root key
         // Capture the property path used in the query to verify it's correct
         _sink.When(x => x.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ParentKey))

--- a/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_with_fallback_to_event_source_id.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/for_KeyResolvers/when_identifying_read_model_key_from_parent_hierarchy_with_fallback_to_event_source_id.cs
@@ -10,6 +10,7 @@ using Cratis.Chronicle.Dynamic;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Storage.EventSequences;
 using Cratis.Chronicle.Storage.Sinks;
+using Cratis.Monads;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Projections.Engine.for_KeyResolvers;
@@ -83,6 +84,7 @@ public class when_identifying_read_model_key_from_parent_hierarchy_with_fallback
         _rootProjection.OwnEventTypes.Returns([_rootEventType]);
         _rootProjection.IdentifiedByProperty.Returns((PropertyPath)"id");
         _rootProjection.Path.Returns((ProjectionPath)"root");
+        _rootProjection.ChildrenPropertyPath.Returns(PropertyPath.NotSet);
 
         _childProjection = Substitute.For<IProjection>();
         _childProjection.HasParent.Returns(true);
@@ -95,6 +97,11 @@ public class when_identifying_read_model_key_from_parent_hierarchy_with_fallback
 
         // When looking up parent event by EventSourceId (ParentKey), return the root event
         _storage.TryGetLastInstanceOfAny(ParentKey, Arg.Is<IEnumerable<EventTypeId>>(x => x.Contains(_rootEventType.Id))).Returns(_rootEvent);
+
+        // The child is not in the sink yet — the direct child-key lookup misses and the
+        // resolution falls through to the parent-key strategies under test.
+        _sink.TryFindRootKeyByChildValue(Arg.Any<PropertyPath>(), ChildKey)
+            .Returns(Option<Key>.None());
 
         // Root projection's key resolver returns the EventSourceId as the key
         _rootProjection.GetKeyResolverFor(_rootEventType).Returns(_ => (_, __, @event) => Task.FromResult(KeyResolverResult.Resolved(new Key(@event.Context.EventSourceId.ToString(), ArrayIndexers.NoIndexers))));

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -177,6 +177,13 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         }
 
         var parentProjection = projection.Parent!;
+
+        // Any parent-based routing below needs an actual parent key value. When the configured parent key
+        // expression resolves to nothing — the event does not carry the property named as the parent key —
+        // fail with a descriptive exception instead of letting the event-sequence lookup throw a bare
+        // ArgumentNullException from converting a null event source id.
+        ThrowIfMissingParentKey(projection, parentKey, @event);
+
         var parentEventTypeIds = parentProjection.OwnEventTypes.Select(_ => _.Id).ToArray();
         logger.FromParentHierarchyParentEventTypes(parentEventTypeIds.Length, string.Join(", ", (IEnumerable<EventTypeId>)parentEventTypeIds));
 
@@ -227,6 +234,14 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         var arrayIndexers = resolvedParentKey.ArrayIndexers.All.ToList();
         arrayIndexers.Add(new ArrayIndexer(childrenPropertyPath, identifiedByProperty, keyValue!));
         return arrayIndexers;
+    }
+
+    static void ThrowIfMissingParentKey(IProjection projection, Key parentKey, AppendedEvent @event)
+    {
+        if (parentKey.Value is null)
+        {
+            throw new MissingParentKeyForChildEvent(projection, @event);
+        }
     }
 
     static bool IsEventHandledByDescendantProjection(IProjection projection, EventTypeId eventTypeId)

--- a/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolvers.cs
@@ -184,6 +184,28 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         // ArgumentNullException from converting a null event source id.
         ThrowIfMissingParentKey(projection, parentKey, @event);
 
+        // A keyed UPDATE to an already-projected child of the root carries the child's own key in the
+        // event content. When the sink already holds that child under the document identified by the
+        // resolved parent key, resolve the placement directly — no parent-event lookup, no creation-event
+        // scan and no rejection guard on every subsequent event of the stream. The parent key must confirm
+        // the located root: the same child key can exist under multiple roots, so the child key alone never
+        // decides the placement. On any miss or mismatch — including when the current event IS the child's
+        // creation event — fall through to the event-sequence strategies.
+        var childKeyValue = key.Value;
+        if (!parentProjection.HasParent &&
+            childKeyValue is not null and not ExpandoObject &&
+            childKeyValue.ToString() != @event.Context.EventSourceId.Value)
+        {
+            var childLocationPath = BuildFullParentChildPropertyPath(projection, identifiedByProperty);
+            var existingChildRoot = await sink.TryFindRootKeyByChildValue(childLocationPath, childKeyValue);
+            if (existingChildRoot.TryGetValue(out var existingChildRootKey) &&
+                Equals(existingChildRootKey.Value?.ToString(), parentKey.Value!.ToString()))
+            {
+                logger.FromParentHierarchyResolvedExistingChildBySink(childKeyValue, childLocationPath.Path, parentKey.Value);
+                return KeyResolverResult.Resolved(parentKey with { ArrayIndexers = new ArrayIndexers([new ArrayIndexer(projection.ChildrenPropertyPath, identifiedByProperty, childKeyValue)]) });
+            }
+        }
+
         var parentEventTypeIds = parentProjection.OwnEventTypes.Select(_ => _.Id).ToArray();
         logger.FromParentHierarchyParentEventTypes(parentEventTypeIds.Length, string.Join(", ", (IEnumerable<EventTypeId>)parentEventTypeIds));
 
@@ -586,9 +608,17 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
             return null;
         }
 
-        if (creationEvent.Context.SequenceNumber >= @event.Context.SequenceNumber)
+        if (creationEvent.Context.SequenceNumber == @event.Context.SequenceNumber)
         {
-            logger.FromParentHierarchyChildCreationEventNotEarlier(creationEvent.Context.SequenceNumber.Value, @event.Context.SequenceNumber.Value);
+            // The current event is itself the earliest candidate creation event — the normal outcome when
+            // resolving a creation event. Nothing earlier exists to anchor to; not an anomaly.
+            logger.FromParentHierarchyCurrentEventIsEarliestCreationEvent(@event.Context.SequenceNumber.Value);
+            return null;
+        }
+
+        if (creationEvent.Context.SequenceNumber > @event.Context.SequenceNumber)
+        {
+            logger.FromParentHierarchyChildCreationEventLaterThanCurrent(creationEvent.Context.SequenceNumber.Value, @event.Context.SequenceNumber.Value);
             return null;
         }
 
@@ -636,14 +666,22 @@ public class KeyResolvers(ILogger<KeyResolvers> logger) : IKeyResolvers
         logger.FromParentHierarchyAttemptingViaChildCreationEvent(eventSourceId);
 
         var headSequenceNumber = await eventSequenceStorage.GetHeadSequenceNumber(creationEventTypes, eventSourceId);
-        if (headSequenceNumber == EventSequenceNumber.Unavailable ||
-            headSequenceNumber >= @event.Context.SequenceNumber)
+        if (headSequenceNumber == EventSequenceNumber.Unavailable)
         {
-            if (headSequenceNumber != EventSequenceNumber.Unavailable)
-            {
-                logger.FromParentHierarchyChildCreationEventNotEarlier(headSequenceNumber.Value, @event.Context.SequenceNumber.Value);
-            }
+            return null;
+        }
 
+        if (headSequenceNumber == @event.Context.SequenceNumber)
+        {
+            // The current event is itself the earliest candidate creation event — the normal outcome when
+            // resolving a creation event. Nothing earlier exists to anchor to; not an anomaly.
+            logger.FromParentHierarchyCurrentEventIsEarliestCreationEvent(@event.Context.SequenceNumber.Value);
+            return null;
+        }
+
+        if (headSequenceNumber > @event.Context.SequenceNumber)
+        {
+            logger.FromParentHierarchyChildCreationEventLaterThanCurrent(headSequenceNumber.Value, @event.Context.SequenceNumber.Value);
             return null;
         }
 

--- a/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
+++ b/Source/Kernel/Core/Projections/Engine/KeyResolversLogMessages.cs
@@ -136,6 +136,12 @@ internal static partial class KeyResolversLogMessages
     [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: all resolution strategies exhausted for child projection '{Path}' with parent key '{ParentKey}' — event will be skipped (no future created). This typically indicates a badly-defined projection.")]
     internal static partial void FromParentHierarchyKeyUnresolvable(this ILogger<KeyResolvers> logger, string path, string parentKey);
 
-    [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: child creation event at seq {CreationSeq} is not earlier than the current event at seq {CurrentSeq} — rejecting to prevent an infinite resolution cycle")]
-    internal static partial void FromParentHierarchyChildCreationEventNotEarlier(this ILogger<KeyResolvers> logger, ulong creationSeq, ulong currentSeq);
+    [LoggerMessage(LogLevel.Warning, "FromParentHierarchy: child creation event candidate at seq {CreationSeq} is later than the current event at seq {CurrentSeq} — rejecting to prevent an infinite resolution cycle")]
+    internal static partial void FromParentHierarchyChildCreationEventLaterThanCurrent(this ILogger<KeyResolvers> logger, ulong creationSeq, ulong currentSeq);
+
+    [LoggerMessage(LogLevel.Debug, "FromParentHierarchy: the current event at seq {SequenceNumber} is itself the earliest candidate creation event on its stream — no earlier creation event to anchor to")]
+    internal static partial void FromParentHierarchyCurrentEventIsEarliestCreationEvent(this ILogger<KeyResolvers> logger, ulong sequenceNumber);
+
+    [LoggerMessage(LogLevel.Debug, "FromParentHierarchy: resolved keyed child update directly from the sink — child key '{ChildKey}' found at '{ChildPath}' under root '{RootKey}'")]
+    internal static partial void FromParentHierarchyResolvedExistingChildBySink(this ILogger<KeyResolvers> logger, object? childKey, string childPath, object? rootKey);
 }

--- a/Source/Kernel/Core/Projections/Engine/MissingParentKeyForChildEvent.cs
+++ b/Source/Kernel/Core/Projections/Engine/MissingParentKeyForChildEvent.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Projections.Engine;
+
+/// <summary>
+/// The exception that is thrown when the configured parent key for a child projection resolves to no value
+/// for an event — the event does not carry the property named as the parent key in the projection definition.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="MissingParentKeyForChildEvent"/> class.
+/// </remarks>
+/// <param name="projection">The child <see cref="IProjection"/> the key was being resolved for.</param>
+/// <param name="event">The <see cref="AppendedEvent"/> that does not carry a value for the parent key.</param>
+public class MissingParentKeyForChildEvent(IProjection projection, AppendedEvent @event) : Exception(
+    $"The parent key for child projection '{projection.Path}' (children at '{projection.ChildrenPropertyPath}', identified by '{projection.IdentifiedByProperty}') " +
+    $"in projection '{projection.Identifier}' resolved to no value for event type '{@event.Context.EventType.Id}' at sequence number {@event.Context.SequenceNumber} " +
+    $"on event source '{@event.Context.EventSourceId}'. The event does not carry the property configured as the parent key for this event type — " +
+    "verify the 'parent' expression in the projection definition against the event's content.")
+{
+    /// <summary>
+    /// Gets the identifier of the projection the key was being resolved for.
+    /// </summary>
+    public ProjectionId ProjectionIdentifier { get; } = projection.Identifier;
+
+    /// <summary>
+    /// Gets the path of the child projection within the projection hierarchy.
+    /// </summary>
+    public ProjectionPath ProjectionPath { get; } = projection.Path;
+
+    /// <summary>
+    /// Gets the property path of the children collection the child projection targets.
+    /// </summary>
+    public PropertyPath ChildrenPropertyPath { get; } = projection.ChildrenPropertyPath;
+
+    /// <summary>
+    /// Gets the identifier of the event type the parent key could not be resolved for.
+    /// </summary>
+    public EventTypeId EventTypeId { get; } = @event.Context.EventType.Id;
+
+    /// <summary>
+    /// Gets the sequence number of the event the parent key could not be resolved for.
+    /// </summary>
+    public EventSequenceNumber SequenceNumber { get; } = @event.Context.SequenceNumber;
+}


### PR DESCRIPTION
## Fixed

- Keyed child updates in hierarchical projections no longer re-resolve the child's creation event on every subsequent event of the same event source: when the event carries the child's key and the child is already projected under the document the resolved parent key identifies, its placement is resolved with a single sink lookup — eliminating the per-event `FromParentHierarchy` Warning flood and the redundant event-sequence lookups that preceded each warning (#3723)
- The creation-event rejection guard in `FromParentHierarchy` now logs at Debug when the current event is itself the earliest candidate creation event — the normal steady-state outcome; only a creation event strictly later than the current event is still rejected with a Warning, as the genuine infinite-cycle anomaly (#3723)
- A child projection event that does not carry the property configured as its parent key now fails with a descriptive `MissingParentKeyForChildEvent` — naming the projection, the children collection, the identified-by property, and the event type, sequence number and event source — instead of a bare `ArgumentNullException (Parameter 'value')` that left failed partitions without a usable message (#3725)
