### PR TITLE
Link the Cratis blog from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ This project is part of [Cratis](https://www.cratis.io) — free, MIT-licensed t
 
 Everything Cratis publishes today is MIT licensed and free to use.
 
+Blog: [blog.cratis.io](https://blog.cratis.io)
+
 ---
 
 ## 🤝 Contributing


### PR DESCRIPTION
Founder-decided: link https://blog.cratis.io from all Cratis surfaces.

Adds a single Blog line to the README's ecosystem section pointing to blog.cratis.io.

Documentation-only; labeled no-release. Humans merge.