### PR TITLE
Fix Chronicle projection, publishing, and key storage defects

### DIFF
--- a/.github/scripts/test-verify-published-docker-tags.py
+++ b/.github/scripts/test-verify-published-docker-tags.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Specs for verify-published-docker-tags.py.
+
+The publish workflow now hard-fails if Docker Hub never resolves a tag after
+push. These specs pin the tag expansion and retry behavior so a future change
+cannot silently stop checking one of the image variants or stop failing when a
+manifest never appears.
+
+Run with: python3 .github/scripts/test-verify-published-docker-tags.py
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import unittest
+
+SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(SCRIPT_DIRECTORY, "verify-published-docker-tags.py")
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(SCRIPT_DIRECTORY))
+
+
+def _load():
+    """Import the verifier, whose filename is not a valid module name."""
+    spec = importlib.util.spec_from_file_location("verify_published_docker_tags", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module spec for {SCRIPT}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+verifier = _load()
+
+
+class for_expected_references(unittest.TestCase):
+    """The release shapes the verifier must insist on."""
+
+    def test_stable_releases_check_the_four_versioned_and_four_latest_tags(self):
+        self.assertEqual(
+            [
+                "cratis/chronicle:1.2.3",
+                "cratis/chronicle:1.2.3-workbench",
+                "cratis/chronicle:1.2.3-development",
+                "cratis/chronicle:1.2.3-development-slim",
+                "cratis/chronicle:latest",
+                "cratis/chronicle:latest-workbench",
+                "cratis/chronicle:latest-development",
+                "cratis/chronicle:latest-development-slim",
+            ],
+            verifier.expected_references("1.2.3", False),
+        )
+
+    def test_prereleases_check_only_the_four_versioned_tags(self):
+        self.assertEqual(
+            [
+                "cratis/chronicle:1.2.3-rc.1",
+                "cratis/chronicle:1.2.3-rc.1-workbench",
+                "cratis/chronicle:1.2.3-rc.1-development",
+                "cratis/chronicle:1.2.3-rc.1-development-slim",
+            ],
+            verifier.expected_references("1.2.3-rc.1", True),
+        )
+
+
+class for_verifying_references(unittest.TestCase):
+    """Retry behavior and failure reporting."""
+
+    def test_retries_only_the_references_still_missing(self):
+        references = [
+            "cratis/chronicle:1.2.3",
+            "cratis/chronicle:1.2.3-workbench",
+        ]
+        calls = []
+        responses = {
+            "cratis/chronicle:1.2.3": [(False, "not found"), (True, "")],
+            "cratis/chronicle:1.2.3-workbench": [(True, "")],
+        }
+
+        def inspect(reference):
+            calls.append(reference)
+            return responses[reference].pop(0)
+
+        sleeps = []
+        verifier.verify_references(
+            references,
+            retries=1,
+            delay_seconds=5,
+            inspect=inspect,
+            sleep=sleeps.append,
+            log=lambda *_: None,
+        )
+
+        self.assertEqual(
+            [
+                "cratis/chronicle:1.2.3",
+                "cratis/chronicle:1.2.3-workbench",
+                "cratis/chronicle:1.2.3",
+            ],
+            calls,
+        )
+        self.assertEqual([5], sleeps)
+
+    def test_eventual_success_allows_short_registry_propagation(self):
+        attempts = [
+            (False, "missing on attempt one"),
+            (False, "missing on attempt two"),
+            (True, ""),
+        ]
+        sleeps = []
+
+        verifier.verify_references(
+            ["cratis/chronicle:1.2.3"],
+            retries=2,
+            delay_seconds=3,
+            inspect=lambda _: attempts.pop(0),
+            sleep=sleeps.append,
+            log=lambda *_: None,
+        )
+
+        self.assertEqual([3, 3], sleeps)
+        self.assertEqual([], attempts)
+
+    def test_permanent_failure_names_every_missing_reference(self):
+        with self.assertRaises(RuntimeError) as error:
+            verifier.verify_references(
+                [
+                    "cratis/chronicle:1.2.3",
+                    "cratis/chronicle:1.2.3-workbench",
+                ],
+                retries=1,
+                delay_seconds=0,
+                inspect=lambda reference: (False, f"missing {reference}"),
+                sleep=lambda _: None,
+                log=lambda *_: None,
+            )
+
+        message = str(error.exception)
+        self.assertIn("cratis/chronicle:1.2.3", message)
+        self.assertIn("cratis/chronicle:1.2.3-workbench", message)
+
+
+class for_the_command_line(unittest.TestCase):
+    """Input validation at the workflow boundary."""
+
+    def test_invalid_versions_are_rejected_before_any_registry_call(self):
+        completed = subprocess.run(
+            [sys.executable, SCRIPT, "--version", "1.2.3+build", "--prerelease", "false"],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("not a valid Docker tag component", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify-published-docker-tags.py
+++ b/.github/scripts/verify-published-docker-tags.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Cratis. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"""Verify that every Docker tag a Chronicle release just pushed resolves on Docker Hub.
+
+Multi-architecture manifest pushes can take a short time to propagate through the
+registry even after the push step returns successfully. This script expands the
+set of tags a Chronicle release must publish and verifies each one with
+`docker buildx imagetools inspect`, retrying only the references that are still
+missing. Stable releases must resolve the four versioned tags and the four
+`latest*` tags; prereleases must resolve only the versioned tags.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+
+REPOSITORY = "cratis/chronicle"
+VARIANT_SUFFIXES = ("", "-workbench", "-development", "-development-slim")
+DOCKER_TAG_COMPONENT = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+DEFAULT_RETRIES = 6
+DEFAULT_DELAY_SECONDS = 10
+
+
+def docker_tag_component(value):
+    """Validate a value that becomes one Docker tag component."""
+    if not DOCKER_TAG_COMPONENT.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            f"{value!r} is not a valid Docker tag component. "
+            "Use only ASCII letters, digits, underscores, periods and dashes, "
+            "starting with a letter, digit or underscore."
+        )
+    return value
+
+
+def prerelease_flag(value):
+    """Parse the workflow's prerelease output into a boolean."""
+    normalized = value.strip().lower()
+    if normalized in ("", "false", "0", "no"):
+        return False
+    if normalized in ("true", "1", "yes"):
+        return True
+    raise argparse.ArgumentTypeError("prerelease must be true or false")
+
+
+def expected_references(version, prerelease):
+    """Return the Docker references a release is required to publish."""
+    references = [f"{REPOSITORY}:{version}{suffix}" for suffix in VARIANT_SUFFIXES]
+    if not prerelease:
+        references.extend(f"{REPOSITORY}:latest{suffix}" for suffix in VARIANT_SUFFIXES)
+    return references
+
+
+def inspect_reference(reference, runner=subprocess.run):
+    """Return whether the Docker reference resolves, plus the last CLI message."""
+    completed = runner(
+        ["docker", "buildx", "imagetools", "inspect", reference],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (completed.stderr or completed.stdout).strip()
+    return completed.returncode == 0, output
+
+
+def verify_references(references, retries=DEFAULT_RETRIES, delay_seconds=DEFAULT_DELAY_SECONDS, inspect=inspect_reference, sleep=time.sleep, log=print):
+    """Verify that every reference resolves, retrying only the ones still missing."""
+    pending = list(references)
+    attempts = retries + 1
+    last_errors = {}
+
+    for attempt in range(1, attempts + 1):
+        log(f"Verification attempt {attempt}/{attempts}: {len(pending)} reference(s) pending")
+        unresolved = []
+
+        for reference in pending:
+            resolved, detail = inspect(reference)
+            if resolved:
+                log(f"Resolved {reference}")
+                continue
+
+            unresolved.append(reference)
+            last_errors[reference] = detail or "docker buildx imagetools inspect failed"
+            log(f"Waiting on {reference}")
+
+        if not unresolved:
+            log("All expected Docker references resolved.")
+            return
+
+        pending = unresolved
+        if attempt < attempts:
+            log(f"Sleeping {delay_seconds} second(s) before retrying {len(unresolved)} unresolved reference(s)")
+            sleep(delay_seconds)
+
+    details = "\n".join(f"- {reference}: {last_errors[reference]}" for reference in pending)
+    raise RuntimeError(
+        f"Docker Hub did not resolve every expected Chronicle tag after {attempts} attempt(s):\n{details}"
+    )
+
+
+def main(argv=None):
+    """Parse arguments and fail the workflow if any expected tag never appears."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, type=docker_tag_component, help="Release version tag component")
+    parser.add_argument("--prerelease", required=True, type=prerelease_flag, help="Whether the release is a prerelease")
+    parser.add_argument("--retries", type=int, default=DEFAULT_RETRIES, help="Additional attempts after the first inspection")
+    parser.add_argument("--delay-seconds", type=int, default=DEFAULT_DELAY_SECONDS, help="Seconds to wait between attempts")
+    args = parser.parse_args(argv)
+
+    if args.retries < 0:
+        parser.error("--retries must be zero or greater")
+    if args.delay_seconds < 0:
+        parser.error("--delay-seconds must be zero or greater")
+
+    references = expected_references(args.version, args.prerelease)
+    print(f"Verifying {len(references)} Docker reference(s) for {args.version}")
+
+    try:
+        verify_references(references, retries=args.retries, delay_seconds=args.delay_seconds)
+    except RuntimeError as error:
+        print(f"::error::{error}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Assert every spec project is in the solution
         run: python3 .github/scripts/assert-solution-membership.py
 
+      # The publish workflow's Docker verification logic is release-only, so this checkout-only spec run is
+      # where a pull request proves the tag expansion, retry and failure behavior before any publication occurs.
+      - name: Spec the published Docker tag verifier
+        run: python3 .github/scripts/test-verify-published-docker-tags.py
+
       - name: Setup .Net
         uses: actions/setup-dotnet@v4
         with:
@@ -126,7 +131,7 @@ jobs:
       - name: Build client packages for every shipped framework
         run: |
           set -e
-          for project in $(find ./Source/Clients -name "*.csproj" ! -name "*.Specs.csproj"); do
+          find ./Source/Clients -name "*.csproj" ! -name "*.Specs.csproj" -print0 | while IFS= read -r -d '' project; do
             dotnet build "$project" --configuration Release -p:IsPackaging=true -p:DisableProxyGenerator=true -p:DisableDockerBuild=true
           done
           dotnet build ./Source/Kernel/Contracts/Contracts.csproj --configuration Release -p:IsPackaging=true -p:DisableProxyGenerator=true -p:DisableDockerBuild=true
@@ -406,7 +411,7 @@ jobs:
           mkdir -p ./coverage-reports
           
           # Find all coverage.cobertura.xml files from artifacts and copy them
-          find ./all-coverage-results -name "coverage.cobertura.xml" -type f | while read file; do
+          find ./all-coverage-results -name "coverage.cobertura.xml" -type f | while IFS= read -r file; do
             echo "Found coverage file: $file"
             # Create unique directory for each coverage file
             dirname_hash=$(echo "$file" | md5sum | cut -d' ' -f1)
@@ -443,13 +448,16 @@ jobs:
           echo "key=coverage-cache-${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Collect coverage statistics
+        env:
+          COVERAGE_REF_NAME: ${{ github.head_ref || github.ref_name }}
+          COVERAGE_MESSAGE: ${{ github.event.head_commit.message || format('Coverage update for {0}', github.head_ref || github.ref_name) }}
         run: |
           .github/scripts/collect-coverage.sh \
             "./coverage-reports" \
             "./Documentation/statistics/coverage-data.js" \
-            "${{ github.head_ref || github.ref_name }}" \
+            "$COVERAGE_REF_NAME" \
             "${{ github.sha }}" \
-            "${{ github.event.head_commit.message || format('Coverage update for {0}', github.head_ref || github.ref_name) }}"
+            "$COVERAGE_MESSAGE"
 
   # Running the benchmarks takes ~13 minutes and sits on the critical path behind dotnet-build, which made it
   # the single thing deciding how long a pull request takes to go green. It cannot fail a build either

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,13 +124,15 @@ jobs:
           fail-on-cache-miss: false
 
       - name: Collect coverage statistics for release
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           .github/scripts/collect-coverage.sh \
             "./coverage-reports" \
             "./Documentation/statistics/coverage-data.js" \
             "${{ needs.release.outputs.version }}" \
             "${{ github.sha }}" \
-            "${{ github.event.head_commit.message }}"
+            "$HEAD_COMMIT_MESSAGE"
 
       - name: Commit coverage statistics
         run: |
@@ -281,7 +283,7 @@ jobs:
 
       - name: Build and Create NuGet packages
         run: |
-          for project in $(find ./Source/Clients -name "*.csproj" ! -name "*.Specs.csproj"); do
+          find ./Source/Clients -name "*.csproj" ! -name "*.Specs.csproj" -print0 | while IFS= read -r -d '' project; do
             dotnet pack "$project" --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:IsPackaging=true -p:Version=${{ needs.release.outputs.version }} -p:PackageVersion=${{ needs.release.outputs.version }} -p:SourceRevisionId=${{ github.sha }}
           done
           # Also pack the Contracts project from Kernel
@@ -449,9 +451,11 @@ jobs:
           if [ "${{ needs.release.outputs.prerelease }}" != "true" ]; then
             TAGS="${TAGS}\ncratis/chronicle:latest"
           fi
-          echo "tags<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$TAGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "tags<<EOF"
+            printf '%b\n' "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Production Docker Image
         uses: docker/build-push-action@v5
@@ -530,9 +534,11 @@ jobs:
           if [ "${{ needs.release.outputs.prerelease }}" != "true" ]; then
             TAGS="${TAGS}\ncratis/chronicle:latest-workbench"
           fi
-          echo "tags<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$TAGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "tags<<EOF"
+            printf '%b\n' "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Workbench Image
         uses: docker/build-push-action@v5
@@ -594,9 +600,11 @@ jobs:
           if [ "${{ needs.release.outputs.prerelease }}" != "true" ]; then
             TAGS="${TAGS}\ncratis/chronicle:latest-development"
           fi
-          echo "tags<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$TAGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "tags<<EOF"
+            printf '%b\n' "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Development Docker Image
         uses: docker/build-push-action@v5
@@ -673,9 +681,11 @@ jobs:
           if [ "${{ needs.release.outputs.prerelease }}" != "true" ]; then
             TAGS="${TAGS}\ncratis/chronicle:latest-development-slim"
           fi
-          echo "tags<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$TAGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "tags<<EOF"
+            printf '%b\n' "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build Development Slim Docker Image
         uses: docker/build-push-action@v5
@@ -688,6 +698,40 @@ jobs:
           tags: ${{ steps.docker-tags.outputs.tags }}
           build-args: |
             VERSION=${{ needs.release.outputs.version }}
+
+  verify-published-docker-tags:
+    if: needs.release.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - release
+      - publish-docker-production
+      - publish-docker-workbench
+      - publish-docker-development
+      - publish-docker-development-slim
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Verify published Docker tags
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+          RELEASE_PRERELEASE: ${{ needs.release.outputs.prerelease }}
+        run: |
+          python3 .github/scripts/verify-published-docker-tags.py \
+            --version "$RELEASE_VERSION" \
+            --prerelease "$RELEASE_PRERELEASE"
 
   verify-published:
     # A merged pull request that publishes nothing is the failure mode that silently costs a release: the release

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionsExtensions/TestTypes.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionsExtensions/TestTypes.cs
@@ -22,6 +22,10 @@ public record TypeWithEventSequenceAttribute([Key] Guid Id, string Name);
 [Passive]
 public record TypeWithPassiveAttribute([Key] Guid Id, string Name);
 
+[Passive]
+[FromEvent<SomeEvent>]
+public record TypeWithPassiveAndFromEventAttribute([Key] Guid Id, string Name);
+
 [NotRewindable]
 public record TypeWithNotRewindableAttribute([Key] Guid Id, string Name);
 

--- a/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionsExtensions/when_checking_has_model_bound_projection_attributes/with_passive_attribute_and_from_event_attribute.cs
+++ b/Source/Clients/DotNET.Specs/Projections/ModelBound/for_ModelBoundProjectionsExtensions/when_checking_has_model_bound_projection_attributes/with_passive_attribute_and_from_event_attribute.cs
@@ -3,11 +3,11 @@
 
 namespace Cratis.Chronicle.Projections.ModelBound.for_ModelBoundProjectionsExtensions.when_checking_has_model_bound_projection_attributes;
 
-public class with_passive_attribute : Specification
+public class with_passive_attribute_and_from_event_attribute : Specification
 {
     bool _result;
 
-    void Because() => _result = typeof(TypeWithPassiveAttribute).HasModelBoundProjectionAttributes();
+    void Because() => _result = typeof(TypeWithPassiveAndFromEventAttribute).HasModelBoundProjectionAttributes();
 
-    [Fact] void should_return_false() => _result.ShouldBeFalse();
+    [Fact] void should_return_true() => _result.ShouldBeTrue();
 }

--- a/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionsExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ModelBoundProjectionsExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.ReadModels;
 
 namespace Cratis.Chronicle.Projections.ModelBound;
 
@@ -20,7 +21,7 @@ public static class ModelBoundProjectionsExtensions
     {
         try
         {
-            if (type.GetCustomAttributes().Any(attr => attr is IProjectionAnnotation || attr is EventSequenceAttribute))
+            if (type.GetCustomAttributes().Any(IsModelBoundProjectionAttribute))
             {
                 return true;
             }
@@ -32,7 +33,7 @@ public static class ModelBoundProjectionsExtensions
             {
                 var parameters = primaryConstructor.GetParameters();
                 if (parameters.Any(param => param.GetCustomAttributes()
-                                                    .Any(attr => attr is IProjectionAnnotation)))
+                                                    .Any(IsModelBoundProjectionAttribute)))
                 {
                     return true;
                 }
@@ -40,12 +41,16 @@ public static class ModelBoundProjectionsExtensions
 
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             return properties.Any(property => property.GetCustomAttributes()
-                                                      .Any(attr => attr is IProjectionAnnotation));
+                                                      .Any(IsModelBoundProjectionAttribute));
         }
         catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or TypeLoadException or ReflectionTypeLoadException)
         {
             return false;
         }
     }
+
+    static bool IsModelBoundProjectionAttribute(object attribute) =>
+        attribute is EventSequenceAttribute ||
+        attribute is IProjectionAnnotation and not PassiveAttribute;
 }
 

--- a/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/given/chronicle_authentication_services.cs
+++ b/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/given/chronicle_authentication_services.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using Cratis.Chronicle.Security;
+using Cratis.Chronicle.Server.Authentication.OpenIddict;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.Server.Authentication.for_ServiceCollectionExtensions.given;
+
+public class chronicle_authentication_services : Specification
+{
+    protected ChronicleAuthenticationServices BuildServices(SharedDataProtectionKeys? sharedKeys = null)
+    {
+        sharedKeys ??= new();
+        var dataProtectionKeys = sharedKeys.CreateGrain();
+        var grainFactory = Substitute.For<IGrainFactory>();
+        grainFactory.GetGrain<IDataProtectionKeys>(Arg.Any<string>()).Returns(dataProtectionKeys);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(grainFactory);
+        services.AddChronicleAuthentication(new Cratis.Chronicle.Configuration.ChronicleOptions
+        {
+            Authentication = new Cratis.Chronicle.Configuration.Authentication
+            {
+                Enabled = false
+            }
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        return new(
+            serviceProvider,
+            grainFactory,
+            dataProtectionKeys,
+            sharedKeys,
+            serviceProvider.GetRequiredService<GrainBasedXmlRepository>(),
+            serviceProvider.GetRequiredService<IXmlRepository>(),
+            serviceProvider.GetRequiredService<IOptions<KeyManagementOptions>>(),
+            serviceProvider.GetRequiredService<IDataProtectionProvider>());
+    }
+
+    protected sealed record ChronicleAuthenticationServices(
+        ServiceProvider ServiceProvider,
+        IGrainFactory GrainFactory,
+        IDataProtectionKeys DataProtectionKeys,
+        SharedDataProtectionKeys SharedKeys,
+        GrainBasedXmlRepository ConcreteRepository,
+        IXmlRepository XmlRepository,
+        IOptions<KeyManagementOptions> KeyManagementOptions,
+        IDataProtectionProvider DataProtectionProvider);
+
+    protected sealed class SharedDataProtectionKeys
+    {
+        readonly object _gate = new();
+        readonly Dictionary<string, string> _keys = [];
+
+        public int Count
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _keys.Count;
+                }
+            }
+        }
+
+        public string[] Snapshot()
+        {
+            lock (_gate)
+            {
+                return [.. _keys.Values];
+            }
+        }
+
+        public IDataProtectionKeys CreateGrain()
+        {
+            var grain = Substitute.For<IDataProtectionKeys>();
+            grain.GetAllKeys().Returns(_ =>
+            {
+                lock (_gate)
+                {
+                    return Task.FromResult<IEnumerable<string>>([.. _keys.Values]);
+                }
+            });
+            grain.StoreKey(Arg.Any<string>(), Arg.Any<string>()).Returns(callInfo =>
+            {
+                lock (_gate)
+                {
+                    _keys[(string)callInfo[0]] = (string)callInfo[1];
+                }
+
+                return Task.CompletedTask;
+            });
+
+            return grain;
+        }
+    }
+
+    protected static string Normalize(XElement element) => element.ToString(SaveOptions.DisableFormatting);
+}

--- a/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_protecting_and_unprotecting_with_the_same_provider.cs
+++ b/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_protecting_and_unprotecting_with_the_same_provider.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Cratis.Chronicle.Server.Authentication.for_ServiceCollectionExtensions;
+
+public class when_protecting_and_unprotecting_with_the_same_provider : given.chronicle_authentication_services
+{
+    ChronicleAuthenticationServices _services;
+    string _plaintext;
+    string _protectedPayload;
+    string _unprotectedPayload;
+    IReadOnlyCollection<XElement> _storedKeys;
+
+    void Establish()
+    {
+        _services = BuildServices();
+        _plaintext = "chronicle-protect-within-one-provider";
+    }
+
+    void Because()
+    {
+        var protector = _services.DataProtectionProvider.CreateProtector("chronicle.server.specs.authentication.same-provider");
+        _protectedPayload = protector.Protect(_plaintext);
+        _unprotectedPayload = protector.Unprotect(_protectedPayload);
+        _storedKeys = _services.XmlRepository.GetAllElements();
+    }
+
+    void Destroy() => _services.ServiceProvider.Dispose();
+
+    [Fact] void should_store_the_generated_key_through_the_grain() => _services.DataProtectionKeys.Received(1).StoreKey(Arg.Any<string>(), Arg.Any<string>());
+    [Fact] void should_update_the_shared_key_collection() => _services.SharedKeys.Count.ShouldEqual(1);
+    [Fact] void should_make_the_current_key_visible_through_the_repository() => Normalize(_storedKeys.Single()).ShouldEqual(Normalize(XElement.Parse(_services.SharedKeys.Snapshot().Single())));
+    [Fact] void should_unprotect_with_the_same_provider() => _unprotectedPayload.ShouldEqual(_plaintext);
+}

--- a/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_resolving_the_data_protection_repository.cs
+++ b/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_resolving_the_data_protection_repository.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Server.Authentication.for_ServiceCollectionExtensions;
+
+public class when_resolving_the_data_protection_repository : given.chronicle_authentication_services
+{
+    ChronicleAuthenticationServices _services;
+
+    void Establish() => _services = BuildServices();
+
+    void Destroy() => _services.ServiceProvider.Dispose();
+
+    [Fact] void should_register_the_interface_as_the_concrete_repository() => ReferenceEquals(_services.ConcreteRepository, _services.XmlRepository).ShouldBeTrue();
+    [Fact] void should_configure_key_management_to_use_that_same_repository() => ReferenceEquals(_services.ConcreteRepository, _services.KeyManagementOptions.Value.XmlRepository).ShouldBeTrue();
+}

--- a/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_two_providers_share_the_same_grain_backed_key_ring.cs
+++ b/Source/Kernel/Server.Specs/Authentication/for_ServiceCollectionExtensions/when_two_providers_share_the_same_grain_backed_key_ring.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Cratis.Chronicle.Server.Authentication.for_ServiceCollectionExtensions;
+
+public class when_two_providers_share_the_same_grain_backed_key_ring : given.chronicle_authentication_services
+{
+    SharedDataProtectionKeys _sharedKeys;
+    ChronicleAuthenticationServices _first;
+    ChronicleAuthenticationServices _second;
+    string _plaintext;
+    string _protectedPayload;
+    string _unprotectedPayload;
+
+    void Establish()
+    {
+        _sharedKeys = new();
+        _first = BuildServices(_sharedKeys);
+        _second = BuildServices(_sharedKeys);
+        _plaintext = "chronicle-cross-provider-roundtrip";
+    }
+
+    void Because()
+    {
+        _protectedPayload = _first.DataProtectionProvider
+            .CreateProtector("chronicle.server.specs.authentication.cross-provider")
+            .Protect(_plaintext);
+        _unprotectedPayload = _second.DataProtectionProvider
+            .CreateProtector("chronicle.server.specs.authentication.cross-provider")
+            .Unprotect(_protectedPayload);
+    }
+
+    void Destroy()
+    {
+        _first.ServiceProvider.Dispose();
+        _second.ServiceProvider.Dispose();
+    }
+
+    [Fact] void should_store_the_key_once_in_shared_grain_backed_storage() => _sharedKeys.Count.ShouldEqual(1);
+    [Fact] void should_allow_the_second_provider_to_unprotect_without_any_filesystem_sharing() => _unprotectedPayload.ShouldEqual(_plaintext);
+    [Fact] void should_make_the_shared_key_visible_to_the_second_provider() => _second.XmlRepository.GetAllElements().Count.ShouldEqual(_sharedKeys.Count);
+}

--- a/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
+++ b/Source/Kernel/Server/Authentication/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.AspNetCore.Identity;
 using OpenIddict.Validation.AspNetCore;
@@ -49,9 +50,11 @@ public static class ServiceCollectionExtensions
         var encryptionCertificateRing = Cratis.Chronicle.Security.EncryptionCertificateRing.From(chronicleOptions);
         services.AddSingleton<Cratis.Chronicle.Security.IEncryptionCertificateRing>(encryptionCertificateRing);
 
-        // Configure Data Protection (required for webhook secret encryption)
-        // This is set up here to ensure it's available even when OpenIddict is disabled
-        services.AddSingleton<IXmlRepository, GrainBasedXmlRepository>();
+        // Configure Data Protection with Chronicle's shared storage so every node uses the same authentication key ring.
+        services.AddSingleton<GrainBasedXmlRepository>();
+        services.AddSingleton<IXmlRepository>(sp => sp.GetRequiredService<GrainBasedXmlRepository>());
+        services.AddOptions<KeyManagementOptions>()
+            .Configure<GrainBasedXmlRepository>((options, repository) => options.XmlRepository = repository);
         var dataProtectionBuilder = services.AddDataProtection()
             .SetApplicationName("Chronicle");
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_a_row_matches_but_the_changeset_also_has_blind_root_properties.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_a_row_matches_but_the_changeset_also_has_blind_root_properties.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.given;
+using MongoDB.Bson;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.and_a_row_matches_but_the_changeset_also_has_blind_root_properties.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join;
+
+/// <summary>
+/// The filtered root join should still stamp the matched row, but the blind root properties must not hitch a
+/// ride on an arbitrary UpdateOne. The matched row should therefore differ only by the joined payload itself,
+/// and every unrelated row should stay byte-identical.
+/// </summary>
+/// <param name="ctx">The context the specs assert against.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_a_row_matches_but_the_changeset_also_has_blind_root_properties(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : a_sink_over_several_rows(fixture)
+    {
+        protected override object? JoinKey => MatchingValue.ToString();
+
+        protected override IReadOnlyCollection<PropertyDifference> RootPropertyDifferences =>
+        [
+            new(new PropertyPath(WellKnownProperties.Subject), null, BlindSubject),
+            new(new PropertyPath(OrdinaryRootProperty), string.Empty, OrdinaryRootValue)
+        ];
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_stamp_the_row_carrying_the_matching_value() => ctx.StampedOn(a_sink_over_several_rows.RowWithTheMatchingValue).ShouldEqual(a_sink_over_several_rows.StampedValue);
+    [Fact]
+    void should_change_only_the_join_payload_on_the_matching_row()
+    {
+        var expected = ctx.DocumentsBeforeTheJoin[a_sink_over_several_rows.RowWithTheMatchingValue].DeepClone().AsBsonDocument;
+        expected[a_sink_over_several_rows.StampedProperty] = a_sink_over_several_rows.StampedValue;
+        expected[WellKnownProperties.LastHandledEventSequenceNumber] = new BsonInt64((long)EventSequenceNumber.First.Value);
+
+        ctx.DocumentsAfterTheJoin[a_sink_over_several_rows.RowWithTheMatchingValue].ShouldEqual(expected);
+    }
+
+    [Fact] void should_leave_the_row_carrying_another_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithAnotherValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_with_a_null_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithANullColumn).ShouldBeTrue();
+    [Fact] void should_leave_the_row_without_the_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithoutTheColumn).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_blind_root_properties_inside_a_bulk_window.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_blind_root_properties_inside_a_bulk_window.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.given;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.and_no_rows_match_but_the_changeset_changes_blind_root_properties_inside_a_bulk_window.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join;
+
+/// <summary>
+/// Bulk mode shares the same follow-up UpdateOne path as the immediate write path, so the blind root update
+/// must be suppressed there too. A valid no-match root join with direct root properties must leave every
+/// seeded row byte-identical even when the sink is inside a bulk window.
+/// </summary>
+/// <param name="ctx">The context the specs assert against.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_no_rows_match_but_the_changeset_changes_blind_root_properties_inside_a_bulk_window(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : a_sink_over_several_rows(fixture)
+    {
+        readonly Guid _nonMatchingValue = Guid.NewGuid();
+
+        protected override object? JoinKey => _nonMatchingValue.ToString();
+
+        protected override bool UseBulkMode => true;
+
+        protected override IReadOnlyCollection<PropertyDifference> RootPropertyDifferences =>
+        [
+            new(new PropertyPath(WellKnownProperties.Subject), null, BlindSubject),
+            new(new PropertyPath(OrdinaryRootProperty), string.Empty, OrdinaryRootValue)
+        ];
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_leave_the_row_carrying_the_matching_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithTheMatchingValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_carrying_another_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithAnotherValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_with_a_null_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithANullColumn).ShouldBeTrue();
+    [Fact] void should_leave_the_row_without_the_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithoutTheColumn).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_only_the_root_subject.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_only_the_root_subject.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.given;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.and_no_rows_match_but_the_changeset_changes_only_the_root_subject.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join;
+
+/// <summary>
+/// The join itself matches nothing, so the root-level subject change has no document it can legally target.
+/// The only correct outcome is that every stored row stays byte-identical to the seeded state.
+/// </summary>
+/// <param name="ctx">The context the specs assert against.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_no_rows_match_but_the_changeset_changes_only_the_root_subject(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : a_sink_over_several_rows(fixture)
+    {
+        readonly Guid _nonMatchingValue = Guid.NewGuid();
+
+        protected override object? JoinKey => _nonMatchingValue.ToString();
+
+        protected override IReadOnlyCollection<PropertyDifference> RootPropertyDifferences =>
+        [
+            new(new PropertyPath(WellKnownProperties.Subject), null, BlindSubject)
+        ];
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_leave_the_row_carrying_the_matching_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithTheMatchingValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_carrying_another_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithAnotherValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_with_a_null_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithANullColumn).ShouldBeTrue();
+    [Fact] void should_leave_the_row_without_the_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithoutTheColumn).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_the_root_subject_and_an_ordinary_property.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/and_no_rows_match_but_the_changeset_changes_the_root_subject_and_an_ordinary_property.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Changes;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.given;
+
+using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.and_no_rows_match_but_the_changeset_changes_the_root_subject_and_an_ordinary_property.context;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join;
+
+/// <summary>
+/// A root-level join may enrich zero or many rows through its filtered UpdateMany, but it has no single _id
+/// target for unrelated root property updates. When the join matches nothing, both the subject change and the
+/// ordinary root property change must therefore disappear entirely.
+/// </summary>
+/// <param name="ctx">The context the specs assert against.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_no_rows_match_but_the_changeset_changes_the_root_subject_and_an_ordinary_property(context ctx) : IClassFixture<context>
+{
+    public class context(MongoDBFixture fixture) : a_sink_over_several_rows(fixture)
+    {
+        readonly Guid _nonMatchingValue = Guid.NewGuid();
+
+        protected override object? JoinKey => _nonMatchingValue.ToString();
+
+        protected override IReadOnlyCollection<PropertyDifference> RootPropertyDifferences =>
+        [
+            new(new PropertyPath(WellKnownProperties.Subject), null, BlindSubject),
+            new(new PropertyPath(OrdinaryRootProperty), string.Empty, OrdinaryRootValue)
+        ];
+    }
+
+    [Fact] void should_not_throw_from_mongodb() => ctx.Error.ShouldBeNull();
+    [Fact] void should_leave_the_row_carrying_the_matching_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithTheMatchingValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_carrying_another_value_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithAnotherValue).ShouldBeTrue();
+    [Fact] void should_leave_the_row_with_a_null_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithANullColumn).ShouldBeTrue();
+    [Fact] void should_leave_the_row_without_the_column_untouched() => ctx.IsUnchanged(a_sink_over_several_rows.RowWithoutTheColumn).ShouldBeTrue();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/GuidJoinedReadModel.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/GuidJoinedReadModel.cs
@@ -3,4 +3,4 @@
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_for_a_root_level_join.given;
 
-public record GuidJoinedReadModel(string Id, Guid JoinedOn, string Stamped);
+public record GuidJoinedReadModel(string Id, Guid JoinedOn, string Stamped, string OrdinaryRootProperty);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_over_several_rows.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_over_several_rows.cs
@@ -34,6 +34,26 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
     public const string StampedValue = "stamped-by-the-join";
 
     /// <summary>
+    /// The subject value carried by a blind root-level property change.
+    /// </summary>
+    public const string BlindSubject = "blind-root-subject";
+
+    /// <summary>
+    /// A regular root property included beside a join to prove all blind root updates are suppressed.
+    /// </summary>
+    public const string OrdinaryRootProperty = "ordinaryRootProperty";
+
+    /// <summary>
+    /// The value carried by the regular blind root property change.
+    /// </summary>
+    public const string OrdinaryRootValue = "blind-root-write";
+
+    /// <summary>
+    /// The property changed by the correctly filtered join payload.
+    /// </summary>
+    public const string StampedProperty = "stamped";
+
+    /// <summary>
     /// The row whose joined-on column holds <see cref="MatchingValue"/>.
     /// </summary>
     public const string RowWithTheMatchingValue = "row-with-the-matching-value";
@@ -54,7 +74,6 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
     public const string RowWithoutTheColumn = "row-without-the-column";
 
     const string JoinedOnProperty = "joinedOn";
-    const string StampedProperty = "stamped";
 
     IMongoClient _client = default!;
     IMongoCollection<BsonDocument> _collection = default!;
@@ -86,6 +105,16 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
     /// </summary>
     protected abstract object? JoinKey { get; }
 
+    /// <summary>
+    /// Gets whether the sink should apply the changes inside a bulk window.
+    /// </summary>
+    protected virtual bool UseBulkMode => false;
+
+    /// <summary>
+    /// Gets root property differences that have no document key target during a root-level join.
+    /// </summary>
+    protected virtual IReadOnlyCollection<PropertyDifference> RootPropertyDifferences => [];
+
     /// <inheritdoc/>
     public async Task InitializeAsync()
     {
@@ -105,6 +134,11 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
         await InsertRows();
         DocumentsBeforeTheJoin = await ReadRows();
 
+        if (UseBulkMode)
+        {
+            await _sink.BeginBulk();
+        }
+
         try
         {
             await _sink.ApplyChanges(
@@ -115,6 +149,13 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
         catch (Exception error)
         {
             Error = error;
+        }
+        finally
+        {
+            if (UseBulkMode)
+            {
+                await _sink.EndBulk();
+            }
         }
 
         DocumentsAfterTheJoin = await ReadRows();
@@ -176,24 +217,28 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
             {
                 ["_id"] = RowWithTheMatchingValue,
                 [JoinedOnProperty] = new BsonBinaryData(MatchingValue, GuidRepresentation.Standard),
-                [StampedProperty] = string.Empty
+                [StampedProperty] = string.Empty,
+                [OrdinaryRootProperty] = string.Empty
             },
             new BsonDocument
             {
                 ["_id"] = RowWithAnotherValue,
                 [JoinedOnProperty] = new BsonBinaryData(Guid.NewGuid(), GuidRepresentation.Standard),
-                [StampedProperty] = string.Empty
+                [StampedProperty] = string.Empty,
+                [OrdinaryRootProperty] = string.Empty
             },
             new BsonDocument
             {
                 ["_id"] = RowWithANullColumn,
                 [JoinedOnProperty] = BsonNull.Value,
-                [StampedProperty] = string.Empty
+                [StampedProperty] = string.Empty,
+                [OrdinaryRootProperty] = string.Empty
             },
             new BsonDocument
             {
                 ["_id"] = RowWithoutTheColumn,
-                [StampedProperty] = string.Empty
+                [StampedProperty] = string.Empty,
+                [OrdinaryRootProperty] = string.Empty
             }
         ]);
 
@@ -217,6 +262,11 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
                     new ExpandoObject(),
                     [new PropertyDifference(new PropertyPath(StampedProperty), string.Empty, StampedValue)])
             ]));
+
+        if (RootPropertyDifferences.Count != 0)
+        {
+            changeset.Add(new PropertiesChanged<ExpandoObject>(new ExpandoObject(), RootPropertyDifferences));
+        }
 
         return changeset;
     }

--- a/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
@@ -147,7 +147,9 @@ public class Sink(
         // upsert a phantom Group keyed on UserId. Use the join-targets-only filter (Empty)
         // in this case so only existing documents are updated.
         var hasJoined = changeset.HasJoined();
+        var hasActualRootLevelJoin = HasActualRootLevelJoin(changeset.Changes);
         var onlyPropertyUpdatesAlongsideJoin = hasJoined && hasDirectKeyScopedChanges && !hasConstructiveChanges;
+        var shouldSuppressRootUpdateAfterRootLevelJoin = hasActualRootLevelJoin && onlyPropertyUpdatesAlongsideJoin;
 
         // Compute the _id filter value only when the document is actually keyed by _id. For a join whose
         // target documents are matched by the join column (the Empty filter below), the resolved key carries
@@ -223,6 +225,14 @@ public class Sink(
 
         var converted = await changesetConverter.ToUpdateDefinition(key, changeset, eventSequenceNumber);
         if (!converted.hasChanges) return [];
+
+        // ChangesetConverter has already executed the correctly filtered UpdateMany for the root join.
+        // Any remaining direct root PropertiesChanged have no single _id target, so issuing the follow-up
+        // UpdateOne would pick an arbitrary document (Filter.Empty) and corrupt it.
+        if (shouldSuppressRootUpdateAfterRootLevelJoin)
+        {
+            return [];
+        }
 
         if (_isBulkMode)
         {
@@ -456,6 +466,11 @@ public class Sink(
                 observer.OnCompleted);
         });
     }
+
+    static bool HasActualRootLevelJoin(IEnumerable<Change> changes) =>
+        changes
+            .OfType<Joined>()
+            .Any(joined => !joined.ArrayIndexers.All.Any());
 
     /// <summary>
     /// Builds the clause that restricts a write to documents that have not yet observed the given event.


### PR DESCRIPTION
# Summary

Bundles four Chronicle reliability fixes into one patch release. The Data Protection correction moves authentication key storage from the unintended node-local fallback to Chronicle's shared storage.

## Fixed

- Prevented `[Passive]` read models with fluent projections from registering empty duplicate model-bound projections. (#3757)
- Added post-push Docker Hub verification for every Chronicle image variant so incomplete releases fail visibly. (#3770)
- Prevented root-level join events from applying blind MongoDB updates to unrelated read-model documents. (#3784)
- Configured ASP.NET Data Protection and certificate-rotation diagnostics to use the same shared grain-backed key repository. Upgrading invalidates existing authentication cookies and outstanding Identity/OpenIddict tokens once; users and clients must sign in again, while durable Chronicle secrets remain unaffected. (#3803)
