### PR TITLE
Keep replay results and child removals on the in-memory sink

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -438,6 +438,23 @@ jobs:
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      # A published image that cannot start must fail here, not at the consumer - 15.37.0-15.38.2 shipped
+      # unable to start because nothing ever booted what was pushed. Build the native arch locally and boot it.
+      - name: Build boot-test image
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/Production/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: chronicle-boot-test:production
+          build-args: |
+            VERSION=${{ needs.release.outputs.version }}
+
+      - name: Boot the image before publishing
+        run: bash ./Docker/boot-test.sh chronicle-boot-test:production production
+
       - name: Build Production Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -519,6 +536,20 @@ jobs:
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Build boot-test image
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/Workbench/Dockerfile
+          load: true
+          tags: chronicle-boot-test:workbench
+          build-args: |
+            VERSION=${{ needs.release.outputs.version }}
+
+      - name: Boot the image before publishing
+        run: bash ./Docker/boot-test.sh chronicle-boot-test:workbench workbench
+
       - name: Build Workbench Image
         uses: docker/build-push-action@v5
         with:
@@ -582,6 +613,23 @@ jobs:
           echo "tags<<EOF" >> $GITHUB_OUTPUT
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      # Boots with no environment at all - the documented zero-config consumer invocation. That exact path
+      # aborted at startup for every development image from 16.33.1 onward without CI noticing.
+      - name: Build boot-test image
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/Development/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: chronicle-boot-test:development
+          build-args: |
+            VERSION=${{ needs.release.outputs.version }}
+
+      - name: Boot the image before publishing
+        run: bash ./Docker/boot-test.sh chronicle-boot-test:development development
 
       - name: Build Development Docker Image
         uses: docker/build-push-action@v5
@@ -661,6 +709,21 @@ jobs:
           echo "tags<<EOF" >> $GITHUB_OUTPUT
           echo -e "$TAGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build boot-test image
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ./Docker/DevelopmentSlim/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: chronicle-boot-test:development-slim
+          build-args: |
+            VERSION=${{ needs.release.outputs.version }}
+
+      - name: Boot the image before publishing
+        run: bash ./Docker/boot-test.sh chronicle-boot-test:development-slim development-slim
 
       - name: Build Development Slim Docker Image
         uses: docker/build-push-action@v5

