### PR TITLE
Run the full out-of-process matrix on hot-core changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,51 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Review ownership of the hot core.
+#
+# Only the hot core is listed. Ownership over the whole repository would put a maintainer in front of
+# every documentation typo and would be routed around within a week; this file exists so that the
+# areas where a fix breaks a sibling path - and where an autofix bot has twice committed a mechanical
+# rewrite that broke the build outright (`c237e5e74`, `aedafe1bc`) - cannot change without a
+# maintainer looking at it.
+#
+# The paths below mirror `.github/hot-core-paths.txt` one for one, and
+# `.github/scripts/detect-hot-core-changes.py --verify` fails the build if they ever stop matching.
+# That script runs on every pull request, so the two contracts cannot drift in silence.
+#
+# PLACEHOLDER-OWNER: the owner below is a placeholder and does not resolve. A CODEOWNERS entry whose
+# owner is not a real user or team that has read access to this repository is ignored by GitHub - the
+# file parses, the rule is listed, and nothing whatsoever is enforced. Replace
+# `@Cratis/kernel-maintainers` with the real team or users and delete this paragraph, including the
+# `PLACEHOLDER-OWNER` marker: the hot-core gate emits a warning on every pull request while the
+# marker is present, and stops as soon as it is gone. Ownership only becomes review *enforcement*
+# once "Require review from Code Owners" is enabled in branch protection, which is a repository
+# setting and not something this file can do on its own.
+
+# area: Observer handling
+/Source/Kernel/Core/Observation/ @Cratis/kernel-maintainers
+
+# area: Projection key resolution and the changeset pipeline
+/Source/Kernel/Core/Projections/ @Cratis/kernel-maintainers
+
+# area: Changeset consolidation
+/Source/Infrastructure/Changes/ @Cratis/kernel-maintainers
+
+# area: AppendedEventsQueue
+/Source/Kernel/Core/EventSequences/*AppendedEventsQueue* @Cratis/kernel-maintainers
+
+# area: Compliance (PII and encryption)
+/Source/Kernel/Core/Compliance/ @Cratis/kernel-maintainers
+
+# area: MongoDB sink
+/Source/Kernel/Storage.MongoDB/Sinks/ @Cratis/kernel-maintainers
+
+# area: SQL sink
+/Source/Kernel/Storage.Sql/Sinks/ @Cratis/kernel-maintainers
+
+# The contracts that decide all of the above. Weakening the hot-core list, the gate, or this file
+# should cost the same review as changing the code they protect.
+/.github/CODEOWNERS @Cratis/kernel-maintainers
+/.github/hot-core-paths.txt @Cratis/kernel-maintainers
+/.github/workflows/hot-core-gate.yml @Cratis/kernel-maintainers
+/.github/scripts/detect-hot-core-changes.py @Cratis/kernel-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,39 +13,36 @@
 # `.github/scripts/detect-hot-core-changes.py --verify` fails the build if they ever stop matching.
 # That script runs on every pull request, so the two contracts cannot drift in silence.
 #
-# PLACEHOLDER-OWNER: the owner below is a placeholder and does not resolve. A CODEOWNERS entry whose
-# owner is not a real user or team that has read access to this repository is ignored by GitHub - the
-# file parses, the rule is listed, and nothing whatsoever is enforced. Replace
-# `@Cratis/kernel-maintainers` with the real team or users and delete this paragraph, including the
-# `PLACEHOLDER-OWNER` marker: the hot-core gate emits a warning on every pull request while the
-# marker is present, and stops as soon as it is gone. Ownership only becomes review *enforcement*
-# once "Require review from Code Owners" is enabled in branch protection, which is a repository
-# setting and not something this file can do on its own.
+# Ownership here requests review; it does not require it. "Require review from Code Owners" is a
+# branch-protection setting and is deliberately NOT enabled, so a pull request touching these paths
+# auto-requests @Cratis/core and can still merge without their approval. What does block is the
+# `hot-core-gate` check, which runs the full out-of-process integration matrix for changes under
+# these paths. Enabling code-owner review later needs no change to this file.
 
 # area: Observer handling
-/Source/Kernel/Core/Observation/ @Cratis/kernel-maintainers
+/Source/Kernel/Core/Observation/ @Cratis/core
 
 # area: Projection key resolution and the changeset pipeline
-/Source/Kernel/Core/Projections/ @Cratis/kernel-maintainers
+/Source/Kernel/Core/Projections/ @Cratis/core
 
 # area: Changeset consolidation
-/Source/Infrastructure/Changes/ @Cratis/kernel-maintainers
+/Source/Infrastructure/Changes/ @Cratis/core
 
 # area: AppendedEventsQueue
-/Source/Kernel/Core/EventSequences/*AppendedEventsQueue* @Cratis/kernel-maintainers
+/Source/Kernel/Core/EventSequences/*AppendedEventsQueue* @Cratis/core
 
 # area: Compliance (PII and encryption)
-/Source/Kernel/Core/Compliance/ @Cratis/kernel-maintainers
+/Source/Kernel/Core/Compliance/ @Cratis/core
 
 # area: MongoDB sink
-/Source/Kernel/Storage.MongoDB/Sinks/ @Cratis/kernel-maintainers
+/Source/Kernel/Storage.MongoDB/Sinks/ @Cratis/core
 
 # area: SQL sink
-/Source/Kernel/Storage.Sql/Sinks/ @Cratis/kernel-maintainers
+/Source/Kernel/Storage.Sql/Sinks/ @Cratis/core
 
 # The contracts that decide all of the above. Weakening the hot-core list, the gate, or this file
 # should cost the same review as changing the code they protect.
-/.github/CODEOWNERS @Cratis/kernel-maintainers
-/.github/hot-core-paths.txt @Cratis/kernel-maintainers
-/.github/workflows/hot-core-gate.yml @Cratis/kernel-maintainers
-/.github/scripts/detect-hot-core-changes.py @Cratis/kernel-maintainers
+/.github/CODEOWNERS @Cratis/core
+/.github/hot-core-paths.txt @Cratis/core
+/.github/workflows/hot-core-gate.yml @Cratis/core
+/.github/scripts/detect-hot-core-changes.py @Cratis/core

--- a/.github/hot-core-paths.txt
+++ b/.github/hot-core-paths.txt
@@ -1,0 +1,71 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# The hot core - the areas where a fix breaks a sibling path.
+#
+# THE RULE: a pull request touching any path listed here runs the full out-of-process integration
+# matrix and must have it green, and needs a review from the owner in `.github/CODEOWNERS`.
+#
+# This file is a committed contract, not documentation. `.github/scripts/detect-hot-core-changes.py`
+# reads it on every pull request and decides whether `.github/workflows/hot-core-gate.yml` runs the
+# matrix or no-ops green, and the same script asserts that every pattern here is also owned in
+# `.github/CODEOWNERS` - so the two can never drift apart in silence.
+#
+# WHY THESE AREAS AND NOT OTHERS: twenty of the last seventy-three regressions were fixes that broke
+# a sibling path, and they concentrate in the areas below. Twice the repair was a rollback that
+# deliberately reinstated a known bug because the fix could not be made without breaking a sibling
+# (`b3e03dbb8`, `d1c168c7e`). The out-of-process integration matrix is the only oracle that has
+# reliably caught this class, and on a pull request it otherwise runs the default storage backend
+# only - so the three non-default backends, where the sibling breakage usually surfaces, are exactly
+# what a hot-core change is currently allowed to merge without.
+#
+# FORMAT: one pattern per line, under an `# area:` heading that names the area it belongs to; the
+# heading is what the gate prints back to the author. `**` matches any character including `/`, `*`
+# matches any character except `/`. Every pattern is verified to match at least one tracked file, so
+# the list cannot rot into fiction after a rename - the plan's own path list had already gone stale
+# (`Source/Kernel/Grains/Observation` moved to `Source/Kernel/Core/Observation`) before it was wired.
+#
+# Spec trees are deliberately absent. `Source/Kernel/Core.Specs/**` and the integration suites change
+# constantly and a change confined to them cannot break a sibling runtime path; including them would
+# make the expensive matrix the default and teach everyone to route around it.
+
+# area: Observer handling
+# `Observer.Handling.cs` and the rest of the observer grain family - catchup, replay, failing,
+# rescue, watchdog, subscriber selection. The single densest source of the "fixed one path, broke
+# the neighbouring one" incidents, because every observer kind shares this state machine.
+Source/Kernel/Core/Observation/**
+
+# area: Projection key resolution and the changeset pipeline
+# `Projections/Engine/KeyResolvers.cs` decides which read-model document an event lands on;
+# `Projections/Engine/Pipelines/**` and the `ProjectionChangeset*` mediator/notifier/forwarder carry
+# the changeset from the engine to the sink. A key-resolution change that is right for one shape of
+# projection - root join, keyed child, parent hierarchy - has repeatedly been wrong for another.
+Source/Kernel/Core/Projections/**
+
+# area: Changeset consolidation
+# `Changeset.cs` consolidates child additions, resolved joins and property changes into the set of
+# changes a sink applies. Its consolidation rules are the shared substrate under every sink, so a
+# change here reaches MongoDB and SQL at once.
+Source/Infrastructure/Changes/**
+
+# area: AppendedEventsQueue
+# The fan-out from an append to every subscribed observer, including backpressure, coalescing and
+# partition interleaving. Concurrency-shaped, and its failures are invisible to a single-backend run.
+Source/Kernel/Core/EventSequences/*AppendedEventsQueue*
+
+# area: Compliance (PII and encryption)
+# Crypto-shredding: key provisioning, apply/release around projections and read models. A defect
+# here is silent - it degrades per property rather than failing a query - so nothing but an
+# end-to-end run against a real store observes it.
+Source/Kernel/Core/Compliance/**
+
+# area: MongoDB sink
+# The default backend's sink and its changeset-to-update translation. Every pull request already
+# exercises this one; it is listed because a change here is the classic way a MongoDB-shaped
+# assumption merges green and breaks SQLite, PostgreSQL and MSSQL on the nightly.
+Source/Kernel/Storage.MongoDB/Sinks/**
+
+# area: SQL sink
+# The sink shared by SQLite, PostgreSQL and MSSQL - the three backends a pull request does not run
+# today, which is precisely why a change here needs the full matrix.
+Source/Kernel/Storage.Sql/Sinks/**

--- a/.github/scripts/detect-hot-core-changes.py
+++ b/.github/scripts/detect-hot-core-changes.py
@@ -1,0 +1,256 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Decides whether a change reaches the hot core, and says which paths made it decide that.
+
+`.github/hot-core-paths.txt` is a committed contract naming the areas where a fix breaks a sibling
+path. `.github/workflows/hot-core-gate.yml` asks this script one question per pull request - does
+this diff touch any of them - and runs the full out-of-process integration matrix when the answer is
+yes. That matrix is the only oracle that has reliably caught the class, and a pull request otherwise
+runs the default storage backend alone.
+
+The answer is never just a boolean. A pull request that suddenly waits on ninety integration jobs
+needs to know why, so every run prints the paths it matched under the area heading they belong to,
+to the log and to the job summary. An unexplained wait is a gate people learn to route around.
+
+`--verify` checks the contract itself instead of a diff: every pattern still matches a tracked file,
+and every pattern is owned in `.github/CODEOWNERS`. Both fail closed. A pattern that matches nothing
+is a rename that quietly disarmed the gate - the path list this replaced had already gone stale that
+way - and a pattern missing from CODEOWNERS is the same disarming on the review side.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+CONTRACT = ".github/hot-core-paths.txt"
+CODEOWNERS = ".github/CODEOWNERS"
+PLACEHOLDER_MARKER = "PLACEHOLDER-OWNER"
+AREA_PREFIX = "# area:"
+
+
+def read_contract(root):
+    """Returns the contract as a list of `(area, pattern)` pairs, in file order."""
+    areas = []
+    current = None
+    with open(os.path.join(root, CONTRACT), encoding="utf-8") as file:
+        for line in file:
+            stripped = line.strip()
+            if stripped.startswith(AREA_PREFIX):
+                current = stripped[len(AREA_PREFIX):].strip()
+                continue
+
+            if not stripped or stripped.startswith("#"):
+                continue
+
+            if current is None:
+                raise SystemExit(f"::error::{CONTRACT} has a pattern before any `{AREA_PREFIX}` heading: {stripped}")
+
+            areas.append((current, stripped))
+
+    if not areas:
+        raise SystemExit(f"::error::{CONTRACT} lists no patterns, so the hot-core gate would never fire.")
+
+    return areas
+
+
+def to_regex(pattern):
+    """Translates a contract pattern to a regex; `**` crosses `/`, `*` does not."""
+    compiled = ""
+    index = 0
+    while index < len(pattern):
+        if pattern.startswith("**", index):
+            compiled += ".*"
+            index += 2
+        elif pattern[index] == "*":
+            compiled += "[^/]*"
+            index += 1
+        elif pattern[index] == "?":
+            compiled += "[^/]"
+            index += 1
+        else:
+            compiled += re.escape(pattern[index])
+            index += 1
+
+    return re.compile(f"^{compiled}$")
+
+
+def git(root, *arguments):
+    """Runs git in the repository and returns its stdout, failing loudly rather than silently empty."""
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False)
+
+    if result.returncode != 0:
+        raise SystemExit(f"::error::`git {' '.join(arguments)}` failed: {result.stderr.strip()}")
+
+    return result.stdout
+
+
+def tracked_files(root):
+    """Returns every file git tracks, as repository-relative forward-slash paths."""
+    return [_ for _ in git(root, "ls-files").splitlines() if _]
+
+
+def changed_files(root, base, head, files_from):
+    """Returns the changed paths, either read from a file/stdin or taken from a diff range."""
+    if files_from:
+        text = sys.stdin.read() if files_from == "-" else open(files_from, encoding="utf-8").read()
+        return [_.strip() for _ in text.splitlines() if _.strip()]
+
+    if not base:
+        raise SystemExit("::error::Pass --base (and optionally --head), or --files-from.")
+
+    return [_ for _ in git(root, "diff", "--name-only", f"{base}...{head}").splitlines() if _]
+
+
+def matches(contract, paths):
+    """Returns `{area: [path, ...]}` for every path a contract pattern matches, areas in contract order."""
+    expressions = [(area, to_regex(pattern)) for area, pattern in contract]
+    found = {}
+    for area, expression in expressions:
+        hits = sorted(path for path in paths if expression.match(path))
+        if hits:
+            found.setdefault(area, [])
+            found[area].extend(hit for hit in hits if hit not in found[area])
+
+    return found
+
+
+def emit(text):
+    """Writes a line to the log and, when running in Actions, to the job summary."""
+    print(text)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as file:
+            file.write(text + "\n")
+
+
+def output(name, value):
+    """Writes a step output when running in Actions."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a", encoding="utf-8") as file:
+            file.write(f"{name}={value}\n")
+
+
+def counted(count, noun):
+    """Returns `count` and `noun`, pluralized, so the printed explanation reads as a sentence."""
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def report(found, changed):
+    """Prints why the gate decided what it decided, and returns whether the hot core was touched."""
+    if not found:
+        emit("## Hot-core gate: no hot-core path touched")
+        emit("")
+        emit(f"None of the {counted(len(changed), 'changed file')} is listed in `{CONTRACT}`, so the "
+             "full out-of-process integration matrix is skipped and this gate passes immediately.")
+        return False
+
+    total = sum(len(_) for _ in found.values())
+    emit("## Hot-core gate: the full out-of-process integration matrix runs")
+    emit("")
+    emit(f"This pull request changes {counted(total, 'hot-core file')} of "
+         f"{counted(len(changed), 'changed file')}, so it runs every storage backend out of process "
+         "rather than the default one only. That matrix is the only check that has reliably caught a "
+         "fix breaking a sibling path.")
+    emit("")
+    for area, paths in found.items():
+        emit(f"**{area}**")
+        emit("")
+        for path in paths:
+            emit(f"- `{path}`")
+        emit("")
+
+    return True
+
+
+def verify(root, contract):
+    """Fails when a pattern matches nothing, or is not owned in CODEOWNERS."""
+    problems = []
+
+    tracked = tracked_files(root)
+    for area, pattern in contract:
+        expression = to_regex(pattern)
+        if not any(expression.match(_) for _ in tracked):
+            problems.append(
+                f"`{pattern}` (area: {area}) matches no tracked file. Either the code moved and the "
+                f"gate is now disarmed for that area, or the pattern was never right - fix "
+                f"{CONTRACT} rather than deleting the entry.")
+
+    owned = owned_paths(root)
+    for area, pattern in contract:
+        expected = as_codeowners_path(pattern)
+        if expected not in owned:
+            problems.append(
+                f"`{pattern}` (area: {area}) has no owner. Add `{expected} <owner>` to {CODEOWNERS} "
+                f"so a change there cannot merge without a maintainer looking at it.")
+
+    if problems:
+        for problem in problems:
+            print(f"::error::{problem}", file=sys.stderr)
+        raise SystemExit(1)
+
+    print(f"{len(contract)} hot-core patterns all match tracked files and all have an owner in {CODEOWNERS}.")
+
+    if PLACEHOLDER_MARKER in read_text(root, CODEOWNERS):
+        print(f"::warning file={CODEOWNERS}::{CODEOWNERS} still carries the {PLACEHOLDER_MARKER} "
+              "marker, so its owner does not resolve. GitHub ignores a rule whose owner is not a real "
+              "user or team with read access - the file parses and enforces nothing. Set the real "
+              "owner and delete the marker.")
+
+
+def read_text(root, path):
+    """Returns the contents of a repository file."""
+    with open(os.path.join(root, path), encoding="utf-8") as file:
+        return file.read()
+
+
+def owned_paths(root):
+    """Returns the set of paths CODEOWNERS assigns an owner to."""
+    found = set()
+    for line in read_text(root, CODEOWNERS).splitlines():
+        stripped = line.split("#")[0].strip()
+        if not stripped:
+            continue
+
+        parts = stripped.split()
+        if len(parts) >= 2 and any(_.startswith("@") for _ in parts[1:]):
+            found.add(parts[0])
+
+    return found
+
+
+def as_codeowners_path(pattern):
+    """Returns the CODEOWNERS spelling of a contract pattern - a directory, or an anchored glob."""
+    return "/" + (pattern[:-2] if pattern.endswith("/**") else pattern)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="Base revision of the diff to inspect.")
+    parser.add_argument("--head", default="HEAD", help="Head revision of the diff to inspect.")
+    parser.add_argument("--files-from", help="Read changed paths from this file, or `-` for stdin.")
+    parser.add_argument("--verify", action="store_true", help="Check the contract itself instead of a diff.")
+    arguments = parser.parse_args()
+
+    root = git(os.getcwd(), "rev-parse", "--show-toplevel").strip()
+    contract = read_contract(root)
+
+    if arguments.verify:
+        verify(root, contract)
+        return
+
+    changed = changed_files(root, arguments.base, arguments.head, arguments.files_from)
+    touched = report(matches(contract, changed), changed)
+    output("touched", "true" if touched else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/hot-core-gate.yml
+++ b/.github/workflows/hot-core-gate.yml
@@ -1,0 +1,209 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# The gate between a hot-core change and main.
+#
+# Twenty of the last seventy-three regressions were fixes that broke a sibling path, concentrated in
+# the areas listed in `.github/hot-core-paths.txt`, and the out-of-process integration matrix is the
+# only oracle that has reliably caught them. On a pull request that matrix runs the default storage
+# backend alone, so a hot-core change can merge today without ever running the three backends where
+# the sibling breakage usually surfaces. This runs the full matrix for exactly those changes.
+#
+# WHY A SEPARATE WORKFLOW, AND WHY NO `paths:` FILTER: required status checks are configured per
+# repository, not per path, so the check has to report on every pull request or it blocks the ones it
+# was never meant to gate - a required check that never reports leaves a pull request "expected"
+# forever. `hot-core-gate` therefore runs unconditionally and is green in one of two ways: instantly,
+# because no hot-core path was touched, or after the full matrix has passed. `.NET Build &
+# Integration` cannot host it, because that workflow carries a `paths:` filter of its own and does
+# not start at all for a documentation-only pull request.
+
+name: Hot Core Gate
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+
+env:
+  DOTNET8_VERSION: "8.0.410"
+  DOTNET9_VERSION: "9.0.x"
+  DOTNET_VERSION: "10.0.x"
+  # Own cache and image tag. Sharing `.NET Build & Integration`'s would mean racing a workflow this
+  # one cannot wait on, and losing that race silently produces an empty restore.
+  HOT_CORE_DEV_CACHE: "hot-core-dev-cache-${{ github.sha }}"
+  HOT_CORE_IMAGE: "ghcr.io/cratis/chronicle:hot-core-${{ github.sha }}"
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      touched: ${{ steps.detect.outputs.touched }}
+
+    steps:
+      # The full history is what makes the diff against the base commit possible; the default
+      # shallow fetch does not contain it.
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Runs on every pull request, hot core or not, because a pattern that has stopped matching any
+      # file - a rename - disarms the gate without failing anything, and a pattern with no owner
+      # disarms the review half the same way.
+      - name: Assert the hot-core contract is intact
+        run: python3 .github/scripts/detect-hot-core-changes.py --verify
+
+      # Prints every hot-core path it matched, under its area heading, to the log and the job
+      # summary. An author who is suddenly waiting on the whole matrix has to be able to see why.
+      - name: Detect hot-core changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$BASE_SHA" ]; then
+            echo "Manual run - there is no pull request to diff, so the full matrix runs unconditionally."
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          python3 .github/scripts/detect-hot-core-changes.py --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  # Builds what the matrix consumes. This deliberately does not restore `.NET Build & Integration`'s
+  # caches: they are keyed on the same commit but written by a workflow this one neither depends on
+  # nor can wait for, so reading them is a race whose losing branch is an empty `bin` and a matrix
+  # that passes without running anything. A gate that fails open is the failure mode this program
+  # exists to remove. The cost is paid only by pull requests that touch the hot core.
+  build:
+    needs: [detect]
+    if: needs.detect.outputs.touched == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      dotnet-cache-key: ${{ steps.export.outputs.key }}
+      chronicle-image: ${{ steps.export.outputs.image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .Net
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            ${{ env.DOTNET8_VERSION }}
+            ${{ env.DOTNET9_VERSION }}
+            ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore obj cache
+        uses: actions/cache@v4
+        with:
+          # Package-aware key, as in `.NET Build & Integration`: a dependency bump must not restore
+          # an obj cache built against a different package set.
+          path: ./**/obj
+          key: hot-core-obj-cache-${{ hashFiles('**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets') }}-${{ github.sha }}
+          restore-keys: |
+            hot-core-obj-cache-${{ hashFiles('**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets') }}-
+
+      - uses: actions/cache@v4
+        with:
+          path: ./**/bin
+          key: ${{ env.HOT_CORE_DEV_CACHE }}
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add GitHub Package Registry to NuGet
+        run: |
+          dotnet nuget update source github --username cratis --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text || \
+          dotnet nuget add source --name github --username cratis --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text https://nuget.pkg.github.com/cratis/index.json
+
+      # The integration shards run `--no-build` against the DEVELOPMENT-symbol build, so that is the
+      # variant the cache has to hold.
+      - name: Build with DEVELOPMENT symbol
+        run: dotnet build --configuration Release -p:EnableDevelopmentSymbol=true -p:DisableProxyGenerator=true -p:DisableDockerBuild=true
+
+      # The out-of-process shards start this image instead of hosting the kernel themselves, so
+      # without it there is no "out of process" to test.
+      - name: Build and push development Docker image
+        run: |
+          dotnet publish Source/Kernel/Server/Server.csproj \
+            --configuration Debug \
+            --no-restore \
+            -o Source/Kernel/Server/out
+          docker build -t "${{ env.HOT_CORE_IMAGE }}" -f Docker/Local/Dockerfile .
+          docker push ${{ env.HOT_CORE_IMAGE }}
+
+      - name: Export cache key and image
+        id: export
+        run: |
+          echo "key=${{ env.HOT_CORE_DEV_CACHE }}" >> "$GITHUB_OUTPUT"
+          echo "image=${{ env.HOT_CORE_IMAGE }}" >> "$GITHUB_OUTPUT"
+
+  # The same reusable workflow the nightly run uses, with `all-providers` on: every storage backend,
+  # out of process, not just the default one a pull request gets.
+  full-out-of-process-matrix:
+    needs: [detect, build]
+    if: needs.detect.outputs.touched == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/integration.yml
+    secrets: inherit
+    with:
+      dotnet-cache-key: ${{ needs.build.outputs.dotnet-cache-key }}
+      chronicle-image: ${{ needs.build.outputs.chronicle-image }}
+      all-providers: true
+
+  # The single check to mark required in branch protection. It reports on every pull request, which
+  # is the whole point: a required check that is sometimes absent blocks pull requests it does not
+  # apply to. `if: always()` is what lets it run after skipped jobs - without it a skipped dependency
+  # would skip this too, and a skipped required check never reports.
+  hot-core-gate:
+    needs: [detect, build, full-out-of-process-matrix]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide
+        env:
+          DETECT: ${{ needs.detect.result }}
+          TOUCHED: ${{ needs.detect.outputs.touched }}
+          BUILD: ${{ needs.build.result }}
+          MATRIX: ${{ needs.full-out-of-process-matrix.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::Hot-core detection did not complete ($DETECT), so whether this pull request reaches the hot core is unknown. Failing closed."
+            exit 1
+          fi
+
+          if [ "$TOUCHED" != "true" ]; then
+            echo "No hot-core path is touched by this pull request. The full out-of-process integration matrix is not required here."
+            exit 0
+          fi
+
+          if [ "$BUILD" != "success" ] || [ "$MATRIX" != "success" ]; then
+            echo "::error::This pull request changes the hot core, and the full out-of-process integration matrix did not pass (build: $BUILD, matrix: $MATRIX). See the 'Detect hot-core changes' summary for the paths that put it here."
+            exit 1
+          fi
+
+          echo "This pull request changes the hot core and the full out-of-process integration matrix is green."

--- a/PLAN-reliability-program.md
+++ b/PLAN-reliability-program.md
@@ -206,6 +206,13 @@ warnings-as-errors Release), and the bot repeatedly rewrote hot kernel files.
 **Done when:** CODEOWNERS is active on hot-core paths, and the user confirms bot direct-commit is
 off.
 
+**Status:** `.github/CODEOWNERS` exists and mirrors `.github/hot-core-paths.txt` one for one, with
+the mirroring asserted on every PR. **Blocked-on-user, and the file enforces nothing until it is
+done:** the owner is the placeholder `@Cratis/kernel-maintainers`, and GitHub silently ignores a
+rule whose owner is not a real user or team with read access — the file parses and no review is
+required. The gate warns on every PR while the `PLACEHOLDER-OWNER` marker is present. Ownership
+only becomes *enforcement* once "Require review from Code Owners" is on in branch protection.
+
 ### Task 0.7 — Release hygiene on GitHub Releases
 **Traces to:** the releases-page evaluation in §1 — broken releases are unmarked and
 indistinguishable from good ones, so consumers (and dependency bots) keep pulling them; the
@@ -298,12 +305,17 @@ run through real kernel storage rather than parallel implementations.
 areas; two rollbacks deliberately reinstated known bugs (`b3e03dbb8`, `d1c168c7e`). The OOP
 integration matrix is the only oracle that has reliably caught this class.
 
-**Hot-core paths** (verify exact current paths before wiring):
-- `Source/Kernel/Grains/Observation/**` (esp. `Observer.Handling`)
-- Projection key resolution (`KeyResolvers`) and `Changeset`/changeset consolidation
-- `AppendedEventsQueue`
+**Hot-core paths** — now a committed contract in `.github/hot-core-paths.txt`, one pattern per area
+with its evidence, asserted on every PR to still match tracked files and to be owned in CODEOWNERS.
+The list this section originally carried had already gone stale: the observation grains live under
+`Source/Kernel/Core/Observation/**`, not `Source/Kernel/Grains/Observation/**`. The seven patterns:
+- `Source/Kernel/Core/Observation/**` (esp. `Observer.Handling.cs`)
+- `Source/Kernel/Core/Projections/**` (key resolution — `Engine/KeyResolvers.cs` — and the
+  changeset pipeline)
+- `Source/Infrastructure/Changes/**` (changeset consolidation)
+- `Source/Kernel/Core/EventSequences/*AppendedEventsQueue*`
 - `Source/Kernel/Core/Compliance/**` (PII/encryption)
-- The SQL and MongoDB sink implementations
+- `Source/Kernel/Storage.MongoDB/Sinks/**` and `Source/Kernel/Storage.Sql/Sinks/**`
 
 **Implementation**
 1. In the PR workflow, add a changed-paths condition: any PR touching these paths must run the
@@ -314,6 +326,14 @@ integration matrix is the only oracle that has reliably caught this class.
 
 **Done when:** a draft PR touching `KeyResolvers.cs` shows the OOP matrix as a required, running
 check; a PR not touching hot paths doesn't pay the cost.
+
+**Status:** `.github/workflows/hot-core-gate.yml` implements both halves — it carries no `paths:`
+filter so the `hot-core-gate` check reports on every PR, green immediately when nothing hot-core is
+touched and green only after the full matrix when something is, and it prints the matched paths
+under their area heading so the author sees why they are waiting. It is a separate workflow rather
+than a job in `dotnet-build.yml` because that workflow's own `paths:` filter would leave the check
+absent — and therefore permanently pending — on a PR it does not apply to. **Blocked-on-user:**
+marking `hot-core-gate` required is a branch-protection setting.
 
 ### Task 1.4 — History-integration guards for parallel agent work
 **Traces to:** a stale agent worktree silently reverted a sibling branch's merged compliance
@@ -436,11 +456,11 @@ decision only the user can make.
 | 0.3 | Silent-success sweep | in review | #3734, #3737 | proto exit-code + protoc gate; zero-test guards; solution-membership gate |
 | 0.4 | Path-filter audit | partial | #3737 | `Chronicle.slnx` added; §8-f completes the rest |
 | 0.5 | Red-workflow alarm | in review | #3736 | advisory (files an issue), never fails a build |
-| 0.6 | Autofix bots → suggesters | todo | | CODEOWNERS in-repo; bot permission is blocked-on-user |
+| 0.6 | Autofix bots → suggesters | partial | | CODEOWNERS + `.github/hot-core-paths.txt` in-repo; the owner handle is a `PLACEHOLDER-OWNER` and enforces nothing until set, and bot permission is blocked-on-user |
 | 0.7 | Release hygiene on GitHub Releases | partial | | 12 broken releases warned retroactively; notes-quality gate = §8-g; NuGet deprecation blocked-on-user |
 | 1.1 | Shared storage contract suite | todo | | start: extract the 3 hand-copied watermark suites; then replay-lifecycle |
 | 1.2 | Harness convergence (finish) | todo | | compliance no-op + `WaitForCompletion` lying come first |
-| 1.3 | Hot-core OOP gate + CODEOWNERS | todo | | shares CODEOWNERS with 0.6 |
+| 1.3 | Hot-core OOP gate + CODEOWNERS | partial | | `hot-core-gate.yml` runs the full matrix on hot-core paths and no-ops green otherwise; the plan's `Source/Kernel/Grains/Observation` was stale (now `Source/Kernel/Core/Observation`); marking `hot-core-gate` required in branch protection is blocked-on-user |
 | 1.4 | History-integration guards | todo | | branch-protection part is blocked-on-user |
 | 2.1 | Deterministic completion signals | todo | | design doc first; after 1.2/1.3 |
 | 2.2 | Release train + soak | todo | | blocked-on-user: cadence decision; use the unused prerelease flag as the RC channel |

--- a/PLAN-reliability-program.md
+++ b/PLAN-reliability-program.md
@@ -207,11 +207,12 @@ warnings-as-errors Release), and the bot repeatedly rewrote hot kernel files.
 off.
 
 **Status:** `.github/CODEOWNERS` exists and mirrors `.github/hot-core-paths.txt` one for one, with
