### PR TITLE
Link release announcements to the Cratis blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,3 +393,5 @@ Distributed under the **MIT License**. See [`LICENSE`](./LICENSE) for full detai
 - [Microsoft Orleans](https://github.com/dotnet/orleans) — distributed actor framework used in the Chronicle Kernel
 - [Louis3797/awesome-readme-template](https://github.com/Louis3797/awesome-readme-template) — README inspiration
 - All our [contributors](https://github.com/cratis/chronicle/graphs/contributors) and the open-source community ❤️
+
+Release notes and announcements: the [Cratis blog](https://blog.cratis.io).


### PR DESCRIPTION
One-line README addition pointing at the Cratis blog. Labeled `patch` so merging cuts a patch release that publishes the updated package metadata (descriptions/tags from the discoverability wave) to the registries.