### PR TITLE
chore: follow-ups that must survive an AI session become GitHub issues

### DIFF
--- a/.ai/rules/general.md
+++ b/.ai/rules/general.md
@@ -211,4 +211,5 @@ AI-assisted sessions produce working artifacts: plans, handover documents, sessi
 - Create every such artifact inside **`.ai-work/`** at the repository root — never at the repository root itself, never under documentation folders, never anywhere else.
 - `.ai-work/` is gitignored and must stay untracked. Never commit anything inside it, never `git add -f` anything inside it, and never remove the ignore entry.
 - These artifacts must never enter git history or reach GitHub — not on any branch. If you find one tracked in git, move it into `.ai-work/` and remove it from tracking in a dedicated commit.
+- A genuine follow-up that must survive the session is **not** a work record — suggest opening a GitHub issue for it (or open one when asked) so future work is tracked where everyone can see it, instead of leaving a planning file behind.
 - Knowledge that must outlive the session belongs in the repository's documentation structure through normal review, not in a work record.

--- a/.ai/rules/local-work-artifacts.md
+++ b/.ai/rules/local-work-artifacts.md
@@ -15,6 +15,9 @@ dumps, and similar coordination files. These are **work records, not documentati
 - These artifacts must never enter git history or reach GitHub — not on any branch.
   If you find one tracked in git, move it into `.ai-work/` and remove it from
   tracking in a dedicated commit.
+- A genuine follow-up that must survive the session is **not** a work record — suggest
+  opening a GitHub issue for it (or open one when asked) so future work is tracked
+  where everyone can see it, instead of leaving a planning file behind.
 - Knowledge that must outlive the session (real documentation, ADRs, operator
   guides) is written deliberately into the repository's documentation structure
   through normal review — not left behind as a work record.


### PR DESCRIPTION
Extends the .ai-work/ rule: durable follow-up work is suggested as a GitHub issue instead of being left behind as a planning file.