-the mirroring asserted on every PR. **Blocked-on-user, and the file enforces nothing until it is
-done:** the owner is the placeholder `@Cratis/kernel-maintainers`, and GitHub silently ignores a
-rule whose owner is not a real user or team with read access — the file parses and no review is
-required. The gate warns on every PR while the `PLACEHOLDER-OWNER` marker is present. Ownership
-only becomes *enforcement* once "Require review from Code Owners" is on in branch protection.
+the mirroring asserted on every PR. The owner is **`@Cratis/core`** (einari, woksin, cratis-bot),
+chosen 2026-08-18 — a real team, so the rule resolves and review is auto-requested. **Code-owner
+review is deliberately not required**: "Require review from Code Owners" stays off, so these paths
+request a reviewer without blocking a merge. What blocks is the `hot-core-gate` check, which the
+user agreed to mark required — that is the remaining repository setting. Autofix-bot direct-commit
+permission is still blocked-on-user.
 
 ### Task 0.7 — Release hygiene on GitHub Releases
 **Traces to:** the releases-page evaluation in §1 — broken releases are unmarked and
@@ -456,7 +457,7 @@ decision only the user can make.
 | 0.3 | Silent-success sweep | **done** | #3737, #3762 | zero-test guards, solution-membership gate, generators exit non-zero. #3734 (proto regen) still held for Einar |
 | 0.4 | Path-filter audit | **done** | #3737, #3761 | 13 of 17 required paths were uncovered; all closed by widening, contract asserted in CI |
 | 0.5 | Red-workflow alarm | **done** | #3736 | advisory; would flag benchmarks + integration.yml today |
