### PR TITLE
Move Chronicle examples into client snippets

### DIFF
--- a/Documentation/client-snippets/compliance/erasure/allow-new-key.md
+++ b/Documentation/client-snippets/compliance/erasure/allow-new-key.md
@@ -1,0 +1,10 @@
+```csharp
+public static class ComplianceErasureAllowNewKey
+{
+    public static async Task Allow(ChronicleClient chronicleClient)
+    {
+        var eventStore = await chronicleClient.GetEventStore("Sales");
+        await eventStore.PII.AllowNewEncryptionKeyFor("person-42");
+    }
+}
+```

--- a/Documentation/client-snippets/compliance/erasure/delete-key.md
+++ b/Documentation/client-snippets/compliance/erasure/delete-key.md
@@ -1,0 +1,10 @@
+```csharp
+public static class ComplianceErasureDeleteKey
+{
+    public static async Task Delete(ChronicleClient chronicleClient)
+    {
+        var eventStore = await chronicleClient.GetEventStore("Sales");
+        await eventStore.PII.DeleteEncryptionKeyFor("person-42");
+    }
+}
+```

--- a/Documentation/client-snippets/configuration/tls/validation-enabled.md
+++ b/Documentation/client-snippets/configuration/tls/validation-enabled.md
@@ -1,0 +1,8 @@
+```csharp
+public static class ConfigurationTlsValidationEnabled
+{
+    public static ChronicleOptions Create() =>
+        ChronicleOptions.FromConnectionString(
+            "chronicle://my-server:35000?skipTlsValidation=false");
+}
+```

--- a/Documentation/client-snippets/hosting/aspire/pin-image.md
+++ b/Documentation/client-snippets/hosting/aspire/pin-image.md
@@ -1,0 +1,18 @@
+```csharp
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+public static class HostingAspirePinImage
+{
+    public static IResourceBuilder<ChronicleResource> Configure(
+        IDistributedApplicationBuilder builder) =>
+        builder
+            .AddCratisChronicle(configure: chronicle => chronicle
+                .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
+                .WithEncryptionCertificate(
+                    "certs/encryption.pfx",
+                    "YourPassword"))
+            .WithImageTag("16.26.0");
+}
+```

--- a/Documentation/client-snippets/hosting/aspire/rotation-previous-certificate.md
+++ b/Documentation/client-snippets/hosting/aspire/rotation-previous-certificate.md
@@ -1,0 +1,27 @@
+```csharp
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Cratis.Chronicle.Aspire;
+
+public static class HostingAspireRotationPreviousCertificate
+{
+    public static IResourceBuilder<ChronicleResource> Configure(
+        IDistributedApplicationBuilder builder) =>
+        builder
+            .AddCratisChronicle(configure: chronicle => chronicle
+                .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
+                .WithEncryptionCertificate(
+                    "certs/encryption-2026.pfx",
+                    "YourNewPassword"))
+            .WithBindMount(
+                "certs/encryption-2025.pfx",
+                "/certs/encryption-previous.pfx",
+                isReadOnly: true)
+            .WithEnvironment(
+                "Cratis__Chronicle__EncryptionCertificate__Previous__0__CertificatePath",
+                "/certs/encryption-previous.pfx")
+            .WithEnvironment(
+                "Cratis__Chronicle__EncryptionCertificate__Previous__0__CertificatePassword",
+                "YourOldPassword");
+}
+```

--- a/Documentation/compliance/erasing-a-subject.md
+++ b/Documentation/compliance/erasing-a-subject.md
@@ -10,10 +10,7 @@ A right-to-erasure request arrives naming one person, and Chronicle gives you ex
 
 Erasure in Chronicle is the deletion of an encryption key. Every `[PII]` value is encrypted at append time under a key held for the event's [subject](../concepts/subject), so deleting that key makes every PII value for that subject unreadable at once, without touching the append-only log:
 
-```csharp
-var eventStore = await chronicleClient.GetEventStore("Sales");
-await eventStore.PII.DeleteEncryptionKeyFor("person-42");
-```
+<ChronicleClientTabs snippet="compliance/erasure/delete-key" />
 
 `IEventStore.PII` is an `IPIIManager`. `DeleteEncryptionKeyFor` removes every revision of the key, evicts it from every silo's cache, and records the erasure so that nothing puts the key back afterwards.
 
@@ -59,10 +56,7 @@ The practical consequence is worth knowing before you erase:
 
 If the same person later has a lawful basis to be protected again, say so:
 
-```csharp
-var eventStore = await chronicleClient.GetEventStore("Sales");
-await eventStore.PII.AllowNewEncryptionKeyFor("person-42");
-```
+<ChronicleClientTabs snippet="compliance/erasure/allow-new-key" />
 
 That creates no key. It authorizes the next `[PII]` value written for the subject to provision a fresh, independent one — which protects data written from then on and can decrypt nothing that came before. The erased key itself never comes back. Like the erasure, the authorization covers every event store in the namespace.
 

