### PR TITLE
Probe the closed PR publish trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish
+# Closed-unmerged trigger probe; this branch is never merged.
 
 # Publish runs are grouped per pull request, and never cancelled.
 #


### PR DESCRIPTION
## Purpose
- Diagnose why merged patch PR #3833 created no Publish workflow run.
- This probe is closed unmerged and must never release.

## Expected result
- Closing unmerged should create a Publish workflow run whose release job skips because `merged == false`.

## Effects
- No merge, package, image, release, deployment, or production effect.