-| 0.6 | Autofix bots → suggesters | partial | | CODEOWNERS + `.github/hot-core-paths.txt` in repo, but the owner is a `PLACEHOLDER-OWNER` and enforces nothing until set; bot permission is blocked-on-user |
+| 0.6 | Autofix bots → suggesters | partial | | CODEOWNERS owned by `@Cratis/core`, mirroring `.github/hot-core-paths.txt` and asserted in CI; review requested but not required by choice; bot permission is blocked-on-user |
 | 0.7 | Release hygiene on GitHub Releases | partial | | 12 broken releases warned retroactively; notes-quality gate = §8-g; NuGet deprecation blocked-on-user |
 | 1.1 | Shared storage contract suite | **done (core)** | #3749–#3752, #3754 | 9 cases × 3 sinks; found D-8, D-9, ChildRemovedFromAll. Remaining: constraints + key storage suites |
 | 1.2 | Harness convergence (finish) | partial | #3759, #3760 | WaitForCompletion no longer lies (merged); compliance wiring open. ReadModelScenario runs NO compliance — feature, not wiring |


### PR DESCRIPTION
# Summary

Internal CI only: a change touching the parts of the kernel where fixes historically break sibling paths now runs the full out-of-process integration matrix, and those paths gain code owners. A change touching none of them passes the gate immediately. No user-facing changes.