### PR TITLE
Add generated Python contracts package

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -1,0 +1,89 @@
+name: Publish Python Contracts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to publish
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Build contracts
+        working-directory: Source/Kernel/Contracts
+        run: dotnet build -c Release
+
+      - name: Generate proto files
+        run: |
+          dotnet run \
+            --project Source/Tools/ProtoGenerator/ProtoGenerator.csproj -- \
+            Source/Kernel/Contracts/bin/Release/net10.0/Cratis.Chronicle.Contracts.dll \
+            Source/Kernel/Protobuf
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: Source/Clients/Python/pyproject.toml
+
+      - name: Install package tooling
+        working-directory: Source/Clients/Python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Generate Python contracts
+        working-directory: Source/Clients/Python
+        run: python generate.py --proto-root ../../Kernel/Protobuf
+
+      - name: Test generated contracts
+        working-directory: Source/Clients/Python
+        run: pytest
+
+      - name: Build distributions
+        working-directory: Source/Clients/Python
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.version }}
+        run: python build_package.py
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-contract-distributions
+          path: Source/Clients/Python/dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi-python-contracts
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-contract-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -1,0 +1,68 @@
+name: Python Contracts
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "Source/Clients/Python/**"
+      - "Source/Kernel/Protobuf/**"
+      - ".github/workflows/python-contracts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.14"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: Source/Clients/Python/pyproject.toml
+
+      - name: Install package tooling
+        working-directory: Source/Clients/Python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Generate Python contracts
+        working-directory: Source/Clients/Python
+        run: python generate.py --proto-root ../../Kernel/Protobuf
+
+      - name: Check formatting
+        working-directory: Source/Clients/Python
+        run: ruff format --check generate.py build_package.py tests
+
+      - name: Lint
+        working-directory: Source/Clients/Python
+        run: ruff check generate.py build_package.py tests
+
+      - name: Test generated contracts
+        working-directory: Source/Clients/Python
+        run: pytest
+
+      - name: Build and check distributions
+        working-directory: Source/Clients/Python
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0"
+        run: python build_package.py

