### PR TITLE
Add job timeouts and PR concurrency to workflows

### DIFF
--- a/.github/workflows/ai-corpus-validation.yml
+++ b/.github/workflows/ai-corpus-validation.yml
@@ -20,6 +20,7 @@ jobs:
   validate:
     name: Validate AI corpus
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/.github/workflows/auto-approve-publish-deployments.yml
+++ b/.github/workflows/auto-approve-publish-deployments.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   approve:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Approve pending npm/nuget deployments
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,7 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cleanup-pr-artifacts.yml
+++ b/.github/workflows/cleanup-pr-artifacts.yml
@@ -1,5 +1,9 @@
 name: Cleanup PR Artifacts
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/client-snippets.yml
+++ b/.github/workflows/client-snippets.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: 30
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Trigger Documentation Build
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -49,6 +49,7 @@ on:
 jobs:
   dotnet-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     outputs:
       dotnet-cache-key: ${{ steps.export-cache-key.outputs.key }}
       chronicle-image: ${{ steps.export-cache-key.outputs.image }}
@@ -161,6 +162,7 @@ jobs:
   # (non-DEVELOPMENT) behavior.
   dotnet-build-development:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: read
@@ -216,6 +218,7 @@ jobs:
 
   specs:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [dotnet-build]
     steps:
       - name: Checkout code
@@ -272,6 +275,7 @@ jobs:
 
   integration-api:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [dotnet-build]
     steps:
       - name: Checkout code
@@ -334,6 +338,7 @@ jobs:
 
   mongodb:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [dotnet-build]
     steps:
       - name: Checkout code
@@ -381,6 +386,7 @@ jobs:
   coverage-merge-and-cache:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [specs, integration, integration-api, mongodb]
     outputs:
       coverage-cache-key: ${{ steps.export-coverage-key.outputs.key }}
@@ -469,6 +475,7 @@ jobs:
   # minutes off the critical path rather than ~13 on it.
   benchmarks-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     needs: [dotnet-build]
 
     steps:

--- a/.github/workflows/generate-protos.yml
+++ b/.github/workflows/generate-protos.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   generate-protos:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/grpc-compatibility.yml
+++ b/.github/workflows/grpc-compatibility.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   check-compatibility:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/hot-core-gate.yml
+++ b/.github/workflows/hot-core-gate.yml
@@ -41,6 +41,7 @@ env:
 jobs:
   detect:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       touched: ${{ steps.detect.outputs.touched }}
 
@@ -83,6 +84,7 @@ jobs:
     needs: [detect]
     if: needs.detect.outputs.touched == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -182,6 +184,7 @@ jobs:
     needs: [detect, build, full-out-of-process-matrix]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Decide

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     outputs:
       client-matrix: ${{ steps.client.outputs.matrix }}
       kernel-matrix: ${{ steps.kernel.outputs.matrix }}
@@ -82,6 +83,7 @@ jobs:
   client-integration-specs:
     needs: [discover]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover.outputs.client-matrix) }}
@@ -190,6 +192,7 @@ jobs:
   kernel-integration-specs:
     needs: [discover]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover.outputs.kernel-matrix) }}
@@ -259,6 +262,7 @@ jobs:
   clustering-integration-specs:
     needs: [discover]
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover.outputs.clustering-matrix) }}

--- a/.github/workflows/issue-analysis.yml
+++ b/.github/workflows/issue-analysis.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Categorize Issues in GitHub Project
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       issues: read

--- a/.github/workflows/kotlin-build.yml
+++ b/.github/workflows/kotlin-build.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   kotlin-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/markdown-verification.yml
+++ b/.github/workflows/markdown-verification.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-elixir-client.yml
+++ b/.github/workflows/publish-elixir-client.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   publish-elixir-client:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/publish-kotlin-client.yml
+++ b/.github/workflows/publish-kotlin-client.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   publish-kotlin-client:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/publish-typescript-client.yml
+++ b/.github/workflows/publish-typescript-client.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   publish-typescript-client:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,7 @@ jobs:
     # doing any work at all, on top of the concurrency key above keeping them out of each other's way.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -105,6 +106,7 @@ jobs:
   coverage-statistics:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
     permissions:
       contents: write
@@ -153,6 +155,7 @@ jobs:
   dotnet-x64:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:
@@ -181,6 +184,7 @@ jobs:
   dotnet-arm64:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
     needs: [release]
 
     steps:
@@ -209,6 +213,7 @@ jobs:
   workbench:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:
@@ -255,6 +260,7 @@ jobs:
   dotnet-pack-and-publish:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-x64, dotnet-arm64, workbench, dotnet-x64-development, dotnet-arm64-development]
     permissions:
       # Required for NuGet trusted publishing using OIDC tokens
