### PR TITLE
Fix startup with stale projection definitions

### DIFF
--- a/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/given/a_startup_task.cs
+++ b/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/given/a_startup_task.cs
@@ -2,10 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Captures;
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Observation.Reactors;
+using Cratis.Chronicle.Concepts.Observation.Reducers;
+using Cratis.Chronicle.Concepts.Projections;
 using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventTypes;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Namespaces;
@@ -15,6 +23,7 @@ using Cratis.Chronicle.Observation.Reactors.Kernel;
 using Cratis.Chronicle.Observation.Webhooks;
 using Cratis.Chronicle.Patching;
 using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Setup.Authentication;
 using Cratis.Chronicle.Storage;
@@ -45,7 +54,9 @@ public class a_startup_task : Specification
     protected IReadModelsManager _readModelsManager = null!;
     protected IProjectionsManager _projectionsManager = null!;
     protected IWebhooks _webhooksManager = null!;
+    protected ICapturesManager _capturesManager = null!;
     protected IJobsManager _jobsManager = null!;
+    protected IEventSequences _eventSequences = null!;
     protected IObserver _reducerObserver = null!;
     protected IObserver _reactorObserver = null!;
     protected EventStoreName _eventStore;
@@ -73,7 +84,9 @@ public class a_startup_task : Specification
         _readModelsManager = Substitute.For<IReadModelsManager>();
         _projectionsManager = Substitute.For<IProjectionsManager>();
         _webhooksManager = Substitute.For<IWebhooks>();
+        _capturesManager = Substitute.For<ICapturesManager>();
         _jobsManager = Substitute.For<IJobsManager>();
+        _eventSequences = Substitute.For<IEventSequences>();
         _reducerObserver = Substitute.For<IObserver>();
         _reactorObserver = Substitute.For<IObserver>();
 
@@ -97,6 +110,9 @@ public class a_startup_task : Specification
         _eventStoreStorage.Reactors.Returns(_reactorDefinitionsStorage);
         _eventStoreStorage.Reducers.Returns(_reducerDefinitionsStorage);
         _namespaceStorage.Observers.Returns(_observerStateStorage);
+        _observerStateStorage.GetAll().Returns(Task.FromResult<IEnumerable<ObserverState>>([]));
+        _reactorDefinitionsStorage.GetAll().Returns(Task.FromResult<IEnumerable<ReactorDefinition>>([]));
+        _reducerDefinitionsStorage.GetAll().Returns(Task.FromResult<IEnumerable<ReducerDefinition>>([]));
 
         _patchManager.ApplyPatches().Returns(Task.CompletedTask);
         _systemNamespaces.EnsureDefault().Returns(Task.CompletedTask);
@@ -106,7 +122,9 @@ public class a_startup_task : Specification
         _projectionsManager.Ensure().Returns(Task.CompletedTask);
         _projectionsManager.GetProjectionDefinitions().Returns(Task.FromResult<IEnumerable<ProjectionDefinition>>([]));
         _webhooksManager.Ensure().Returns(Task.CompletedTask);
+        _capturesManager.Ensure().Returns(Task.CompletedTask);
         _jobsManager.Rehydrate().Returns(Task.CompletedTask);
+        _eventSequences.Rehydrate().Returns(Task.CompletedTask);
         _reducerObserver.Ensure().Returns(Task.CompletedTask);
         _reactorObserver.Ensure().Returns(Task.CompletedTask);
         _eventTypes.DiscoverAndRegister(_eventStore).Returns(Task.CompletedTask);
@@ -121,7 +139,9 @@ public class a_startup_task : Specification
         _grainFactory.GetGrain<IReadModelsManager>(_eventStore).Returns(_readModelsManager);
         _grainFactory.GetGrain<IProjectionsManager>(_eventStore).Returns(_projectionsManager);
         _grainFactory.GetGrain<IWebhooks>(_eventStore).Returns(_webhooksManager);
+        _grainFactory.GetGrain<ICapturesManager>(_eventStore).Returns(_capturesManager);
         _grainFactory.GetGrain<IJobsManager>(0, new JobsManagerKey(_eventStore, _namespace)).Returns(_jobsManager);
+        _grainFactory.GetGrain<IEventSequences>(0, new EventSequencesKey(_eventStore, _namespace)).Returns(_eventSequences);
         _grainFactory.GetGrain<IObserver>(_reducerObserverKey).Returns(_reducerObserver);
         _grainFactory.GetGrain<IObserver>(_reactorObserverKey).Returns(_reactorObserver);
         _namespaces.GetAll().Returns(Task.FromResult<IEnumerable<EventStoreNamespaceName>>([_namespace]));
@@ -132,6 +152,22 @@ public class a_startup_task : Specification
         var execute = typeof(ChronicleServerStartupTask).GetMethod("Execute", BindingFlags.Instance | BindingFlags.NonPublic)!;
         return (Task)execute.Invoke(_startupTask, [CancellationToken.None])!;
     }
