### PR TITLE
Fail waiting for observer completion when it cannot be determined

### DIFF
--- a/Documentation/events/observing-appends.mdx
+++ b/Documentation/events/observing-appends.mdx
@@ -50,6 +50,13 @@ When you need to wait until observers affected by an append operation have compl
 
 If any affected observer fails while catching up, the returned result includes failed partitions.
 
+Waiting only means something when there are observers behind the connection. The in-process testing
+surfaces (`EventScenario` and `EventStoreForTesting`) run the event sequence without a silo, so an
+append there never reaches a projection, reducer, or reactor. Rather than report that everything
+completed, `WaitForCompletion()` throws `CannotWaitForObserverCompletion` on an append result that
+carries no observer surface — assert on the scenario's own surface, or move the check to an
+out-of-process integration spec where observers genuinely run.
+
 ### Append
 
 <ChronicleClientTabs snippet="events/observing-appends/wait-for-completion-append" />

--- a/Source/Clients/DotNET.Specs/Observation/for_AppendResultWaitForCompletionExtensions/when_waiting_for_completion/and_there_is_no_observer_surface.cs
+++ b/Source/Clients/DotNET.Specs/Observation/for_AppendResultWaitForCompletionExtensions/when_waiting_for_completion/and_there_is_no_observer_surface.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Observation.for_AppendResultWaitForCompletionExtensions.when_waiting_for_completion;
+
+public class and_there_is_no_observer_surface : Specification
+{
+    AppendResult _appendResult;
+    Exception _exception;
+
+    void Establish() => _appendResult = new AppendResult
+    {
+        EventStore = "event-store",
+        EventStoreNamespace = "event-store-namespace",
+        EventSequenceId = EventSequenceId.Log,
+        SequenceNumber = 42UL
+    };
+
+    async Task Because() => _exception = await Catch.Exception(async () => await _appendResult.WaitForCompletion());
+
+    [Fact] void should_not_report_that_observers_completed() => _exception.ShouldBeOfExactType<CannotWaitForObserverCompletion>();
+}

--- a/Source/Clients/DotNET/EventSequences/EventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/EventSequence.cs
@@ -565,6 +565,18 @@ public class EventSequence(
         };
     }
 
+    /// <summary>
+    /// Gets the observer service to carry on the append result, or <see langword="null"/> when the connection has none.
+    /// </summary>
+    /// <returns>The <see cref="Contracts.Observation.IObservers"/>, or <see langword="null"/> when the connection has no observer surface.</returns>
+    /// <remarks>
+    /// The in-process testing surfaces connect through a services implementation that has no observer surface and
+    /// throws <see cref="NotSupportedException"/> for it, while appending itself must keep working there. The absence
+    /// is therefore carried on the result rather than thrown here - and
+    /// <see cref="Observation.AppendResultWaitForCompletionExtensions.WaitForCompletion"/> turns it into a
+    /// <see cref="Observation.CannotWaitForObserverCompletion"/> at the point where it actually matters. A
+    /// <see langword="null"/> here means "no observer surface exists", never "no observers were affected".
+    /// </remarks>
     Contracts.Observation.IObservers? GetObservers()
     {
         try
@@ -573,6 +585,7 @@ public class EventSequence(
         }
         catch (NotSupportedException)
         {
+            // Deferred, not swallowed: waiting for completion fails by name instead of reporting success.
             return null;
         }
     }

--- a/Source/Clients/DotNET/Observation/AppendResultWaitForCompletionExtensions.cs
+++ b/Source/Clients/DotNET/Observation/AppendResultWaitForCompletionExtensions.cs
@@ -18,6 +18,12 @@ public static class AppendResultWaitForCompletionExtensions
     /// <param name="appendResult">The append result to wait for observer completion for.</param>
     /// <param name="timeout">Optional timeout. If none is provided, it defaults to 5 seconds.</param>
     /// <returns>An <see cref="AppendResultWaitForCompletionResult"/> describing completion and any failures.</returns>
