### PR TITLE
Remove the fixed costs from connecting to a Chronicle, and let an embedded one skip auth

### DIFF
--- a/Documentation/connection-strings/server.md
+++ b/Documentation/connection-strings/server.md
@@ -99,16 +99,25 @@ For the example above, the client queries the SRV records for
 
 Chronicle supports multiple authentication modes. The mode is determined by the credentials present in the connection string:
 
-- **None**: No credentials provided
-- **Client credentials**: Username and password supplied in the authority section
+- **Client credentials**: Username and password supplied in the authority section. This is also what a
+  connection string with *no* credentials falls back to — it performs the exchange with the development
+  credentials rather than connecting anonymously
 - **API key**: `apiKey` query parameter
+- **None**: `auth=none` query parameter — the client presents no credentials at all
 
-You cannot combine client credentials and API key authentication in the same connection string.
+You cannot combine client credentials and API key authentication in the same connection string. `auth=none`
+overrides both, so credentials left behind by a shared configuration cannot quietly turn the exchange back on.
+
+`auth=none` only works against a server running with
+[authentication turned off](../hosting/configuration/authentication.md#turning-authentication-off), which is
+meant for a Chronicle embedded alongside its own client rather than reachable over a network. Against a server
+that enforces authentication, every call fails as unauthenticated.
 
 ## Query parameters
 
 | Parameter | Type | Description | Example |
 |-----------|------|-------------|---------|
+| `auth` | string | Set to `none` to connect without presenting credentials | `?auth=none` |
 | `apiKey` | string | API key for API key authentication | `?apiKey=your-api-key` |
 | `skipTlsValidation` | boolean | Connects over TLS without validating the server certificate | `?skipTlsValidation=true` |
 | `loadBalancer` | string | Load balancer strategy when multiple servers are configured | `?loadBalancer=round-robin` |

--- a/Documentation/hosting/configuration/authentication.md
+++ b/Documentation/hosting/configuration/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Authentication is always enabled. When `authority` is not configured, Chronicle uses its built-in OpenIdDict OAuth authority. When `authority` is set to an external OAuth provider URL, Chronicle will use that instead of the internal authority.
+Authentication is enabled by default. When `authority` is not configured, Chronicle uses its built-in OpenIdDict OAuth authority. When `authority` is set to an external OAuth provider URL, Chronicle will use that instead of the internal authority.
 
 Identity provider certificate configuration is documented on [Identity Provider Certificate](identity-provider-certificate.md).
 
@@ -9,6 +9,7 @@ Identity provider certificate configuration is documented on [Identity Provider 
 ```json
 {
   "authentication": {
+    "enabled": true,
     "authority": null,
     "defaultAdminUsername": "admin"
   }
@@ -17,8 +18,34 @@ Identity provider certificate configuration is documented on [Identity Provider 
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
+| enabled | bool | true | Whether authentication is enforced. See [Turning authentication off](#turning-authentication-off) |
 | authority | string | null | External OAuth authority URL |
 | defaultAdminUsername | string | "admin" | Default admin username created on first startup when `adminUser` is not configured |
+
+## Turning authentication off
+
+Setting `enabled` to `false` removes authentication from the server entirely. There is no token authority, no
+`/connect/token` endpoint, no identity endpoints and no bootstrap admin user, and every gRPC service and HTTP
+endpoint answers anonymously. A client connects to it with `auth=none` in its connection string:
+
+```text
+chronicle://localhost:35000?auth=none
+```
+
+**This is only for a Chronicle that is not reachable as a server.** It exists for an instance embedded in a
+single container or process, talking to its own client over loopback, thrown away with the process — a play
+sandbox, a disposable test host. There the credential exchange protects nothing and costs every client
+seconds of cold start: acquiring the first access token takes 1.9 seconds on an unconstrained machine and 3.7
+under a half-core container limit, almost all of it warming the token endpoint's request pipeline.
+
+Anywhere a network can reach the server, leaving this off publishes the whole event store — every event, every
+read model, every management operation — to anyone who can open a socket to it. It is not a development
+convenience to be left on by accident; treat it as part of the deployment topology.
+
+A client using `auth=none` against a server that does enforce authentication fails every call as
+unauthenticated. Note also that a connection string with *no* credentials does not mean this — it still
+performs a client-credentials exchange using the development credentials, which is what it has always done.
+`auth=none` is the explicit form.
 
 ## Admin user bootstrap
 

--- a/Documentation/hosting/configuration/environment-variables.md
+++ b/Documentation/hosting/configuration/environment-variables.md
@@ -45,6 +45,7 @@ the same way (`compliance.encryption.migrateFromDefaultStorage` becomes
 | Cratis__Chronicle__Observers__MaximumBackoffDelay | Maximum observer backoff delay in seconds |
 | Cratis__Chronicle__ReadModels__ReplayedVersionsToKeep | Number of replay-generated read model versions to keep |
 | Cratis__Chronicle__Events__Queues | Number of event queues |
+| Cratis__Chronicle__Authentication__Enabled | Whether authentication is enforced (default `true`) - see [Authentication](authentication.md#turning-authentication-off) before turning it off |
 | Cratis__Chronicle__Authentication__Authority | External OAuth authority URL |
 | Cratis__Chronicle__Authentication__DefaultAdminUsername | Default admin username |
 | Cratis__Chronicle__Authentication__AdminUser__Username | Bootstrap admin username (falls back to the default admin username when empty) |

--- a/Source/Clients/Connections/AuthenticationMode.cs
+++ b/Source/Clients/Connections/AuthenticationMode.cs
@@ -17,4 +17,15 @@ public enum AuthenticationMode
     /// API key authentication.
     /// </summary>
     ApiKey = 1,
+
+    /// <summary>
+    /// No authentication - the client presents no credentials at all.
+    /// </summary>
+    /// <remarks>
+    /// Only usable against a server running with authentication turned off
+    /// (<c>Cratis:Chronicle:Authentication:Enabled=false</c>), which is meant for a Chronicle embedded in the
+    /// same container or process as its client. Against any server that enforces authentication, every call
+    /// fails as unauthenticated.
+    /// </remarks>
+    None = 2,
 }

--- a/Source/Clients/Connections/ChronicleConnectionStringBuilder.cs
+++ b/Source/Clients/Connections/ChronicleConnectionStringBuilder.cs
@@ -25,6 +25,8 @@ public class ChronicleConnectionStringBuilder : DbConnectionStringBuilder
     const string PasswordKey = "Password";
     const string SchemeKey = "Scheme";
     const string ApiKeyKey = "apiKey";
+    const string AuthKey = "auth";
+    const string NoAuthenticationValue = "none";
     const string SkipTlsValidationKey = "skipTlsValidation";
     const string LoadBalancerKey = "loadBalancer";
     const string SrvNameServerKey = "srvNameServer";
@@ -179,6 +181,13 @@ public class ChronicleConnectionStringBuilder : DbConnectionStringBuilder
             var hasApiKey = !string.IsNullOrEmpty(ApiKey);
             var hasNoAuthentication = !hasUsername && !hasPassword && !hasApiKey;
 
+            // Asking for no authentication is deliberate and beats anything else the connection string carries -
+            // credentials left in place by a shared configuration must not quietly turn the exchange back on.
+            if (NoAuthentication)
+            {
+                return AuthenticationMode.None;
+            }
+
             if (hasClientCredentials && hasApiKey)
             {
                 throw new AmbiguousAuthenticationMode();
@@ -195,6 +204,32 @@ public class ChronicleConnectionStringBuilder : DbConnectionStringBuilder
             }
 
             throw new MissingAuthentication();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the client connects without presenting any credentials, expressed as
+    /// <c>auth=none</c> in the connection string.
+    /// </summary>
+    /// <remarks>
+    /// Only works against a server running with authentication turned off
+    /// (<c>Cratis:Chronicle:Authentication:Enabled=false</c>). Note that omitting credentials entirely does
+    /// <em>not</em> mean this - a connection string with no credentials still performs a client-credentials
+    /// exchange using the development credentials, which is what it has always done.
+    /// </remarks>
+    public bool NoAuthentication
+    {
+        get => ContainsKey(AuthKey) && string.Equals((string)this[AuthKey], NoAuthenticationValue, StringComparison.OrdinalIgnoreCase);
+        set
+        {
+            if (value)
+            {
+                this[AuthKey] = NoAuthenticationValue;
+            }
+            else
+            {
+                Remove(AuthKey);
+            }
         }
     }
 

--- a/Source/Clients/Connections/ChronicleConnectionStringBuilderExtensions.cs
+++ b/Source/Clients/Connections/ChronicleConnectionStringBuilderExtensions.cs
@@ -83,6 +83,23 @@ public static class ChronicleConnectionStringBuilderExtensions
     }
 
     /// <summary>
+    /// Connects without presenting any credentials.
+    /// </summary>
+    /// <param name="builder">The <see cref="ChronicleConnectionStringBuilder"/> to configure.</param>
+    /// <returns>The <see cref="ChronicleConnectionStringBuilder"/> for fluent configuration.</returns>
+    /// <remarks>
+    /// Only works against a server running with authentication turned off
+    /// (<c>Cratis:Chronicle:Authentication:Enabled=false</c>) - typically a Chronicle embedded in the same
+    /// container or process as its client. It skips the token exchange entirely, which is what makes a cold
+    /// start of such an instance fast.
+    /// </remarks>
+    public static ChronicleConnectionStringBuilder WithoutAuthentication(this ChronicleConnectionStringBuilder builder)
+    {
+        builder.NoAuthentication = true;
+        return builder;
+    }
+
+    /// <summary>
     /// Sets the API key for API key authentication.
     /// </summary>
     /// <param name="builder">The <see cref="ChronicleConnectionStringBuilder"/> to configure.</param>

--- a/Source/Clients/DotNET.Specs/Connections/for_ChronicleConnectionString/when_parsing_url_without_authentication_requested.cs
+++ b/Source/Clients/DotNET.Specs/Connections/for_ChronicleConnectionString/when_parsing_url_without_authentication_requested.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+
+namespace Cratis.Chronicle.Clients.Connections.for_ChronicleConnectionString;
+
+public class when_parsing_url_without_authentication_requested : Specification
+{
+    ChronicleConnectionString _url;
+    ChronicleConnectionString _withCredentialsToo;
+
+    void Establish()
+    {
+        _url = new ChronicleConnectionString("chronicle://localhost:35000?auth=none");
+
+        // Credentials left behind by a shared configuration must not quietly turn the exchange back on.
+        _withCredentialsToo = new ChronicleConnectionString("chronicle://someone:secret@localhost:35000?auth=none");
+    }
+
+    [Fact] void should_have_correct_host() => _url.ServerAddress.Host.ShouldEqual("localhost");
+    [Fact] void should_have_no_authentication_mode() => _url.AuthenticationMode.ShouldEqual(AuthenticationMode.None);
+    [Fact] void should_have_no_authentication_mode_even_when_credentials_are_present() => _withCredentialsToo.AuthenticationMode.ShouldEqual(AuthenticationMode.None);
+}

--- a/Source/Clients/DotNET.Specs/Connections/for_ChronicleConnectionStringBuilderExtensions/when_using_without_authentication.cs
+++ b/Source/Clients/DotNET.Specs/Connections/for_ChronicleConnectionStringBuilderExtensions/when_using_without_authentication.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnectionStringBuilderExtensions;
+
+public class when_using_without_authentication : Specification
+{
+    ChronicleConnectionStringBuilder _builder;
+    AuthenticationMode _mode;
+
+    void Establish() => _builder = new ChronicleConnectionStringBuilder();
+
+    void Because() => _mode = _builder.WithHost("localhost").WithoutAuthentication().AuthenticationMode;
+
+    [Fact] void should_present_no_credentials() => _mode.ShouldEqual(AuthenticationMode.None);
+    [Fact] void should_record_it_on_the_builder() => _builder.NoAuthentication.ShouldBeTrue();
+}

--- a/Source/Kernel/Core/Configuration/Authentication.cs
+++ b/Source/Kernel/Core/Configuration/Authentication.cs
@@ -9,6 +9,19 @@ namespace Cratis.Chronicle.Configuration;
 public class Authentication
 {
     /// <summary>
+    /// Gets whether authentication is enforced. Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// Turning this off removes authentication from the server entirely - no token authority, no identity
+    /// endpoints, no bootstrap admin user, and every gRPC service and HTTP endpoint answers anonymously. It
+    /// exists for a Chronicle that is not reachable as a server at all: one embedded in a single container or
+    /// process, talking to its own client over loopback, disposed with the process. There the credential
+    /// exchange protects nothing and costs every client seconds of cold start. Anywhere a network can reach the
+    /// server, leaving this off publishes the whole event store to anyone who can open a socket.
+    /// </remarks>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
     /// Gets the authentication authority URL. If not configured, uses the internal OAuth authority.
     /// </summary>
     public string? Authority { get; init; }

--- a/Source/Kernel/Core/Services/Clients/ConnectionService.cs
+++ b/Source/Kernel/Core/Services/Clients/ConnectionService.cs
@@ -54,6 +54,15 @@ internal sealed class ConnectionService(
 
                 try
                 {
+                    // The session is established the moment the client is registered, and the first keep-alive is
+                    // how the client learns that - it does not treat itself as connected until one arrives. Send it
+                    // straight away rather than after a first interval, or every client everywhere pays the whole
+                    // keep-alive interval before it can do anything.
+                    subject.OnNext(new ConnectionKeepAlive
+                    {
+                        ConnectionId = request.ConnectionId
+                    });
+
                     while (!context.CancellationToken.IsCancellationRequested)
                     {
                         await Task.Delay(_keepAliveInterval).ConfigureAwait(false);

--- a/Source/Kernel/Core/Services/Clients/ConnectionService.cs
+++ b/Source/Kernel/Core/Services/Clients/ConnectionService.cs
@@ -37,7 +37,11 @@ internal sealed class ConnectionService(
         ConnectRequest request,
         CallContext context = default)
     {
-        var subject = new Subject<ConnectionKeepAlive>();
+        // Replaying, so the first keep-alive is not lost. It is sent as soon as the client is registered, which
+        // races the transport subscribing to this subject - and a plain Subject drops what it has no subscriber
+        // for, which would silently put the client back to waiting a full interval. One is all that needs
+        // replaying: a keep-alive carries nothing but the connection it belongs to.
+        var subject = new ReplaySubject<ConnectionKeepAlive>(1);
         var connectedClients = grainFactory.GetConnectedClients(localSiloDetails.SiloAddress);
 
         _ = Task.Run(

--- a/Source/Kernel/Core/Setup/Authentication/AuthenticationService.cs
+++ b/Source/Kernel/Core/Setup/Authentication/AuthenticationService.cs
@@ -46,6 +46,11 @@ internal sealed class AuthenticationService(
     /// <inheritdoc/>
     public async Task EnsureDefaultAdminUser()
     {
+        if (!_options.Authentication.Enabled)
+        {
+            return;
+        }
+
         logger.CheckingForDefaultAdminUser();
 
         var existingUsers = await userStorage.GetAll();
@@ -119,6 +124,11 @@ internal sealed class AuthenticationService(
     /// <inheritdoc/>
     public async Task EnsureBootstrapClients()
     {
+        if (!_options.Authentication.Enabled)
+        {
+            return;
+        }
+
         var clients = _options.Clients;
         if (!clients.Any())
         {
@@ -162,6 +172,11 @@ internal sealed class AuthenticationService(
     /// <inheritdoc/>
     public async Task EnsureDefaultClientCredentials()
     {
+        if (!_options.Authentication.Enabled)
+        {
+            return;
+        }
+
         const string defaultClientId = "chronicle-dev-client";
         const string defaultClientSecret = "chronicle-dev-secret";
 

--- a/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/OpenIddict/OpenIddictServiceCollectionExtensions.cs
@@ -32,8 +32,9 @@ public static class OpenIddictServiceCollectionExtensions
         Configuration.ChronicleOptions chronicleOptions,
         Cratis.Chronicle.Security.IEncryptionCertificateRing encryptionCertificateRing)
     {
-        // Disable OpenIddict if using an external authority or if OAuthAuthority feature is disabled
-        if (!chronicleOptions.Features.OAuthAuthority || !chronicleOptions.Authentication.UseInternalAuthority)
+        // Disable OpenIddict if authentication is off entirely, if using an external authority, or if the
+        // OAuthAuthority feature is disabled
+        if (!chronicleOptions.Authentication.Enabled || !chronicleOptions.Features.OAuthAuthority || !chronicleOptions.Authentication.UseInternalAuthority)
         {
             return services;
         }

--- a/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
@@ -66,6 +66,20 @@ public static class ServiceCollectionExtensions
                 .UnprotectKeysWithAnyCertificate([.. encryptionCertificateRing.All.Select(_ => _.Certificate)]);
         }
 
+        // Everything from here on exists to authenticate callers. With authentication off there is nothing to
+        // authenticate them against, so the token authority, the identity stack and the schemes are all skipped
+        // and the fallback policy lets every request through. Data Protection above stays either way - webhook
+        // secret encryption depends on it and has nothing to do with authentication.
+        if (!chronicleOptions.Authentication.Enabled)
+        {
+            services.AddAuthorizationBuilder()
+                .SetFallbackPolicy(new AuthorizationPolicyBuilder()
+                    .RequireAssertion(_ => true)
+                    .Build());
+
+            return services;
+        }
+
         // Add ASP.NET Identity
         services.AddIdentityCore<User>(options =>
             {

--- a/Source/Kernel/Server/Program.cs
+++ b/Source/Kernel/Server/Program.cs
@@ -357,10 +357,15 @@ if (serveWorkbench)
     app.UseStaticFiles(workbenchStaticFileOptions);
 }
 
-// Add authentication and authorization middleware AFTER routing but BEFORE endpoints
-app.UseMiddleware<GrpcAuthenticationMiddleware>();
-app.UseAuthentication();
-app.UseAuthorization();
+// Add authentication and authorization middleware AFTER routing but BEFORE endpoints. With authentication off
+// there are no schemes registered for UseAuthentication to resolve, and the fallback policy authorizes
+// everything, so both are skipped rather than run against an empty stack.
+if (chronicleOptions.Authentication.Enabled)
+{
+    app.UseMiddleware<GrpcAuthenticationMiddleware>();
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
 
 if (chronicleOptions.Features.Api)
 {
@@ -380,10 +385,14 @@ if (chronicleOptions.Features.Api)
     });
 }
 
-// Map Identity API endpoints for SPA authentication - MUST be before MapControllers
-app.MapGroup("/identity")
-    .MapIdentityApi<User>()
-    .AllowAnonymous();
+// Map Identity API endpoints for SPA authentication - MUST be before MapControllers. They are backed by the
+// ASP.NET Identity stack, which is not registered when authentication is off.
+if (chronicleOptions.Authentication.Enabled)
+{
+    app.MapGroup("/identity")
+        .MapIdentityApi<User>()
+        .AllowAnonymous();
+}
 
 // Map controllers for API and OAuth
 if (chronicleOptions.Features.Api || chronicleOptions.Features.OAuthAuthority)
@@ -438,7 +447,10 @@ Console.CancelKeyPress += (sender, eventArgs) =>
     eventArgs.Cancel = true;
 };
 
-logger.ServerStarted(chronicleOptions.Port);
+// Announced from ApplicationStarted, not from here. Kestrel binds during RunAsync, so logging it before the call
+// made the message arrive around half a second before the port accepted anything - and entrypoint scripts, test
+// fixtures and orchestrators that gate on this line would then connect to a socket that did not exist yet.
+app.Lifetime.ApplicationStarted.Register(() => logger.ServerStarted(chronicleOptions.Port));
 
 await app.RunAsync(cancellationToken.Token);
 

--- a/Source/Kernel/Services.Specs/Services/Clients/for_ConnectionService/when_connecting/and_the_client_subscribes.cs
+++ b/Source/Kernel/Services.Specs/Services/Clients/for_ConnectionService/when_connecting/and_the_client_subscribes.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net;
+using Cratis.Chronicle.Clients;
+using Cratis.Chronicle.Configuration;
+using Cratis.Chronicle.Contracts.Clients;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using KernelConnectionService = Cratis.Chronicle.Services.Clients.ConnectionService;
+
+namespace Cratis.Chronicle.Services.Clients.for_ConnectionService.when_connecting;
+
+/// <summary>
+/// A client does not consider itself connected until the first keep-alive arrives, so withholding that first
+/// heartbeat for a whole interval charges every client the interval before it can do anything.
+/// </summary>
+public class and_the_client_subscribes : Specification
+{
+    const int KeepAliveIntervalSeconds = 30;
+
+    IConnectionService _connectionService;
+    IConnectedClients _connectedClients;
+    ConnectionKeepAlive _firstKeepAlive;
+    bool _arrived;
+
+    void Establish()
+    {
+        var silo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 1);
+        _connectedClients = Substitute.For<IConnectedClients>();
+
+        var grainFactory = Substitute.For<IGrainFactory>();
+        grainFactory.GetGrain<IConnectedClients>(silo.ToParsableString(), Arg.Any<string>()).Returns(_connectedClients);
+
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(silo);
+
+        // Long enough that a heartbeat arriving on the interval could not be mistaken for the immediate one.
+        var options = new ChronicleOptions { ConnectedClients = new() { KeepAliveIntervalSeconds = KeepAliveIntervalSeconds } };
+
+        _connectionService = new KernelConnectionService(
+            grainFactory,
+            localSiloDetails,
+            NullLogger<KernelConnectionService>.Instance,
+            Options.Create(options));
+    }
+
+    async Task Because()
+    {
+        using var received = new SemaphoreSlim(0, 1);
+        using var subscription = _connectionService.Connect(new ConnectRequest { ConnectionId = "the-client" })
+            .Subscribe(keepAlive =>
+            {
+                _firstKeepAlive = keepAlive;
+                received.Release();
+            });
+
+        _arrived = await received.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact] void should_send_a_keep_alive_without_waiting_for_the_interval() => _arrived.ShouldBeTrue();
+    [Fact] void should_identify_the_connection_it_belongs_to() => _firstKeepAlive.ConnectionId.ShouldEqual("the-client");
+    [Fact] async Task should_register_the_client_first() => await _connectedClients.Received(1).OnClientConnected("the-client", Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
+}

--- a/Source/Workbench/.frontend/App.tsx
+++ b/Source/Workbench/.frontend/App.tsx
@@ -17,8 +17,9 @@ import { basePath as configuredBasePath } from '../Utils/basePath';
 const isDevelopment = import.meta.env.MODE === 'development';
 
 function App() {
-    // Normalized to '' at the root, so it can be concatenated everywhere without producing a double slash.
-    // The router still wants a path to match on, hence the '/' fallback for the outer route.
+    // Normalized to '' at the root, so it can be concatenated everywhere without producing a double slash -
+    // which is the same value the meta tag already yielded when unset, so the routes below are unchanged when
+    // the Workbench is served where it always has been.
     const basePath = configuredBasePath;
 
     return (
@@ -32,7 +33,7 @@ function App() {
                         <BrowserRouter>
                             <AuthProvider>
                                 <Routes>
-                                    <Route path={basePath || '/'}>
+                                    <Route path={basePath}>
                                         <Route path='login' element={<BlankLayout />}>
                                             <Route path='' element={<Login />} />
                                         </Route>

--- a/Source/Workbench/.frontend/App.tsx
+++ b/Source/Workbench/.frontend/App.tsx
@@ -12,12 +12,14 @@ import { BusyIndicatorDialog } from '@cratis/components/Dialogs';
 import { ConfirmationDialog } from 'Components/Dialogs';
 import { Arc } from '@cratis/arc.react';
 import { MVVM } from '@cratis/arc.react.mvvm';
+import { basePath as configuredBasePath } from '../Utils/basePath';
 
 const isDevelopment = import.meta.env.MODE === 'development';
 
 function App() {
-    const basePathElement = document.querySelector('meta[name="base-path"]') as HTMLMetaElement;
-    const basePath = basePathElement?.content ?? '/';
+    // Normalized to '' at the root, so it can be concatenated everywhere without producing a double slash.
+    // The router still wants a path to match on, hence the '/' fallback for the outer route.
+    const basePath = configuredBasePath;
 
     return (
         <Arc
@@ -30,7 +32,7 @@ function App() {
                         <BrowserRouter>
                             <AuthProvider>
                                 <Routes>
-                                    <Route path={basePath}>
+                                    <Route path={basePath || '/'}>
                                         <Route path='login' element={<BlankLayout />}>
                                             <Route path='' element={<Login />} />
                                         </Route>

--- a/Source/Workbench/Features/Security/AuthContext.tsx
+++ b/Source/Workbench/Features/Security/AuthContext.tsx
@@ -3,6 +3,7 @@
 
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { absolutePath } from '../../Utils/basePath';
 
 export interface AuthContextType {
     isAuthenticated: boolean;
@@ -33,7 +34,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     const checkAuth = async () => {
         try {
             // Try to access a protected endpoint to verify authentication
-            const response = await fetch('/api/event-stores', {
+            const response = await fetch(absolutePath('/api/event-stores'), {
                 credentials: 'include',
             });
 
@@ -41,7 +42,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
                 setIsAuthenticated(true);
             } else if (response.status === 401) {
                 setIsAuthenticated(false);
-                navigate('/login');
+                navigate(absolutePath('/login'));
             }
         } catch (error) {
             console.error('Auth check error:', error);
@@ -53,12 +54,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
     const logout = async () => {
         try {
-            await fetch('/identity/logout', {
+            await fetch(absolutePath('/identity/logout'), {
                 method: 'POST',
                 credentials: 'include',
             });
             setIsAuthenticated(false);
-            navigate('/login');
+            navigate(absolutePath('/login'));
         } catch (error) {
             console.error('Logout error:', error);
         }

--- a/Source/Workbench/Features/Security/LoginViewModel.ts
+++ b/Source/Workbench/Features/Security/LoginViewModel.ts
@@ -4,6 +4,7 @@
 import { injectable } from 'tsyringe';
 import { Guid } from '@cratis/fundamentals';
 import { ChangePasswordForUser, GetStatus, SetInitialAdminPassword } from 'Api/Security';
+import { absolutePath } from '../../Utils/basePath';
 
 @injectable()
 export class LoginViewModel {
@@ -46,7 +47,7 @@ export class LoginViewModel {
         this.errorMessage = '';
 
         try {
-            const response = await fetch('/api/security/login', {
+            const response = await fetch(absolutePath('/api/security/login'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -92,7 +93,7 @@ export class LoginViewModel {
     }
 
     async signInWithIdentityApi() {
-        const response = await fetch('/identity/login?useCookies=true', {
+        const response = await fetch(absolutePath('/identity/login?useCookies=true'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -105,7 +106,7 @@ export class LoginViewModel {
         });
 
         if (response.ok) {
-            window.location.href = '/';
+            window.location.href = absolutePath('/');
         } else {
             this.errorMessage = 'Failed to complete sign in. Please try again.';
         }

--- a/Source/Workbench/Features/Security/ProtectedRoute.tsx
+++ b/Source/Workbench/Features/Security/ProtectedRoute.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { ProgressSpinner } from 'Components/ProgressSpinner';
+import { absolutePath } from '../../Utils/basePath';
 
 interface ProtectedRouteProps {
     children: ReactNode;
@@ -29,7 +30,7 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
     }
 
     if (!isAuthenticated) {
-        return <Navigate to="/login" state={{ from: location }} replace />;
+        return <Navigate to={absolutePath('/login')} state={{ from: location }} replace />;
     }
 
     return <>{children}</>;

--- a/Source/Workbench/Utils/basePath.ts
+++ b/Source/Workbench/Utils/basePath.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The path prefix the Workbench is served under, normalized to either an empty string or a leading-slash path
+ * with no trailing slash.
+ *
+ * The value comes from the `base-path` meta tag, which the server rewrites into `index.html` when it serves the
+ * Workbench somewhere other than the root of its origin - behind a reverse proxy on a path prefix, for example.
+ * Reading it from a module rather than a hook is what lets view models and other non-component code build the
+ * same URLs the components do.
+ */
+export const basePath = normalizeBasePath(readConfiguredBasePath());
+
+/**
+ * Builds an absolute URL path for a Workbench route or endpoint, prefixed with {@link basePath}.
+ * @param path The root-relative path, with or without a leading slash.
+ * @returns The path to use against this origin.
+ */
+export function absolutePath(path: string): string {
+    const relative = path.startsWith('/') ? path : `/${path}`;
+
+    return `${basePath}${relative}`;
+}
+
+/**
+ * Normalizes a configured base path to either an empty string, for the root, or a leading-slash path with no
+ * trailing slash.
+ * @param configured The value as configured, in whatever shape it was written.
+ * @returns The normalized prefix.
+ */
+export function normalizeBasePath(configured: string | null | undefined): string {
+    const trimmed = configured?.trim() ?? '';
+
+    if (trimmed === '' || trimmed === '/') {
+        return '';
+    }
+
+    const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+
+    return withLeadingSlash.endsWith('/') ? withLeadingSlash.slice(0, -1) : withLeadingSlash;
+}
+
+function readConfiguredBasePath(): string {
+    if (typeof document === 'undefined') {
+        return '';
+    }
+
+    return (document.querySelector('meta[name="base-path"]') as HTMLMetaElement | null)?.content ?? '';
+}

--- a/Source/Workbench/Utils/for_basePath/when_building_an_absolute_path.ts
+++ b/Source/Workbench/Utils/for_basePath/when_building_an_absolute_path.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { absolutePath, basePath } from '../basePath';
+
+describe('when building an absolute path', () => {
+    // No base-path meta tag is present in the test document, so this exercises the root case - the one every
+    // existing deployment is in, and the one a prefix must not change.
+    it('should resolve to the root', () => basePath.should.equal(''));
+    it('should keep a path that already leads with a slash', () => absolutePath('/api/event-stores').should.equal('/api/event-stores'));
+    it('should add a leading slash to one that lacks it', () => absolutePath('api/event-stores').should.equal('/api/event-stores'));
+    it('should keep the query string', () => absolutePath('/identity/login?useCookies=true').should.equal('/identity/login?useCookies=true'));
+    it('should resolve the root path itself', () => absolutePath('/').should.equal('/'));
+});

--- a/Source/Workbench/Utils/for_basePath/when_normalizing_what_was_configured.ts
+++ b/Source/Workbench/Utils/for_basePath/when_normalizing_what_was_configured.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { normalizeBasePath } from '../basePath';
+
+describe('when normalizing what was configured', () => {
+    it('should treat an absent value as the root', () => normalizeBasePath(undefined).should.equal(''));
+    it('should treat a null value as the root', () => normalizeBasePath(null).should.equal(''));
+    it('should treat an empty value as the root', () => normalizeBasePath('').should.equal(''));
+    it('should treat a lone slash as the root', () => normalizeBasePath('/').should.equal(''));
+    it('should keep a single segment', () => normalizeBasePath('/workbench').should.equal('/workbench'));
+    it('should keep every segment of a nested prefix', () => normalizeBasePath('/api/play/a-session/workbench').should.equal('/api/play/a-session/workbench'));
+    it('should add a missing leading slash', () => normalizeBasePath('workbench').should.equal('/workbench'));
+    it('should drop a trailing slash', () => normalizeBasePath('/workbench/').should.equal('/workbench'));
+    it('should ignore surrounding whitespace', () => normalizeBasePath('  /workbench  ').should.equal('/workbench'));
+});


### PR DESCRIPTION
Three fixes to what a Chronicle costs before it can serve anything, plus the switch that makes an embedded one cheap. Measured against a play sandbox running the kernel and its client in one container: together these remove ~3s of a 7.3s cold start on an unconstrained machine, and ~5s of ~15s under a half-core limit.

## Added

- `Cratis:Chronicle:Authentication:Enabled` turns authentication off entirely — no token authority, no identity endpoints, no bootstrap admin user, and every gRPC service and HTTP endpoint answers anonymously. For a Chronicle embedded in one container or process with its own client over loopback, where the credential exchange protects nothing and costs every client seconds of cold start. Anywhere a network can reach the server, leaving it off publishes the whole event store (#3791)
- `auth=none` in a connection string, and `WithoutAuthentication()` on the builder, connect without presenting credentials. Omitting credentials still means client credentials with the development pair, as it always has — `auth=none` is the explicit form and overrides anything else the connection string carries (#3791)

## Fixed

- Connecting a client no longer waits a full keep-alive interval. The server withheld its first heartbeat for `KeepAliveIntervalSeconds` while the client waits on exactly that heartbeat to consider itself connected, so every connect everywhere cost the interval — a flat second by default, unaffected by how much CPU the machine had, because it was a delay rather than work (#3790)
- The "started successfully - ready and listening" message is logged once Kestrel has bound the port, rather than roughly half a second before it. Entrypoint scripts, test fixtures and orchestrators that gate on that line were connecting to a socket that did not exist yet (#3792)
- The Workbench works when served under a path prefix. It already learns its prefix from the `base-path` meta tag and hands it to Arc, but its auth probe, login, logout and post-login redirect asked for root-absolute paths regardless — so under a prefix the probe hit whatever else was at the root and the Workbench sent the user to a `/login` that was not there