+
+    protected static ProjectionDefinition CreateProjectionDefinition(ProjectionId identifier, ReadModelIdentifier readModel) => new(
+        ProjectionOwner.Client,
+        EventSequenceId.Log,
+        identifier,
+        readModel,
+        true,
+        true,
+        new JsonObject(),
+        new Dictionary<EventType, FromDefinition>(),
+        new Dictionary<EventType, JoinDefinition>(),
+        new Dictionary<PropertyPath, ChildrenDefinition>(),
+        [],
+        new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+        new Dictionary<EventType, RemovedWithDefinition>(),
+        new Dictionary<EventType, RemovedWithJoinDefinition>());
 
     class TestAuthenticationService : IAuthenticationService
     {

--- a/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/when_executing/and_one_of_two_persisted_projection_definitions_is_rejected.cs
+++ b/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/when_executing/and_one_of_two_persisted_projection_definitions_is_rejected.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Projections.Engine;
+using NSubstitute.ExceptionExtensions;
+
+namespace Orleans.Hosting.for_ChronicleServerStartupTask.when_executing;
+
+public class and_one_of_two_persisted_projection_definitions_is_rejected : given.a_startup_task
+{
+    ProjectionDefinition _acceptedDefinition;
+    ProjectionDefinition _rejectedDefinition;
+    Exception _exception;
+
+    void Establish()
+    {
+        _acceptedDefinition = CreateProjectionDefinition("accepted-projection", "accepted-read-model");
+        _rejectedDefinition = CreateProjectionDefinition("rejected-projection", "rejected-read-model");
+        _projectionsManager.GetProjectionDefinitions().Returns([_acceptedDefinition, _rejectedDefinition]);
+        _projectionsServiceClient
+            .Register(
+                _eventStore,
+                Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.Contains(_rejectedDefinition)))
+            .ThrowsAsync(new ProjectionDefinitionRegistrationFailed(
+                _rejectedDefinition.Identifier,
+                new MissingChildCollectionInReadModelSchema(
+                    _rejectedDefinition.Identifier,
+                    "children",
+                    _rejectedDefinition.ReadModel,
+                    [])));
+    }
+
+    async Task Because() => _exception = await Catch.Exception(Execute);
+
+    [Fact] void should_not_prevent_the_server_from_starting() => _exception.ShouldBeNull();
+    [Fact] void should_register_the_accepted_definition_individually() => _projectionsServiceClient.Received(1).Register(_eventStore, Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _acceptedDefinition })));
+    [Fact] void should_attempt_to_register_the_rejected_definition_individually() => _projectionsServiceClient.Received(1).Register(_eventStore, Arg.Is<IEnumerable<ProjectionDefinition>>(definitions => definitions.SequenceEqual(new[] { _rejectedDefinition })));
+    [Fact] void should_continue_rehydrating_after_the_rejected_definition() => _jobsManager.Received(1).Rehydrate();
+}

--- a/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/when_executing/and_projection_registration_fails_without_attribution.cs
+++ b/Source/Kernel/Core.Specs/Setup/for_ChronicleServerStartupTask/when_executing/and_projection_registration_fails_without_attribution.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using NSubstitute.ExceptionExtensions;
+
+namespace Orleans.Hosting.for_ChronicleServerStartupTask.when_executing;
+
+public class and_projection_registration_fails_without_attribution : given.a_startup_task
+{
+    Exception _registrationFailure;
+    Exception _exception;
+
+    void Establish()
+    {
+        var definition = CreateProjectionDefinition("projection", "read-model");
+        _registrationFailure = new Exception("Projection service unavailable");
+        _projectionsManager.GetProjectionDefinitions().Returns([definition]);
+        _projectionsServiceClient
+            .Register(_eventStore, Arg.Any<IEnumerable<ProjectionDefinition>>())
+            .ThrowsAsync(_registrationFailure);
+    }
+
+    async Task Because() => _exception = await Catch.Exception(Execute);
+
+    [Fact] void should_propagate_the_failure() => _exception.ShouldEqual(_registrationFailure);
+    [Fact] void should_not_continue_rehydrating() => _jobsManager.DidNotReceive().Rehydrate();
+}

--- a/Source/Kernel/Core/Setup/ChronicleServerStartupTask.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerStartupTask.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Captures;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
 using Cratis.Chronicle.EventSequences;
 using Cratis.Chronicle.EventTypes;
 using Cratis.Chronicle.Jobs;
@@ -17,6 +18,10 @@ using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Setup.Authentication;
 using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using ProjectionDefinitionRegistrationFailed = Cratis.Chronicle.Projections.Engine.ProjectionDefinitionRegistrationFailed;
 
 namespace Orleans.Hosting;
 