+    /// <exception cref="CannotWaitForObserverCompletion">Thrown when the append result carries no observer surface, which is the case for the in-process testing surfaces.</exception>
+    /// <remarks>
+    /// An append that never reached the log has nothing to wait for and completes trivially. An append that reached
+    /// the log but carries no observer surface is a different thing entirely: completion is unknowable, so it is
+    /// reported as a failure by name rather than as success.
+    /// </remarks>
     public static async Task<AppendResultWaitForCompletionResult> WaitForCompletion(this IAppendResultForObserverCompletion appendResult, TimeSpan? timeout = default)
     {
         if (appendResult.TailSequenceNumber.IsUnavailable)
@@ -25,12 +31,8 @@ public static class AppendResultWaitForCompletionExtensions
             return new(true, []);
         }
 
-        var observers = appendResult.Observers;
-
-        if (observers is null)
-        {
-            return new(true, []);
-        }
+        var observers = appendResult.Observers ??
+            throw new CannotWaitForObserverCompletion(appendResult.EventStore, appendResult.EventSequenceId);
 
         timeout ??= TimeSpanFactory.DefaultTimeout();
         using var cts = new CancellationTokenSource(timeout.Value);

--- a/Source/Clients/DotNET/Observation/CannotWaitForObserverCompletion.cs
+++ b/Source/Clients/DotNET/Observation/CannotWaitForObserverCompletion.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.EventSequences;
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// The exception that is thrown when observer completion is waited for on an append result that carries no observer surface.
+/// </summary>
+/// <remarks>
+/// Waiting is only meaningful against a connection that actually has observers behind it. The in-process testing
+/// surfaces (<c>EventScenario</c>, <c>EventStoreForTesting</c>) run the event sequence without a silo, so no
+/// projection, reducer or reactor ever runs from an append there and there is nothing whose completion could be
+/// observed. Reporting success would let a spec assert that downstream work finished when none of it was ever
+/// started, so the wait fails by name instead - assert on the scenario's own surface, or move the spec to an
+/// out-of-process integration spec where observers genuinely run.
+/// </remarks>
+/// <param name="eventStore">The <see cref="EventStoreName"/> the append targeted.</param>
+/// <param name="eventSequenceId">The <see cref="EventSequenceId"/> the append targeted.</param>
+public class CannotWaitForObserverCompletion(EventStoreName eventStore, EventSequenceId eventSequenceId)
+    : Exception($"Cannot wait for observer completion of event sequence '{eventSequenceId}' in event store '{eventStore}' - the append result carries no observer surface. In-process test scenarios run no observers, so completion cannot be determined.");

--- a/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_waiting_for_observer_completion.cs
+++ b/Source/Clients/Testing.Specs/EventSequences/for_EventScenario/when_waiting_for_observer_completion.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Observation;
+
+namespace Cratis.Chronicle.Testing.EventSequences.for_EventScenario;
+
+/// <summary>
+/// The scenario runs the kernel event sequence grain without a silo, so no projection, reducer or reactor ever runs
+/// from an append here. Waiting for their completion must fail loudly rather than report success - a success would
+/// let a spec assert that downstream work finished when none of it was ever started.
+/// </summary>
+public class when_waiting_for_observer_completion : Specification, IDisposable
+{
+    EventScenario _scenario;
+    AppendResult _appendResult;
+    Exception _exception;
+
+    void Establish() => _scenario = new EventScenario();
+
+    async Task Because()
+    {
+        _appendResult = await _scenario.EventLog.Append(EventSourceId.New(), new TestEvent("hello"));
+        _exception = await Catch.Exception(async () => await _appendResult.WaitForCompletion());
+    }
+
+    [Fact] void should_have_appended_the_event() => _appendResult.ShouldBeSuccessful();
+    [Fact] void should_not_report_that_observers_completed() => _exception.ShouldBeOfExactType<CannotWaitForObserverCompletion>();
+
+    public void Dispose() => _scenario.Dispose();
+}