--- a/Documentation/compliance/key-lifecycle.md
+++ b/Documentation/compliance/key-lifecycle.md
@@ -70,10 +70,7 @@ The fence is not a ban on the subject identifier. Ada's D98 ruling settled that 
 
 A subscription copies a subject's key across event stores, but never across namespaces — the namespace is the tenancy boundary and the copy always stays inside it. So the set of places a key can have reached is exactly *every event store, in the namespace you erased in*, and that is the set a single erasure now covers:
 
-```csharp
-var eventStore = await chronicleClient.GetEventStore("Sales");
-await eventStore.PII.DeleteEncryptionKeyFor("person-42");
-```
+<ChronicleClientTabs snippet="compliance/erasure/delete-key" />
 
 That one call now runs in three phases:
 
@@ -100,10 +97,7 @@ The fence is written even in event stores that never held a key for the subject.
 
 When a person who was erased has a lawful basis to be protected again, authorize a new key explicitly:
 
-```csharp
-var eventStore = await chronicleClient.GetEventStore("Sales");
-await eventStore.PII.AllowNewEncryptionKeyFor("person-42");
-```
+<ChronicleClientTabs snippet="compliance/erasure/allow-new-key" />
 
 Like erasure, this reaches every event store in the namespace, and like erasure it is a deliberate, explicit act rather than something ordinary traffic can cause. It does **not** create a key. It sets `NewKeyAllowed` on the fence, and the next `[PII]` value appended for that subject mints a fresh key at revision `ErasedThrough + 1`.
 

--- a/Documentation/configuration/tls.mdx
+++ b/Documentation/configuration/tls.mdx
@@ -38,9 +38,7 @@ The client always connects over TLS, but by default it does **not** validate the
 
 Once you run against a server whose certificate is verifiable, turn validation on with `skipTlsValidation=false` in the connection string:
 
-```csharp
-var options = ChronicleOptions.FromConnectionString("chronicle://my-server:35000?skipTlsValidation=false");
-```
+<ChronicleClientTabs snippet="configuration/tls/validation-enabled" />
 
 You can also set it on the client's TLS options as `SkipCertificateValidation = false`. **Either setting alone is enough** — the two combine so that whichever one asks for validation wins, and an omitted second setting can never silently turn validation back off.
 

--- a/Documentation/hosting/aspire.mdx
+++ b/Documentation/hosting/aspire.mdx
@@ -58,15 +58,7 @@ The password argument is optional, but supply it: Chronicle reads the file as PK
 
 `WithEncryptionCertificate` sets the **active** certificate. Chronicle also accepts previously active certificates, kept for decryption only, so a rotation needs no downtime — see [Rotating the certificate](./encryption-certificate.md#rotating-the-certificate). There is no builder method for that list yet; mount the previous certificate and point the configuration at it directly:
 
-```csharp
-var chronicle = builder
-    .AddCratisChronicle(configure: chronicle => chronicle
-        .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
-        .WithEncryptionCertificate("certs/encryption-2026.pfx", "YourNewPassword"))
-    .WithBindMount("certs/encryption-2025.pfx", "/certs/encryption-previous.pfx", isReadOnly: true)
-    .WithEnvironment("Cratis__Chronicle__EncryptionCertificate__Previous__0__CertificatePath", "/certs/encryption-previous.pfx")
-    .WithEnvironment("Cratis__Chronicle__EncryptionCertificate__Previous__0__CertificatePassword", "YourOldPassword");
-```
+<ChronicleClientTabs snippet="hosting/aspire/rotation-previous-certificate" />
 
 `AddCratisChronicle` returns the resource builder, so `WithBindMount` and `WithEnvironment` chain straight onto it. The bind mount is what `WithEncryptionCertificate` would have done for you: the path in the environment variable is the path *inside* the container, so a host path handed straight to Chronicle names a file it cannot see.
 
@@ -163,13 +155,7 @@ For development, drop the whole callback. The development image brings its own M
 
 Both tags above float. `AddCratisChronicle` picks the tag for you, so a production deployment tracks whatever `cratis/chronicle:latest` happens to be at pull time — two deployments of the same AppHost can land on different Chronicle versions. Pin an exact version by chaining `WithImageTag` after the call:
 
-```csharp
-var chronicle = builder
-    .AddCratisChronicle(configure: chronicle => chronicle
-        .WithTlsCertificate("certs/chronicle.pfx", "YourPassword")
-        .WithEncryptionCertificate("certs/encryption.pfx", "YourPassword"))
-    .WithImageTag("16.26.0");
-```
+<ChronicleClientTabs snippet="hosting/aspire/pin-image" />
 
 `WithImageTag` overrides the tag the integration selected while leaving the image and registry alone, and it does not change which image *class* is used — a `configure` callback still selects the production image. Pin to a released Chronicle version, and treat the upgrade as a deliberate change.
 


### PR DESCRIPTION
# Summary

Moves newly added C# examples out of shared Chronicle pages and into compiled client-owned snippets so the multi-client docs gate remains strict.

## Fixed

- Replace seven direct C# fences with five reusable Chronicle client snippets
- Compile the erasure, TLS, Aspire certificate-rotation and image-pin examples with zero warnings