@@ -29,14 +34,36 @@ namespace Orleans.Hosting;
 /// <param name="projectionsServiceClient"><see cref="IProjectionsServiceClient"/> for registering projections with local silos.</param>
 /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
 /// <param name="authenticationService"><see cref="IAuthenticationService"/> for managing authentication.</param>
+/// <param name="logger">The logger.</param>
 internal sealed class ChronicleServerStartupTask(
     IStorage storage,
     IEventTypes eventTypes,
     IReactors reactors,
     IProjectionsServiceClient projectionsServiceClient,
     IGrainFactory grainFactory,
-    IAuthenticationService authenticationService) : ILifecycleParticipant<ISiloLifecycle>
+    IAuthenticationService authenticationService,
+    ILogger<ChronicleServerStartupTask> logger) : ILifecycleParticipant<ISiloLifecycle>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChronicleServerStartupTask"/> class without logging.
+    /// </summary>
+    /// <param name="storage"><see cref="IStorage"/> for storing data.</param>
+    /// <param name="eventTypes"><see cref="IEventTypes"/> for managing kernel event types.</param>
+    /// <param name="reactors"><see cref="IReactors"/> for managing kernel reactors.</param>
+    /// <param name="projectionsServiceClient"><see cref="IProjectionsServiceClient"/> for registering projections with local silos.</param>
+    /// <param name="grainFactory"><see cref="IGrainFactory"/> for creating grains.</param>
+    /// <param name="authenticationService"><see cref="IAuthenticationService"/> for managing authentication.</param>
+    internal ChronicleServerStartupTask(
+        IStorage storage,
+        IEventTypes eventTypes,
+        IReactors reactors,
+        IProjectionsServiceClient projectionsServiceClient,
+        IGrainFactory grainFactory,
+        IAuthenticationService authenticationService)
+        : this(storage, eventTypes, reactors, projectionsServiceClient, grainFactory, authenticationService, NullLogger<ChronicleServerStartupTask>.Instance)
+    {
+    }
+
     /// <inheritdoc/>
     public void Participate(ISiloLifecycle lifecycle)
     {
@@ -80,7 +107,7 @@ internal sealed class ChronicleServerStartupTask(
             await capturesManager.Ensure();
 
             var projectionDefinitions = await projectionsManager.GetProjectionDefinitions();
-            await projectionsServiceClient.Register(eventStore, projectionDefinitions);
+            await RegisterPersistedProjectionDefinitions(eventStore, projectionDefinitions);
 
             var rehydrateAll = (await namespaces.GetAll()).Select(async namespaceName =>
             {
@@ -99,6 +126,33 @@ internal sealed class ChronicleServerStartupTask(
 #if DEVELOPMENT
         await authenticationService.EnsureDefaultClientCredentials();
 #endif
+    }
+
+    async Task RegisterPersistedProjectionDefinitions(EventStoreName eventStore, IEnumerable<ProjectionDefinition> projectionDefinitions)
+    {
+        var definitions = projectionDefinitions.ToArray();
+        try
+        {
+            await projectionsServiceClient.Register(eventStore, definitions);
+            return;
+        }
+        catch (Exception exception) when (ProjectionDefinitionRegistrationFailed.TryFindIdentifier(exception, out _))
+        {
+            // A stored client definition can be incompatible with a newer server. Retry definitions individually so
+            // compatible projections are restored while stale ones wait for the client to replace them after startup.
+        }
+
+        foreach (var definition in definitions)
+        {
+            try
+            {
+                await projectionsServiceClient.Register(eventStore, [definition]);
+            }
+            catch (Exception exception) when (ProjectionDefinitionRegistrationFailed.TryFindIdentifier(exception, out var identifier))
+            {
+                logger.FailedRegisteringPersistedProjectionDefinition(exception, identifier);
+            }
+        }
     }
 
     async Task RehydrateReducerAndReactorObservers(EventStoreName eventStore, EventStoreNamespaceName namespaceName)

--- a/Source/Kernel/Core/Setup/ChronicleServerStartupTaskLogging.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerStartupTaskLogging.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Projections;
+using Microsoft.Extensions.Logging;
+
+namespace Orleans.Hosting;
+
+/// <summary>
+/// Holds log messages for <see cref="ChronicleServerStartupTask"/>.
+/// </summary>
+internal static partial class ChronicleServerStartupTaskLogging
+{
+    [LoggerMessage(LogLevel.Warning, "Skipping persisted projection definition '{Identifier}' during startup because the current engine rejected it. Chronicle will continue starting so a client can re-register the projection with its current definition")]
+    internal static partial void FailedRegisteringPersistedProjectionDefinition(this ILogger<ChronicleServerStartupTask> logger, Exception exception, ProjectionId identifier);
+}


### PR DESCRIPTION
# Summary

Chronicle upgrades no longer require deleting persisted observer state when an older client projection definition is incompatible with the upgraded server.

## Fixed

- Chronicle now continues starting when persisted client projection definitions are stale, allowing clients to reconnect and register their current definitions without losing observer progress.
