### PR TITLE
Fix read-model resolution and silo startup issues

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.2-conceptjsonfix.1" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.2" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.1" />
     <PackageVersion Include="Cratis.Arc" Version="22.3.0" />
     <PackageVersion Include="Cratis.Arc.Core" Version="22.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.1" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.2-conceptjsonfix.1" />
     <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.1" />
     <PackageVersion Include="Cratis.Arc" Version="22.3.0" />
     <PackageVersion Include="Cratis.Arc.Core" Version="22.3.0" />

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenFromAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenFromAttribute.cs
@@ -13,6 +13,16 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// <param name="key">Optional property name on the event that identifies the child. Defaults to WellKnownExpressions.EventSourceId.</param>
 /// <param name="identifiedBy">Optional property name on the child model that identifies it. If not specified, will look for [Key] attribute, then an Id property by convention, finally defaulting to WellKnownExpressions.EventSourceId.</param>
 /// <param name="parentKey">Optional property name that identifies the parent. Defaults to WellKnownExpressions.EventSourceId.</param>
+/// <remarks>
+/// This subscribes <typeparamref name="TEvent"/> only for the child collection - AutoMap eligibility for its
+/// payload stays scoped to the child, and it cannot, by itself, overwrite a root property of the same name.
+/// That changes the moment anything else on the same model root also references <typeparamref name="TEvent"/>
+/// (for example a <c>[SetFromContext&lt;TEvent&gt;]</c> on an unrelated root property that only wants an
+/// <see cref="Cratis.Chronicle.Events.EventContext"/> value): the event then also gets a root-level subscription, and every one of its
+/// payload properties becomes AutoMap-eligible against any same-named root property - independent of which
+/// attribute added the root subscription. Fence an affected root property with <see cref="NoAutoMapAttribute"/>
+/// when this is not wanted.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class ChildrenFromAttribute<TEvent>(
     string? key = default,

--- a/Source/Clients/DotNET/Projections/ModelBound/SetFromContextAttribute.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/SetFromContextAttribute.cs
@@ -8,6 +8,15 @@ namespace Cratis.Chronicle.Projections.ModelBound;
 /// </summary>
 /// <typeparam name="TEvent">The type of event to set from.</typeparam>
 /// <param name="contextPropertyName">Optional name of the property on the event context. If not specified, uses the model property name.</param>
