### PR TITLE
Fix the password change, duplicate client id and observed name regressions from the Arc command move

### DIFF
--- a/Source/Clients/Api.Specs/Security/for_ChangePasswordForUser/when_handling.cs
+++ b/Source/Clients/Api.Specs/Security/for_ChangePasswordForUser/when_handling.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Commands;
+using Cratis.Chronicle.Contracts.Security;
+
+namespace Cratis.Chronicle.Api.Security.for_ChangePasswordForUser;
+
+/// <summary>
+/// The kernel verifies the current password before it changes it, so every value the user typed - the
+/// old password included - has to reach the request. Dropping one leaves the change rejected as invalid.
+/// </summary>
+public class when_handling : Specification
+{
+    static readonly Guid _userId = Guid.Parse("3c1d2e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f");
+    const string OldPassword = "the-old-password";
+    const string Password = "the-new-password";
+    const string ConfirmedPassword = "the-new-password";
+
+    IUsers _users;
+    ChangePasswordForUser _command;
+
+    void Establish()
+    {
+        _users = Substitute.For<IUsers>();
+        _users.ChangeUserPassword(Arg.Any<ChangeUserPasswordRequest>()).Returns(CommandResult.Success(Guid.NewGuid()));
+        _command = new ChangePasswordForUser(_userId, OldPassword, Password, ConfirmedPassword);
+    }
+
+    async Task Because() => await _command.Handle(_users);
+
+    [Fact] void should_forward_every_value_to_the_kernel() => _users.Received(1).ChangeUserPassword(
+        Arg.Is<ChangeUserPasswordRequest>(request =>
+            request.UserId == _userId &&
+            request.OldPassword == OldPassword &&
+            request.Password == Password &&
+            request.ConfirmedPassword == ConfirmedPassword));
+}

--- a/Source/Clients/Api/Security/ChangePasswordForUser.cs
+++ b/Source/Clients/Api/Security/ChangePasswordForUser.cs
@@ -31,6 +31,7 @@ public record ChangePasswordForUser(
         users.ChangeUserPassword(new()
         {
             UserId = UserId,
+            OldPassword = oldPassword,
             Password = Password,
             ConfirmedPassword = ConfirmedPassword
         }).EnsureSuccess();

--- a/Source/Kernel/Core.Specs/EventStores/for_EventStoreNames/when_observing_event_stores.cs
+++ b/Source/Kernel/Core.Specs/EventStores/for_EventStoreNames/when_observing_event_stores.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage;
+using Cratis.Json;
+
+namespace Cratis.Chronicle.EventStores.for_EventStoreNames;
+
+/// <summary>
+/// The names travel to the Workbench through a serializer that picks the collection converter from the
+/// runtime type. A lazily projected sequence over <see cref="EventStoreName"/> still carries the concept as its
+/// first generic argument, which makes the concept-collection converter claim a sequence of strings and blow up
+/// on the way out - the in-memory backend hands over a list, which is exactly the shape that triggers it.
+/// </summary>
+public class when_observing_event_stores : Specification
+{
+    static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        Converters =
+        {
+            new EnumerableConceptAsJsonConverterFactory(),
+            new ConceptAsJsonConverterFactory()
+        }
+    };
+
+    IStorage _storage;
+    IEnumerable<string> _emitted;
+    string _json;
+
+    void Establish()
+    {
+        _storage = Substitute.For<IStorage>();
+        var stores = new ReplaySubject<IEnumerable<EventStoreName>>(1);
+        stores.OnNext(new List<EventStoreName> { EventStoreName.System, "some-store" });
+        _storage.ObserveEventStores().Returns(stores);
+    }
+
+    void Because()
+    {
+        EventStoreNames.ObserveEventStores(_storage).Subscribe(names => _emitted = names);
+        _json = JsonSerializer.Serialize<object>(_emitted, _serializerOptions);
+    }
+
+    [Fact] void should_emit_the_names_as_strings() => _emitted.ShouldContainOnly(EventStoreName.System.Value, "some-store");
+    [Fact] void should_serialize_as_a_plain_string_array() => _json.ShouldEqual("""["System","some-store"]""");
+}

