### PR TITLE
Add Building a Client documentation section

### DIFF
--- a/Documentation/building-a-client/authentication-and-bearer-tokens.md
+++ b/Documentation/building-a-client/authentication-and-bearer-tokens.md
@@ -1,0 +1,121 @@
+# Authentication and bearer tokens
+
+Every call a Chronicle client makes to the Kernel over gRPC needs a bearer token attached to it.
+This page describes the exchange a new client has to implement to get one, keep it fresh, and
+attach it correctly — reverse-engineered from the .NET client's reference implementation, since
+that's where the behavior is defined today.
+
+:::note
+This page is about how a **client authenticates to the Kernel**. Chronicle also has
+`BearerTokenAuthorization`, `BasicAuthorization`, and `OAuthAuthorization` types in its .NET
+client — those configure *outbound* authorization for **Webhooks** and **External Services**
+targets the Kernel calls out to. They're unrelated to how a client authenticates itself, and
+naming a new client's own types the same way as those would be a confusing coincidence, not a
+pattern to follow.
+:::
+
+## The three authentication modes
+
+Which mode a connection uses is decided entirely by what's present in the connection string —
+there's no separate flag:
+
+| Mode | Connection string carries | What happens |
+|---|---|---|
+| Client credentials | `username:password@host` (or nothing at all) | Exchanged for a bearer token via OAuth's `client_credentials` grant |
+| API key | `?apiKey=...` query parameter | Sent as-is (no exchange) |
+| None | `?auth=none` query parameter | No credentials presented at all — only works against a server with authentication turned off |
+
+Supplying both client credentials and an API key in the same connection string is an error
+(`AmbiguousAuthenticationMode`); supplying neither and not asking for `auth=none` is also an error
+(`MissingAuthentication`) — except that an *empty* connection string is treated as client
+credentials rather than an error, because of the development default below. See
+[Connection string elements](./connection-string-elements.md) for the full grammar.
+
+## Client credentials really means OAuth client-credentials
+
+It's easy to assume `username:password@host` is HTTP Basic auth. It isn't. The username and
+password in the connection string map directly onto an OAuth `client_credentials` grant: username
+becomes `client_id`, password becomes `client_secret`, and the client exchanges them for an access
+token by calling the Kernel's own token endpoint before making any other RPC:
+
+```text
+POST https://{host}:{port}/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id={username}&client_secret={password}
+```
+
+The response is parsed for `access_token` and `expires_in` (a missing `expires_in` defaults to
+3600 seconds). The client secret is never sent as a Basic-auth header, and it's never sent on
+every call — only once, to get a token, which is what then goes on every call.
+
+### Development defaults
+
+A connection string with no credentials at all still resolves to client-credentials mode — it
+substitutes two well-known development values rather than connecting anonymously:
+
+```text
+client_id     = chronicle-dev-client
+client_secret = chronicle-dev-secret
+```
+
+`chronicle://localhost:35000` and `chronicle://chronicle-dev-client:chronicle-dev-secret@localhost:35000`
+are exactly equivalent. This is what makes local development work with no setup, and it's also why
+those two values are not a secret worth protecting — they're baked into every Chronicle client and
+meaningless outside a server explicitly configured to accept them.
+
+## Attaching the token to a call
+
+Once a token exists, it goes on every outgoing gRPC call as a metadata header:
+
+```text
+authorization: Bearer {access_token}
+```
+
+A gRPC client interceptor is the natural place to do this — it needs to run for unary calls and
+every streaming variant (client-streaming, server-streaming, duplex), and it needs one more piece
+of behavior beyond just attaching the header: if a call comes back `Unauthenticated`, force a token
+refresh and retry the call exactly once before giving up. That single retry is what makes a token
+that expires mid-session invisible to the caller instead of surfacing as a hard failure.
+
+## Keeping the token fresh
+
+A well-behaved client refreshes proactively rather than waiting to be rejected:
+
+- Track when the token was issued and how long it's valid for (`expires_in`).
+- Treat it as needing renewal a margin *before* actual expiry — a 60-second margin is a reasonable
+  default — so a call that starts just before expiry doesn't race the clock.
+- If a refresh attempt fails (the token endpoint is briefly unreachable, say), keep serving the
+  still-technically-valid cached token rather than failing every call until the endpoint recovers.
+  Throttle repeated failed-refresh attempts (a few seconds between retries) so a down token
+  endpoint doesn't turn into a tight retry loop on every call.
+- Treat an *explicit* refresh request (triggered by the 401-retry above) differently from routine
+  proactive renewal: it should bypass the failure throttle, since it's evidence-driven rather than
+  a guess that the token might be stale.
+
+### Optional: caching a token to disk
+
+Short-lived processes — a CLI invoked once per command, a script run from cron — pay the full
+token-exchange cost on every single invocation if the token only ever lives in memory. A client
+worth using from tooling like that benefits from an optional decorator that persists the token to
+a local file (client ID, token, and expiry — nothing else) and reuses it across process
+invocations until it's genuinely close to expiring, deleting the cache file and fetching fresh on
+an explicit refresh. Treat a missing or corrupt cache file as "no token" and fetch normally rather
+than failing — a cache is an optimization, never a dependency.
+
+## What a new client needs to implement
+
+- Determine the auth mode from the connection string (client credentials / API key / none), with
+  the same "empty means development defaults" and "both present is an error" rules.
+- For client credentials, perform the OAuth `client_credentials` exchange against
+  `/connect/token` on the configured host.
+- Attach `authorization: Bearer {token}` to every call, across every streaming shape your gRPC
+  library exposes.
+- Cache the token, refresh it proactively ahead of expiry, and retry once on a 401.
+- Never log a raw connection string or a raw token — see
+  [Connection string elements](./connection-string-elements.md#never-log-the-unredacted-form) for
+  why and how the .NET client avoids it.
+
+Next: [Clustering and the connection lifecycle](./clustering-and-connection-lifecycle.md) covers
+what happens before and after that first authenticated call — picking a server and staying
+connected to it.

--- a/Documentation/building-a-client/client-history.md
+++ b/Documentation/building-a-client/client-history.md
@@ -1,0 +1,115 @@
+# How TypeScript, Elixir, and Kotlin were built
+
+The layering described in [Layering an idiomatic client](./layering-an-idiomatic-client.md) isn't
+a plan that was designed up front and then followed three times. It's what actually happened, in
+three separate repositories, in three different orders, and it's worth knowing the real story —
+including the parts that didn't go smoothly — before starting a fourth.
+
+## The one thing all three got from Chronicle itself
+
+Before any of the three repos below existed, Chronicle's own release pipeline already generated
+and published a contracts package per language, gated on a `wire-compatibility` check, in lockstep
+with the kernel's own version number. That's covered in
+[Two ways to start](./starting-points.md) and isn't repeated here — what follows is what each team
+built *on top of* that foundation, and it's the part that varied.
+
+## Chronicle.TypeScript
+
+TypeScript's client was scaffolded almost entirely by an autonomous coding-agent session against a
+near-empty repository — one commit added the connection layer, the event log, and a Node.js test
+app all at once. That's a different bootstrap style from the other two, and it shows in the pace of
+what followed: a decorator-based artifact-discovery system (`@eventType` and friends) landed within
+a day, the repo was migrated to Yarn v4 workspaces shortly after to make the client and its console
+sample buildable as one unit, and a full build-and-publish pipeline for `@cratis/chronicle` on npm
+followed within the same week.
+
+One early fix is worth calling out on its own: switching the package's module output to ESM to
+resolve a conflict with `@cratis/chronicle.contracts` — direct evidence that the idiomatic package
+was already depending on the separately published contracts package, and that module-format
+mismatches between a hand-written idiomatic package and a generated dependency are a real thing to
+watch for, not a hypothetical one.
+
+Today `@cratis/chronicle` is the only publishable module in the repo — there's no TypeScript
+equivalent of a convenience/hosting package yet (no Express, Fastify, or NestJS integration). It
+ships as a deliberately fine-grained set of subpath exports (`./events`, `./projections`, `./jobs`,
+`./webhooks`, and about twenty others) rather than one monolithic entry point, and publishes via
+npm's OIDC trusted-publishing flow rather than a stored token.
+
+## Chronicle.Elixir
+
+Elixir went the opposite direction: a single large, hand-authored commit landed the entire initial
+client — connection, event log, constraints, projections, reactors, reducers, read models — plus a
+full console sample, in one shot. Its `mix.exs` already depended on
+`{:cratis_chronicle_contracts, ">= 0.1.0"}` at that very first commit, confirming the contracts
+package existed and was consumable before the idiomatic client did.
+
+The most instructive moment in Elixir's history is a compile failure that only showed up once the
+contracts package became a *real* external dependency rather than something built alongside it in
+the same checkout: code that built struct literals against the contracts package's types at compile
+time worked fine while both were in the same workspace, and broke the moment `cratis_chronicle_contracts`
+was fetched as an ordinary Hex dependency. The fix was to build those structs at runtime instead.
+It's a concrete warning for any client: test against the *published* contracts package early, not
+just a local build of it — some failures only exist across that boundary.
+
+Elixir also had to resolve an OTP application-name collision (renaming the app from `:chronicle` to
+`:cratis_chronicle` while keeping the Hex package name `cratis_chronicle`), and added a CI job that
+runs *after* publishing specifically to verify the just-published package is actually installable
+and usable — not just that it built.
+
+Like TypeScript, Elixir has one publishable module (`cratis_chronicle`) and no convenience/hosting
+package yet — no Phoenix integration exists. Its documentation and README have also drifted further
+behind its actual feature set than the other two repos', which is worth noting as a caution rather
+than following as a model: keeping docs in step with a fast-moving client is a real cost, not a
+byproduct.
+
+## Chronicle.Kotlin
+
+Kotlin is the newest of the three and, so far, the most structurally complete. Like Elixir, it was
+hand-built first by the maintainer in a dense initial commit, with agent-assisted work picking up
+afterward. Two things distinguish its trajectory:
+
+**Java support arrived deliberately, within a week of the Kotlin client existing at all.** Kotlin's
+`suspend` functions aren't callable from Java, so the client grew a hand-written blocking bridge
+class per service (`EventLogJavaBridge`, `ReadModelsJavaBridge`, and so on) rather than asking Java
+consumers to deal with coroutines. Supporting two languages from one artifact turned out to need an
+explicit safeguard, too: a binary-compatibility validator was added specifically because adding a
+property to a Kotlin data class silently breaks any Java caller using a positional constructor —
+without the validator, that kind of break had already happened twice before it was caught in
+review rather than in someone's build.
+
+**A Spring Boot starter followed, once — and only once — the idiomatic client had artifact
+auto-discovery to build on.** `io.cratis:chronicle-spring-boot-starter` landed about two months
+after the Kotlin client's bootstrap, in a single ~1000-line commit covering auto-configuration,
+`ChronicleProperties`, and per-request namespace resolution (fixed, HTTP-header, subdomain, or
+authentication-claim based). It's the direct JVM counterpart of `Cratis.Chronicle.AspNetCore`, and
+its existence is the clearest confirmation of the convenience-package layer being a real, proven
+pattern — it's just the one client so far that's actually built it.
+
+Kotlin also added a fourth module, `io.cratis:chronicle-testing`, for in-process test support — the
+optional testing layer mentioned in
+[Layering an idiomatic client](./layering-an-idiomatic-client.md#convenience-packages-sit-above-that-and-are-optional).
+
+### A real gap worth learning from
+
+As of today, Chronicle.Kotlin's publish workflow releases only the `Source` module to Maven
+Central. The `Testing` and `Integrations:SpringBoot` modules have had valid Maven coordinates and
+working build configuration since the commit that added them — but the CI publish job list was
+never updated to include them, so neither has actually shipped a release through automation. It's
+a small, easy mistake to repeat: adding a new publishable module's build configuration is necessary
+but not sufficient. The CI publish pipeline needs the same update, explicitly, or the module simply
+never reaches its registry no matter how correct it is.
+
+## What this means for a fourth client
+
+- Don't wait to have the "right" bootstrap style figured out — Chronicle's three clients started
+  three different ways (agent-scaffolded, hand-built dense-commit, hand-built dense-commit) and all
+  converged on the same shape.
+- Test against the *published* contracts package, not just a local build of it, before you trust
+  that dependency boundary.
+- A convenience/hosting package is worth building once the idiomatic client is stable and there's
+  an obvious dominant framework to target in your ecosystem — not before, and not automatically.
+- If you add a new publishable module later (a testing package, a hosting package), double-check
+  your CI publish job actually includes it. It's the single most common way this goes wrong.
+- Keep documentation moving at the same pace as the client, deliberately — it's the thing most
+  likely to fall behind if it isn't treated as part of the same unit of work. See
+  [Documentation and snippets](./documentation-and-snippets.md) next.

--- a/Documentation/building-a-client/clustering-and-connection-lifecycle.md
+++ b/Documentation/building-a-client/clustering-and-connection-lifecycle.md
@@ -1,0 +1,107 @@
+# Clustering and the connection lifecycle
+
+[Connection Strings → Server support](../connection-strings/server.md) is the canonical reference
+for the connection string format, the load-balancer strategies, and DNS SRV lookup, written for
+someone configuring an existing client. This page covers the same ground from the other side: what
+a **new client** actually has to implement to participate correctly in a multi-server Chronicle
+cluster, and the parts of the picture that page doesn't cover — the wire-compatibility handshake
+and the reconnect loop.
+
+## Discovering the server list
+
+A connection string names either an explicit, comma-separated list of hosts (`chronicle://a,b,c`)
+or, with the `chronicle+srv://` scheme, a single DNS name to resolve via SRV records — the same
+mechanism `mongodb+srv://` uses. For SRV, the client queries `_chronicle._tcp.<host>` and treats
+the returned targets, ordered by SRV priority then weight, as the candidate list. **This
+resolution happens fresh on every connect and every reconnect**, not once at startup — a server
+added to or removed from DNS is picked up automatically the next time the client needs to pick one,
+with no client-side configuration change and no restart.
+
+## Picking a server: load balancer strategies
+
+A load balancer strategy is a single operation: given the current candidate list, return the one
+server to connect to next. It's invoked on every connect, including every reconnect after a
+dropped session — a client doesn't fail over to a fixed backup, it re-runs the same selection.
+
+Implement at least these three; `least-connections` is the sensible default:
+
+- **`least-connections`** — the real default, and the most involved. Every Chronicle server
+  exposes two *anonymous* endpoints (anonymous because a client needs to ask before it has
+  authenticated): `GET /connections/count` reports how many clients are connected to that specific
+  server, and `POST /connections/reserve` reserves a slot ahead of actually connecting. Probe every
+  candidate in parallel, pick the lowest count (breaking ties randomly, not by list order), then
+  reserve a slot on the winner before starting the real connect handshake. A server that doesn't
+  answer within a short timeout (2 seconds is what the .NET client uses) is treated as maximally
+  loaded rather than failing selection outright, so a restarting or briefly unreachable server just
+  gets routed around. Add a small random jitter (up to 250ms) before every probe, not only the
+  first, so that a fleet of clients starting or reconnecting together doesn't send synchronized
+  probe bursts. The reservation itself expires on its own after a short window (30 seconds) if it
+  never converts into a real connection, so an abandoned attempt doesn't permanently inflate a
+  server's reported count.
+- **`round-robin`** — cycle through the candidate list in order, but start each client instance at
+  a random offset. Without the random start, a fleet of identical client instances all begin at
+  index zero and stay in lockstep on the same server.
+- **`random`** — pick uniformly at random on every connect. The simplest strategy, and a reasonable
+  first one to ship while `least-connections` is still being built.
+
+The full mechanics of the probe/reserve dance — including why the reservation exists at all — are
+written out in detail in
+[Connection Strings → Server support: How least-connections picks a server](../connection-strings/server.md#how-least-connections-picks-a-server).
+A new client's `least-connections` implementation should match that behavior, not just the name.
+
+## The wire-compatibility handshake
+
+Before a connection is usable, the client and server need to agree they're speaking the same
+contract — not just the same protocol version, but the same set of services, messages, and fields.
+Chronicle does this with an actual structural diff, not a version-number check:
+
+Every contracts package — .NET's included — carries a compiled `FileDescriptorSet` (`chronicle.desc`
+in the non-.NET packages) generated from the exact same `.proto` files the server was built from.
+On connect, before treating the connection as usable, the client sends its descriptor set to the
+server, which parses it and compares it structurally against its own: removed services or methods,
+changed method signatures or streaming shape, removed messages, and fields or enum values that were
+removed, retyped, relabeled, or renamed (fields are matched by their protobuf field *number*, not
+name, so a rename is detected even though the wire format itself wouldn't break). **Pure additions
+are never reported as incompatible** — a client is only broken by things it can no longer find, not
+by things the server has grown since the client shipped.
+
+If the server reports any incompatibility, the client should raise a hard error and refuse to
+proceed — better a clear "your client's contract doesn't match this server" failure at connect time
+than a stream of confusing per-call errors later. Against an older server that doesn't support the
+compatibility check at all, fall back to fetching its descriptor set and comparing on the client
+side instead — don't skip the check entirely just because the newer RPC isn't there.
+
+This is precisely why the contracts package matters so much: your client's copy of `chronicle.desc`
+*is* the thing being checked. A hand-generated or stale set of bindings doesn't just risk subtly
+wrong types — it risks a hard rejection at connect time, which is the system working as intended.
+
+## Staying connected
+
+A gRPC channel doesn't tell you when the server it's pointed at goes away — TCP can stay
+technically open on a server that's stopped responding. Chronicle handles this with a server-pushed
+keep-alive stream and a client-side watchdog:
+
+- The server pushes a keep-alive on an open stream at a steady interval. The client just needs to
+  notice one arriving.
+- The watchdog checks, on a short fixed interval (roughly once a second is enough), whether a
+  keep-alive has arrived recently (a threshold of a few seconds — five is a reasonable default). If
+  not, treat the session as dropped immediately rather than waiting for an RPC to fail.
+- On a dropped session, reconnect with **exponential backoff, capped** — doubling the wait each
+  attempt starting from around a second, up to a ceiling around 30 seconds — rather than hammering
+  a server that's still coming back up. A cancellation should stop the loop outright rather than be
+  treated as a failed attempt to back off from.
+- The reconnect path is the *same* connect path described above: re-resolve addresses (DNS may have
+  changed), re-run load-balancer selection (the server that dropped isn't guaranteed to be the one
+  to reconnect to), and re-run the compatibility check.
+
+## What a new client needs to implement
+
+- Parse both connection-string forms (explicit host list, `+srv`) and re-resolve on every connect.
+- Ship at least `least-connections` (matching the probe/reserve protocol) and `round-robin`.
+- Embed the compiled descriptor set from your contracts package and run the compatibility check
+  before treating a connection as usable; fail hard, don't degrade silently, on a real mismatch.
+- Run a keep-alive watchdog with capped exponential backoff, reusing the same connect path for
+  reconnects that the initial connect uses.
+
+Next: [Connection string elements](./connection-string-elements.md) covers the object model most
+clients wrap around the string itself.

--- a/Documentation/building-a-client/connection-string-elements.md
+++ b/Documentation/building-a-client/connection-string-elements.md
@@ -1,0 +1,88 @@
+# Connection string elements
+
+[Connection Strings → Server support](../connection-strings/server.md) is the grammar reference —
+the scheme, every query parameter, and what each one means. Don't re-derive that grammar from
+scratch or from this page; treat it as the spec. This page is narrower: the object model a client
+SDK typically wraps around that grammar, using the .NET client's `ChronicleConnectionString` and
+`ChronicleConnectionStringBuilder` as the reference shape, since that's the most complete
+implementation that exists today.
+
+## Parse into a value, don't pass strings around
+
+Every client so far parses the connection string once, into a typed value, rather than
+re-parsing or grep-ing the raw string wherever a setting is needed. The .NET client's parsed shape
+exposes:
+
+| Property | Comes from |
+|---|---|
+| `ServerAddress` / `ServerAddresses` | the host list (single value / full list) |
+| `IsSrv` | whether the `+srv` scheme was used |
+| `LoadBalancer` | the `loadBalancer` parameter, defaulting to `least-connections` |
+| `SrvNameServer` | the `srvNameServer` parameter, for `+srv` lookups |
+| `Username` / `Password` | the credentials in the authority section |
+| `AuthenticationMode` | **computed**, not stored — derived from which credentials are present |
+| `ApiKey` | the `apiKey` parameter |
+| `SkipTlsValidation` | the `skipTlsValidation` parameter |
+| `CertificatePath` / `CertificatePassword` | client certificate options |
+
+`AuthenticationMode` being computed rather than stored is worth copying deliberately: it means
+there's exactly one place that can get the "both credentials and API key present" or "neither
+present" cases wrong, and it can never drift out of sync with the fields it's derived from.
+
+## Offer a builder, not string concatenation
+
+Constructing a connection string by hand — string-formatting a host, a port, and a pile of query
+parameters — is exactly the kind of thing that quietly produces an invalid or ambiguous string
+(wrong separator, double `?`, an unescaped credential). A fluent builder that knows the grammar is
+worth offering alongside the parser. The shape worth matching:
+
+```csharp
+new ChronicleConnectionStringBuilder()
+    .WithHost("chronicle.production.example.com")
+    .WithPort(35000)
+    .WithCredentials(username, password)
+    .WithLoadBalancer("round-robin")
+    .Build();
+```
+
+with equivalents for `WithServerAddresses(...)` (multiple hosts), `WithDevelopmentCredentials()`,
+`WithApiKey(...)`, `WithoutAuthentication()` (`auth=none`), `WithTlsValidationSkipped()`, and
+`WithCertificate(path, password)`. `Build()` should validate as it assembles — the same
+"credentials and API key together is an error" rule the parser enforces should be enforced here
+too, at construction time rather than at first-connect time.
+
+## Never log the unredacted form
+
+A connection string carries the client secret, and possibly an API key or a certificate password —
+in full. `ToString()` (or whatever renders it back to a string) should render everything, because
+something in the client genuinely needs the real value to connect with. But that real value should
+never end up in a log line or an error message as-is.
+
+Offer a second rendering — the .NET client calls it `Redacted` — that keeps everything a log
+entry needs to be useful (scheme, host, port, non-sensitive options) and replaces every credential
+with a fixed placeholder. Use that form, specifically, everywhere the client itself logs the
+connection string — connecting, reconnecting, reporting a connection failure. This is not a
+theoretical concern: the .NET client's own log messages used to write the unredacted string on
+every connect, and the fix was exactly to route those call sites through `Redacted` instead. A new
+client should get this right from its first log statement rather than patch it in later.
+
+## Building blocks worth keeping separate
+
+Two things are easy to conflate but should stay as distinct concepts in the object model:
+
+- **The load-balancer strategy name** (`loadBalancer=round-robin`) selects *which* built-in
+  strategy runs. It should also be overridable programmatically with a custom strategy
+  implementation for callers who need one the built-ins don't cover — don't make the string
+  parameter the only way in.
+- **TLS validation** (`skipTlsValidation`) is a connection-string concern, but certificate
+  configuration for a client presenting its *own* certificate (`certificatePath`,
+  `certificatePassword`) is a related but separate concern from validating the *server's*
+  certificate. Keep them as separate settings even though they both live under "TLS" in the query
+  string.
+
+See the full parameter table in
+[Connection Strings → Server support](../connection-strings/server.md#query-parameters) for every
+name, type, and example.
+
+Next: [How TypeScript, Elixir, and Kotlin were built](./client-history.md) puts all of this in the
+order it actually happened.

--- a/Documentation/building-a-client/documentation-and-snippets.md
+++ b/Documentation/building-a-client/documentation-and-snippets.md
@@ -1,0 +1,76 @@
+# Documentation and snippets
+
+Chronicle's docs are published as one site, aggregated at build time from a `Documentation/`
+folder in each product repo — including every client repo. A new client needs to shape its
+`Documentation/` folder the same way from day one, because the shared Chronicle pages actively rely
+on every participating client having one.
+
+This page is an orientation, not the full mechanics — those are already written down in
+[Contributing to Clients](../contributing/clients/#shared-documentation-snippets). Read
+that page for the complete rules on snippet IDs, CI validation, and adding a client to the shared
+tab system. What follows is the shape to start from.
+
+## The standard shape
+
+```text
+Documentation/
+├── toc.yml
+├── index.md                    landing page for this client's docs
+├── getting-started.md
+├── client-snippets/**          source-only — never becomes a public page
+└── <client-specific-pages>     install, connection setup, framework integration, troubleshooting
+```
+
+`Documentation/client-snippets/**` is the important one to get right early: it's not a docs page
+at all, it's the source for the language-specific code shown in the *shared* Chronicle docs. A
+shared page says:
+
+```mdx
+<ChronicleClientTabs snippet="events/appending/example" />
+```
+
+and the site looks for a matching snippet ID under every registered client's snippet root — your
+client shows up in that tab group the moment
+`Documentation/client-snippets/events/appending/example.md` exists, with a single fenced code block
+in your language. No other wiring makes a client opt-in; the file's presence is the whole
+mechanism.
+
+## Why concepts live in the shared docs, not in your repo
+
+Resist the pull to write your own "Events" or "Projections" page inside your client's docs. Those
+concepts are the same across every client — what differs is only the code that expresses them. A
+client-specific page is for things that are genuinely different per client: installation, how a
+connection gets configured in your language's idioms, framework/hosting integration, decorators or
+annotations, and troubleshooting. Everything else belongs in the shared Chronicle pages, with your
+code shown through a snippet.
+
+If your client doesn't support a workflow yet, that fact belongs *in the snippet*, not as prose on
+the shared page — an explicit "this client doesn't support this yet" snippet keeps the claim next
+to the code, where whoever adds the capability is already looking, instead of rotting silently in a
+shared page nobody remembers to update.
+
+## Keep a validator in CI
+
+Every existing client repo runs a snippet validator (`Documentation/validate-client-snippets.py` in
+today's clients) that compiles every snippet against the real client source, wired into a CI
+workflow that triggers on changes to either `Documentation/client-snippets/**` or `Source/**`. This
+is what stops a client API change from silently leaving the shared docs' code examples broken —
+without it, a snippet is just a string nobody checks. Build the equivalent for your language before
+your first snippet ships, not after the first drift is reported.
+
+## Two parallel trees, if your artifact serves two languages
+
+Chronicle.Kotlin serves both Kotlin and Java from a single published artifact, and its
+`Documentation/` folder reflects that directly: `client-snippets/` for Kotlin and a fully parallel
+`client-snippets-java/` for Java, with every subfolder mirrored between the two. If your client
+does the same — one package, two idiomatic surfaces — plan for two snippet trees from the start
+rather than retrofitting a second one later.
+
+## Getting a new client wired into the published site
+
+Once your `Documentation/` folder exists, getting it into the published site alongside the other
+four clients is a short, concrete checklist — see
+[Contributing to Clients → Add another Chronicle client](../contributing/clients/#add-another-chronicle-client)
+for the exact steps (registering the repo, adding it to the client-docs config, wiring the sync
+workflow). That's also the point to talk to the Cratis team again if you haven't already — getting
+a new client's docs live on the site is a one-time setup they can do quickly.

--- a/Documentation/building-a-client/index.md
+++ b/Documentation/building-a-client/index.md
@@ -1,0 +1,62 @@
+# Building a Chronicle Client
+
+Chronicle speaks gRPC. In theory that means any language with a gRPC implementation can talk to
+it. In practice, hand-rolling a client means solving the same handful of hard problems every
+client has to solve before it can do anything useful: generating strongly-typed bindings from the
+wire contract, exchanging credentials for a token and keeping that token fresh, discovering and
+load-balancing across a cluster of servers, reconnecting when a connection drops, and rejecting a
+server whose contract has drifted instead of silently sending it garbage.
+
+None of that is domain logic. It's the same plumbing whether the client ends up written in Go,
+Python, Rust, or Java — and it's exactly the plumbing Chronicle's own team has already built,
+three times over, for TypeScript, Elixir, and Kotlin. This section is that experience written
+down, so a fourth client doesn't have to rediscover it.
+
+## The shape of every Chronicle client so far
+
+Every client Chronicle has shipped follows the same layering, whether or not that was the plan
+going in:
+
+```mermaid
+flowchart TB
+    proto["Kernel .proto files\n(Source/Kernel/Protobuf)"]
+    contracts["Generated contracts package\n(published, one per language)"]
+    idiomatic["Idiomatic client\n(the thing developers import)"]
+    convenience["Convenience / hosting packages\n(optional — ASP.NET Core, Spring Boot, …)"]
+
+    proto --> contracts --> idiomatic --> convenience
+```
+
+- **[Two ways to start](./starting-points.md)** — use the `.proto` files directly, or ask the
+  Cratis team to generate and publish a contracts package for your language. Most clients so far
+  took the second path.
+- **[Layering an idiomatic client](./layering-an-idiomatic-client.md)** — why the generated
+  contracts are deliberately not the client developers use, and how a raw client and optional
+  convenience packages sit on top of them.
+- **[Authentication and bearer tokens](./authentication-and-bearer-tokens.md)** — how a client
+  turns connection-string credentials into a bearer token on every call, and keeps it fresh.
+- **[Clustering and the connection lifecycle](./clustering-and-connection-lifecycle.md)** — what
+  a client has to implement to be a good citizen of a multi-server Chronicle cluster.
+- **[Connection string elements](./connection-string-elements.md)** — the object model a client
+  SDK typically wraps around the connection string grammar.
+- **[How TypeScript, Elixir, and Kotlin were built](./client-history.md)** — the real history,
+  including what worked, what didn't, and what's still incomplete.
+- **[Documentation and snippets](./documentation-and-snippets.md)** — how a new client repo's
+  `Documentation/` folder plugs into the shared Chronicle docs site.
+
+## Talk to us first
+
+Before generating anything yourself, get in touch with the Cratis team. Every contracts package
+Chronicle has shipped so far — TypeScript, Elixir, and Kotlin — was generated from the kernel's
+own `.proto` files and published to the right registry (npm, Hex, Maven Central) from Chronicle's
+own release pipeline, version-locked to the kernel release it matches. That pipeline already
+exists; turning it on for a new language is normally a matter of days, not the weeks it takes to
+build a `protoc` toolchain from scratch and get the packaging right. See
+[Two ways to start](./starting-points.md) for what that conversation looks like and what you get
+out of it.
+
+:::note
+This section is written for whoever builds and maintains a **new** Chronicle client — Cratis team
+members and community contributors alike. If you're building an *application on* Chronicle rather
+than a new client SDK, you want the [get started](../get-started/) guide instead.
+:::

--- a/Documentation/building-a-client/layering-an-idiomatic-client.md
+++ b/Documentation/building-a-client/layering-an-idiomatic-client.md
@@ -1,0 +1,103 @@
+# Layering an idiomatic client
+
+A generated contracts package is not something you'd want to hand a developer and call it a day.
+It's a faithful mechanical translation of the wire format — service interfaces, message types,
+`int64` fields as `bigint`, `Guid` as whatever protobuf-net's BCL extensions say a `Guid` is. It
+has no decorators, no fluent builder, no idea what a "read model" or a "reactor" is. That's by
+design: it's generated on every kernel release, so nothing generated can carry hand-written
+idiomatic API surface without it being overwritten the next time.
+
+The idiomatic client is a second, separate thing built *on top of* the contracts package, hand
+written and hand maintained, with its own release cadence. This split — raw contracts underneath,
+idiomatic API on top — is the one structural decision every Chronicle client has made so far,
+independent of language.
+
+```mermaid
+flowchart TB
+    subgraph gen["Generated — tracks the kernel's release cadence"]
+        contracts["Contracts package\n@cratis/chronicle.contracts · io.cratis:chronicle-contracts · cratis_chronicle_contracts"]
+    end
+    subgraph hand["Hand-maintained, its own release cadence"]
+        idiomatic["Idiomatic client\n@cratis/chronicle · io.cratis:chronicle · cratis_chronicle"]
+        testing["Optional: in-process testing module\nio.cratis:chronicle-testing"]
+        convenience["Optional: convenience / hosting package\nCratis.Chronicle.AspNetCore · io.cratis:chronicle-spring-boot-starter"]
+    end
+    contracts --> idiomatic
+    idiomatic --> testing
+    idiomatic --> convenience
+```
+
+## Why the split exists
+
+- **The generated layer can't carry taste.** Attribute-based artifact discovery, fluent builders,
+  a `ChronicleClient` → `EventStore` → `EventLog` API shape — none of that survives regeneration.
+  It has to live somewhere the generator never touches.
+- **The two layers version independently.** The contracts package tracks the kernel's release
+  number; the idiomatic client tracks its own API stability. Chronicle.Kotlin, for example, is
+  presently at `2.1.1` while the `io.cratis:chronicle-contracts` package it depends on tracks the
+  kernel's `16.x` version — two numbers, two meanings, on purpose.
+- **The value contract, not the whole API, is what has to agree across languages.** Only what
+  crosses the wire — how a `Guid`, a date, a duration, a concept, a derived type is serialized —
+  has to be identical everywhere. Everything above that (dependency injection, task scheduling,
+  how a language discovers its own artifacts) is free to be idiomatic. See
+  [The Value Contract](../contributing/clients/value-contract.md) for the exact, short list of
+  things that must agree, and
+  [Client Types](../contributing/clients/client-types.md) for how the .NET client's own project
+  dependency graph reflects this layering internally.
+
+## How C# does it differently — and why that's not the model to copy
+
+C#'s idiomatic client, `Cratis.Chronicle`, does not depend on a separately published contracts
+NuGet package the way the other three languages do. Instead, `Contracts.csproj` is referenced
+directly and packaged as a **runtime-only** dependency: it ships inside the `Cratis.Chronicle`
+NuGet package under `runtimes/`, invisible to IntelliSense and uncompilable against directly, while
+the SDK's own types occupy `lib/`. A build-time step (`GrpcClients`, using
+`System.Reflection.Emit`) even pre-generates the gRPC client implementations that would otherwise
+need a compile-time reference to the internalized contracts types. The mechanics are in
+[Internalization](../contributing/clients/internalization.md).
+
+That's possible because C# is Chronicle's own implementation language and NuGet's `ref`/`lib`
+split gives it a tool the other ecosystems don't have as cleanly. It is not a pattern to reach for
+in a new client. The other three languages hide the seam a simpler way: publish the contracts
+package on its own, and let the idiomatic client's package name and its exports be the only thing
+a developer ever consumes directly. Nobody imports `@cratis/chronicle.contracts` in application
+code; they import `@cratis/chronicle`, which happens to depend on it.
+
+## The raw client is usable on its own
+
+The idiomatic client — on its own, with no convenience package — is a complete, general-purpose
+client. It's what you reach for in a console tool, a script, a background worker, or a test
+project. Every one of the four existing clients treats this as the default entry point:
+
+```typescript
+const client = new ChronicleClient(ChronicleOptions.development());
+const store = await client.getEventStore('MyStore');
+await store.eventLog.append('employee-123', new EmployeeHired('Jane', 'Doe'));
+```
+
+## Convenience packages sit above that, and are optional
+
+Once the raw client is stable, it's common — not mandatory — to build a thin package on top that
+wires the client into a specific hosting environment: registering it in a DI container, resolving
+configuration from the host's standard config system, binding request-scoped concerns like tenant
+or identity to the current HTTP request. C# has done this since early on with
+`Cratis.Chronicle.AspNetCore`. Kotlin followed the same shape much later, once its idiomatic
+client's artifact-discovery machinery existed to build on: `io.cratis:chronicle-spring-boot-starter`
+provides Spring auto-configuration, `ChronicleProperties`, and per-request namespace resolution
+(fixed, HTTP-header, subdomain, or authentication-claim based) — the direct JVM analogue of the
+ASP.NET Core package.
+
+TypeScript and Elixir don't have an equivalent yet (no Express/Fastify/NestJS package for
+TypeScript, no Phoenix package for Elixir). That's a genuine gap in those ecosystems today, not a
+sign the pattern doesn't apply — build a convenience package when your idiomatic client is stable
+enough to build one on top of, and there's an obvious dominant hosting framework in your language
+to target.
+
+A fourth, optional layer is worth knowing about too: an **in-process testing module**
+(`io.cratis:chronicle-testing` in Kotlin, `Cratis.Chronicle.Testing`/`Cratis.Chronicle.XUnit` in
+.NET) that depends on the idiomatic client and lets application code exercise slices without a
+live kernel. It's the same "build it once the layer beneath is stable" story as the convenience
+package, just aimed at test authors instead of host authors.
+
+Next: [Authentication and bearer tokens](./authentication-and-bearer-tokens.md) covers the first
+thing the idiomatic client actually has to do once it opens a connection.

--- a/Documentation/building-a-client/starting-points.md
+++ b/Documentation/building-a-client/starting-points.md
@@ -42,17 +42,24 @@ TypeScript, Elixir, and Kotlin's contracts packages, for your language. Concrete
    whole release on a wire-compatibility check, so a contracts package can never ship out of step
    with the server it talks to.
 
-This is precisely how it happened for the three clients that exist today:
+This is precisely how it happened for every contracts package that exists today:
 
 | Language | Contracts package | Registry |
 |---|---|---|
 | TypeScript | `@cratis/chronicle.contracts` | npm |
 | Kotlin/Java | `io.cratis:chronicle-contracts` | Maven Central |
 | Elixir | `cratis_chronicle_contracts` | Hex |
+| Python | `cratis-chronicle-contracts` | PyPI |
 
-None of those three client repos generate or own their own contracts — the packages are built and
-published from three parallel jobs in Chronicle's own `publish.yml`, all consuming the same
-`.proto` artifact, all gated behind the same `wire-compatibility` check. See
+Python is the newest addition, and it's worth noticing what stage it's at: the contracts package
+exists and publishes on its own, but there's no idiomatic `Chronicle.Python` repo built on top of
+it yet. That's expected — [layering an idiomatic client](./layering-an-idiomatic-client.md) on top
+of the contracts package is a separate, later step, not something that has to land in the same
+change as the contracts package itself.
+
+None of these client repos generate or own their own contracts — the packages are built and
+published from parallel jobs in Chronicle's own `publish.yml`, all consuming the same `.proto`
+artifact, all gated behind the same `wire-compatibility` check. See
 [the client history](./client-history.md) for how quickly this actually happened once the
 generator existed: Elixir's idiomatic client already depended on a published, versioned contracts
 package (`{:cratis_chronicle_contracts, ">= 0.1.0"}`) in its very first commit.

--- a/Documentation/building-a-client/starting-points.md
+++ b/Documentation/building-a-client/starting-points.md
@@ -1,0 +1,76 @@
+# Two ways to start
+
+Before writing a line of idiomatic code, a new client needs typed bindings for Chronicle's gRPC
+services. There are two ways to get them, and they're not equally good uses of your time.
+
+## Option A: generate from the `.proto` files yourself
+
+Chronicle's gRPC service and message definitions are code-first: they're written in C# using
+[protobuf-net.Grpc](https://github.com/protobuf-net/protobuf-net.Grpc) attributes
+(`[Service]`, `[Operation]`), and standard `.proto` files are extracted from the compiled
+contracts assembly by a tool called `ProtoGenerator`. Those extracted files live in
+`Source/Kernel/Protobuf/*.proto` in the Chronicle repository and are regenerated on every kernel
+build — see [Protobuf Extraction](../contributing/clients/protobuf-extraction.md) for exactly how
+that works.
+
+Because they're standard proto3, any language with a gRPC/protobuf toolchain can generate client
+bindings from them directly:
+
+```bash
+protoc \
+  -I Source/Kernel/Protobuf \
+  --go_out=. \
+  --go-grpc_out=. \
+  Source/Kernel/Protobuf/*.proto
+```
+
+This is the fully self-service path. Nobody has to grant you anything — the files are in the
+repository. It's also the slower path: you own getting the `protoc` invocation right for your
+language's plugin ecosystem, you own re-running it every time the kernel's contract changes, and
+you own publishing and versioning the result yourself.
+
+## Option B: ask the Cratis team for a generated package (recommended)
+
+The alternative is to ask the Cratis team to turn on the same pipeline that already produces
+TypeScript, Elixir, and Kotlin's contracts packages, for your language. Concretely, that pipeline:
+
+1. Extracts `.proto` files from the kernel's contracts assembly (the step Option A does by hand).
+2. Runs your language's code generator against them.
+3. Publishes the result to the registry your ecosystem actually uses — npm, Hex, Maven Central,
+   NuGet, wherever idiomatic packages for that language live.
+4. Version-locks the published package to the kernel release it was generated from, and gates the
+   whole release on a wire-compatibility check, so a contracts package can never ship out of step
+   with the server it talks to.
+
+This is precisely how it happened for the three clients that exist today:
+
+| Language | Contracts package | Registry |
+|---|---|---|
+| TypeScript | `@cratis/chronicle.contracts` | npm |
+| Kotlin/Java | `io.cratis:chronicle-contracts` | Maven Central |
+| Elixir | `cratis_chronicle_contracts` | Hex |
+
+None of those three client repos generate or own their own contracts — the packages are built and
+published from three parallel jobs in Chronicle's own `publish.yml`, all consuming the same
+`.proto` artifact, all gated behind the same `wire-compatibility` check. See
+[the client history](./client-history.md) for how quickly this actually happened once the
+generator existed: Elixir's idiomatic client already depended on a published, versioned contracts
+package (`{:cratis_chronicle_contracts, ">= 0.1.0"}`) in its very first commit.
+
+### Why this is worth asking for
+
+- **It's fast.** The generator, the packaging conventions, and the publish pipeline already exist
+  and already work for three ecosystems. Adding a fourth is mostly configuration, not invention.
+- **It stays correct without your attention.** The package versions in lockstep with the kernel
+  and is protected by the wire-compatibility gate — you're not responsible for noticing that the
+  kernel added a field or renamed a service.
+- **It's published where your ecosystem expects it.** A hand-generated set of files sitting in a
+  `vendor/` folder is not something other people in your language's community can `npm install` or
+  `mix deps.get`. A registry package is.
+- **It's the internal team's day-to-day workflow too.** Asking isn't a special-case request that
+  routes around some other, more official process — it *is* the process the Cratis team already
+  uses for every language it supports.
+
+Reach out to the Cratis team to start that conversation. Once the contracts package exists and is
+publishing on its own release cadence, move on to
+[layering an idiomatic client on top of it](./layering-an-idiomatic-client.md).

--- a/Documentation/building-a-client/toc.yml
+++ b/Documentation/building-a-client/toc.yml
@@ -1,0 +1,16 @@
+- name: Overview
+  href: index.md
+- name: Two ways to start
+  href: starting-points.md
+- name: Layering an idiomatic client
+  href: layering-an-idiomatic-client.md
+- name: Authentication and bearer tokens
+  href: authentication-and-bearer-tokens.md
+- name: Clustering and the connection lifecycle
+  href: clustering-and-connection-lifecycle.md
+- name: Connection string elements
+  href: connection-string-elements.md
+- name: How TypeScript, Elixir, and Kotlin were built
+  href: client-history.md
+- name: Documentation and snippets
+  href: documentation-and-snippets.md

--- a/Documentation/contributing/clients/index.mdx
+++ b/Documentation/contributing/clients/index.mdx
@@ -1,5 +1,11 @@
 # Contributing to Clients
 
+> Starting a brand-new client from scratch? [Building a Chronicle Client](../../building-a-client/)
+> is the onboarding story — starting points, the idiomatic-client layering, authentication,
+> clustering, and the real history of the TypeScript, Elixir, and Kotlin clients. This page and the
+> rest of this section are the deep reference for how Chronicle's own clients are built and
+> maintained.
+
 Below are the core principles for building public facing APIs exposed in our clients:
 
 - APIs should be lovable

--- a/Documentation/contributing/index.md
+++ b/Documentation/contributing/index.md
@@ -4,5 +4,6 @@
 | ------- | ----------- |
 | [Integration Tests](./integration-tests.md) | How to run and work with integration tests. |
 | [PrimeUI License](./primeui-license.md) | Supplying the PrimeReact/PrimeUI license key when working on the Workbench. |
+| [Building a Client](../building-a-client/) | Starting a brand-new Chronicle client from scratch. |
 | [Clients](./clients/) | Contributing to the clients. |
 | [Kernel](./kernel/index.md) | Contributing to the Kernel. |

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -68,6 +68,8 @@
   href: workbench/toc.yml
 - name: Hosting
   href: hosting/toc.yml
+- name: Building a Client
+  href: building-a-client/toc.yml
 - name: Contributing
   href: contributing/toc.yml
 - name: Statistics


### PR DESCRIPTION
# Summary

New Chronicle clients so far — TypeScript, Elixir, and Kotlin — each rediscovered the same
handful of hard problems on their own before they could do anything useful: generating bindings
from the wire contract, exchanging credentials for a token, load-balancing and reconnecting across
a cluster, and rejecting a server whose contract has drifted. This adds a new documentation
section that writes that experience down, so a future client doesn't have to rediscover it.

## Added

- Documentation section "Building a Client" (`Documentation/building-a-client/`) covering: the two
  ways to start a new client (raw `.proto` files vs. asking the Cratis team for a generated,
  registry-published contracts package); how the raw-contracts / idiomatic-client / convenience-
  package layering works and why C#'s internalization approach isn't the model to copy for a new
  language; authentication and bearer tokens (the OAuth client-credentials exchange, token
  caching/refresh, and how it differs from the Security namespace types used for Webhook/External
  Service authorization); clustering and the connection lifecycle (SRV resolution, load-balancer
  strategies, the wire-compatibility handshake, the reconnect watchdog) written for an SDK
  implementer and cross-linked into the existing connection-strings docs rather than duplicating
  them; the connection-string object model a client SDK typically wraps around the grammar; the
  real, sourced history of how TypeScript, Elixir, and Kotlin were actually built; and how a new
  client's `Documentation/` folder and snippets should be shaped.
