### PR TITLE
Only run Claude Assistant when @claude is mentioned

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,10 @@
 name: Claude Assistant
 
+# One concurrency group per issue / pull request instead of one global group:
+# with the global group, a mention on one issue cancelled Claude's in-flight work
+# on a completely different issue.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 
@@ -23,7 +26,18 @@ permissions:
 
 jobs:
   claude-response:
+    # Only start a runner when Claude is actually addressed. Without this gate the
+    # workflow booted a runner and checked out the repository for every comment,
+    # review and issue event in the repository (~150 runs/week), even though the
+    # action itself then found no @claude mention and did nothing. Issue opened /
+    # assigned events stay ungated because assignment is itself the signal.
+    if: >-
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of the Actions throttling remediation (org was runner-starved on 2026-08-25 and this workflow was the largest source of pointless hosted runs on the shared 20-slot pool).

- **Gate**: `claude-response` only starts when the triggering comment/review body contains `@claude`. Previously every single comment, review and issue event booted a runner, checked out the repo and exited (~150 runs / ~800 min per week measured over the last 7 days). `issues: [opened, assigned]` events stay ungated — assignment is itself the signal.
- **Concurrency**: per-issue/PR group instead of one global group — a mention on one issue no longer cancels Claude's in-flight work on another.
- **timeout-minutes: 30** (was: 6 h default).

No change to permissions or the action invocation itself. Validated with YAML parse + actionlint.