--- a/Source/Clients/Python/.gitignore
+++ b/Source/Clients/Python/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+.venv/
+dist/
+src/cratis_chronicle_contracts/*_pb2.py
+src/cratis_chronicle_contracts/*_pb2.pyi
+src/cratis_chronicle_contracts/*_pb2_grpc.py
+src/cratis_chronicle_contracts/protobuf_net/

--- a/Source/Clients/Python/LICENSE
+++ b/Source/Clients/Python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Cratis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Source/Clients/Python/README.md
+++ b/Source/Clients/Python/README.md
@@ -1,0 +1,26 @@
+# Chronicle Python contracts
+
+This project packages the non-idiomatic Python gRPC messages and stubs generated from Chronicle's canonical
+`.proto` files. The package is intended for the idiomatic
+[`Cratis/Chronicle.Python`](https://github.com/Cratis/Chronicle.Python) client.
+
+Generated modules are build artifacts and must not be edited. Change the Chronicle C# contracts or proto
+generator, regenerate the schemas, and build this package again.
+
+## Build locally
+
+From this directory:
+
+```shell
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+python generate.py --proto-root ../../Kernel/Protobuf
+pytest
+python build_package.py
+```
+
+`build_package.py` refuses to build when generated messages or gRPC stubs are absent.
+
+This package exposes the generated wire surface. It does not establish support, compatibility, or feature parity
+for an idiomatic Python client.

--- a/Source/Clients/Python/build_package.py
+++ b/Source/Clients/Python/build_package.py
@@ -1,0 +1,58 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Build the generated contracts package after validating generation output."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+PACKAGE_ROOT = ROOT / "src" / "cratis_chronicle_contracts"
+
+
+def main() -> None:
+    messages = list(PACKAGE_ROOT.glob("*_pb2.py"))
+    stubs = list(PACKAGE_ROOT.glob("*_pb2_grpc.py"))
+    if not messages or not stubs:
+        raise SystemExit("Generated messages and gRPC stubs are required. Run generate.py first.")
+
+    shutil.rmtree(ROOT / "dist", ignore_errors=True)
+    subprocess.run([sys.executable, "-m", "build"], cwd=ROOT, check=True)
+    distributions = [*sorted((ROOT / "dist").glob("*.whl")), *sorted((ROOT / "dist").glob("*.tar.gz"))]
+    if len(distributions) != 2:
+        raise SystemExit(f"Expected one wheel and one source distribution, found {len(distributions)}")
+
+    wheel = next(path for path in distributions if path.suffix == ".whl")
+    source_distribution = next(path for path in distributions if path.name.endswith(".tar.gz"))
+    required_generated_paths = (
+        "cratis_chronicle_contracts/events_pb2.py",
+        "cratis_chronicle_contracts/events_pb2_grpc.py",
+        "cratis_chronicle_contracts/protobuf_net/bcl_pb2.py",
+    )
+    with zipfile.ZipFile(wheel) as archive:
+        wheel_paths = set(archive.namelist())
+    missing_from_wheel = [path for path in required_generated_paths if path not in wheel_paths]
+    if missing_from_wheel:
+        raise SystemExit(f"Generated contracts missing from wheel: {missing_from_wheel}")
+
+    with tarfile.open(source_distribution, "r:gz") as archive:
+        source_paths = tuple(archive.getnames())
+    missing_from_source = [
+        path
+        for path in required_generated_paths
+        if not any(candidate.endswith(f"/src/{path}") for candidate in source_paths)
+    ]
+    if missing_from_source:
+        raise SystemExit(f"Generated contracts missing from source distribution: {missing_from_source}")
+
+    subprocess.run([sys.executable, "-m", "twine", "check", *(str(path) for path in distributions)], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/Source/Clients/Python/generate.py
+++ b/Source/Clients/Python/generate.py
@@ -1,0 +1,98 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Generate package-local Python messages and gRPC stubs from Chronicle proto files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import tempfile
+from importlib import import_module
+from importlib.resources import files
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).parent / "src" / "cratis_chronicle_contracts"
+GENERATED_SUFFIXES = ("_pb2.py", "_pb2.pyi", "_pb2_grpc.py")
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proto-root", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _clean_generated_files() -> None:
+    for path in PACKAGE_ROOT.rglob("*"):
+        if path.is_file() and path.name.endswith(GENERATED_SUFFIXES):
+            path.unlink()
+
+    generated_directory = PACKAGE_ROOT / "protobuf_net"
+    if generated_directory.exists():
+        shutil.rmtree(generated_directory)
+
+
+def _prepare_proto_tree(source: Path, destination: Path) -> list[Path]:
+    proto_files: list[Path] = []
+    for source_file in sorted(source.rglob("*.proto")):
+        relative_path = source_file.relative_to(source)
+        normalized_path = Path(*("protobuf_net" if part == "protobuf-net" else part for part in relative_path.parts))
+        destination_file = destination / normalized_path
+        destination_file.parent.mkdir(parents=True, exist_ok=True)
+        contents = source_file.read_text().replace('"protobuf-net/bcl.proto"', '"protobuf_net/bcl.proto"')
+        destination_file.write_text(contents)
+        proto_files.append(normalized_path)
+    return proto_files
+
+
+def _rewrite_imports(path: Path) -> None:
+    contents = path.read_text()
+    if path.parent == PACKAGE_ROOT:
+        contents = re.sub(r"^import ([A-Za-z0-9_]+_pb2) as ", r"from . import \1 as ", contents, flags=re.MULTILINE)
+        contents = contents.replace("from protobuf_net import bcl_pb2 as", "from .protobuf_net import bcl_pb2 as")
+    else:
+        contents = contents.replace("from protobuf_net import bcl_pb2 as", "from . import bcl_pb2 as")
+    path.write_text(contents)
+
+
+def generate(proto_root: Path) -> None:
+    proto_root = proto_root.resolve()
+    if not proto_root.is_dir():
+        raise SystemExit(f"Proto root does not exist: {proto_root}")
+
+    _clean_generated_files()
+    PACKAGE_ROOT.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        normalized_root = Path(temporary_directory)
+        proto_files = _prepare_proto_tree(proto_root, normalized_root)
+        grpc_include_root = files("grpc_tools").joinpath("_proto")
+        arguments = [
+            "grpc_tools.protoc",
+            f"-I{normalized_root}",
+            f"-I{grpc_include_root}",
+            f"--python_out={PACKAGE_ROOT}",
+            f"--pyi_out={PACKAGE_ROOT}",
+            f"--grpc_python_out={PACKAGE_ROOT}",
+            *(str(path) for path in proto_files),
+        ]
+        protoc = import_module("grpc_tools.protoc")
+        result = protoc.main(arguments)
+        if result != 0:
+            raise SystemExit(result)
+
+    nested_package = PACKAGE_ROOT / "protobuf_net"
+    nested_package.mkdir(exist_ok=True)
+    (nested_package / "__init__.py").write_text(
+        "# Copyright (c) Cratis. All rights reserved.\n"
+        "# Licensed under the MIT license. See LICENSE file in the project root for full license information.\n"
+    )
+
+    for generated_file in PACKAGE_ROOT.rglob("*.py"):
+        if generated_file.name.endswith(("_pb2.py", "_pb2_grpc.py")):
+            _rewrite_imports(generated_file)
+
+
+if __name__ == "__main__":
+    generate(_arguments().proto_root)

--- a/Source/Clients/Python/pyproject.toml
+++ b/Source/Clients/Python/pyproject.toml
@@ -1,0 +1,70 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cratis-chronicle-contracts"
+dynamic = ["version"]
+description = "Generated Python gRPC contracts for Cratis Chronicle"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Cratis", email = "post@cratis.io" }]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Typing :: Typed",
+]
+dependencies = [
+    "grpcio>=1.83.0,<2",
+    "protobuf>=7.35.1,<8",
+]
+
+[project.optional-dependencies]
+dev = [
+    "build",
+    "grpcio-tools==1.83.0",
+    "pytest",
+    "ruff",
+    "twine",
+]
+
+[project.urls]
+Repository = "https://github.com/Cratis/Chronicle.git"
+Issues = "https://github.com/Cratis/Chronicle/issues"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
+
+[tool.hatch.build]
+artifacts = [
+    "src/cratis_chronicle_contracts/*_pb2.py",
+    "src/cratis_chronicle_contracts/*_pb2.pyi",
+    "src/cratis_chronicle_contracts/*_pb2_grpc.py",
+    "src/cratis_chronicle_contracts/protobuf_net/**",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cratis_chronicle_contracts"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "UP"]

--- a/Source/Clients/Python/src/cratis_chronicle_contracts/__init__.py
+++ b/Source/Clients/Python/src/cratis_chronicle_contracts/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Generated Python gRPC contracts for Cratis Chronicle."""

--- a/Source/Clients/Python/tests/test_generated_contracts.py
+++ b/Source/Clients/Python/tests/test_generated_contracts.py
@@ -1,0 +1,26 @@
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+from importlib import import_module
+
+events_pb2 = import_module("cratis_chronicle_contracts.events_pb2")
+events_pb2_grpc = import_module("cratis_chronicle_contracts.events_pb2_grpc")
+bcl_pb2 = import_module("cratis_chronicle_contracts.protobuf_net.bcl_pb2")
+
+
+def test_event_contract_is_importable() -> None:
+    event_type = events_pb2.EventType(Id="example", Generation=1)
+
+    assert event_type.Id == "example"
+    assert event_type.Generation == 1
+
+
+def test_event_service_stub_is_generated() -> None:
+    assert hasattr(events_pb2_grpc, "EventTypesStub")
+
+
+def test_protobuf_net_contract_is_importable() -> None:
+    value = bcl_pb2.Guid(lo=1, hi=2)
+
+    assert value.lo == 1
+    assert value.hi == 2


### PR DESCRIPTION
# Summary

Provide a generated Python contract package from Chronicle's canonical protobuf surface so the idiomatic Python client does not copy or hand-maintain wire definitions. Publication remains a manual, maintainer-approved action until PyPI trusted publishing is configured.

## Added

- Generated `cratis-chronicle-contracts` Python package build with typed messages and gRPC stubs (#3806)
- Import, package-content, wheel, and source-distribution verification (#3806)
- Python 3.10 and 3.14 pull request checks for contract generation (#3806)
- Manual PyPI trusted-publishing workflow guarded by a dedicated environment (#3806)