--- a/Source/Kernel/Core.Specs/Namespaces/for_NamespaceNames/when_observing_namespaces.cs
+++ b/Source/Kernel/Core.Specs/Namespaces/for_NamespaceNames/when_observing_namespaces.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reactive.Subjects;
+using System.Text.Json;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Namespaces;
+using Cratis.Json;
+
+namespace Cratis.Chronicle.Namespaces.for_NamespaceNames;
+
+/// <summary>
+/// Same guard as for the event store names: what leaves the read model must be a materialized string
+/// collection, not a lazy projection the JSON converters can misread.
+/// </summary>
+public class when_observing_namespaces : Specification
+{
+    static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        Converters =
+        {
+            new EnumerableConceptAsJsonConverterFactory(),
+            new ConceptAsJsonConverterFactory()
+        }
+    };
+
+    IStorage _storage;
+    IEnumerable<string> _emitted;
+    string _json;
+
+    void Establish()
+    {
+        _storage = Substitute.For<IStorage>();
+        var namespaces = new ReplaySubject<IEnumerable<NamespaceState>>(1);
+        namespaces.OnNext(new List<NamespaceState>
+        {
+            new(EventStoreNamespaceName.Default, DateTimeOffset.UtcNow),
+            new("tenant-a", DateTimeOffset.UtcNow)
+        });
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Namespaces.ObserveAll().Returns(namespaces);
+    }
+
+    void Because()
+    {
+        NamespaceNames.ObserveNamespaces("some-store", _storage).Subscribe(names => _emitted = names);
+        _json = JsonSerializer.Serialize<object>(_emitted, _serializerOptions);
+    }
+
+    [Fact] void should_emit_the_names_as_strings() => _emitted.ShouldContainOnly(EventStoreNamespaceName.Default.Value, "tenant-a");
+    [Fact] void should_serialize_as_a_plain_string_array() => _json.ShouldEqual("""["Default","tenant-a"]""");
+}

--- a/Source/Kernel/Core.Specs/Security/for_AddApplication/given/an_add_application_command.cs
+++ b/Source/Kernel/Core.Specs/Security/for_AddApplication/given/an_add_application_command.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Security;
+
+namespace Cratis.Chronicle.Security.for_AddApplication.given;
+
+public class an_add_application_command : Specification
+{
+    protected static readonly Guid ApplicationIdentifier = Guid.Parse("7f4a3d1c-6f4e-4d0a-9c1b-2b3c4d5e6f70");
+    protected const string ClientIdentifier = "some-client";
+    protected const string Secret = "some-secret";
+
+    protected IGrainFactory _grainFactory;
+    protected IStorage _storage;
+    protected IApplicationStorage _applications;
+    protected IEventSequence _eventLog;
+    protected AddApplication _command;
+
+    void Establish()
+    {
+        _grainFactory = Substitute.For<IGrainFactory>();
+        _storage = Substitute.For<IStorage>();
+        _applications = Substitute.For<IApplicationStorage>();
+        _storage.System.Applications.Returns(_applications);
+
+        _eventLog = Substitute.For<IEventSequence>();
+        _grainFactory.GetGrain<IEventSequence>(Arg.Any<string>()).Returns(_eventLog);
+        _eventLog.Append(
+            Arg.Any<EventSourceId>(),
+            Arg.Any<object>(),
+            Arg.Any<CorrelationId>(),
+            Arg.Any<IEnumerable<Causation>>(),
+            Arg.Any<Identity>(),
+            Arg.Any<IEnumerable<Tag>>(),
+            Arg.Any<EventSourceType>(),
+            Arg.Any<EventStreamType>(),
+            Arg.Any<EventStreamId>()).Returns(AppendResult.Success(CorrelationId.New(), EventSequenceNumber.First));
+
+        _command = new AddApplication(ApplicationIdentifier, ClientIdentifier, Secret);
+    }
+}