--- a/Source/Clients/Testing.Specs/Events/for_EventStoreForTesting/when_waiting_for_observer_completion.cs
+++ b/Source/Clients/Testing.Specs/Events/for_EventStoreForTesting/when_waiting_for_observer_completion.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Testing.ReadModels;
+
+namespace Cratis.Chronicle.Testing.Events.for_EventStoreForTesting;
+
+/// <summary>
+/// The in-process event store has no kernel behind it, so an append never reaches an observer. Waiting for observer
+/// completion must fail loudly rather than report success - the same honesty the scenario surface owes a spec author.
+/// </summary>
+public class when_waiting_for_observer_completion : Specification
+{
+    IClientArtifactsProvider _clientArtifactsProvider;
+    EventStoreForTesting _eventStore;
+    AppendResult _appendResult;
+    Exception _exception;
+
+    void Establish()
+    {
+        _clientArtifactsProvider = Substitute.For<IClientArtifactsProvider>();
+        _clientArtifactsProvider.EventTypes.Returns([typeof(ModuleCreated)]);
+        _eventStore = new EventStoreForTesting(null, _clientArtifactsProvider);
+    }
+
+    async Task Because()
+    {
+        _appendResult = await _eventStore.EventLog.Append(EventSourceId.New(), new ModuleCreated("Some module"));
+        _exception = await Catch.Exception(async () => await _appendResult.WaitForCompletion());
+    }
+
+    [Fact] void should_have_appended_the_event() => _appendResult.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_report_that_observers_completed() => _exception.ShouldBeOfExactType<CannotWaitForObserverCompletion>();
+}

--- a/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
+++ b/Source/Clients/Testing/EventSequences/InProcessEventSequence.cs
@@ -23,11 +23,26 @@ namespace Cratis.Chronicle.Testing.EventSequences;
 /// Factory for creating and setting up a kernel <see cref="KernelEventSequences::EventSequence"/> grain for in-process testing.
 /// </summary>
 /// <remarks>
-/// The kernel grain runs fully in-process without a real Orleans silo. Real implementations are used for all
-/// dependencies except <c>IStorage</c> (in-memory) and
-/// <see cref="Metrics.IMeter{T}"/> / <see cref="Microsoft.Extensions.Logging.ILogger{T}"/> (null implementations).
-/// This means constraint validation, hash calculation, event serialization, migration, and compliance all run
-/// through the actual kernel code paths.
+/// <para>
+/// The kernel grain runs in-process without a real Orleans silo. Real implementations are used for all
+/// dependencies except <c>IStorage</c> (in-memory) and <see cref="Microsoft.Extensions.Logging.ILogger{T}"/>
+/// (null logger). This means constraint validation, hash calculation, event serialization, migration, and
+/// compliance all run through the actual kernel code paths.
+/// </para>
+/// <para>
+/// <b>What it deliberately does not run: observers.</b> The grain is constructed directly and its
+/// <c>OnActivateAsync</c> - which is what an Orleans silo would call - never runs, so the appended-events queue it
+/// would resolve there stays unset and the enqueue after each append is a no-op. No projection, reducer or reactor
+/// is ever driven by an append made here. Waiting for observer completion on the resulting append result therefore
+/// throws <see cref="Observation.CannotWaitForObserverCompletion"/> rather than reporting that everything completed.
+/// </para>
+/// <para>
+/// The unset activation state is otherwise benign: the constraint-version check resolves to
+/// <see cref="InProcessConstraintsGrain"/> and is a no-op, the state-persistence interval keeps its field default,
+/// and the meter passed as <see langword="null"/> is only ever dereferenced inside <c>OnActivateAsync</c> - every
+/// metrics call on the append path goes through a null-conditional scope. Adding a kernel-side use of any of these
+/// outside <c>OnActivateAsync</c> would break that, so keep this list in step with the grain.
+/// </para>
 /// </remarks>
 internal static class InProcessEventSequence
 {


### PR DESCRIPTION
## Added

- `CannotWaitForObserverCompletion` names the case where completion cannot be established

## Changed

- Waiting for observer completion on an append that carries no observer surface now fails by name instead of reporting success, so an in-process spec can no longer assert that downstream work finished when none of it was started