+/// <remarks>
+/// This only ever reads <see cref="Cratis.Chronicle.Events.EventContext"/>, never <typeparamref name="TEvent"/>'s own payload - but it
+/// still subscribes the projection to <typeparamref name="TEvent"/>. Once subscribed, AutoMap becomes eligible
+/// for every one of <typeparamref name="TEvent"/>'s payload properties against any same-named property on the
+/// model, regardless of which attribute caused the subscription. If <typeparamref name="TEvent"/> is not
+/// otherwise referenced, a same-named payload property can silently overwrite an unrelated, explicitly-sourced
+/// model property with no attribute anywhere near it that looks responsible. Fence an affected property with
+/// <see cref="NoAutoMapAttribute"/> when this is not wanted.
+/// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = true)]
 public sealed class SetFromContextAttribute<TEvent>(string? contextPropertyName = default) : Attribute, IProjectionAnnotation, ISetFromContextAttribute
 {

--- a/Source/Kernel/Core.Specs/Projections/for_IProjectionsManager/when_inspecting_grain_call_interleaving.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_IProjectionsManager/when_inspecting_grain_call_interleaving.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Orleans.Concurrency;
+
+namespace Cratis.Chronicle.Projections.for_IProjectionsManager;
+
+/// <summary>
+/// Reproduces #3848 - Ensure() does no work of its own (it only activates the grain), so it must not queue
+/// FIFO behind whatever else is already pending on this non-reentrant grain, such as the client Register()
+/// fan-out during a rolling redeploy. Without interleaving, the silo's own startup call to Ensure() can sit
+/// behind that queue long enough to hit Orleans' response timeout and crash the host for work it never does.
+/// </summary>
+public class when_inspecting_grain_call_interleaving : Specification
+{
+    bool _ensureIsInterleaved;
+
+    void Because() => _ensureIsInterleaved = IsInterleaved(typeof(IProjectionsManager).GetMethod(nameof(IProjectionsManager.Ensure))!);
+
+    [Fact] void should_interleave_ensuring_the_projections_manager_exists() => _ensureIsInterleaved.ShouldBeTrue();
+
+    static bool IsInterleaved(MethodInfo method) => Attribute.IsDefined(method, typeof(AlwaysInterleaveAttribute));
+}

--- a/Source/Kernel/Core.Specs/Projections/for_ImmediateProjection/when_getting_model_instance/and_definition_has_not_been_set_yet.cs
+++ b/Source/Kernel/Core.Specs/Projections/for_ImmediateProjection/when_getting_model_instance/and_definition_has_not_been_set_yet.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Storage.EventSequences;
+using Microsoft.Extensions.Logging;
+using Orleans.Core;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Projections.for_ImmediateProjection.when_getting_model_instance;
+
+/// <summary>
+/// Reproduces #3846 - a passive read model's projection definition is set lazily from the first observed
+/// event of its kind, so a query for a key can arrive before that has ever happened. Duplicates
+/// given.an_immediate_projection's setup rather than inheriting from it, because TestKitSilo allows only
+/// one grain per test silo and this spec needs the storage state to already carry a null ReadModel at the
+/// point the grain is created.
+/// </summary>
+public class and_definition_has_not_been_set_yet : Specification
+{
+    const string EventStore = "the-event-store";
+    const string Projection = "the-projection";
+    const string ReadModelKey = "the-read-model-key";
+
+    ImmediateProjection _grain;
+    TestKitSilo _silo;
+    ProjectionResult _result;
+
+    async Task Establish()
+    {
+        _silo = new TestKitSilo();
+        var projection = Substitute.For<IProjection>();
+        projection.SubscribeDefinitionsChanged(Arg.Any<INotifyProjectionDefinitionsChanged>()).Returns(Task.CompletedTask);
+
+        var storage = Substitute.For<Storage.IStorage>();
+        var eventStoreStorage = Substitute.For<Storage.IEventStoreStorage>();
+        var namespaceStorage = Substitute.For<Storage.IEventStoreNamespaceStorage>();
+        storage.GetEventStore(EventStore).Returns(eventStoreStorage);
+        eventStoreStorage.GetNamespace(EventStoreNamespaceName.Default).Returns(namespaceStorage);
+        namespaceStorage.GetEventSequence(EventSequenceId.Log).Returns(Substitute.For<IEventSequenceStorage>());
+
+        var logger = Substitute.For<ILogger<ImmediateProjection>>();
+        logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+
+        _silo.AddService(storage);
+        _silo.AddService(Substitute.For<IExpandoObjectConverter>());
+        _silo.AddService(logger);
+        _silo.AddProbe(_ => projection);
+
+        var stateStorage = Substitute.For<IStorage<ProjectionDefinition>>();
+        stateStorage.State = new ProjectionDefinition(
+            ProjectionOwner.Client,
+            EventSequenceId.Log,
+            Projection,
+            null!,
+            true,
+            true,
+            new JsonObject(),
+            new Dictionary<EventType, FromDefinition>(),
+            new Dictionary<EventType, JoinDefinition>(),
+            new Dictionary<PropertyPath, ChildrenDefinition>(),
+            [],
+            new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+            new Dictionary<EventType, RemovedWithDefinition>(),
+            new Dictionary<EventType, RemovedWithJoinDefinition>());
+        _silo.Options.StorageFactory = _ => stateStorage;
+
+        var key = new ImmediateProjectionKey(Projection, EventStore, EventStoreNamespaceName.Default, EventSequenceId.Log, ReadModelKey);
+        _grain = await _silo.CreateGrainAsync<given.TestableImmediateProjection>(key.ToString());
+    }
+
+    async Task Because() => _result = await _grain.GetModelInstance();
+
+    [Fact] void should_not_have_a_read_model() => _result.HasReadModel.ShouldBeFalse();
+}

--- a/Source/Kernel/Core/Projections/IProjectionsManager.cs
+++ b/Source/Kernel/Core/Projections/IProjectionsManager.cs
@@ -16,6 +16,13 @@ public interface IProjectionsManager : IGrainWithStringKey
     /// Ensure the existence of the projections manager.
     /// </summary>
     /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// A no-op call whose only purpose is activating the grain, so it must not queue FIFO behind whatever
+    /// else is already pending on this non-reentrant grain (typically a client Register() fan-out during a
+    /// rolling redeploy) - the silo's own startup path calls this and has no resilience against waiting on
+    /// a busy queue for work this call never does (#3848).
+    /// </remarks>
+    [AlwaysInterleave]
     Task Ensure();
 
     /// <summary>

--- a/Source/Kernel/Core/Projections/ImmediateProjection.cs
+++ b/Source/Kernel/Core/Projections/ImmediateProjection.cs
@@ -82,7 +82,12 @@ public class ImmediateProjection(
         {
             if (State.ReadModel is null)
             {
-                throw new ProjectionDefinitionNotSet(new ProjectionKey(_projectionKey!.ProjectionId, _projectionKey.EventStore));
+                // A passive projection's definition is set lazily, from the first event of its kind observed
+                // anywhere in the store, rather than eagerly at startup. Before that has happened, this is
+                // indistinguishable from "no matching event for this key yet" - the documented null contract
+                // for a read model that was never created - so it resolves the same way instead of throwing.
+                logger.NoDefinitionSetYet();
+                return ProjectionResult.Empty;
             }
 
             var readModelKey = new ReadModelGrainKey(State.ReadModel, _projectionKey.EventStore);

--- a/Source/Kernel/Core/Projections/ImmediateProjectionsLogging.cs
+++ b/Source/Kernel/Core/Projections/ImmediateProjectionsLogging.cs
@@ -18,6 +18,9 @@ internal static partial class ImmediateProjectionsLogMessages
     [LoggerMessage(LogLevel.Trace, "Using cached model instance for projection.")]
     internal static partial void UsingCachedModelInstance(this ILogger<ImmediateProjection> logger);
 
+    [LoggerMessage(LogLevel.Trace, "Projection definition has not been set yet; resolving as no read model.")]
+    internal static partial void NoDefinitionSetYet(this ILogger<ImmediateProjection> logger);
+
     [LoggerMessage(LogLevel.Error, "Failed getting model instance for projection.")]
     internal static partial void FailedGettingModelInstance(this ILogger<ImmediateProjection> logger, Exception exception);
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoSinkHarness.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/MongoSinkHarness.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.Sinks;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks;
@@ -35,7 +36,7 @@ public class MongoSinkHarness : ISinkHarness
         var typeFormats = new TypeFormats();
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         var collections = new SinkCollections(definition, database);
-        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, definition);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, definition, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(definition, mongoDBConverter, collections, expandoObjectConverter);
 
         return new Sink(definition, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ChangesetConverter/when_creating_the_join_filter_target/given/a_changeset_converter_over_typed_columns.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ChangesetConverter/when_creating_the_join_filter_target/given/a_changeset_converter_over_typed_columns.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_ChangesetConverter.when_creating_the_join_filter_target.given;
 
@@ -49,7 +50,7 @@ public class a_changeset_converter_over_typed_columns : Specification
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         _converter = new ChangesetConverter(
             readModel,
-            new MongoDBConverter(expandoObjectConverter, typeFormats, readModel),
+            new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance),
             Substitute.For<ISinkCollections>(),
             expandoObjectConverter);
     }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/given/GuidKeyedReadModel.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/given/GuidKeyedReadModel.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter.given;
+
+public record GuidKeyedReadModel(Guid Id);

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/given/a_mongodb_converter.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/given/a_mongodb_converter.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter.given;
 
@@ -13,11 +14,13 @@ public class a_mongodb_converter : Specification
     protected IExpandoObjectConverter _expandoObjectConverter;
     protected ITypeFormats _typeFormats;
     protected ReadModelDefinition _model;
+    protected ILogger<MongoDBConverter> _logger;
 
     void Establish()
     {
         _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
         _typeFormats = Substitute.For<ITypeFormats>();
+        _logger = Substitute.For<ILogger<MongoDBConverter>>();
         _model = new ReadModelDefinition(
             typeof(ReadModel).FullName,
             nameof(ReadModel),
@@ -32,6 +35,6 @@ public class a_mongodb_converter : Specification
                 { ReadModelGeneration.First, JsonSchema.FromType<ReadModel>() },
             },
             []);
-        _converter = new(_expandoObjectConverter, _typeFormats, _model);
+        _converter = new(_expandoObjectConverter, _typeFormats, _model, _logger);
     }
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_a_concept_list_to_bson_value.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_a_concept_list_to_bson_value.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter;
@@ -35,7 +36,7 @@ public class when_converting_a_concept_list_to_bson_value : Specification
                 { ReadModelGeneration.First, JsonSchema.FromType<TaggedReadModel>() },
             },
             []);