--- a/Docker/boot-test.sh
+++ b/Docker/boot-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Boots a freshly built Chronicle image the way a consumer would and fails unless it comes up healthy.
+# Runs in publish.yml before an image is pushed: a published image that cannot start must fail the
+# publish, not the consumer - server images 15.37.0-15.38.2 shipped unable to start at all, and every
+# development image from 16.33.1 to 16.34.x aborted at startup, because nothing ever booted what was pushed.
+#
+# Usage: boot-test.sh <image> <variant>
+#   variant: development | development-slim | production | workbench
+
+set -euo pipefail
+
+IMAGE="$1"
+VARIANT="$2"
+
+NETWORK="boot-test-net"
+SERVER="boot-test-server"
+MONGO="boot-test-mongo"
+TIMEOUT="${BOOT_TEST_TIMEOUT:-180}"
+
+cleanup() {
+    docker rm -f "$SERVER" "$MONGO" > /dev/null 2>&1 || true
+    docker network rm "$NETWORK" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fail() {
+    echo "::error::Boot test failed for $IMAGE ($VARIANT): $1"
+    echo "--- container logs ($SERVER) ---"
+    docker logs "$SERVER" 2>&1 || true
+    exit 1
+}
+
+start_mongo() {
+    docker run -d --name "$MONGO" --network "$NETWORK" mongo:8 --replSet rs0 --bind_ip_all > /dev/null
+    for _ in $(seq 1 60); do
+        if docker exec "$MONGO" mongosh --quiet --eval "db.adminCommand('ping')" > /dev/null 2>&1; then
+            docker exec "$MONGO" mongosh --quiet --eval \
+                "try { rs.status(); } catch (e) { rs.initiate({_id: 'rs0', members: [{_id: 0, host: '$MONGO:27017'}]}); }" > /dev/null
+            return
+        fi
+        sleep 1
+    done
+    echo "::error::MongoDB for the boot test never became ready"
+    docker logs "$MONGO" 2>&1 || true
+    exit 1
+}
+
+docker network create "$NETWORK" > /dev/null
+
+PORT=35000
+case "$VARIANT" in
+    development)
+        # The documented zero-configuration consumer invocation - no environment, embedded MongoDB.
+        docker run -d --name "$SERVER" --network "$NETWORK" -p 35000:35000 "$IMAGE" > /dev/null
+        ;;
+    production|development-slim)
+        # These images use external storage - run them the way Docker/README.md documents.
+        start_mongo
+        docker run -d --name "$SERVER" --network "$NETWORK" -p 35000:35000 \
+            -e Cratis__Chronicle__Storage__Type=MongoDB \
+            -e "Cratis__Chronicle__Storage__ConnectionDetails=mongodb://$MONGO:27017" \
+            "$IMAGE" > /dev/null
+        ;;
+    workbench)
+        docker run -d --name "$SERVER" -p 8080:80 "$IMAGE" > /dev/null
+        PORT=8080
+        ;;
+    *)
+        echo "Unknown variant: $VARIANT" >&2
+        exit 64
+        ;;
+esac
+
+echo "Waiting up to ${TIMEOUT}s for $IMAGE to listen on port $PORT..."
+for i in $(seq 1 "$TIMEOUT"); do
+    state=$(docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' "$SERVER")
+    if [[ "$state" != running* ]]; then
+        fail "container stopped (state: $state) after ${i}s"
+    fi
+    if (exec 3<> "/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then
+        echo "$IMAGE is listening on port $PORT after ${i}s - confirming it stays up..."
+        sleep 10
+        state=$(docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' "$SERVER")
+        if [[ "$state" != running* ]]; then
+            fail "container bound port $PORT but stopped right after (state: $state)"
+        fi
+        echo "$IMAGE is running and listening on port $PORT."
+        exit 0
+    fi
+    sleep 1
+done
+fail "never listened on port $PORT within ${TIMEOUT}s (container still running - startup hang)"

--- a/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_a_second_replay_follows_the_first.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_a_second_replay_follows_the_first.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Sinks.for_InMemorySink.when_ending_a_replay;
+
+public class and_a_second_replay_follows_the_first : given.a_sink_with_a_replayed_read_model
+{
+    int? _count;
+
+    async Task Establish()
+    {
+        await _sink.BeginReplay(ReplayContext());
+        await _sink.ApplyChanges(_key, ChangesetSettingCountTo(1), 42UL);
+        await _sink.EndReplay(ReplayContext());
+    }
+
+    async Task Because()
+    {
+        await _sink.BeginReplay(ReplayContext());
+        await _sink.EndReplay(ReplayContext());
+        _count = await CurrentCount();
+    }
+
+    [Fact] void should_not_carry_the_first_replay_into_the_second() => _count.ShouldEqual(1);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_the_replay_produced_no_writes.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_the_replay_produced_no_writes.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Sinks.for_InMemorySink.when_ending_a_replay;
+
+public class and_the_replay_produced_no_writes : given.a_sink_with_a_replayed_read_model
+{
+    int? _count;
+
+    async Task Establish()
+    {
+        await _sink.ApplyChanges(_key, ChangesetSettingCountTo(1), 42UL);
+        await _sink.BeginReplay(ReplayContext());
+    }
+
+    async Task Because()
+    {
+        await _sink.EndReplay(ReplayContext());
+        _count = await CurrentCount();
+    }
+
+    [Fact] void should_leave_the_read_model_alone() => _count.ShouldEqual(1);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_the_replay_produced_writes.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/and_the_replay_produced_writes.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.InMemory.Sinks.for_InMemorySink.when_ending_a_replay;
+
+public class and_the_replay_produced_writes : given.a_sink_with_a_replayed_read_model
+{
+    int? _count;
+
+    async Task Establish()
+    {
+        await _sink.ApplyChanges(_key, ChangesetSettingCountTo(1), 42UL);
+        await _sink.BeginReplay(ReplayContext());
+        await _sink.ApplyChanges(_key, ChangesetSettingCountTo(2), 43UL);
+    }
+
+    async Task Because()
+    {
+        await _sink.EndReplay(ReplayContext());
+        _count = await CurrentCount();
+    }
+
+    [Fact] void should_serve_what_the_replay_produced() => _count.ShouldEqual(2);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/given/a_sink_with_a_replayed_read_model.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_ending_a_replay/given/a_sink_with_a_replayed_read_model.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Globalization;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage.ReadModels;
+
+namespace Cratis.Chronicle.Storage.InMemory.Sinks.for_InMemorySink.when_ending_a_replay.given;
+
+public class a_sink_with_a_replayed_read_model : Specification
+{
+    protected InMemorySink _sink;
+    protected Key _key;
+
+    void Establish()
+    {
+        _key = new Key("counter-1", ArrayIndexers.NoIndexers);
+        _sink = new InMemorySink(CreateReadModelDefinition(), new TypeFormats());
+    }
+
+    protected static IChangeset<AppendedEvent, ExpandoObject> ChangesetSettingCountTo(int count)
+    {
+        var state = new ExpandoObject();
+        ((IDictionary<string, object?>)state)["count"] = count;
+
+        PropertyDifference[] differences = [new PropertyDifference(new PropertyPath("count"), null, count)];
+        var propertiesChanged = new PropertiesChanged<ExpandoObject>(state, differences);
+
+        var changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        changeset.InitialState.Returns(new ExpandoObject());
+        Change[] changes = [propertiesChanged];
+        changeset.Changes.Returns(changes);
+        return changeset;
+    }
+
+    protected static ReplayContext ReplayContext() => new(
+        new ReadModelType("test-read-model", ReadModelGeneration.First),
+        "TestReadModel",
+        "TestReadModel-revert",
+        DateTimeOffset.UtcNow);
+
+    protected async Task<int?> CurrentCount()
+    {
+        var instance = await _sink.FindOrDefault(_key);
+        if (instance is null)
+        {
+            return null;
+        }
+
+        return Convert.ToInt32(((IDictionary<string, object?>)instance)["count"], CultureInfo.InvariantCulture);
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-read-model",
+            "TestReadModel",
+            "TestReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, new JsonSchema() }
+            },
+            []);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_removing_a_child_from_all/and_two_read_models_hold_the_child.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Sinks/for_InMemorySink/when_removing_a_child_from_all/and_two_read_models_hold_the_child.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.Storage.InMemory.Sinks.for_InMemorySink.when_removing_a_child_from_all;
+
+public class and_two_read_models_hold_the_child : Specification
+{
+    const string ChildrenProperty = "children";
+    const string IdentifiedByProperty = "childId";
+
+    InMemorySink _sink;
+    Key _written;
+    Key _other;
+    IEnumerable<string> _remainingOnOther;
+
+    async Task Establish()
+    {
+        _written = new Key("parent-1", ArrayIndexers.NoIndexers);
+        _other = new Key("parent-2", ArrayIndexers.NoIndexers);
+        _sink = new InMemorySink(CreateReadModelDefinition(), new TypeFormats());
+
+        // The read model being written has its state rebuilt from the changeset, so only a model the
+        // write does not touch can show that the removal reached every model holding the child.
+        await _sink.ApplyChanges(_other, ChangesetAddingChildren("shared-child", "kept-child"), 1UL);
+    }
+
+    async Task Because()
+    {
+        await _sink.ApplyChanges(_written, ChangesetRemovingChildFromAll("shared-child"), 2UL);
+        _remainingOnOther = await ChildIdsFor(_other);
+    }
+
+    [Fact] void should_remove_the_child_from_a_read_model_the_write_never_touched() => _remainingOnOther.ShouldNotContain("shared-child");
+    [Fact] void should_leave_the_children_that_do_not_match() => _remainingOnOther.ShouldContainOnly(["kept-child"]);
+
+    static IChangeset<AppendedEvent, ExpandoObject> ChangesetAddingChildren(params string[] childIds)
+    {
+        var changes = childIds.Select(childId =>
+        {
+            var child = new ExpandoObject();
+            ((IDictionary<string, object?>)child)[IdentifiedByProperty] = childId;
+
+            return (Change)new ChildAdded(
+                child,
+                new PropertyPath(ChildrenProperty),
+                new PropertyPath(IdentifiedByProperty),
+                childId,
+                ArrayIndexers.NoIndexers);
+        }).ToArray();
+
+        var changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        changeset.InitialState.Returns(new ExpandoObject());
+        changeset.Changes.Returns(changes);
+        return changeset;
+    }
+
+    static IChangeset<AppendedEvent, ExpandoObject> ChangesetRemovingChildFromAll(string childId) =>
+        ChangesetWith(new ChildRemovedFromAll(
+            new PropertyPath(ChildrenProperty),
+            new PropertyPath(IdentifiedByProperty),
+            childId,
+            ArrayIndexers.NoIndexers));
+
+    static IChangeset<AppendedEvent, ExpandoObject> ChangesetWith(Change change)
+    {
+        var changeset = Substitute.For<IChangeset<AppendedEvent, ExpandoObject>>();
+        changeset.InitialState.Returns(new ExpandoObject());
+        Change[] changes = [change];
+        changeset.Changes.Returns(changes);
+        return changeset;
+    }
+
+    async Task<IEnumerable<string>> ChildIdsFor(Key key)
+    {
+        var instance = await _sink.FindOrDefault(key);
+        if (!((IDictionary<string, object?>)instance!).TryGetValue(ChildrenProperty, out var children) || children is null)
+        {
+            return [];
+        }
+
+        return ((IEnumerable<object>)children)
+            .Select(child => (string)((IDictionary<string, object?>)child)[IdentifiedByProperty]!)
+            .ToArray();
+    }
+
+    static ReadModelDefinition CreateReadModelDefinition() =>
+        new(
+            "test-read-model",
+            "TestReadModel",
+            "TestReadModel",
+            ReadModelOwner.Client,
+            ReadModelSource.Code,
+            ReadModelObserverType.Projection,
+            ReadModelObserverIdentifier.Unspecified,
+            SinkDefinition.None,
+            new Dictionary<ReadModelGeneration, JsonSchema>
+            {
+                { ReadModelGeneration.First, new JsonSchema() }
+            },
+            []);
+}

--- a/Source/Kernel/Storage.InMemory/Sinks/InMemorySink.cs
+++ b/Source/Kernel/Storage.InMemory/Sinks/InMemorySink.cs
@@ -151,6 +151,14 @@ public class InMemorySink(
             return Task.FromResult<IEnumerable<FailedPartition>>([]);
         }
 
+        // Removing a child from every model that matches spans documents, so it cannot be expressed by
+        // applying changes to the one being written - the persistent sinks run it across the container
+        // at this point, and leaving it out here dropped it silently.
+        foreach (var childRemovedFromAll in changeset.Changes.OfType<ChildRemovedFromAll>())
+        {
+            RemoveChildFromAll(childRemovedFromAll);
+        }
+
         var result = ApplyActualChanges(key, changeset.Changes, state);
         ((dynamic)result).id = key.Value;
         lock (_collectionLock)
@@ -190,13 +198,22 @@ public class InMemorySink(
     /// <inheritdoc/>
     public Task BeginReplay(ReplayContext context)
     {
-        _isReplaying = true;
+        lock (_collectionLock)
+        {
+            // A replay starts from nothing, so anything a previous replay left behind must go. Keeping it
+            // would let a second replay finish holding documents the first one produced.
+            _rewindCollection.Clear();
+            _rewindLastHandledEventSequenceNumbers.Clear();
+            _isReplaying = true;
+        }
+
         return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
     public Task ResumeReplay(ReplayContext context)
     {
+        // Resuming continues an interrupted replay, so what it has already written is kept.
         _isReplaying = true;
         return Task.CompletedTask;
     }
@@ -204,7 +221,37 @@ public class InMemorySink(
     /// <inheritdoc/>
     public Task EndReplay(ReplayContext context)
     {
-        _isReplaying = false;
+        lock (_collectionLock)
+        {
+            // The replay wrote to the rewind collection, so ending it has to promote that collection -
+            // without this the sink kept serving the pre-replay documents and the entire replay result
+            // was discarded. The persistent sinks swap the replay container in at this point.
+            //
+            // A replay that produced no writes is a no-op, not an instruction to empty the read model:
+            // promoting an empty collection would turn a transient race - the job observing no keys
+            // before the event index caught up - into permanent data loss, which is why MongoDB guards
+            // its rename the same way.
+            if (_rewindCollection.Count > 0)
+            {
+                _collection.Clear();
+                _lastHandledEventSequenceNumbers.Clear();
+
+                foreach (var (key, value) in _rewindCollection)
+                {
+                    _collection[key] = value;
+                }
+
+                foreach (var (key, value) in _rewindLastHandledEventSequenceNumbers)
+                {
+                    _lastHandledEventSequenceNumbers[key] = value;
+                }
+            }
+
+            _rewindCollection.Clear();
+            _rewindLastHandledEventSequenceNumbers.Clear();
+            _isReplaying = false;
+        }
+
         return Task.CompletedTask;
     }
 
@@ -316,6 +363,22 @@ public class InMemorySink(
 
         return !LastHandledEventSequenceNumbers.TryGetValue(keyValue, out var lastHandled) ||
                lastHandled < eventSequenceNumber.Value;
+    }
+
+    void RemoveChildFromAll(ChildRemovedFromAll childRemoved)
+    {
+        lock (_collectionLock)
+        {
+            foreach (var document in Collection.Values)
+            {
+                var children = document.EnsureCollection<ExpandoObject, object>(childRemoved.ChildrenProperty, childRemoved.ArrayIndexers);
+                var child = children.FindByKey(childRemoved.IdentifiedByProperty, childRemoved.Key);
+                if (child is not null)
+                {
+                    children.Remove(child);
+                }
+            }
+        }
     }
 
     ExpandoObject ApplyActualChanges(Key key, IEnumerable<Change> changes, ExpandoObject state)


### PR DESCRIPTION
## Fixed

- Completing a replay against the in-memory sink no longer discards everything the replay produced — the replayed documents are promoted the way the persistent sinks swap in their replay container, while an empty replay is still left as a no-op
- Removing a child from all read models that match on identity now applies on the in-memory sink instead of being silently ignored