### PR TITLE
Raise Python contracts minimum version and simplify generation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,8 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
+        - language: python
+          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-python-client.yml
+++ b/.github/workflows/publish-python-client.yml
@@ -8,21 +8,32 @@ on:
         type: string
         required: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$ ]]; then
+            echo "::error::Version '$VERSION' is not a valid release version"
+            exit 1
+          fi
+
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
           cache: pip
@@ -49,25 +60,27 @@ jobs:
         run: python build_package.py
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-contract-distributions
           path: Source/Clients/Python/dist/
           if-no-files-found: error
+          retention-days: 7
 
   publish:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: pypi-python-contracts
     permissions:
       id-token: write
 
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: python-contract-distributions
           path: dist/
 
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -14,13 +14,15 @@ on:
       - "Source/Kernel/Protobuf/**"
       - ".github/workflows/python-contracts.yml"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -28,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/python-contracts.yml
+++ b/.github/workflows/python-contracts.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 

--- a/Source/Clients/Python/generate.py
+++ b/Source/Clients/Python/generate.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import argparse
-import re
 import shutil
 import tempfile
 from importlib import import_module
@@ -14,6 +13,7 @@ from importlib.resources import files
 from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).parent / "src" / "cratis_chronicle_contracts"
+PACKAGE_NAME = PACKAGE_ROOT.name
 GENERATED_SUFFIXES = ("_pb2.py", "_pb2.pyi", "_pb2_grpc.py")
 
 
@@ -34,26 +34,22 @@ def _clean_generated_files() -> None:
 
 
 def _prepare_proto_tree(source: Path, destination: Path) -> list[Path]:
+    # Proto files are rooted under a directory named after the installed package so that protoc computes
+    # fully-qualified, already-correct imports (e.g. `from cratis_chronicle_contracts import events_pb2`)
+    # instead of the bare top-level imports it would otherwise emit for messages defined in other files.
     proto_files: list[Path] = []
+    package_directory = destination / PACKAGE_NAME
     for source_file in sorted(source.rglob("*.proto")):
         relative_path = source_file.relative_to(source)
         normalized_path = Path(*("protobuf_net" if part == "protobuf-net" else part for part in relative_path.parts))
-        destination_file = destination / normalized_path
+        destination_file = package_directory / normalized_path
         destination_file.parent.mkdir(parents=True, exist_ok=True)
-        contents = source_file.read_text().replace('"protobuf-net/bcl.proto"', '"protobuf_net/bcl.proto"')
+        contents = source_file.read_text().replace(
+            '"protobuf-net/bcl.proto"', f'"{PACKAGE_NAME}/protobuf_net/bcl.proto"'
+        )
         destination_file.write_text(contents)
-        proto_files.append(normalized_path)
+        proto_files.append(Path(PACKAGE_NAME) / normalized_path)
     return proto_files
-
-
-def _rewrite_imports(path: Path) -> None:
-    contents = path.read_text()
-    if path.parent == PACKAGE_ROOT:
-        contents = re.sub(r"^import ([A-Za-z0-9_]+_pb2) as ", r"from . import \1 as ", contents, flags=re.MULTILINE)
-        contents = contents.replace("from protobuf_net import bcl_pb2 as", "from .protobuf_net import bcl_pb2 as")
-    else:
-        contents = contents.replace("from protobuf_net import bcl_pb2 as", "from . import bcl_pb2 as")
-    path.write_text(contents)
 
 
 def generate(proto_root: Path) -> None:
@@ -72,9 +68,9 @@ def generate(proto_root: Path) -> None:
             "grpc_tools.protoc",
             f"-I{normalized_root}",
             f"-I{grpc_include_root}",
-            f"--python_out={PACKAGE_ROOT}",
-            f"--pyi_out={PACKAGE_ROOT}",
-            f"--grpc_python_out={PACKAGE_ROOT}",
+            f"--python_out={PACKAGE_ROOT.parent}",
+            f"--pyi_out={PACKAGE_ROOT.parent}",
+            f"--grpc_python_out={PACKAGE_ROOT.parent}",
             *(str(path) for path in proto_files),
         ]
         protoc = import_module("grpc_tools.protoc")
@@ -88,10 +84,6 @@ def generate(proto_root: Path) -> None:
         "# Copyright (c) Cratis. All rights reserved.\n"
         "# Licensed under the MIT license. See LICENSE file in the project root for full license information.\n"
     )
-
-    for generated_file in PACKAGE_ROOT.rglob("*.py"):
-        if generated_file.name.endswith(("_pb2.py", "_pb2_grpc.py")):
-            _rewrite_imports(generated_file)
 
 
 if __name__ == "__main__":

--- a/Source/Clients/Python/pyproject.toml
+++ b/Source/Clients/Python/pyproject.toml
@@ -7,7 +7,7 @@ name = "cratis-chronicle-contracts"
 dynamic = ["version"]
 description = "Generated Python gRPC contracts for Cratis Chronicle"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Cratis", email = "post@cratis.io" }]
@@ -17,8 +17,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -64,7 +62,7 @@ testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["B", "E", "F", "I", "UP"]


### PR DESCRIPTION
# Summary

`cratis-chronicle-contracts` now targets a narrower, more current set of Python runtimes, and the generation script no longer duplicates work `protoc` already does for us.

## Removed

- Dropped Python 3.10 and 3.11 support for `cratis-chronicle-contracts`; the package now requires Python >=3.12, matching the support window used by major scientific-Python projects such as NumPy.