-        _converter = new(new ExpandoObjectConverter(typeFormats), typeFormats, model);
+        _converter = new(new ExpandoObjectConverter(typeFormats), typeFormats, model, NullLogger<MongoDBConverter>.Instance);
     }
 
     void Because() => _result = _converter.ToBsonValue(

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_key_to_bson_value/and_key_value_does_not_match_the_declared_guid_format.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_MongoDBConverter/when_converting_key_to_bson_value/and_key_value_does_not_match_the_declared_guid_format.cs
@@ -11,7 +11,12 @@ using MongoDB.Bson;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_MongoDBConverter.when_converting_key_to_bson_value;
 
-public class and_read_model_schema_has_no_properties : a_mongodb_converter
+/// <summary>
+/// Reproduces #3844 - a read model whose key property schema reports the "guid" format (a plain
+/// Guid-typed Id, the same shape a ConceptAs&lt;string&gt; key ends up with) must not crash the partition
+/// when the actual key value, such as an organization name, is not a Guid.
+/// </summary>
+public class and_key_value_does_not_match_the_declared_guid_format : a_mongodb_converter
 {
     BsonValue _result;
     Key _key;
@@ -19,9 +24,9 @@ public class and_read_model_schema_has_no_properties : a_mongodb_converter
     void Establish()
     {
         _model = new ReadModelDefinition(
-            "empty-model",
-            "empty-model",
-            "empty-model",
+            "string-keyed-model",
+            "string-keyed-model",
+            "string-keyed-model",
             ReadModelOwner.Client,
             ReadModelSource.Code,
             ReadModelObserverType.Projection,
@@ -29,15 +34,16 @@ public class and_read_model_schema_has_no_properties : a_mongodb_converter
             SinkDefinition.None,
             new Dictionary<ReadModelGeneration, JsonSchema>
             {
-                { ReadModelGeneration.First, new JsonSchema() }
+                { ReadModelGeneration.First, JsonSchema.FromType<GuidKeyedReadModel>() }
             },
             []);
+        _typeFormats = new TypeFormats();
         _converter = new(_expandoObjectConverter, _typeFormats, _model, _logger);
-        _key = new Key("key-value", ArrayIndexers.NoIndexers);
+        _key = new Key("Powerworks", ArrayIndexers.NoIndexers);
     }
 
     void Because() => _result = _converter.ToBsonValue(_key);
 
     [Fact] void should_return_a_bson_value() => _result.ShouldNotBeNull();
-    [Fact] void should_return_string_representation_of_key() => _result.AsString.ShouldEqual("key-value");
+    [Fact] void should_fall_back_to_the_untyped_string_representation() => _result.AsString.ShouldEqual("Powerworks");
 }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/given/a_child_collection_compliance_scenario.cs
@@ -98,7 +98,7 @@ public abstract class a_child_collection_compliance_scenario(MongoDBFixture fixt
             []);
 
         Collections = new SinkCollections(ReadModel, database);
-        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, ReadModel);
+        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, ReadModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(ReadModel, mongoDBConverter, Collections, sinkConverter);
         Sink = new Sink(ReadModel, mongoDBConverter, Collections, changesetConverter, sinkConverter);
     }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionCompliance/when_a_projection_persists_a_child_collection_with_pii.cs
