### PR TITLE
Fix DateTimeOffset in generated gRPC contracts

### DIFF
--- a/Source/Kernel/Contracts/Jobs/IJobs.cs
+++ b/Source/Kernel/Contracts/Jobs/IJobs.cs
@@ -243,7 +243,7 @@ public class JobSummaryResponse
     /// Gets or sets the Created.
     /// </summary>
     [ProtoMember(5)]
-    public DateTimeOffset Created { get; set; }
+    public Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset Created { get; set; }
 
     /// <summary>
     /// Gets or sets the StatusChanges.

--- a/Source/Kernel/Contracts/Security/IApplications.cs
+++ b/Source/Kernel/Contracts/Security/IApplications.cs
@@ -134,11 +134,11 @@ public class ApplicationResponse
     /// Gets or sets the CreatedAt.
     /// </summary>
     [ProtoMember(4)]
-    public DateTimeOffset CreatedAt { get; set; }
+    public Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset CreatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the LastModifiedAt.
     /// </summary>
     [ProtoMember(5)]
-    public DateTimeOffset? LastModifiedAt { get; set; }
+    public Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset LastModifiedAt { get; set; }
 }

--- a/Source/Kernel/Contracts/Security/IUsers.cs
+++ b/Source/Kernel/Contracts/Security/IUsers.cs
@@ -238,13 +238,13 @@ public class UserResponse
     /// Gets or sets the CreatedAt.
     /// </summary>
     [ProtoMember(5)]
-    public DateTimeOffset CreatedAt { get; set; }
+    public Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset CreatedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the LastModifiedAt.
     /// </summary>
     [ProtoMember(6)]
-    public DateTimeOffset? LastModifiedAt { get; set; }
+    public Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset LastModifiedAt { get; set; }
 
     /// <summary>
     /// Gets or sets the HasLoggedIn.

--- a/Source/Tools/GrpcCodeGenerator.Specs/for_TypeHelper/when_getting_type_name/for_datetime_offset.cs
+++ b/Source/Tools/GrpcCodeGenerator.Specs/for_TypeHelper/when_getting_type_name/for_datetime_offset.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Tools.GrpcCodeGenerator.for_TypeHelper.when_getting_type_name;
+
+public class for_datetime_offset : Specification
+{
+    string _typeName = string.Empty;
+    string _nullableTypeName = string.Empty;
+
+    void Because()
+    {
+        _typeName = TypeHelper.GetTypeName(typeof(DateTimeOffset));
+        _nullableTypeName = TypeHelper.GetTypeName(typeof(DateTimeOffset?));
+    }
+
+    [Fact] void should_use_the_serializable_date_time_offset_contract() =>
+        _typeName.ShouldEqual("Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset");
+    [Fact] void should_represent_nullable_values_with_the_reference_type() =>
+        _nullableTypeName.ShouldEqual("Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset");
+}

--- a/Source/Tools/GrpcCodeGenerator.Specs/for_generated_contracts/when_serializing_date_time_offset_response.cs
+++ b/Source/Tools/GrpcCodeGenerator.Specs/for_generated_contracts/when_serializing_date_time_offset_response.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Security;
+using ProtoBuf;
+
+namespace Cratis.Chronicle.Tools.GrpcCodeGenerator.for_generated_contracts;
+
+public class when_serializing_date_time_offset_response : Specification
+{
+    DateTimeOffset _createdAt;
+    DateTimeOffset _lastModifiedAt;
+    ApplicationResponse _result = null!;
+
+    void Establish()
+    {
+        _createdAt = DateTimeOffset.UtcNow;
+        _lastModifiedAt = _createdAt.AddMinutes(1);
+    }
+
+    void Because()
+    {
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, new ApplicationResponse
+        {
+            CreatedAt = _createdAt,
+            LastModifiedAt = _lastModifiedAt
+        });
+        stream.Position = 0;
+        _result = Serializer.Deserialize<ApplicationResponse>(stream);
+    }
+
+    [Fact] void should_round_trip_created_at() => ((DateTimeOffset)_result.CreatedAt).ShouldEqual(_createdAt);
+    [Fact] void should_round_trip_last_modified_at() => ((DateTimeOffset?)_result.LastModifiedAt).ShouldEqual(_lastModifiedAt);
+}

--- a/Source/Tools/GrpcCodeGenerator/TypeHelper.cs
+++ b/Source/Tools/GrpcCodeGenerator/TypeHelper.cs
@@ -201,7 +201,7 @@ public static class TypeHelper
 
         if (type == typeof(DateTimeOffset))
         {
-            return "DateTimeOffset";
+            return "Cratis.Chronicle.Contracts.Primitives.SerializableDateTimeOffset";
         }
 
         if (type == typeof(DateTime))
@@ -219,7 +219,8 @@ public static class TypeHelper
 
         if (genericDef == typeof(Nullable<>))
         {
-            return $"{GetTypeName(genericArgs[0])}?";
+            var nullableTypeName = GetTypeName(genericArgs[0]);
+            return genericArgs[0] == typeof(DateTimeOffset) ? nullableTypeName : $"{nullableTypeName}?";
         }
 
         if (genericDef.FullName?.StartsWith("System.Collections.Generic.IEnumerable`", StringComparison.Ordinal) == true)


### PR DESCRIPTION
# Summary

Generated administration contracts now use Chronicle's protobuf-safe timestamp representation instead of exposing unsupported `DateTimeOffset` values.

## Fixed

- Jobs, users, and applications can be read through generated gRPC clients without timestamp serialization failures. (#3788)