--- a/Source/Kernel/Core.Specs/Security/for_AddApplication/when_handling/and_client_id_is_already_registered.cs
+++ b/Source/Kernel/Core.Specs/Security/for_AddApplication/when_handling/and_client_id_is_already_registered.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Security;
+using Cratis.Chronicle.Services.Security;
+
+namespace Cratis.Chronicle.Security.for_AddApplication.when_handling;
+
+/// <summary>
+/// A client id identifies an OAuth client to OpenIddict, so registering it twice would leave token issuance
+/// depending on which of the two records the store happens to return - the command must refuse instead.
+/// </summary>
+public class and_client_id_is_already_registered : given.an_add_application_command
+{
+    Exception _exception;
+
+    void Establish() => _applications.GetByClientId(Arg.Any<ClientId>(), Arg.Any<CancellationToken>()).Returns(new Storage.Security.Application
+    {
+        Id = Guid.NewGuid(),
+        ClientId = ClientIdentifier
+    });
+
+    async Task Because() => _exception = await Catch.Exception(async () => await _command.Handle(_grainFactory, _storage));
+
+    [Fact] void should_reject_the_command() => _exception.ShouldBeOfExactType<ApplicationClientIdAlreadyRegistered>();
+    [Fact] void should_name_the_client_id_in_the_message() => _exception.Message.ShouldContain(ClientIdentifier);
+    [Fact] void should_not_append_any_event() => _eventLog.DidNotReceive().Append(
+        Arg.Any<EventSourceId>(),
+        Arg.Any<object>(),
+        Arg.Any<CorrelationId>(),
+        Arg.Any<IEnumerable<Causation>>(),
+        Arg.Any<Identity>(),
+        Arg.Any<IEnumerable<Tag>>(),
+        Arg.Any<EventSourceType>(),
+        Arg.Any<EventStreamType>(),
+        Arg.Any<EventStreamId>());
+}

--- a/Source/Kernel/Core.Specs/Security/for_AddApplication/when_handling/and_client_id_is_not_registered.cs
+++ b/Source/Kernel/Core.Specs/Security/for_AddApplication/when_handling/and_client_id_is_not_registered.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Security;
+
+namespace Cratis.Chronicle.Security.for_AddApplication.when_handling;
+
+public class and_client_id_is_not_registered : given.an_add_application_command
+{
+    void Establish() => _applications.GetByClientId(Arg.Any<ClientId>(), Arg.Any<CancellationToken>()).Returns((Storage.Security.Application?)null);
+
+    async Task Because() => await _command.Handle(_grainFactory, _storage);
+
+    [Fact] void should_append_application_added_for_the_application() => _eventLog.Received(1).Append(
+        (EventSourceId)ApplicationIdentifier.ToString(),
+        Arg.Is<ApplicationAdded>(_ => _.ClientId == (ClientId)ClientIdentifier),
+        Arg.Any<CorrelationId>(),
+        Arg.Any<IEnumerable<Causation>>(),
+        Arg.Any<Identity>(),
+        Arg.Any<IEnumerable<Tag>>(),
+        Arg.Any<EventSourceType>(),
+        Arg.Any<EventStreamType>(),
+        Arg.Any<EventStreamId>());
+
+    [Fact] void should_store_a_hashed_secret_rather_than_the_plain_text_one() => _eventLog.Received(1).Append(
+        Arg.Any<EventSourceId>(),
+        Arg.Is<ApplicationAdded>(_ => _.ClientSecret.Value != Secret && !string.IsNullOrEmpty(_.ClientSecret.Value)),
+        Arg.Any<CorrelationId>(),
+        Arg.Any<IEnumerable<Causation>>(),
+        Arg.Any<Identity>(),
+        Arg.Any<IEnumerable<Tag>>(),
+        Arg.Any<EventSourceType>(),
+        Arg.Any<EventStreamType>(),
+        Arg.Any<EventStreamId>());
+}

--- a/Source/Kernel/Core/EventStores/EventStoreNames.cs
+++ b/Source/Kernel/Core/EventStores/EventStoreNames.cs
@@ -38,5 +38,5 @@ public record EventStoreNames()
     /// <returns>An observable subject emitting collections of event store names.</returns>
     internal static ISubject<IEnumerable<string>> ObserveEventStores(IStorage storage) =>
         storage.ObserveEventStores()
-            .TransformSubject(stores => stores.Select(s => s.Value));
+            .TransformSubject<IEnumerable<Concepts.EventStoreName>, IEnumerable<string>>(stores => stores.Select(s => s.Value).ToArray());
 }

--- a/Source/Kernel/Core/Namespaces/NamespaceNames.cs
+++ b/Source/Kernel/Core/Namespaces/NamespaceNames.cs
@@ -5,6 +5,7 @@ using System.Reactive.Subjects;
 using Cratis.Arc.Queries.ModelBound;
 using Cratis.Chronicle.Grpc;
 using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Namespaces;
 
 namespace Cratis.Chronicle.Namespaces;
 
