### PR TITLE
Build Python contracts from committed proto schemas

### DIFF
--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -21,22 +21,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Build contracts
-        working-directory: Source/Kernel/Contracts
-        run: dotnet build -c Release
-
-      - name: Generate proto files
-        run: |
-          dotnet run \
-            --project Source/Tools/ProtoGenerator/ProtoGenerator.csproj -- \
-            Source/Kernel/Contracts/bin/Release/net10.0/Cratis.Chronicle.Contracts.dll \
-            Source/Kernel/Protobuf
-
       - name: Setup Python
         uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
## Fixed

- Build the generated Python contracts package from the committed `Source/Kernel/Protobuf` schemas, matching the TypeScript, Kotlin, and Elixir client pipelines.
- Stop the Python publication workflow from running the currently broken live C# proto regeneration path, which can fail most packages while exiting successfully and then publish stale files (#3712).

## Context

Independent `v16.38.2` validation found that the existing publication workflow reports generation errors for 22 of 23 schema packages but exits 0. The Python generation, tests, wheel, source distribution, and Twine checks then pass against the pre-existing committed schemas, making the run misleadingly green.

The broader generator and wire-contract work remains owned by #3768. This narrow workflow change makes the publication source explicit and consistent with the other generated clients; it does not publish a package or wire Python into automatic Chronicle releases.

Closes the workflow-source decision in #3806 if maintainers choose the committed-schema publication path documented there. PyPI Trusted Publisher and protected-environment setup remain separate administrator work.

## Verification

- `ruff format --check generate.py build_package.py tests`
- `ruff check generate.py build_package.py tests`
- `pytest` — 3 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=16.38.2 python build_package.py`
- `python -m twine check dist/*`
- Inspected wheel for message, type-stub, gRPC-stub, and `protobuf_net/bcl_pb2.py` contents
- YAML language-server diagnostics clean
