### PR TITLE
Provision the namespace database before its first table read on SQL backends

### DIFF
--- a/Integration/Client/for_ReadModels/given/a_projection_with_events.cs
+++ b/Integration/Client/for_ReadModels/given/a_projection_with_events.cs
@@ -31,16 +31,22 @@ public class a_projection_with_events(ChronicleFixture chronicleFixture) : Speci
     }
 
     /// <summary>
-    /// Polls the materialized read model until it holds at least <paramref name="expectedCount"/>
-    /// instances, or the default timeout elapses.
+    /// Polls the materialized read model until at least <paramref name="expectedCount"/> instances have
+    /// caught up with every event appended to their event source, or the default timeout elapses.
     /// </summary>
-    /// <param name="expectedCount">The minimum number of instances to wait for.</param>
+    /// <param name="expectedCount">The minimum number of caught-up instances to wait for.</param>
     /// <returns>The instances once the expected count is reached.</returns>
     /// <remarks>
     /// <see cref="SomeReadModel"/> is materialized, so <c>GetInstances</c> now reads the sink instead of
     /// replaying — a read straight after appending can race the projection engine's catch-up unless
     /// something polls for the result to appear, the same gap <c>GetInstanceById</c> callers close
     /// elsewhere in this suite.
+    /// <para>
+    /// The document appears in the sink as soon as the first event is applied, so counting documents
+    /// only waits for half the catch-up: the second event that sets <c>Value</c> can still be in flight.
+    /// Every event source in this context appends <see cref="SomeEvent"/> and then
+    /// <see cref="AnotherEvent"/>, so a non-null <c>Value</c> is what marks an instance as caught up.
+    /// </para>
     /// </remarks>
     protected async Task<IEnumerable<SomeReadModel>> WaitTillInstancesAreVisible(int expectedCount)
     {
@@ -48,7 +54,7 @@ public class a_projection_with_events(ChronicleFixture chronicleFixture) : Speci
         while (true)
         {
             var instances = await EventStore.ReadModels.GetInstances<SomeReadModel>();
-            if (instances.Count() >= expectedCount)
+            if (instances.Count(_ => _.Value is not null) >= expectedCount)
             {
                 return instances;
             }

--- a/Integration/Client/for_ReadModels/when_getting_instances/with_multiple_event_sources.cs
+++ b/Integration/Client/for_ReadModels/when_getting_instances/with_multiple_event_sources.cs
@@ -31,11 +31,24 @@ public class with_multiple_event_sources(context context) : Given<context>(conte
 
             Results = await WaitTillInstancesAreVisible(2);
         }
+
+        /// <summary>
+        /// Gets the projected instance for the event source that appended <paramref name="number"/>.
+        /// </summary>
+        /// <param name="number">The number the event source's <see cref="SomeEvent"/> carried.</param>
+        /// <returns>The instance belonging to that event source.</returns>
+        /// <remarks>
+        /// <c>GetInstances</c> reads the sink, and no sink promises an order — MongoDB answers in
+        /// insertion order while SQL Server answers in clustered-key order, which puts
+        /// <c>another-source</c> first. Identify each instance by what its event source appended
+        /// rather than by where the backend happened to place it.
+        /// </remarks>
+        public SomeReadModel InstanceFor(int number) => Results.Single(_ => _.Number == number);
     }
 
     [Fact] void should_return_two_instances() => Context.Results.Count().ShouldEqual(2);
-    [Fact] void should_have_first_instance_with_first_events() => Context.Results.First().Number.ShouldEqual(Context.FirstEvent.Number);
-    [Fact] void should_have_first_instance_value() => Context.Results.First().Value.ShouldEqual(Context.SecondEvent.Value);
-    [Fact] void should_have_second_instance_with_second_events() => Context.Results.Last().Number.ShouldEqual(Context.ThirdEvent.Number);
-    [Fact] void should_have_second_instance_value() => Context.Results.Last().Value.ShouldEqual(Context.FourthEvent.Value);
+    [Fact] void should_have_an_instance_for_the_first_event_source() => Context.Results.Count(_ => _.Number == Context.FirstEvent.Number).ShouldEqual(1);
+    [Fact] void should_have_the_first_event_sources_value() => Context.InstanceFor(Context.FirstEvent.Number).Value.ShouldEqual(Context.SecondEvent.Value);
+    [Fact] void should_have_an_instance_for_the_second_event_source() => Context.Results.Count(_ => _.Number == Context.ThirdEvent.Number).ShouldEqual(1);
+    [Fact] void should_have_the_second_event_sources_value() => Context.InstanceFor(Context.ThirdEvent.Number).Value.ShouldEqual(Context.FourthEvent.Value);
 }

--- a/Source/Kernel/Storage.Sql/Database.cs
+++ b/Source/Kernel/Storage.Sql/Database.cs
@@ -606,6 +606,13 @@ public class Database(IServiceProvider serviceProvider, IOptions<ChronicleOption
         var dbContext = createDbContext(dbContextOptions, tableName);
 #pragma warning restore CA2000
 
+        // Every event store / namespace pair lives in its own database, and PostgreSQL / SQL Server
+        // refuse a connection to one that does not exist yet. Namespace() creates it on the way past,
+        // but nothing guarantees it ran first: appending to a namespace reaches its event-sequence
+        // table through here, so a namespace whose Namespaces table was never touched arrives at a
+        // database that is not there. Provision it the same way GetOrCreateReadModelDbContext does.
+        await EnsureDatabaseExists(dbContext, connectionString);
+
         // Per-table migration is handled by the table-specific migrator (EnsureTableExists)
         // which already caches "already migrated" inside the migrator implementation, so we
         // only need to call it once per request — the migrator itself will fast-path on


### PR DESCRIPTION
## Fixed

- Appending events to a second, non-default namespace on PostgreSQL or SQL Server no longer fails with "database does not exist" — the per-namespace database is now provisioned before its event-sequence tables are first read, the same way read-model contexts already do