@@ -308,6 +314,7 @@ jobs:
   notify-arc:
     if: needs.release.outputs.publish == 'true' && needs.release.outputs.prerelease != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-pack-and-publish]
 
     steps:
@@ -356,6 +363,7 @@ jobs:
   dotnet-x64-development:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:
@@ -384,6 +392,7 @@ jobs:
   dotnet-arm64-development:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
     needs: [release]
 
     steps:
@@ -412,6 +421,7 @@ jobs:
   publish-docker-production:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-x64, dotnet-arm64, workbench, dotnet-x64-development, dotnet-arm64-development]
 
     steps:
@@ -507,6 +517,7 @@ jobs:
   publish-docker-workbench:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-x64, dotnet-arm64, workbench, dotnet-x64-development, dotnet-arm64-development]
 
     steps:
@@ -561,6 +572,7 @@ jobs:
   publish-docker-development:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-x64, dotnet-arm64, workbench, dotnet-x64-development, dotnet-arm64-development]
 
     steps:
@@ -642,6 +654,7 @@ jobs:
   publish-docker-development-slim:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release, dotnet-x64, dotnet-arm64, workbench, dotnet-x64-development, dotnet-arm64-development]
 
     steps:
@@ -709,6 +722,7 @@ jobs:
   verify-published-docker-tags:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     needs:
@@ -752,6 +766,7 @@ jobs:
     # which is what makes it safe to trust here.
     if: always() && github.event_name == 'pull_request' && needs.release.result == 'success' && needs.release.outputs.publish != 'true' && !contains(github.event.pull_request.labels.*.name, 'no-release')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: [release]
 
     steps:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.release.outputs.version }}
       publish: ${{ steps.release.outputs.should-publish }}
@@ -43,6 +44,7 @@ jobs:
   kernel:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release]
 
     steps:
@@ -78,6 +80,7 @@ jobs:
   workbench:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release]
 
     steps:
@@ -125,6 +128,7 @@ jobs:
   kernel-development:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release]
 
     steps:
@@ -167,6 +171,7 @@ jobs:
   publish-nuget-packages:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [release, workbench]
 
     steps:
@@ -219,6 +224,7 @@ jobs:
   publish-docker:
     if: needs.release.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [workbench, kernel, kernel-development, release]
 
     steps:

--- a/.github/workflows/timing-coupling-ratchet.yml
+++ b/.github/workflows/timing-coupling-ratchet.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   timing-coupling-ratchet:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   typescript-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/.github/workflows/verify-semver-label.yml
+++ b/.github/workflows/verify-semver-label.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Require exactly one release-intent label

--- a/.github/workflows/verify-spec-coverage-retained.yml
+++ b/.github/workflows/verify-spec-coverage-retained.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/workbench-build.yml
+++ b/.github/workflows/workbench-build.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   node-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Part of the org-wide Actions throttling remediation. Mechanical, rule-based sweep:

- **timeout-minutes** on every job that had none (previously 6 h default): quick checks 15, builds 30, publish/release 60, integration/benchmarks 120.
- **concurrency + cancel-in-progress** only on pull-request-triggered verification workflows — never on publish/release/deploy, `pull_request_target`, `workflow_run` or reusable (`workflow_call`) workflows.

Every edited file re-parsed as YAML before commit. Files changed:
- .github/workflows/ai-corpus-validation.yml
- .github/workflows/auto-approve-publish-deployments.yml
- .github/workflows/benchmarks.yml
- .github/workflows/claude.yml
- .github/workflows/cleanup-pr-artifacts.yml
- .github/workflows/client-snippets.yml
- .github/workflows/codeql.yml
- .github/workflows/documentation.yml
- .github/workflows/dotnet-build.yml
- .github/workflows/generate-protos.yml
- .github/workflows/grpc-compatibility.yml
- .github/workflows/hot-core-gate.yml
- .github/workflows/integration.yml
- .github/workflows/issue-analysis.yml
- .github/workflows/kotlin-build.yml
- .github/workflows/markdown-verification.yml
- .github/workflows/publish-elixir-client.yml
- .github/workflows/publish-kotlin-client.yml
- .github/workflows/publish-typescript-client.yml
- .github/workflows/publish.yml
- .github/workflows/pull-requests.yml
- .github/workflows/timing-coupling-ratchet.yml
- .github/workflows/typescript-build.yml
- .github/workflows/verify-semver-label.yml
- .github/workflows/verify-spec-coverage-retained.yml
- .github/workflows/workbench-build.yml