### PR TITLE
chore: add verify-no-work-records guard workflow

### DIFF
--- a/.github/workflows/verify-no-work-records.yml
+++ b/.github/workflows/verify-no-work-records.yml
@@ -1,0 +1,10 @@
+name: Verify No Work Records
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  verify:
+    uses: Cratis/Workflows/.github/workflows/verify-no-work-records.yml@main


### PR DESCRIPTION
Fails any PR or push that tracks AI session work records or .ai-work/ content. CI enforcement for .ai/rules/local-work-artifacts.md.