### PR TITLE
Add 'How Chronicle compares' link to README documentation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Full documentation is available at **[https://www.cratis.io/chronicle/](https://
 | [Architecture](https://www.cratis.io/chronicle/architecture/) | How the kernel, clients, storage, and read models fit together |
 | [Hosting](https://www.cratis.io/chronicle/hosting/) | Production and development deployment options |
 | [Building a Client](https://www.cratis.io/chronicle/building-a-client/) | Implement the gRPC contract in a new language |
+| [How Chronicle compares](https://www.cratis.io/compare-event-sourcing-dotnet/) | Version-pinned, source-cited comparison of event sourcing options for .NET |
 | [Contributing](./Documentation/contributing/index.md) | How to build and contribute to Chronicle |
 
 ---


### PR DESCRIPTION
## Summary

Adds a single line to the README documentation table linking the canonical, version-pinned event sourcing comparison page on cratis.io:

- [How Chronicle compares](https://www.cratis.io/compare-event-sourcing-dotnet/) — version-pinned, source-cited comparison of event sourcing options for .NET.

The comparison itself lives on cratis.io as the single source of truth (per-row citations, retrieval dates, caveats, refresh promise; no performance/maturity/superiority claims about any tool, including Chronicle). This README carries only the link, so the fact matrix has exactly one place to be maintained and refreshed.

## Placement reasoning

- The deep comparison is deliberately **not** duplicated here or on other surfaces — comparison facts go stale per compared-tool release, so they live in one refresh-governed page.
- It is deliberately **not** placed on cratis.no (the executive site carries conviction and direction, not competitor tables) and **not** on the GitHub org profile (a comparison line without its method note and caveats is risk without context).