### PR TITLE
chore: surface the .ai-work/ local work artifact rule in the instruction corpus

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -203,3 +203,12 @@ All gates pass before merging, opening a PR, or marking a slice complete — exc
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 ```
+
+## Local AI work artifacts — `.ai-work/` only
+
+AI-assisted sessions produce working artifacts: plans, handover documents, session notes, continuation prompts, status boards, scratch analyses, research dumps. These are **work records, not documentation**:
+
+- Create every such artifact inside **`.ai-work/`** at the repository root — never at the repository root itself, never under documentation folders, never anywhere else.
+- `.ai-work/` is gitignored and must stay untracked. Never commit anything inside it, never `git add -f` anything inside it, and never remove the ignore entry.
+- These artifacts must never enter git history or reach GitHub — not on any branch. If you find one tracked in git, move it into `.ai-work/` and remove it from tracking in a dedicated commit.
+- Knowledge that must outlive the session belongs in the repository's documentation structure through normal review, not in a work record.


### PR DESCRIPTION
AI session work records must live in the gitignored .ai-work/ folder and never enter git history. Companion to .ai/rules/local-work-artifacts.md.