@@ -99,7 +99,7 @@ public class when_a_projection_persists_a_child_collection_with_pii(when_a_proje
                 []);
 
             var collections = new SinkCollections(readModel, database);
-            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, sinkConverter);
             var sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, sinkConverter);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionDerivedType/when_a_projection_persists_a_polymorphic_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelChildCollectionDerivedType/when_a_projection_persists_a_polymorphic_child.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -73,7 +74,7 @@ public class when_a_projection_persists_a_polymorphic_child(when_a_projection_pe
                 []);
 
             var collections = new SinkCollections(readModel, database);
-            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+            var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, sinkConverter);
             var sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, sinkConverter);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_ReadModelRekeyedCompliance/when_a_rekeyed_projection_persists_pii.cs
@@ -95,7 +95,7 @@ public class when_a_rekeyed_projection_persists_pii(MongoDBFixture fixture) : Sp
             []);
 
         _collections = new SinkCollections(readModel, database);
-        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel);
+        var mongoDBConverter = new MongoDBConverter(sinkConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, _collections, sinkConverter);
         _sink = new Sink(readModel, mongoDBConverter, _collections, changesetConverter, sinkConverter);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_a_dictionary_property_is_set_then_a_sibling_property_changes.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
@@ -10,9 +11,9 @@ using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Projections.Engine;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
-
 using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_a_dictionary_property_is_set_then_a_sibling_property_changes.context;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
