### PR TITLE
Stagger daily package update schedule

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -2,7 +2,7 @@ name: Update Packages
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '13 4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Part of the org-wide Actions throttling remediation: all 36 repos ran **Update Packages at exactly 06:00 UTC**, stampeding the shared 20-slot hosted-runner pool (a factor in the 2026-08-25 runner starvation). This repo's slot is now `13 4 * * *` (UTC), assigned deterministically so no two repos share a minute and none sit on the congested top of the hour. One-line change; YAML validated.