@@ -37,5 +38,5 @@ public record NamespaceNames()
         storage.GetEventStore(new Concepts.EventStoreName(eventStore))
             .Namespaces
             .ObserveAll()
-            .TransformSubject(namespaces => namespaces.Select(n => (string)n.Name));
+            .TransformSubject<IEnumerable<NamespaceState>, IEnumerable<string>>(namespaces => namespaces.Select(n => (string)n.Name).ToArray());
 }

--- a/Source/Kernel/Core/Security/AddApplication.cs
+++ b/Source/Kernel/Core/Security/AddApplication.cs
@@ -4,6 +4,7 @@
 using Cratis.Arc.Commands.ModelBound;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.Grpc;
+using Cratis.Chronicle.Storage;
 using Microsoft.AspNetCore.Identity;
 using ApplicationId = Cratis.Chronicle.Concepts.Security.ApplicationId;
 using ClientId = Cratis.Chronicle.Concepts.Security.ClientId;
@@ -25,9 +26,17 @@ public record AddApplication(Guid Id, string ClientId, string ClientSecret)
     /// Handles the command by appending an <see cref="ApplicationAdded"/> event to the event log.
     /// </summary>
     /// <param name="grainFactory">The <see cref="IGrainFactory"/> to get event sequence grains with.</param>
+    /// <param name="storage">The <see cref="IStorage"/> to check existing applications in.</param>
     /// <returns>Awaitable task.</returns>
-    internal async Task Handle(IGrainFactory grainFactory)
+    /// <exception cref="Services.Security.ApplicationClientIdAlreadyRegistered">Thrown when an application with the same client identifier is already registered.</exception>
+    internal async Task Handle(IGrainFactory grainFactory, IStorage storage)
     {
+        var existing = await storage.System.Applications.GetByClientId((ClientId)ClientId);
+        if (existing is not null)
+        {
+            throw new Services.Security.ApplicationClientIdAlreadyRegistered(ClientId);
+        }
+
         var hashedSecret = new PasswordHasher<object>().HashPassword(null!, ClientSecret);
         var @event = new ApplicationAdded((ClientId)ClientId, (ClientSecret)hashedSecret);
         var eventSequence = grainFactory.GetEventLog();

--- a/Source/Kernel/Core/Services/Security/ApplicationClientIdAlreadyRegistered.cs
+++ b/Source/Kernel/Core/Services/Security/ApplicationClientIdAlreadyRegistered.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Services.Security;
+
+/// <summary>
+/// The exception that is thrown when an application is added with a client identifier that is already registered.
+/// </summary>
+/// <param name="clientId">The client identifier that is already in use.</param>
+public class ApplicationClientIdAlreadyRegistered(string clientId) : Exception($"An application with client id '{clientId}' is already registered");

--- a/Source/Kernel/Core/Services/Security/Applications.cs
+++ b/Source/Kernel/Core/Services/Security/Applications.cs
@@ -22,7 +22,7 @@ internal sealed class Applications(IGrainFactory grainFactory, IStorage storage)
     public Task<CommandResult> AddApplication(AddApplicationRequest request, CallContext callContext = default) =>
         CommandExecutor.Execute(
             new Chronicle.Security.AddApplication(request.Id, request.ClientId, request.ClientSecret),
-            command => command.Handle(grainFactory));
+            command => command.Handle(grainFactory, storage));
 
     /// <inheritdoc/>
     public Task<CommandResult> ChangeApplicationSecret(ChangeApplicationSecretRequest request, CallContext callContext = default) =>


### PR DESCRIPTION
# Summary

Follow-up to #2946, which moved the kernel's user, application, event store and namespace operations onto Arc commands and read models with generated gRPC contracts. Verifying that merge end to end surfaced three places where the rewritten code no longer did what the service methods it replaced did.

## Fixed

- Changing a password from the Workbench (including the forced change at login) failed with "Current password is required." because the current password was no longer sent to the kernel
- Adding an application with a client id that is already registered is rejected with a clear message instead of creating a second application with the same client id
- The Workbench's event store and namespace lists were empty on the in-memory storage backend because the observed names failed to serialize
