### PR TITLE
Point the documentation badge at the docs-site workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
     <a href="https://github.com/Cratis/Chronicle/actions/workflows/publish.yml">
       <img src="https://github.com/cratis/Chronicle/actions/workflows/publish.yml/badge.svg" alt="Publish">
     </a>
-    <a href="https://github.com/Cratis/Documentation/actions/workflows/pages.yml">
-      <img src="https://github.com/Cratis/Documentation/actions/workflows/pages.yml/badge.svg" alt="Documentation site">
+    <a href="https://github.com/Cratis/Documentation/actions/workflows/docs-site.yml">
+      <img src="https://github.com/Cratis/Documentation/actions/workflows/docs-site.yml/badge.svg" alt="Documentation site">
     </a>
   </p>
 </div>


### PR DESCRIPTION
The README's Documentation-site badge pointed at Cratis/Documentation workflow pages.yml, which no longer exists — the badge image 404s. The Documentation site builds from docs-site.yml, so the badge and its link now point there. README-only; no package or release effect.