### PR TITLE
Freeze spec sleeps behind a per-file ratchet

### DIFF
--- a/.ai/rules/specs.csharp.md
+++ b/.ai/rules/specs.csharp.md
@@ -96,6 +96,26 @@ From `Cratis.Specifications`: `.ShouldEqual(expected)`, `.ShouldBeTrue()`, `.Sho
 - Single-statement assertion lambdas use expression-body form (RCS1021) — `[Fact] void should_x() => result.ShouldEqual(...)`, not a `{ … }` block. Don't break long `should_` lines; don't add blank lines between `should_` methods.
 - **Prefer a concept's sentinel over a raw empty primitive.** When a `ConceptAs<T>` / `EventSourceId<T>` value is expected — as an argument, a mock setup, or an assertion — use its `NotSet` (or `Empty` / `New()`) static rather than a `string.Empty` / `Guid.Empty` / `0` that implicitly converts. It states intent and survives a sentinel-value change (see [concepts.md](./concepts.md)). Reserve raw `string.Empty` for genuinely non-concept `string` values (e.g. asserting a decrypted-to-empty JSON payload).
 
+## Never sleep — await a fact, not a duration
+
+**A spec never waits on the clock for the system under test.** `Thread.Sleep`, a bare `Task.Delay`, or a `SpinWait` before an assertion makes the spec pass because the machine happened to be fast enough, and it silently writes today's latency into the suite: the next fix that shifts timing in the observer/projection core then breaks specs that have nothing to do with it. That coupling — not the bugs being fixed — is the single largest source of regressions in Chronicle, and it is why fixes there keep getting rolled back.
+
+Wait on a signal instead:
+
+| Waiting for | Await |
+|---|---|
+| observers to catch up with an append | `appendResult.WaitForCompletion()` |
+| client artifacts to be registered with the kernel | `eventStore.WaitForRegistration()` |
+| an observer's state or position | `WaitTillActive` / `WaitTillSubscribed` / `WaitTillReachesEventSequenceNumber` / `WaitForState` (reactors, reducers, projections) |
+| a job | the `JobsWaitHelpers` extensions |
+| anything with no helper yet | build the signal: a `SemaphoreSlim` (or `TaskCompletionSource`) released by the code that observes the event, awaited under a timeout — `Source/Clients/XUnit.Integration/EventAppendCollection.cs` is the shipped example, and it never polls |
+
+A **deadline** is not a sleep — every helper above takes a `timeout`, and a timeout is what turns a hang into a named failure. Sleeping *between* re-checks is: a poll loop is a completion signal you have not built yet, so add the signal rather than another `while` + `Task.Delay`.
+
+Three delays are not waits at all and stay allowed — say which one it is in a comment: a test double that is **slow on purpose** so the test can observe it mid-flight (`Task.Delay(HandleTime)`), an **infrastructure readiness backoff** between retries of a connect/start that can legitimately fail, and a `Task.Delay(1)` / `Task.Yield()` that **widens an interleaving window** in a concurrency spec.
+
+The sleeps that predate this rule are frozen per file in `.github/timing-coupling-baseline.txt`; `.github/workflows/timing-coupling-ratchet.yml` fails a pull request that raises any entry or adds a file. The numbers may only go down.
+
 ## What NOT to spec
 
 Simple properties are compiler-verified. Save spec effort for business logic, coordination between dependencies, and complex transformations.

--- a/.github/scripts/assert-timing-coupling-ratchet.py
+++ b/.github/scripts/assert-timing-coupling-ratchet.py
@@ -1,0 +1,171 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Fails the build when a spec or integration file gains a sleep it did not already have.
+
+Twenty of the last seventy-three regressions were fixes to the timing-coupled observer and
+projection core that broke a sibling path, because the suites wait on the clock instead of on
+a completion signal - `63cf43e38` states outright that the integration suite depends on "the
+implicit 50ms settling buffer". Deterministic completion signals are the real repair; until
+they exist this holds the line so the class stops growing while it is being dismantled.
+
+The baseline is per file rather than a global total. A global number lets one file's
+improvement pay for another file's regression and says nothing about where the failure is; a
+per-file number localizes the failure and lets the migration retire files one at a time.
+Entries may only go down, and a file that is not listed may not sleep at all.
+
+Run with `--report` to print the current counts in baseline format. That is how the baseline
+was seeded and how it is regenerated after a rename - it only writes to stdout, so the change
+still arrives as a reviewable diff.
+"""
+
+import os
+import re
+import sys
+
+BASELINE = ".github/timing-coupling-baseline.txt"
+SEARCH_ROOTS = ("Source", "Integration")
+EXCLUDED_SEGMENTS = {"bin", "obj", "node_modules"}
+EXCLUDED_PATHS = (".claude/worktrees/",)
+SLEEPS = re.compile(r"\b(?:Thread\.Sleep|Task\.Delay|SpinWait|Task\.Yield)\b")
+
+RULE = ".ai/rules/specs.csharp.md"
+
+
+def normalize(path):
+    """Returns a repository-relative path with forward slashes and no leading `./`."""
+    normalized = path.replace("\\", "/")
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def is_in_scope(path):
+    """Returns whether a repository-relative path belongs to the spec and integration suites."""
+    if any(_ in path for _ in EXCLUDED_PATHS):
+        return False
+
+    if path.startswith("Integration/") or path.startswith("Source/Clients/XUnit.Integration/"):
+        return True
+
+    return any(_.endswith(".Specs") for _ in path.split("/"))
+
+
+def sleep_lines(path):
+    """Returns the line numbers where a file waits on the clock, ignoring commented-out code."""
+    with open(path, encoding="utf-8", errors="ignore") as file:
+        lines = file.read().splitlines()
+
+    found = []
+    for number, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if stripped.startswith("//") or stripped.startswith("*"):
+            continue
+
+        found.extend([number] * len(SLEEPS.findall(line)))
+
+    return found
+
+
+def counts_on_disk(root):
+    """Returns the sleep line numbers per in-scope file that has any."""
+    found = {}
+    for search_root in SEARCH_ROOTS:
+        for directory, directories, files in os.walk(os.path.join(root, search_root)):
+            directories[:] = [_ for _ in directories if _ not in EXCLUDED_SEGMENTS]
+            relative = normalize(os.path.relpath(directory, root))
+            for name in files:
+                path = f"{relative}/{name}"
+                if not name.endswith(".cs") or not is_in_scope(path):
+                    continue
+
+                lines = sleep_lines(os.path.join(root, relative, name))
+                if lines:
+                    found[path] = lines
+
+    return found
+
+
+def baseline_counts(root):
+    """Returns the allowed sleep count per file as recorded in the committed baseline."""
+    path = os.path.join(root, BASELINE)
+    if not os.path.isfile(path):
+        print(f"::error::{BASELINE} is missing. The ratchet cannot run without its baseline.")
+        sys.exit(1)
+
+    allowed = {}
+    with open(path, encoding="utf-8") as file:
+        for line in file:
+            entry = line.split("#")[0].strip()
+            if not entry:
+                continue
+
+            count, name = entry.split(None, 1)
+            allowed[normalize(name.strip())] = int(count)
+
+    return allowed
+
+
+def report(on_disk):
+    """Prints the current counts in baseline format, for seeding or regenerating the baseline."""
+    for path in sorted(on_disk):
+        print(f"{len(on_disk[path])} {path}")
+
+
+def raised(on_disk, allowed):
+    """Reports every file that gained a sleep, and returns whether any did."""
+    failed = False
+    for path in sorted(on_disk):
+        current = len(on_disk[path])
+        if path not in allowed:
+            failed = True
+            print(
+                f"::error file={path}::{path} is not in {BASELINE} and waits on the clock "
+                f"{current} time(s), on line(s) {', '.join(str(_) for _ in on_disk[path])}. A spec "
+                f"awaits a fact, not a duration - see {RULE}. If the delay is genuinely not a wait "
+                f"(a test double that is slow on purpose, an infrastructure readiness backoff, or a "
+                f"`Task.Delay(1)` widening an interleaving window), add the entry to {BASELINE} and "
+                f"state which one it is in the pull request."
+            )
+            continue
+
+        if current > allowed[path]:
+            failed = True
+            print(
+                f"::error file={path}::{path} waits on the clock {current} time(s) but "
+                f"{BASELINE} allows {allowed[path]}. The new site(s) are among line(s) "
+                f"{', '.join(str(_) for _ in on_disk[path])}. Baseline entries may only decrease - "
+                f"await a fact instead, see {RULE}."
+            )
+
+    return failed
+
+
+def lowered(on_disk, allowed):
+    """Reports every baseline entry that is now too high, so the author can ratchet it down."""
+    for path in sorted(allowed):
+        current = len(on_disk.get(path, []))
+        if current < allowed[path]:
+            remaining = f"lower its entry to {current}" if current else f"delete its entry from {BASELINE}"
+            print(f"::notice file={path}::{path} now waits on the clock {current} time(s) instead of {allowed[path]} - {remaining}.")
+
+
+def main():
+    """Reports every file that exceeds its baseline as an error and every improvement as a notice."""
+    root = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith("-") else "."
+    on_disk = counts_on_disk(root)
+
+    if "--report" in sys.argv:
+        report(on_disk)
+        return 0
+
+    allowed = baseline_counts(root)
+    total = sum(len(_) for _ in on_disk.values())
+    print(f"{total} sleep site(s) across {len(on_disk)} file(s); {BASELINE} allows {sum(allowed.values())} across {len(allowed)}")
+
+    failed = raised(on_disk, allowed)
+    lowered(on_disk, allowed)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/timing-coupling-baseline.txt
+++ b/.github/timing-coupling-baseline.txt
@@ -1,0 +1,109 @@
+# Timing-coupling ratchet baseline - enforced by .github/scripts/assert-timing-coupling-ratchet.py
+#
+# Each entry is `<count> <path>`: how many `Thread.Sleep` / `Task.Delay` / `SpinWait` /
+# `Task.Yield` sites that file is allowed to contain. A pull request fails when a file exceeds
+# its entry, and when a file that is not listed here sleeps at all.
+#
+# ENTRIES MAY ONLY DECREASE. The ratchet is one-way: removing a sleep and lowering the number
+# needs no explanation, raising one or adding a file needs a stated reason in the pull request.
+# The check prints a notice naming every entry that can now be lowered.
+#
+# A spec awaits a fact, not a duration - see .ai/rules/specs.csharp.md. These entries are the
+# ones that predate that rule; twenty of the last seventy-three regressions were fixes to the
+# timing-coupled observer and projection core that broke a sibling path, which is what this
+# freeze exists to stop growing. Deterministic completion signals are the real repair.
+#
+# An unannotated entry is a wait that stands in for a missing completion signal - work for the
+# migration. An annotated one is a delay that is not a wait at all and is expected to stay:
+#   knob        - a test double that is slow on purpose, so the test can observe it mid-flight
+#   readiness   - an infrastructure backoff between retries of a connect/start that can fail
+#   deadline    - the timeout arm of a `Task.WhenAny`, which is a bound and not a settle
+#   interleave  - a `Task.Delay(1)` / `Task.Yield()` widening a window in a concurrency spec
+#
+# Regenerate after a rename with `python3 .github/scripts/assert-timing-coupling-ratchet.py
+# --report`, then carry the annotations back over - `--report` prints counts only.
+
+2 Integration/Client/ChronicleConfigurableFixture.cs  # readiness
+1 Integration/Client/Projections/Scenarios/ModelBound/when_projecting_with_nested_in_children/clearing_the_nested_object.cs
+1 Integration/Client/Projections/Scenarios/given/a_projection_and_events_appended_to_it.cs
+1 Integration/Client/Projections/Scenarios/when_projecting_with_deferred_parent_resolution/and_resolves_through_second_event_type.cs
+1 Integration/Client/Projections/Scenarios/when_projecting_with_functions/counting_events_per_key.cs
+1 Integration/Client/Projections/Scenarios/when_projecting_with_functions/decrementing_per_key.cs
+1 Integration/Client/Projections/Scenarios/when_projecting_with_functions/incrementing_per_key.cs
+1 Integration/Client/Projections/Scenarios/when_updating_projection_definition/for_materialized_projection_with_deactivated_subscriber.cs
+1 Integration/Client/for_EventSequence/when_appending_events_with_multiple_generation_migrations/UserRegisteredReactor.cs
+1 Integration/Client/for_EventSequence/when_appending_events_with_multiple_generation_migrations/UserRegisteredReducer.cs
+1 Integration/Client/for_EventSequence/when_appending_events_with_multiple_generation_migrations/and_observers_consume_second_generation.cs
+2 Integration/Client/for_EventSequence/when_redacting/EventSequenceRedactionViaSequenceWaitHelpers.cs
+1 Integration/Client/for_EventSequence/when_redacting/NonReplayableReactor.cs
+1 Integration/Client/for_EventSequence/when_redacting/ReactorSubscribedToEventRedacted.cs
+1 Integration/Client/for_EventSequence/when_redacting/SomeReactor.cs
+1 Integration/Client/for_EventSequence/when_redacting/SomeReducer.cs
+1 Integration/Client/for_EventSequence/when_revising/NonReplayableReactor.cs
+1 Integration/Client/for_EventSequence/when_revising/SomeReactor.cs
+1 Integration/Client/for_EventSequence/when_revising/SomeReducer.cs
+1 Integration/Client/for_EventSequence/when_server_restarts/and_events_are_appended_before_restart.cs  # readiness
+1 Integration/Client/for_EventStoreSubscriptions/given/multi_event_store_subscription_setup.cs
+1 Integration/Client/for_EventStoreSubscriptions/given/subscription_states_after_subscribing.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_registering_implicit_subscriptions/and_reactor_infers_external_inbox_subscription.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_subscribing/and_filtering_event_types.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_subscribing/and_forwarding_to_default_namespace.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_subscribing/and_multiple_source_namespaces_send_to_different_targets.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_subscribing/and_reactors_coordinate_tenant_outbox_forwarding.cs
+1 Integration/Client/for_EventStoreSubscriptions/when_subscribing/and_same_namespace_subscribes_from_multiple_sources.cs
+1 Integration/Client/for_PIIManager/when_erasing_a_subject_whose_key_was_forwarded_to_another_event_store.cs
+1 Integration/Client/for_Reactors/ReactorFilteredByEventSourceType.cs  # knob
+1 Integration/Client/for_Reactors/ReactorFilteredByEventStreamType.cs  # knob
+1 Integration/Client/for_Reactors/ReactorFilteredByTag.cs  # knob
+2 Integration/Client/for_Reactors/ReactorThatCanFail.cs
+2 Integration/Client/for_Reactors/ReactorWithReplayHandler.cs
+1 Integration/Client/for_Reactors/ReactorWithoutDelay.cs
+1 Integration/Client/for_Reactors/ReactorWithoutDelayHandlingPii.cs
+1 Integration/Client/for_Reactors/SomeReactor.cs  # knob
+1 Integration/Client/for_ReadModels/given/a_projection_with_events.cs
+1 Integration/Client/for_ReadModels/given/a_projection_with_many_instances.cs
+1 Integration/Client/for_ReadModels/when_a_composed_read_model_lifts_pii/given/two_stored_subjects.cs
+1 Integration/Client/for_ReadModels/when_a_projection_redirects_its_key/and_the_source_subject_is_erased.cs
+1 Integration/Client/for_ReadModels/when_a_read_model_has_a_collection_of_pii_concepts/and_reading_the_instance.cs
+1 Integration/Client/for_ReadModels/when_a_read_model_has_a_collection_of_pii_concepts/and_the_elements_are_objects.cs
+1 Integration/Client/for_ReadModels/when_a_read_model_has_a_nested_pii_concept/and_reading_the_instance.cs
+1 Integration/Client/for_ReadModels/when_a_read_model_has_a_pii_value_object/and_reading_the_instance.cs
+1 Integration/Client/for_ReadModels/when_a_read_model_has_pii_beside_a_geospatial_value/and_reading_the_instance.cs
+1 Integration/Client/for_ReadModels/when_a_subject_owns_a_pii_child_collection/and_reading_the_child_collection.cs
+1 Integration/Client/for_ReadModels/when_getting_instance_with_an_unset_optional/and_the_optional_is_an_enum.cs
+1 Integration/Client/for_ReadModels/when_getting_instances/and_read_model_has_pii_property.cs
+1 Integration/Client/for_ReadModels/when_projecting_a_large_number_of_events/across_many_event_sources.cs
+1 Integration/Client/for_Reducers/ConceptCollectionReducer.cs
+1 Integration/Client/for_Reducers/PointLocationReducer.cs
+1 Integration/Client/for_Reducers/ReducerFilteredByEventSourceType.cs  # knob
+1 Integration/Client/for_Reducers/ReducerFilteredByEventStreamType.cs  # knob
+1 Integration/Client/for_Reducers/ReducerFilteredByTag.cs  # knob
+2 Integration/Client/for_Reducers/ReducerThatCanFail.cs
+1 Integration/Client/for_Reducers/ReducerWithoutDelay.cs
+1 Integration/Client/for_Reducers/ReducerWithoutDelayHandlingPii.cs
+1 Integration/Client/for_Reducers/SlowReducerThatSignalsCompletion.cs  # knob
+1 Integration/Client/for_Reducers/SomeReducer.cs  # knob
+1 Integration/Client/for_Reducers/when_handling_concept_collection/and_reducer_persists_the_concept_collection.cs
+1 Integration/Client/for_Webhooks/InvokedWebhooks.cs
+1 Integration/Client/for_Webhooks/given/webhook_states_after_registering.cs
+2 Integration/Clustering/ClusteringFixture.cs
+1 Integration/Clustering/for_Clustering/when_replaying_a_collapsing_projection.cs
+1 Integration/Clustering/for_ScaledOutClients/ReactorInvocationSignal.cs
+1 Integration/Kernel/for_JobsManager/given/TheJobStep.cs  # knob
+1 Integration/Kernel/for_JobsManager/when_starting/job_with_single_step/and_job_step_fails.cs
+1 Source/Clients/Connections.Specs/for_ConnectionWatchdog/given/a_connection_watchdog.cs  # interleave
+1 Source/Clients/Connections.Specs/for_ConnectionWatchdog/when_keep_alive_is_fresh.cs
+1 Source/Clients/Connections.Specs/for_ConnectionWatchdog/when_starting_twice.cs
+1 Source/Clients/XUnit.Integration/ChronicleFixture.cs  # readiness
+1 Source/Clients/XUnit.Integration/ChronicleOrleansFixture.cs
+1 Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_backpressure/and_channel_capacity_is_exceeded.cs
+3 Source/Kernel/Core.Specs/EventSequences/for_AppendedEventsQueue/when_enqueuing/with_backpressure/and_the_catchup_trigger_faults.cs
+1 Source/Kernel/Core.Specs/Jobs/for_JobStepThrottle/when_acquiring_and_releasing_slots.cs  # knob
+1 Source/Kernel/Core.Specs/Jobs/for_JobStepThrottle/when_observer_partition_limit_is_lower_than_job_step_limit.cs
+1 Source/Kernel/Core.Specs/Observation/EventStoreSubscriptions/for_EventStoreSubscriptionsManager/when_waiting_until_subscribed/and_subscription_definition_arrives_while_waiting.cs
+1 Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ProjectionHandleLock/when_acquiring_coarsely_while_a_stripe_is_held.cs  # deadline
+1 Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ProjectionHandleLock/when_different_event_source_ids_are_acquired_concurrently.cs  # deadline
+1 Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ProjectionHandleLock/when_the_same_event_source_id_is_acquired_concurrently.cs  # interleave
+1 Source/Kernel/Core.Specs/Projections/Engine/Pipelines/for_ProjectionPipeline/given/a_striped_pipeline_over_a_shared_read_model.cs  # interleave
+1 Source/Kernel/Services.Specs/ConcurrentCallGate.cs  # deadline
+1 Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/for_EventCursor/given/a_cursor_over_a_context_whose_async_disposal_suspends.cs  # interleave

--- a/.github/workflows/timing-coupling-ratchet.yml
+++ b/.github/workflows/timing-coupling-ratchet.yml
@@ -1,0 +1,34 @@
+name: Timing Coupling Ratchet
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "**/*.Specs/**/*.cs"
+      - "Integration/**/*.cs"
+      - "Source/Clients/XUnit.Integration/**/*.cs"
+      - ".github/timing-coupling-baseline.txt"
+      - ".github/scripts/assert-timing-coupling-ratchet.py"
+      - ".github/workflows/timing-coupling-ratchet.yml"
+
+permissions:
+  contents: read
+
+# Its own workflow rather than a step in dotnet-build, because it needs nothing but the
+# checkout and must report on a pull request that never reaches a compiler - and because a
+# suite that waits on the clock is a review conversation, not a build failure to be retried.
+jobs:
+  timing-coupling-ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Assert no spec or integration file gained a sleep
+        run: python3 .github/scripts/assert-timing-coupling-ratchet.py


### PR DESCRIPTION
# Summary

Internal specs and CI only: adds the missing rule that a spec awaits a fact rather than a duration, and freezes the sleeps that predate it per file so the count can only go down. No existing sleep is removed and no timing behavior changes. No user-facing changes.