@@ -57,7 +58,7 @@ public class and_a_dictionary_property_is_set_then_a_sibling_property_changes(co
             var typeFormats = new TypeFormats();
             var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
             var collections = new SinkCollections(readModel, _database);
-            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
             _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
             _collection = collections.GetCollection();

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_child_added_has_child_identifier_change_in_same_changeset.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_child_added_has_child_identifier_change_in_same_changeset.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
@@ -9,8 +10,8 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
-
 using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_child_added_has_child_identifier_change_in_same_changeset.context;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
@@ -43,7 +44,7 @@ public class and_child_added_has_child_identifier_change_in_same_changeset(conte
             var typeFormats = new TypeFormats();
             var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
             var collections = new SinkCollections(readModel, _database);
-            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
             _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_compliance_changes_nested_property_after_complex_property_is_set.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_compliance_changes_nested_property_after_complex_property_is_set.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
+
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
@@ -9,8 +10,8 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
-
 using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_compliance_changes_nested_property_after_complex_property_is_set.context;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
@@ -44,7 +45,7 @@ public class and_compliance_changes_nested_property_after_complex_property_is_se
             var typeFormats = new TypeFormats();
             var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
             var collections = new SinkCollections(readModel, _database);
-            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+            var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
             _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_reducer_changes_a_field_on_an_existing_child.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes/and_reducer_changes_a_field_on_an_existing_child.cs
@@ -3,6 +3,7 @@
 
 using System.Dynamic;
 using System.Text.Json.Nodes;
+
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
@@ -15,9 +16,9 @@ using Cratis.Chronicle.Observation.Reducers.Clients;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
-
 using context = Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes.and_reducer_changes_a_field_on_an_existing_child.context;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes;
@@ -59,7 +60,7 @@ public class and_reducer_changes_a_field_on_an_existing_child(context ctx) : ICl
             var typeFormats = new TypeFormats();
             _expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
             var collections = new SinkCollections(readModel, _database);
-            _mongoDBConverter = new MongoDBConverter(_expandoObjectConverter, typeFormats, readModel);
+            _mongoDBConverter = new MongoDBConverter(_expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
             var changesetConverter = new ChangesetConverter(readModel, _mongoDBConverter, collections, _expandoObjectConverter);
             _sink = new Sink(readModel, _mongoDBConverter, collections, changesetConverter, _expandoObjectConverter);
             _pipeline = new ReducerPipeline(readModel, _sink, _objectComparer, new PassthroughReadModelsCompliance(), "test-store", "test-namespace");

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_child_level_join/given/a_sink_over_roots_with_members.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_child_level_join/given/a_sink_over_roots_with_members.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -97,7 +98,7 @@ public abstract class a_sink_over_roots_with_members(MongoDBFixture fixture) : I
         var typeFormats = new TypeFormats();
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         var collections = new SinkCollections(readModel, _client.GetDatabase(_databaseName));
-        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
         _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
         _collection = collections.GetCollection();

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_for_a_joined_read_model.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_for_a_joined_read_model.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -77,7 +78,7 @@ public abstract class a_sink_for_a_joined_read_model<TReadModel>(MongoDBFixture 
         var typeFormats = new TypeFormats();
         _expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         var collections = new SinkCollections(readModel, _client.GetDatabase(_databaseName));
-        _mongoDBConverter = new MongoDBConverter(_expandoObjectConverter, typeFormats, readModel);
+        _mongoDBConverter = new MongoDBConverter(_expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, _mongoDBConverter, collections, _expandoObjectConverter);
         _sink = new Sink(readModel, _mongoDBConverter, collections, changesetConverter, _expandoObjectConverter);
         _collection = collections.GetCollection();

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_over_several_rows.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_for_a_root_level_join/given/a_sink_over_several_rows.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -126,7 +127,7 @@ public abstract class a_sink_over_several_rows(MongoDBFixture fixture) : IAsyncL
         var typeFormats = new TypeFormats();
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         var collections = new SinkCollections(readModel, _client.GetDatabase(_databaseName));
-        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
         _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
         _collection = collections.GetCollection();

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_guarded_on_watermark/given/an_accumulating_read_model.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_applying_changes_guarded_on_watermark/given/an_accumulating_read_model.cs
@@ -10,6 +10,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Concepts.Sinks;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 
 namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_applying_changes_guarded_on_watermark.given;
@@ -38,7 +39,7 @@ public abstract class an_accumulating_read_model(MongoDBFixture fixture) : Speci
         var typeFormats = new TypeFormats();
         var expandoObjectConverter = new ExpandoObjectConverter(typeFormats);
         var collections = new SinkCollections(readModel, database);
-        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
         _sink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
     }

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_SinkParity/given/a_parity_scenario.cs
@@ -16,6 +16,7 @@ using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.ReadModels;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage.InMemory.Sinks;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -98,7 +99,7 @@ public abstract class a_parity_scenario(MongoDBFixture fixture) : Specification
         _inMemorySink = new InMemorySink(readModel, typeFormats);
 
         var collections = new SinkCollections(readModel, database);
-        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel);
+        var mongoDBConverter = new MongoDBConverter(expandoObjectConverter, typeFormats, readModel, NullLogger<MongoDBConverter>.Instance);
         var changesetConverter = new ChangesetConverter(readModel, mongoDBConverter, collections, expandoObjectConverter);
         _mongoSink = new Sink(readModel, mongoDBConverter, collections, changesetConverter, expandoObjectConverter);
 

--- a/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverter.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverter.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Concepts.ReadModels;
 using Cratis.Chronicle.Properties;
 using Cratis.Chronicle.Schemas;
 using Cratis.Strings;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 
@@ -23,10 +24,12 @@ namespace Cratis.Chronicle.Storage.MongoDB.Sinks;
 /// <param name="expandoObjectConverter"><see cref="IExpandoObjectConverter"/> to convert between <see cref="ExpandoObject"/> to <see cref="BsonDocument"/>.</param>
 /// <param name="typeFormats">The <see cref="ITypeFormats"/> for looking up actual types.</param>
 /// <param name="readModel"><see cref="ReadModelDefinition"/> the converter is for.</param>
+/// <param name="logger">The <see cref="ILogger{TCategoryName}"/> for logging.</param>
 public class MongoDBConverter(
     IExpandoObjectConverter expandoObjectConverter,
     ITypeFormats typeFormats,
-    ReadModelDefinition readModel) : IMongoDBConverter
+    ReadModelDefinition readModel,
+    ILogger<MongoDBConverter> logger) : IMongoDBConverter
 {
     /// <inheritdoc/>
     public MongoDBProperty ToMongoDBProperty(PropertyPath propertyPath, ArrayIndexers arrayIndexers)
@@ -148,7 +151,20 @@ public class MongoDBConverter(
         if (typeFormats.IsKnown(schemaProperty.Format!))
         {
             var targetType = typeFormats.GetTypeForFormat(schemaProperty.Format!);
-            return input.ToBsonValue(targetType);
+            try
+            {
+                return input.ToBsonValue(targetType);
+            }
+            catch (Exception)
+            {
+                // The schema's declared format (e.g. "guid") does not always match the actual value - a
+                // ConceptAs<string> key resolved through a schema that reports "guid" is the common shape
+                // (see #3844), and the conversion raises a FormatException. Falling back to the untyped
+                // BSON representation keeps the value queryable under its real shape instead of freezing
+                // the partition with "Unrecognized Guid format."
+                logger.KeyNotConvertible(readModel.Identifier, schemaProperty.Name);
+                return input.ToBsonValue();
+            }
         }
 
         if (input is ExpandoObject expandoObject)

--- a/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverterLogging.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/MongoDBConverterLogging.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+internal static partial class MongoDBConverterLogging
+{
+    // The exception is deliberately not passed. ILogger renders exception.ToString(), and a Guid-formatted
+    // property against a value that is not a Guid embeds the offending value in the parse failure - which
+    // can be the compliance subject. The read model and the property are the diagnostic value; the value
+    // itself is not.
+    [LoggerMessage(LogLevel.Warning, "The value for property '{Property}' of read model '{ReadModel}' does not convert through its declared schema format; storing the untyped value instead")]
+    internal static partial void KeyNotConvertible(this ILogger<MongoDBConverter> logger, ReadModelIdentifier readModel, string property);
+}

--- a/Source/Kernel/Storage.MongoDB/Sinks/SinkFactory.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/SinkFactory.cs
@@ -43,7 +43,8 @@ public class SinkFactory(
         var mongoDBConverter = new MongoDBConverter(
             expandoObjectConverter,
             typeFormats,
-            readModel);
+            readModel,
+            serviceProvider.GetRequiredService<ILogger<MongoDBConverter>>());
 
         var mongoDBSinkCollections = new SinkCollections(
             readModel,


### PR DESCRIPTION
## Fixed
- String-keyed (`ConceptAs<string>`) read-model partition keys no longer raise "Unrecognized Guid format" and freeze the partition when the schema reports a Guid-shaped format that the actual key value does not match. (#3844)
- A `[Passive]` read model's `GetInstanceById` now resolves to `null` instead of throwing `ProjectionDefinitionNotSet` when its projection definition has not been registered yet (the first-ever query before any event of its kind has been observed). (#3846)
- `IProjectionsManager.Ensure()` no longer queues behind unrelated work on its grain, preventing the silo's own startup path from timing out and crashing the host during a rolling redeploy. (#3848)

## Changed
- Documented on `SetFromContextAttribute<TEvent>` and `ChildrenFromAttribute<TEvent>` that referencing an event type gives AutoMap access to its entire payload, even when the attribute itself never reads it. (#3843)
- Bumped `Cratis.Fundamentals` to a prerelease that hardens JSON deserialization of concept values to fail loudly instead of silently producing `null` for an unrecognized underlying value type, found while investigating #3847.