### PR TITLE
Pattern detection: mining engine, storage, client API and documentation

### DIFF
--- a/Documentation/clients/dotnet/patterns.md
+++ b/Documentation/clients/dotnet/patterns.md
@@ -1,0 +1,123 @@
+---
+title: Querying behavior patterns
+description: Ask what a user usually does in a given context, from the .NET client, backed by the patterns Chronicle mined from event history.
+---
+
+[Behavior patterns](/chronicle/patterns/) are recurring combinations of context that Chronicle mined from an event store's history. The .NET client exposes them on `IEventStore.Patterns`.
+
+## Asking what usually happens
+
+Build a context from the facets you know and ask within a scope — normally the user whose behavior you are asking about:
+
+```csharp
+using Cratis.Chronicle.Concepts.Patterns;
+
+var patterns = await eventStore.Patterns.GetPatterns(
+    groupingKey: userId,
+    context: FacetSet.Empty
+        .With(FacetName.Day, DayOfWeek.Monday.ToString())
+        .With(FacetName.TimeBucket, TimeBucket.Morning.ToString()));
+
+foreach (var pattern in patterns)
+{
+    Console.WriteLine($"{pattern.Facets} — {pattern.Confidence.Value:P0} confident, seen {pattern.Occurrences.Value} times");
+}
+```
+
+The context may constrain **any subset** of the facets. Facets the store does not mine are discarded rather than narrowing the lookup to nothing, so a caller can describe its situation in whatever terms it has.
+
+Results are ranked **most specific first**, then most confident. A pattern constraining everything you asked about answers your question; a broader, more confident one answers a question you did not ask.
+
+### An empty result is an answer
+
+`GetPatterns` returns nothing when no pattern clears the confidence bar. That is a true statement — this scope has no established behavior for this context — and it is deliberately not padded with the best of a bad set. Treat "no patterns" as "do not claim to know":
+
+```csharp
+var patterns = await eventStore.Patterns.GetPatterns(userId, context);
+if (!patterns.Any())
+{
+    return "I don't have enough history to say what usually happens here.";
+}
+```
+
+### Thresholds and limits
+
+```csharp
+var patterns = await eventStore.Patterns.GetPatterns(
+    groupingKey: userId,
+    context: context,
+    minimumConfidence: new PatternConfidence(0.8d),
+    maximumResults: 3,
+    cancellationToken: cancellationToken);
+```
+
+Leave `minimumConfidence` and `maximumResults` unset to use whatever the **server** is configured for. The client deliberately does not carry its own copy of the thresholds — a default duplicated here would silently disagree with the configured one the moment either changed.
+
+## Browsing everything a scope established
+
+`GetPatternsForScope` is the listing call — everything held for a scope, unfiltered, including patterns below the confidence threshold. It is what a browsing view binds to, as opposed to `GetPatterns`, which answers a question about one situation.
+
+```csharp
+var everything = await eventStore.Patterns.GetPatternsForScope(userId);
+```
+
+## What you get back
+
+Each result is a `BehaviorPattern`:
+
+| Member | Type | Meaning |
+| --- | --- | --- |
+| `GroupingKey` | `PatternGroupingKey` | The scope the pattern belongs to |
+| `Facets` | `FacetSet` | The facets the pattern constrains |
+| `Occurrences` | `PatternOccurrences` | How many times it has been observed |
+| `Confidence` | `PatternConfidence` | How often it holds when its context is present, 0 to 1 |
+| `Support` | `PatternSupport` | The share of all observed events it was seen in, 0 to 1 |
+| `Weight` | `PatternWeight` | Recency-weighted strength — decays as the behavior goes unseen |
+| `FirstSeen` / `LastSeen` | `DateTimeOffset` | When it was first and last observed |
+
+`Occurrences` counts everything that ever happened; `Weight` is how much of that is still recent. Order by `Weight` when recency matters more than history.
+
+Read a single facet off a pattern with `ValueOf`, and check whether it constrains one at all with `Constrains`:
+
+```csharp
+var pattern = patterns.First();
+var command = pattern.Facets.ValueOf(FacetName.CommandType);
+
+if (pattern.Facets.Constrains(FacetName.TimeBucket))
+{
+    // The pattern is specific to a part of the day.
+}
+```
+
+## Building a context
+
+`FacetSet` is canonical and immutable: facets are ordered by name, at most one value per facet survives, and facets with no value are dropped. `With` returns a new set and **replaces** a facet that is already constrained, so a context built up in steps never depends on the order it was written in.
+
+```csharp
+var context = FacetSet.Empty
+    .With(FacetName.CommandType, "ApproveExpenseReport")
+    .With(FacetName.Day, DayOfWeek.Monday.ToString())
+    .With(FacetName.Day, DayOfWeek.Tuesday.ToString());   // replaces Monday
+```
+
+The facet names are the well-known statics on `FacetName` — `CommandType`, `InitiatorType`, `InitiatorId`, `OnBehalfOf`, `CausedByCommand`, `CorrelationRootId`, `AggregateType`, `Year`, `Month`, `Day` and `TimeBucket`. See [Behavior Patterns](/chronicle/patterns/) for what each one means and which of them are mined by default.
+
+## Making the command visible to mining
+
+`CommandType` and `CausedByCommand` are only as good as what named the command. If you append through [Cratis Arc](/arc/), its command pipeline records a `Command` causation naming the executing command and nothing else is needed.
+
+Appending directly, add the same property to the causation you scope around the work:
+
+```csharp
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Concepts.Patterns;
+
+using (causationManager.BeginScope(
+    "Command",
+    new Dictionary<string, string> { { WellKnownCausationProperties.CommandType, nameof(ApproveExpenseReport) } }))
+{
+    await eventStore.EventLog.Append(expenseReportId, new ExpenseReportApproved(approvedBy));
+}
+```
+
+Use `BeginScope` rather than `Add` for work with a beginning and an end. `Add` is append-only, which is right for a link describing how the work arrived — an HTTP request — but wrong for one describing a bounded piece of work: two such pieces done one after the other both stay on the chain, and the second then reads as caused by the first. That ordering never happened, and pattern mining would learn it as a fact.

--- a/Documentation/clients/dotnet/toc.yml
+++ b/Documentation/clients/dotnet/toc.yml
@@ -8,3 +8,5 @@
   href: captures/toc.yml
 - name: External Services
   href: external-services.md
+- name: Behavior Patterns
+  href: patterns.md

--- a/Documentation/patterns/index.md
+++ b/Documentation/patterns/index.md
@@ -1,0 +1,93 @@
+# Behavior Patterns
+
+Chronicle mines the event history of a store for **recurring behavior** — combinations of context that keep leading to the same action — and lets you ask what usually happens in a situation. The answer is backed by what actually happened, not by a guess.
+
+The question it answers is: *given this user, this day, this time of day, what does this person normally do?* An agent, a workflow, or the Workbench can ask it and act on a real answer, or learn that there is no established behavior and say so.
+
+## What a pattern is
+
+A **behavior pattern** is a combination of facets that recurred often enough and reliably enough to survive:
+
+| Part | Meaning |
+| --- | --- |
+| **Grouping key** | The scope the behavior belongs to — normally the user |
+| **Facets** | The contextual dimensions the pattern constrains, and their values |
+| **Occurrences** | How many times it has been observed |
+| **Confidence** | How often it holds when its context is present, 0 to 1 |
+| **Support** | The share of all observed events it was seen in, 0 to 1 |
+| **Weight** | Recency-weighted strength — decays as the behavior goes unseen |
+| **First seen / last seen** | When it was first and last observed |
+
+A pattern such as `{ Day: Monday, TimeBucket: Morning, CommandType: ApproveExpenseReport }` with a confidence of `0.9` reads as: *on Monday mornings, this person approves expense reports nine times out of ten.*
+
+## Facets
+
+Facets are read off an event's **context** — never its content — so the same vocabulary applies to every event type in every event store.
+
+| Facet | Where it comes from |
+| --- | --- |
+| `CommandType` | The command that produced the event; the event type when nothing above it named itself |
+| `InitiatorType` | `User`, `Agent`, `System` or `Unknown` |
+| `InitiatorId` | The identity that caused the event |
+| `OnBehalfOf` | The identity it acted for, when it acted for someone else |
+| `CausedByCommand` | The command one level up the causation chain |
+| `CorrelationRootId` | The correlation the event belongs to |
+| `AggregateType` | The event source type the event was appended to |
+| `Year`, `Month` | Taken from the event's occurred timestamp |
+| `Day` | Day of week |
+| `TimeBucket` | `EarlyMorning`, `Morning`, `Midday`, `Afternoon`, `Evening` or `Night` |
+
+Every time-derived facet comes from the event's own **occurred** timestamp, never from wall-clock time at processing. A backdated append and a replay both land in the bucket the event actually belongs to.
+
+### Who the behavior belongs to
+
+An agent acting on behalf of a person contributes to **that person's** behavior, not its own — otherwise one habit would be split across every agent that happened to carry it out. The agent is still recorded as the initiator, so agent-driven and user-driven behavior stay distinguishable.
+
+An event nobody can be named for is not mined at all. Its behavior belongs to no scope, and counting it into a catch-all that every unattributed append pours into produces noise rather than a pattern.
+
+## How mining works
+
+Chronicle does not store anything per event. It keeps a bounded **Lossy Counting** sketch per scope:
+
+1. Each event's facets are expanded into every combination up to `MaximumCombinationSize` (3 by default). The cap is what keeps the candidate space polynomial rather than exponential.
+2. Each combination is counted in the sketch. Memory is bounded by the `Error` parameter regardless of how long the stream runs — nothing with a true frequency above the support threshold is ever missed.
+3. A combination that goes unseen **decays**: its weight is multiplied by `DecayFactor` for every day since it was last seen, so behavior that stopped happening sinks below the threshold and is pruned instead of competing forever with what a person does now.
+4. Only combinations clearing both `MinimumSupport` and `MinimumConfidence` are persisted.
+
+Storage therefore scales with **distinct recurring behavior**, not with event volume. A store that appends millions of events but sees a few hundred recurring behaviors holds a few hundred rows.
+
+### Confidence
+
+Confidence reads as the rule *"in this context, this action follows"*: the frequency of the whole combination over the frequency of the same combination without its `CommandType` facet. A combination that names no action is pure context, and its confidence is its support.
+
+## Configuration
+
+Under `Cratis:Chronicle:PatternDetection`:
+
+| Setting | Default | What it does |
+| --- | --- | --- |
+| `Facets` | `CommandType`, `InitiatorType`, `CausedByCommand`, `AggregateType`, `Day`, `TimeBucket` | Which facets take part in the mined combination |
+| `MaximumCombinationSize` | `3` | The largest number of facets a combination may hold |
+| `Error` | `0.001` | The Lossy Counting error parameter — smaller buys accuracy with memory |
+| `MinimumSupport` | `0.01` | The smallest share of events a combination must hold to survive |
+| `MinimumConfidence` | `0.5` | The smallest confidence a combination must hold to survive |
+| `DecayFactor` | `0.99` | Daily decay applied to a combination that has gone unseen |
+
+`Year` and `Month` are deliberately absent from `Facets`: they are kept on a surviving pattern for recency, but combining them multiplies the candidate space by every month the store has been running while splitting one behavior across all of them. Add them when a deployment wants to mine seasonality and can afford the cardinality.
+
+## Naming the command
+
+For `CommandType` and `CausedByCommand` to be meaningful, something above the event has to name the command. [Cratis Arc](/arc/) records a `Command` causation naming the executing command for the duration of that command, so nested commands produce a real "caused by" chain and sibling commands do not. Anything else appending to Chronicle can do the same by putting a `commandType` property on its causation.
+
+Without such a link the mined `CommandType` falls back to the event type, which is still a meaningful action in an event-sourced store — the fact that was recorded *is* what happened.
+
+## Querying patterns
+
+Ask what usually happens with the [.NET client's pattern API](/chronicle/clients/dotnet/patterns/), or over gRPC through the `Patterns` service:
+
+- **`GetPatterns`** — given a partial context, the patterns that apply, ranked by specificity and then confidence.
+- **`GetPatternsForScope`** — everything a scope has established, unfiltered, for browsing.
+
+Specificity outranks confidence in the ranking. A pattern constraining everything you asked about answers your question; a broader, more confident one answers a question you did not ask.
+
+**Nothing clearing the confidence bar returns nothing.** An empty answer is a true statement — this scope has no established behavior for this context — and is not padded with the best of a bad set.

--- a/Documentation/patterns/toc.yml
+++ b/Documentation/patterns/toc.yml
@@ -1,0 +1,2 @@
+- name: Overview
+  href: index.md

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -50,6 +50,8 @@
   href: external-services/toc.yml
 - name: Reactors
   href: reactors/toc.yml
+- name: Behavior Patterns
+  href: patterns/toc.yml
 - name: Subscriptions
   href: subscriptions/toc.yml
 - name: Jobs

--- a/Source/Clients/Connections/ChronicleConnection.cs
+++ b/Source/Clients/Connections/ChronicleConnection.cs
@@ -258,6 +258,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
             callInvoker.CreateGrpcService<IEventStores>(clientFactory),
             callInvoker.CreateGrpcService<INamespaces>(clientFactory),
             callInvoker.CreateGrpcService<IRecommendations>(clientFactory),
+            callInvoker.CreateGrpcService<Contracts.Patterns.IPatterns>(clientFactory),
             callInvoker.CreateGrpcService<IIdentities>(clientFactory),
             callInvoker.CreateGrpcService<IEventSequences>(clientFactory),
             callInvoker.CreateGrpcService<IEventTypes>(clientFactory),

--- a/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/a_scope_disposed_twice.cs
+++ b/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/a_scope_disposed_twice.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Auditing.for_CausationManager.when_scoping;
+
+public class a_scope_disposed_twice : Specification
+{
+    const string Scoped = "Scoped";
+    const string Unscoped = "Unscoped";
+
+    CausationManager _manager;
+
+    public a_scope_disposed_twice()
+    {
+        // The specification runner uses IAsyncLifetime, which puts Establish and Because in a different async
+        // context than the assertions. The chain is ambient state, so it has to be built here.
+        _manager = new();
+
+        var scope = _manager.BeginScope(Scoped, new Dictionary<string, string>());
+        scope.Dispose();
+
+        _manager.Add(Unscoped, new Dictionary<string, string>());
+        scope.Dispose();
+
+        Chain = _manager.GetCurrentChain();
+    }
+
+    IEnumerable<Causation> Chain { get; }
+
+    [Fact] void should_not_remove_anything_the_second_time() => Chain.Any(_ => _.Type.Value == Unscoped).ShouldBeTrue();
+    [Fact] void should_still_have_removed_the_scoped_causation() => Chain.Any(_ => _.Type.Value == Scoped).ShouldBeFalse();
+}

--- a/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/a_scope_within_a_scope.cs
+++ b/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/a_scope_within_a_scope.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Auditing.for_CausationManager.when_scoping;
+
+public class a_scope_within_a_scope : Specification
+{
+    const string Outer = "Outer";
+    const string Inner = "Inner";
+
+    CausationManager _manager;
+
+    public a_scope_within_a_scope()
+    {
+        // The specification runner uses IAsyncLifetime, which puts Establish and Because in a different async
+        // context than the assertions. The chain is ambient state, so it has to be built here.
+        _manager = new();
+
+        using (_manager.BeginScope(Outer, new Dictionary<string, string>()))
+        {
+            using (_manager.BeginScope(Inner, new Dictionary<string, string>()))
+            {
+                InnerChain = _manager.GetCurrentChain();
+            }
+
+            OuterChain = _manager.GetCurrentChain();
+        }
+
+        AfterChain = _manager.GetCurrentChain();
+    }
+
+    IEnumerable<Causation> InnerChain { get; }
+
+    IEnumerable<Causation> OuterChain { get; }
+
+    IEnumerable<Causation> AfterChain { get; }
+
+    [Fact] void should_hold_both_causations_inside_the_inner_scope() => InnerChain.Count().ShouldEqual(3);
+    [Fact] void should_have_the_inner_causation_last() => InnerChain.Last().Type.Value.ShouldEqual(Inner);
+    [Fact] void should_have_the_outer_causation_one_level_up() => InnerChain.ElementAt(1).Type.Value.ShouldEqual(Outer);
+    [Fact] void should_drop_the_inner_causation_when_it_is_disposed() => OuterChain.Any(_ => _.Type.Value == Inner).ShouldBeFalse();
+    [Fact] void should_keep_the_outer_causation_when_the_inner_is_disposed() => OuterChain.Last().Type.Value.ShouldEqual(Outer);
+    [Fact] void should_leave_only_the_root_behind() => AfterChain.Count().ShouldEqual(1);
+}

--- a/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/two_scopes_one_after_the_other.cs
+++ b/Source/Clients/DotNET.Specs/Auditing/for_CausationManager/when_scoping/two_scopes_one_after_the_other.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Auditing.for_CausationManager.when_scoping;
+
+/// <summary>
+/// Two scoped causations one after the other describe two independent pieces of work. The second must not read as
+/// caused by the first - that is an ordering nothing established, and anything mining the chain would learn it as
+/// a fact.
+/// </summary>
+public class two_scopes_one_after_the_other : Specification
+{
+    const string First = "First";
+    const string Second = "Second";
+
+    CausationManager _manager;
+
+    public two_scopes_one_after_the_other()
+    {
+        // The specification runner uses IAsyncLifetime, which puts Establish and Because in a different async
+        // context than the assertions. The chain is ambient state, so it has to be built here.
+        _manager = new();
+
+        using (_manager.BeginScope(First, new Dictionary<string, string>()))
+        {
+        }
+
+        using (_manager.BeginScope(Second, new Dictionary<string, string>()))
+        {
+            SecondChain = _manager.GetCurrentChain();
+        }
+    }
+
+    IEnumerable<Causation> SecondChain { get; }
+
+    [Fact] void should_hold_the_root_and_the_second_causation() => SecondChain.Count().ShouldEqual(2);
+    [Fact] void should_hold_the_second_causation() => SecondChain.Last().Type.Value.ShouldEqual(Second);
+    [Fact] void should_not_hold_the_first_causation() => SecondChain.Any(_ => _.Type.Value == First).ShouldBeFalse();
+    [Fact] void should_leave_only_the_root_behind() => _manager.GetCurrentChain().Count.ShouldEqual(1);
+}

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/given/a_patterns_client.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/given/a_patterns_client.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Contracts;
+using ContractPatterns = Cratis.Chronicle.Contracts.Patterns.IPatterns;
+
+namespace Cratis.Chronicle.Patterns.for_Patterns.given;
+
+public class a_patterns_client : Specification
+{
+    protected const string EventStore = "some-store";
+    protected const string Namespace = "some-namespace";
+
+    protected Chronicle.Patterns.Patterns _client;
+    protected IEventStore _eventStore;
+
+    internal ContractPatterns _patterns;
+
+    void Establish()
+    {
+        var connection = Substitute.For<IChronicleConnection, IChronicleServicesAccessor>();
+        var services = Substitute.For<IServices>();
+        _patterns = Substitute.For<ContractPatterns>();
+        ((IChronicleServicesAccessor)connection).Services.Returns(services);
+        services.Patterns.Returns(_patterns);
+
+        _eventStore = Substitute.For<IEventStore>();
+        _eventStore.Connection.Returns(connection);
+        _eventStore.Name.Returns(new EventStoreName(EventStore));
+        _eventStore.Namespace.Returns(new EventStoreNamespaceName(Namespace));
+
+        _client = new(_eventStore);
+    }
+}

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns/for_a_context.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns/for_a_context.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using ProtoBuf.Grpc;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_Patterns.when_getting_patterns;
+
+public class for_a_context : given.a_patterns_client
+{
+    Contract.GetPatternsRequest _request;
+    IEnumerable<BehaviorPattern> _result;
+
+    void Establish()
+    {
+        _patterns
+            .GetPatterns(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
+            .Returns(
+            [
+                new Contract.Pattern
+                {
+                    GroupingKey = "user-42",
+                    Facets = new Dictionary<string, string> { { "Day", "Monday" }, { "TimeBucket", "Morning" } },
+                    Confidence = 0.9d,
+                    Support = 0.4d,
+                    Occurrences = 12,
+                    Weight = 3.5d,
+                    FirstSeen = DateTimeOffset.UnixEpoch,
+                    LastSeen = DateTimeOffset.UnixEpoch
+                }
+            ]);
+    }
+
+    async Task Because() => _result = await _client.GetPatterns(
+        "user-42",
+        FacetSet.Empty.With(FacetName.Day, "Monday").With(FacetName.TimeBucket, "Morning"),
+        new PatternConfidence(0.6d),
+        5);
+
+    [Fact] void should_ask_for_the_event_store() => _request.EventStore.ShouldEqual(EventStore);
+    [Fact] void should_ask_for_the_namespace() => _request.Namespace.ShouldEqual(Namespace);
+    [Fact] void should_ask_within_the_scope() => _request.GroupingKey.ShouldEqual("user-42");
+    [Fact] void should_pass_the_context() => _request.Context.Count.ShouldEqual(2);
+    [Fact] void should_pass_the_day_from_the_context() => _request.Context["Day"].ShouldEqual("Monday");
+    [Fact] void should_pass_the_minimum_confidence() => _request.MinimumConfidence.ShouldEqual(0.6d);
+    [Fact] void should_pass_the_result_limit() => _request.MaximumResults.ShouldEqual(5);
+
+    [Fact] void should_return_the_pattern() => _result.Count().ShouldEqual(1);
+    [Fact] void should_carry_the_scope() => _result.Single().GroupingKey.Value.ShouldEqual("user-42");
+    [Fact] void should_carry_the_facets() => _result.Single().Facets.Specificity.ShouldEqual(2);
+    [Fact] void should_carry_the_day() => _result.Single().Facets.ValueOf(FacetName.Day).Value.ShouldEqual("Monday");
+    [Fact] void should_carry_the_confidence() => _result.Single().Confidence.Value.ShouldEqual(0.9d);
+    [Fact] void should_carry_the_support() => _result.Single().Support.Value.ShouldEqual(0.4d);
+    [Fact] void should_carry_the_occurrences() => _result.Single().Occurrences.Value.ShouldEqual(12L);
+    [Fact] void should_carry_the_weight() => _result.Single().Weight.Value.ShouldEqual(3.5d);
+}

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns/without_asking_for_a_confidence_or_a_limit.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns/without_asking_for_a_confidence_or_a_limit.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using ProtoBuf.Grpc;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_Patterns.when_getting_patterns;
+
+/// <summary>
+/// The thresholds are the server's. A default duplicated in the client would silently disagree with the configured
+/// one the moment either changed, so an unasked-for confidence or limit goes over the wire as unset.
+/// </summary>
+public class without_asking_for_a_confidence_or_a_limit : given.a_patterns_client
+{
+    Contract.GetPatternsRequest _request;
+
+    void Establish() =>
+        _patterns
+            .GetPatterns(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
+            .Returns([]);
+
+    async Task Because() => await _client.GetPatterns("user-42", FacetSet.Empty.With(FacetName.Day, "Monday"));
+
+    [Fact] void should_leave_the_minimum_confidence_to_the_server() => _request.MinimumConfidence.ShouldEqual(0d);
+    [Fact] void should_leave_the_result_limit_to_the_server() => _request.MaximumResults.ShouldEqual(0);
+}

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_for_scope/a_scope_with_nothing_established.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_for_scope/a_scope_with_nothing_established.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using ProtoBuf.Grpc;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_Patterns.when_getting_patterns_for_scope;
+
+public class a_scope_with_nothing_established : given.a_patterns_client
+{
+    Contract.GetPatternsForScopeRequest _request;
+    IEnumerable<BehaviorPattern> _result;
+
+    void Establish() =>
+        _patterns
+            .GetPatternsForScope(Arg.Do<Contract.GetPatternsForScopeRequest>(request => _request = request), Arg.Any<CallContext>())
+            .Returns([]);
+
+    async Task Because() => _result = await _client.GetPatternsForScope("user-42");
+
+    [Fact] void should_ask_for_the_event_store() => _request.EventStore.ShouldEqual(EventStore);
+    [Fact] void should_ask_for_the_namespace() => _request.Namespace.ShouldEqual(Namespace);
+    [Fact] void should_ask_for_the_scope() => _request.GroupingKey.ShouldEqual("user-42");
+    [Fact] void should_return_nothing() => _result.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET/Auditing/CausationManager.cs
+++ b/Source/Clients/DotNET/Auditing/CausationManager.cs
@@ -39,6 +39,14 @@ public class CausationManager : ICausationManager
         _current.Value.Add(new Causation(DateTimeOffset.UtcNow, type, properties.ToImmutableDictionary()));
     }
 
+    /// <inheritdoc/>
+    public IDisposable BeginScope(CausationType type, IDictionary<string, string> properties)
+    {
+        Add(type, properties);
+        var chain = _current.Value!;
+        return new Scope(chain, chain.Count - 1);
+    }
+
     /// <summary>
     /// Defines the root causation for the current process.
     /// </summary>
@@ -46,5 +54,37 @@ public class CausationManager : ICausationManager
     internal void DefineRoot(IDictionary<string, string> properties)
     {
         Root = new Causation(DateTimeOffset.UtcNow, CausationType.Root, properties.ToImmutableDictionary());
+    }
+
+    /// <summary>
+    /// Removes a causation and everything added after it when disposed.
+    /// </summary>
+    /// <param name="chain">The chain the causation was added to.</param>
+    /// <param name="index">The position the causation was added at.</param>
+    /// <remarks>
+    /// The chain is held by reference rather than read back off the ambient value, because the scope can be
+    /// disposed from a different async branch than the one it was created on - which is exactly what happens when a
+    /// command completes after awaiting. Truncating removes anything added after the causation too, which is what
+    /// last-in first-out means and is the only interpretation that leaves the chain consistent when scopes are
+    /// disposed out of order.
+    /// </remarks>
+    sealed class Scope(List<Causation> chain, int index) : IDisposable
+    {
+        bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            if (index < chain.Count)
+            {
+                chain.RemoveRange(index, chain.Count - index);
+            }
+        }
     }
 }

--- a/Source/Clients/DotNET/Auditing/ICausationManager.cs
+++ b/Source/Clients/DotNET/Auditing/ICausationManager.cs
@@ -27,4 +27,24 @@ public interface ICausationManager
     /// <param name="type">Type to add.</param>
     /// <param name="properties">Properties associated with the causation.</param>
     void Add(CausationType type, IDictionary<string, string> properties);
+
+    /// <summary>
+    /// Adds a causation that lasts only as long as the returned scope.
+    /// </summary>
+    /// <param name="type">Type to add.</param>
+    /// <param name="properties">Properties associated with the causation.</param>
+    /// <returns>An <see cref="IDisposable"/> that removes the causation again.</returns>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Add"/> is append-only, which is right for a link that describes how the work arrived and stays
+    /// true for everything that follows - an HTTP request, a reactor invocation. It is wrong for a link that
+    /// describes one bounded piece of work, because two such pieces done one after the other both end up on the
+    /// chain and the second reads as caused by the first. That is an ordering nothing actually established.
+    /// </para>
+    /// <para>
+    /// Scopes are last-in first-out: disposing one removes its causation and anything added after it. Dispose is
+    /// idempotent, and disposing out of order removes the later scopes with it rather than corrupting the chain.
+    /// </para>
+    /// </remarks>
+    IDisposable BeginScope(CausationType type, IDictionary<string, string> properties);
 }

--- a/Source/Clients/DotNET/DotNET.csproj
+++ b/Source/Clients/DotNET/DotNET.csproj
@@ -35,6 +35,7 @@
 
     <ItemGroup>
         <Compile Include="../../Kernel/Concepts/Captures/*.cs" Link="Concepts/Captures/%(Filename)%(Extension)" />
+        <Compile Include="../../Kernel/Concepts/Patterns/*.cs" Link="Concepts/Patterns/%(Filename)%(Extension)" />
     </ItemGroup>
 
     <Target Name="GrpcClients" BeforeTargets="Build" Condition=" '$(TargetFramework)' != '' AND '$(RuntimeIdentifier)' == '' AND '$(NoBuild)' != 'true' ">

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -22,6 +22,7 @@ using Cratis.Chronicle.ExternalServices;
 using Cratis.Chronicle.Identities;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Patterns;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reactors.SideEffects;
@@ -250,6 +251,8 @@ public class EventStore : IEventStore
             artifactActivator,
             loggerFactory.CreateLogger<EventSeeding>());
 
+        Patterns = new Patterns.Patterns(this);
+
         PII = new Compliance.GDPR.PIIManager(eventStoreName, @namespace, connection);
         Identities = new IdentityManager(eventStoreName, @namespace, connection);
 
@@ -312,6 +315,9 @@ public class EventStore : IEventStore
 
     /// <inheritdoc/>
     public IEventSeeding Seeding { get; }
+
+    /// <inheritdoc/>
+    public IPatterns Patterns { get; }
 
     /// <inheritdoc/>
     public Compliance.GDPR.IPIIManager PII { get; }

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -11,6 +11,7 @@ using Cratis.Chronicle.ExternalServices;
 using Cratis.Chronicle.Identities;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Patterns;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.ReadModels;
@@ -116,6 +117,11 @@ public interface IEventStore
     /// Gets the <see cref="IEventSeeding"/> for the event store.
     /// </summary>
     IEventSeeding Seeding { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IPatterns"/> for the event store.
+    /// </summary>
+    IPatterns Patterns { get; }
 
     /// <summary>
     /// Gets the <see cref="IPIIManager"/> for managing PII encryption keys (GDPR right-to-erasure) for the event store.

--- a/Source/Clients/DotNET/Patterns/IPatterns.cs
+++ b/Source/Clients/DotNET/Patterns/IPatterns.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system for asking what usually happens, backed by the behavior patterns Chronicle mined from the
+/// event history of an event store.
+/// </summary>
+public interface IPatterns
+{
+    /// <summary>
+    /// Get the patterns that apply to a context, most specific and most confident first.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey">scope</see> to ask within - typically a user.</param>
+    /// <param name="context">The <see cref="FacetSet">context</see> to match, which may constrain any subset of the facets.</param>
+    /// <param name="minimumConfidence">The lowest <see cref="PatternConfidence"/> an answer may hold. Defaults to the server's configured threshold.</param>
+    /// <param name="maximumResults">The largest number of answers to return. Defaults to the server's default.</param>
+    /// <param name="cancellationToken">Optional <see cref="CancellationToken"/>.</param>
+    /// <returns>The matching <see cref="BehaviorPattern">patterns</see>, empty when nothing clears the bar.</returns>
+    /// <remarks>
+    /// An empty result is an answer, not a failure: it says this scope has no established behavior for this
+    /// context. Nothing is invented to fill the gap, so a caller can treat "no patterns" as "do not claim to know".
+    /// </remarks>
+    Task<IEnumerable<BehaviorPattern>> GetPatterns(
+        PatternGroupingKey groupingKey,
+        FacetSet context,
+        PatternConfidence? minimumConfidence = default,
+        int maximumResults = 0,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get every pattern established for a scope.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey">scope</see> to get for.</param>
+    /// <param name="cancellationToken">Optional <see cref="CancellationToken"/>.</param>
+    /// <returns>Every <see cref="BehaviorPattern"/> held for the scope.</returns>
+    Task<IEnumerable<BehaviorPattern>> GetPatternsForScope(
+        PatternGroupingKey groupingKey,
+        CancellationToken cancellationToken = default);
+}

--- a/Source/Clients/DotNET/Patterns/PatternConverters.cs
+++ b/Source/Clients/DotNET/Patterns/PatternConverters.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Extension methods for converting patterns from their contract representation.
+/// </summary>
+public static class PatternConverters
+{
+    /// <summary>
+    /// Convert a collection of contract patterns to their client representation.
+    /// </summary>
+    /// <param name="patterns">The patterns to convert.</param>
+    /// <returns>The converted <see cref="BehaviorPattern">patterns</see>.</returns>
+    public static IEnumerable<BehaviorPattern> ToClient(this IEnumerable<Contract.Pattern> patterns) =>
+        [.. patterns.Select(pattern => pattern.ToClient())];
+
+    /// <summary>
+    /// Convert a contract pattern to its client representation.
+    /// </summary>
+    /// <param name="pattern">The pattern to convert.</param>
+    /// <returns>The converted <see cref="BehaviorPattern"/>.</returns>
+    public static BehaviorPattern ToClient(this Contract.Pattern pattern) => new(
+        pattern.GroupingKey,
+        new FacetSet(pattern.Facets.Select(facet => new Facet(new FacetName(facet.Key), new FacetValue(facet.Value)))),
+        pattern.Occurrences,
+        pattern.Confidence,
+        pattern.Support,
+        pattern.Weight,
+        pattern.FirstSeen,
+        pattern.LastSeen);
+}

--- a/Source/Clients/DotNET/Patterns/Patterns.cs
+++ b/Source/Clients/DotNET/Patterns/Patterns.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Contracts;
+using Grpc.Core;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IPatterns"/>.
+/// </summary>
+/// <param name="eventStore">The <see cref="IEventStore"/> the patterns belong to.</param>
+public class Patterns(IEventStore eventStore) : IPatterns
+{
+    readonly IChronicleServicesAccessor _servicesAccessor = (eventStore.Connection as IChronicleServicesAccessor)!;
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BehaviorPattern>> GetPatterns(
+        PatternGroupingKey groupingKey,
+        FacetSet context,
+        PatternConfidence? minimumConfidence = default,
+        int maximumResults = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var patterns = await _servicesAccessor.Services.Patterns.GetPatterns(
+            new()
+            {
+                EventStore = eventStore.Name,
+                Namespace = eventStore.Namespace,
+                GroupingKey = groupingKey,
+                Context = context.Facets.ToDictionary(facet => facet.Name.Value, facet => facet.Value.Value),
+
+                // Zero means "whatever the server is configured for" on both of these. The client does not carry
+                // its own copy of the thresholds - a default duplicated here would silently disagree with the
+                // server's the moment either changed.
+                MinimumConfidence = minimumConfidence?.Value ?? 0d,
+                MaximumResults = maximumResults
+            },
+            new CallContext(new CallOptions(cancellationToken: cancellationToken)));
+
+        return patterns.ToClient();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BehaviorPattern>> GetPatternsForScope(
+        PatternGroupingKey groupingKey,
+        CancellationToken cancellationToken = default)
+    {
+        var patterns = await _servicesAccessor.Services.Patterns.GetPatternsForScope(
+            new()
+            {
+                EventStore = eventStore.Name,
+                Namespace = eventStore.Namespace,
+                GroupingKey = groupingKey
+            },
+            new CallContext(new CallOptions(cancellationToken: cancellationToken)));
+
+        return patterns.ToClient();
+    }
+}

--- a/Source/Clients/Testing/Auditing/CausationManagerForTesting.cs
+++ b/Source/Clients/Testing/Auditing/CausationManagerForTesting.cs
@@ -22,5 +22,17 @@ public class CausationManagerForTesting : ICausationManager
     }
 
     /// <inheritdoc/>
+    public IDisposable BeginScope(CausationType type, IDictionary<string, string> properties) => NullScope.Instance;
+
+    /// <inheritdoc/>
     public IImmutableList<Causation> GetCurrentChain() => ImmutableList<Causation>.Empty;
+
+    sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/Source/Clients/Testing/EventSequences/InProcessServices.cs
+++ b/Source/Clients/Testing/EventSequences/InProcessServices.cs
@@ -18,6 +18,7 @@ using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Contracts.Observation.Reactors;
 using Cratis.Chronicle.Contracts.Observation.Reducers;
 using Cratis.Chronicle.Contracts.Observation.Webhooks;
+using Cratis.Chronicle.Contracts.Patterns;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
 using Cratis.Chronicle.Contracts.Recommendations;
@@ -57,6 +58,9 @@ internal sealed class InProcessServices(
 
     /// <inheritdoc/>
     public IRecommendations Recommendations => throw new NotSupportedException("Recommendations is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public IPatterns Patterns => throw new NotSupportedException("Patterns is not supported in test scenarios.");
 
     /// <inheritdoc/>
     public IIdentities Identities => throw new NotSupportedException("Identities is not supported in test scenarios.");

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -3,7 +3,6 @@
 
 extern alias KernelConcepts;
 extern alias KernelCore;
-
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -24,6 +23,7 @@ using Cratis.Chronicle.Identities;
 using Cratis.Chronicle.Jobs;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Patterns;
 using Cratis.Chronicle.Projections;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Reactors.SideEffects;
@@ -85,6 +85,7 @@ public class EventStoreForTesting : IEventStore
     readonly Lazy<IJobs> _jobs;
     readonly Lazy<IUnitOfWorkManager> _unitOfWorkManager;
     readonly Lazy<IEventSeeding> _seeding;
+    readonly Lazy<IPatterns> _patterns;
     readonly Lazy<IPIIManager> _pii;
     readonly Lazy<IIdentityManager> _identities;
 
@@ -229,6 +230,8 @@ public class EventStoreForTesting : IEventStore
         _failedPartitions = new Lazy<IFailedPartitions>(() => new FailedPartitionsImpl(this));
         _jobs = new Lazy<IJobs>(() => new JobsImpl(this));
         _unitOfWorkManager = new Lazy<IUnitOfWorkManager>(() => new UnitOfWorkManager(this));
+        _patterns = new Lazy<IPatterns>(() => new Patterns.Patterns(this));
+
         _seeding = new Lazy<IEventSeeding>(() => new EventSeeding(
             Name,
             Connection,
@@ -296,6 +299,13 @@ public class EventStoreForTesting : IEventStore
 
     /// <inheritdoc/>
     public IEventSeeding Seeding => _seeding.Value;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Backed by the real client implementation, so a scenario that asks what a scope usually does gets the answer
+    /// the in-process services hold rather than an exception from a surface it is exercising.
+    /// </remarks>
+    public IPatterns Patterns => _patterns.Value;
 
     /// <inheritdoc/>
     public IPIIManager PII => _pii.Value;

--- a/Source/Clients/Testing/InMemoryEventStoreNamespaceStorage.cs
+++ b/Source/Clients/Testing/InMemoryEventStoreNamespaceStorage.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 extern alias KernelConcepts;
-
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Storage.Changes;
 using Cratis.Chronicle.Storage.Events.Constraints;
@@ -11,12 +10,14 @@ using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Keys;
 using Cratis.Chronicle.Storage.Observation;
+using Cratis.Chronicle.Storage.Patterns;
 using Cratis.Chronicle.Storage.Projections;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Recommendations;
 using Cratis.Chronicle.Storage.Seeding;
 using Cratis.Chronicle.Storage.Sinks;
 using Cratis.Chronicle.Testing.EventSequences;
+using InMemoryBehaviorPatternStorage = Cratis.Chronicle.Storage.InMemory.Patterns.BehaviorPatternStorage;
 using InMemoryClosedStreamsConstraintStorage = Cratis.Chronicle.Storage.InMemory.Events.Constraints.ClosedStreamsConstraintStorage;
 using InMemoryEventSequenceStorage = Cratis.Chronicle.Storage.InMemory.EventSequences.EventSequenceStorage;
 using InMemoryUniqueConstraintsStorage = Cratis.Chronicle.Storage.InMemory.Events.Constraints.UniqueConstraintsStorage;
@@ -66,6 +67,13 @@ internal sealed class InMemoryEventStoreNamespaceStorage(
 
     /// <inheritdoc/>
     public IRecommendationStorage Recommendations => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Backed by the real in-memory storage rather than left unsupported, so a specification can query the patterns
+    /// a scenario mined instead of getting an exception from the surface it is exercising.
+    /// </remarks>
+    public IBehaviorPatternStorage Patterns { get; } = new InMemoryBehaviorPatternStorage();
 
     /// <inheritdoc/>
     public IObserverKeyIndexes ObserverKeyIndexes => throw new NotSupportedException();

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 extern alias KernelCore;
-
 using System.Text.Json;
 using Cratis.Chronicle.Changes;
 using Cratis.Chronicle.Contracts;
@@ -22,6 +21,7 @@ using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Contracts.Observation.Reactors;
 using Cratis.Chronicle.Contracts.Observation.Reducers;
 using Cratis.Chronicle.Contracts.Observation.Webhooks;
+using Cratis.Chronicle.Contracts.Patterns;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
 using Cratis.Chronicle.Contracts.Recommendations;
@@ -44,6 +44,8 @@ using KernelEventSequencesService = KernelCore::Cratis.Chronicle.Services.EventS
 using KernelEventStoresService = KernelCore::Cratis.Chronicle.Services;
 using KernelEventTypesService = KernelCore::Cratis.Chronicle.Services.Events.EventTypes;
 using KernelExternalServicesService = KernelCore::Cratis.Chronicle.Services.ExternalServices.ExternalServices;
+using KernelFacetSetGenerator = KernelCore::Cratis.Chronicle.Patterns.FacetSetGenerator;
+using KernelFacetVocabulary = KernelCore::Cratis.Chronicle.Patterns.FacetVocabulary;
 using KernelFailedPartitionsService = KernelCore::Cratis.Chronicle.Services.Observation.FailedPartitions;
 using KernelIdentitiesService = KernelCore::Cratis.Chronicle.Services.Identities.Identities;
 using KernelJobsService = KernelCore::Cratis.Chronicle.Services.Jobs.Jobs;
@@ -52,6 +54,8 @@ using KernelJsonCompliancePropertyValueHandler = KernelCore::Cratis.Chronicle.Co
 using KernelMaterializedReadModelStore = KernelCore::Cratis.Chronicle.ReadModels.MaterializedReadModelStore;
 using KernelNamespacesService = KernelCore::Cratis.Chronicle.Services.Namespaces;
 using KernelObserversService = KernelCore::Cratis.Chronicle.Services.Observation.Observers;
+using KernelPatternMatcher = KernelCore::Cratis.Chronicle.Patterns.PatternMatcher;
+using KernelPatternsService = KernelCore::Cratis.Chronicle.Services.Patterns.Patterns;
 using KernelProjectionChangesetMediator = KernelCore::Cratis.Chronicle.Projections.ProjectionChangesetMediator;
 using KernelProjectionsService = KernelCore::Cratis.Chronicle.Services.Projections.Projections;
 using KernelReactorMediator = KernelCore::Cratis.Chronicle.Observation.Reactors.Clients.ReactorMediator;
@@ -171,6 +175,14 @@ internal sealed class TestingServices(
     readonly Lazy<IRecommendations> _recommendations = new(() =>
         new KernelRecommendationsService(grainFactory, storage));
 
+    readonly Lazy<IPatterns> _patterns = new(() =>
+        new KernelPatternsService(
+            storage,
+            new KernelFacetVocabulary(Options.Create(new KernelCore::Cratis.Chronicle.Configuration.ChronicleOptions())),
+            new KernelFacetSetGenerator(),
+            new KernelPatternMatcher(),
+            Options.Create(new KernelCore::Cratis.Chronicle.Configuration.ChronicleOptions())));
+
     readonly Lazy<IConstraints> _constraints = new(() =>
         new KernelConstraintsService(grainFactory));
 
@@ -278,6 +290,9 @@ internal sealed class TestingServices(
 
     /// <inheritdoc/>
     public IRecommendations Recommendations => _recommendations.Value;
+
+    /// <inheritdoc/>
+    public IPatterns Patterns => _patterns.Value;
 
     /// <inheritdoc/>
     public IUsers Users => _users.Value;

--- a/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_matching/a_context_that_constrains_more_than_the_pattern.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_matching/a_context_that_constrains_more_than_the_pattern.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_BehaviorPattern.when_matching;
+
+public class a_context_that_constrains_more_than_the_pattern : Specification
+{
+    BehaviorPattern _pattern;
+    FacetSet _matchingContext;
+    FacetSet _disagreeingContext;
+    FacetSet _lessConstrainedContext;
+
+    void Establish()
+    {
+        _pattern = new BehaviorPattern(
+            "user-42",
+            new FacetSet([new Facet(FacetName.Day, "Monday")]),
+            10,
+            0.8d,
+            0.2d,
+            5d,
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch);
+
+        _matchingContext = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _disagreeingContext = new FacetSet([new Facet(FacetName.Day, "Tuesday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _lessConstrainedContext = new FacetSet([new Facet(FacetName.TimeBucket, "Morning")]);
+    }
+
+    [Fact] void should_match_a_context_that_agrees_and_says_more() => _pattern.Matches(_matchingContext).ShouldBeTrue();
+    [Fact] void should_not_match_a_context_that_disagrees() => _pattern.Matches(_disagreeingContext).ShouldBeFalse();
+    [Fact] void should_not_match_a_context_that_leaves_its_facet_open() => _pattern.Matches(_lessConstrainedContext).ShouldBeFalse();
+    [Fact] void should_report_its_specificity() => _pattern.Specificity.ShouldEqual(1);
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_EventFeatures/when_getting_facets/from_extracted_features.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_EventFeatures/when_getting_facets/from_extracted_features.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_EventFeatures.when_getting_facets;
+
+public class from_extracted_features : Specification
+{
+    EventFeatures _features;
+    IReadOnlyDictionary<FacetName, FacetValue> _result;
+
+    void Establish() => _features = new EventFeatures(
+        "user-42",
+        "ApproveExpenseReport",
+        InitiatorType.Agent,
+        "agent-7",
+        "user-42",
+        "SubmitExpenseReport",
+        "correlation-1",
+        "ExpenseReport",
+        2026,
+        8,
+        DayOfWeek.Monday,
+        TimeBucket.Morning,
+        new DateTimeOffset(2026, 8, 24, 9, 15, 0, TimeSpan.Zero));
+
+    void Because() => _result = _features.AsFacets();
+
+    [Fact] void should_expose_the_command_type() => _result[FacetName.CommandType].Value.ShouldEqual("ApproveExpenseReport");
+    [Fact] void should_expose_the_initiator_type_by_name() => _result[FacetName.InitiatorType].Value.ShouldEqual("Agent");
+    [Fact] void should_expose_the_command_a_level_up() => _result[FacetName.CausedByCommand].Value.ShouldEqual("SubmitExpenseReport");
+    [Fact] void should_expose_the_aggregate_type() => _result[FacetName.AggregateType].Value.ShouldEqual("ExpenseReport");
+    [Fact] void should_expose_the_day_by_name() => _result[FacetName.Day].Value.ShouldEqual("Monday");
+    [Fact] void should_expose_the_time_bucket_by_name() => _result[FacetName.TimeBucket].Value.ShouldEqual("Morning");
+    [Fact] void should_expose_the_year() => _result[FacetName.Year].Value.ShouldEqual("2026");
+    [Fact] void should_expose_the_month() => _result[FacetName.Month].Value.ShouldEqual("8");
+    [Fact] void should_not_expose_the_grouping_key_as_a_facet() => _result.ContainsKey("GroupingKey").ShouldBeFalse();
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_adding_a_facet/that_is_already_constrained.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_adding_a_facet/that_is_already_constrained.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_adding_a_facet;
+
+public class that_is_already_constrained : Specification
+{
+    FacetSet _original;
+    FacetSet _result;
+
+    void Establish() => _original = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+
+    void Because() => _result = _original.With(FacetName.Day, "Tuesday");
+
+    [Fact] void should_replace_the_value() => _result.ValueOf(FacetName.Day).Value.ShouldEqual("Tuesday");
+    [Fact] void should_not_grow_the_set() => _result.Specificity.ShouldEqual(1);
+    [Fact] void should_leave_the_original_untouched() => _original.ValueOf(FacetName.Day).Value.ShouldEqual("Monday");
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_checking_subset/against_a_more_constrained_set.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_checking_subset/against_a_more_constrained_set.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_checking_subset;
+
+public class against_a_more_constrained_set : Specification
+{
+    FacetSet _narrow;
+    FacetSet _wide;
+    FacetSet _disagreeing;
+
+    void Establish()
+    {
+        _narrow = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+        _wide = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _disagreeing = new FacetSet([new Facet(FacetName.Day, "Tuesday"), new Facet(FacetName.TimeBucket, "Morning")]);
+    }
+
+    [Fact] void should_consider_the_narrow_set_a_subset_of_the_wide_one() => _narrow.IsSubsetOf(_wide).ShouldBeTrue();
+    [Fact] void should_not_consider_the_wide_set_a_subset_of_the_narrow_one() => _wide.IsSubsetOf(_narrow).ShouldBeFalse();
+    [Fact] void should_not_consider_a_set_with_a_different_value_a_subset() => _narrow.IsSubsetOf(_disagreeing).ShouldBeFalse();
+    [Fact] void should_consider_the_empty_set_a_subset_of_anything() => FacetSet.Empty.IsSubsetOf(_wide).ShouldBeTrue();
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_comparing/two_sets_built_in_different_order.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_comparing/two_sets_built_in_different_order.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_comparing;
+
+public class two_sets_built_in_different_order : Specification
+{
+    FacetSet _first;
+    FacetSet _second;
+
+    void Establish()
+    {
+        _first = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _second = new FacetSet([new Facet(FacetName.TimeBucket, "Morning"), new Facet(FacetName.Day, "Monday")]);
+    }
+
+    [Fact] void should_consider_them_equal() => _first.ShouldEqual(_second);
+    [Fact] void should_give_them_the_same_key() => _first.Key.ShouldEqual(_second.Key);
+    [Fact] void should_give_them_the_same_hash_code() => _first.GetHashCode().ShouldEqual(_second.GetHashCode());
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_an_unspecified_value.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_an_unspecified_value.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_creating;
+
+public class with_an_unspecified_value : Specification
+{
+    FacetSet _result;
+
+    void Because() => _result = new FacetSet(
+    [
+        new Facet(FacetName.CommandType, "ApproveExpenseReport"),
+        new Facet(FacetName.CausedByCommand, FacetValue.Unspecified)
+    ]);
+
+    [Fact] void should_drop_the_facet_without_a_value() => _result.Specificity.ShouldEqual(1);
+    [Fact] void should_keep_the_facet_with_a_value() => _result.Constrains(FacetName.CommandType).ShouldBeTrue();
+    [Fact] void should_not_constrain_the_dropped_facet() => _result.Constrains(FacetName.CausedByCommand).ShouldBeFalse();
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_facets_out_of_order.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_facets_out_of_order.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_creating;
+
+public class with_facets_out_of_order : Specification
+{
+    FacetSet _result;
+
+    void Because() => _result = new FacetSet(
+    [
+        new Facet(FacetName.TimeBucket, "Morning"),
+        new Facet(FacetName.CommandType, "ApproveExpenseReport"),
+        new Facet(FacetName.Day, "Monday")
+    ]);
+
+    [Fact] void should_hold_every_facet() => _result.Specificity.ShouldEqual(3);
+    [Fact] void should_order_facets_by_name() => _result.Facets.Select(_ => _.Name.Value).ToArray().ShouldEqual(["CommandType", "Day", "TimeBucket"]);
+    [Fact] void should_build_the_key_in_the_same_order() => _result.Key.Value.ShouldEqual("CommandType=ApproveExpenseReport;Day=Monday;TimeBucket=Morning");
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_the_same_facet_name_twice.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_the_same_facet_name_twice.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_creating;
+
+public class with_the_same_facet_name_twice : Specification
+{
+    FacetSet _result;
+
+    void Because() => _result = new FacetSet(
+    [
+        new Facet(FacetName.Day, "Monday"),
+        new Facet(FacetName.Day, "Tuesday")
+    ]);
+
+    [Fact] void should_keep_only_one_value_for_the_name() => _result.Specificity.ShouldEqual(1);
+    [Fact] void should_keep_the_first_one_seen() => _result.ValueOf(FacetName.Day).Value.ShouldEqual("Monday");
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_values_holding_the_key_separators.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_creating/with_values_holding_the_key_separators.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_creating;
+
+/// <summary>
+/// Two sets whose values differ only in where the separators fall must not produce the same key - the key is what
+/// a pattern is counted and stored by, so a collision would silently merge two unrelated behaviors into one.
+/// </summary>
+public class with_values_holding_the_key_separators : Specification
+{
+    FacetSet _first;
+    FacetSet _second;
+
+    void Because()
+    {
+        _first = new FacetSet([new Facet(FacetName.CommandType, "a=b"), new Facet(FacetName.Day, "c")]);
+        _second = new FacetSet([new Facet(FacetName.CommandType, "a"), new Facet(FacetName.Day, "b=c")]);
+    }
+
+    [Fact] void should_escape_the_separator_in_the_key() => _first.Key.Value.ShouldEqual(@"CommandType=a\=b;Day=c");
+    [Fact] void should_not_produce_the_same_key_for_the_other_set() => _second.Key.ShouldNotEqual(_first.Key);
+    [Fact] void should_not_consider_the_two_sets_equal() => _first.ShouldNotEqual(_second);
+}

--- a/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
+++ b/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents a recurring combination of facets that survived the support and confidence thresholds.
+/// </summary>
+/// <param name="GroupingKey">The scope the pattern belongs to.</param>
+/// <param name="Facets">The <see cref="FacetSet"/> the pattern is expressed in.</param>
+/// <param name="Occurrences">How many times the pattern has been observed.</param>
+/// <param name="Confidence">How often the pattern holds when its context is present.</param>
+/// <param name="Support">The share of all observed events the pattern was seen in.</param>
+/// <param name="Weight">The recency-weighted strength of the pattern.</param>
+/// <param name="FirstSeen">When the pattern was first observed.</param>
+/// <param name="LastSeen">When the pattern was last observed.</param>
+/// <remarks>
+/// Only surviving patterns are persisted, so storage scales with distinct recurring behavior rather than with event
+/// volume - a store that appends millions of events but sees a few hundred recurring behaviors holds a few hundred
+/// rows here.
+/// </remarks>
+public record BehaviorPattern(
+    PatternGroupingKey GroupingKey,
+    FacetSet Facets,
+    PatternOccurrences Occurrences,
+    PatternConfidence Confidence,
+    PatternSupport Support,
+    PatternWeight Weight,
+    DateTimeOffset FirstSeen,
+    DateTimeOffset LastSeen)
+{
+    /// <summary>
+    /// Gets how specific the pattern is - the number of facets it constrains.
+    /// </summary>
+    public int Specificity => Facets.Specificity;
+
+    /// <summary>
+    /// Check whether the pattern applies to a context.
+    /// </summary>
+    /// <param name="context">The <see cref="FacetSet"/> describing the context, which may constrain more facets than the pattern does.</param>
+    /// <returns>True when every facet the pattern constrains is present with the same value in the context, false when not.</returns>
+    public bool Matches(FacetSet context) => Facets.IsSubsetOf(context);
+}

--- a/Source/Kernel/Concepts/Patterns/EventFeatures.cs
+++ b/Source/Kernel/Concepts/Patterns/EventFeatures.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the bounded set of contextual facts extracted from a single event before it is fed into pattern
+/// mining.
+/// </summary>
+/// <param name="GroupingKey">The scope the behavior belongs to - typically the user that caused the event.</param>
+/// <param name="CommandType">The type of command, or the event type when nothing above it named itself.</param>
+/// <param name="InitiatorType">What kind of initiator caused the event.</param>
+/// <param name="InitiatorId">The identifier of the initiator.</param>
+/// <param name="OnBehalfOf">The identity the initiator acted on behalf of.</param>
+/// <param name="CausedByCommand">The command one level up the causation chain.</param>
+/// <param name="CorrelationRootId">The correlation the event belongs to.</param>
+/// <param name="AggregateType">The type of the event source the event was appended to.</param>
+/// <param name="Year">The year the event occurred in.</param>
+/// <param name="Month">The month the event occurred in.</param>
+/// <param name="Day">The day of week the event occurred on.</param>
+/// <param name="TimeBucket">The part of the day the event occurred in.</param>
+/// <param name="Occurred">When the event occurred, the source every time-derived value above was taken from.</param>
+/// <remarks>
+/// Features are derived per event and discarded once mined - nothing here is persisted. Every time-derived value
+/// comes from the event's own occurred timestamp, never from wall-clock time at processing, so a backdated append
+/// and a replay both land in the bucket the event actually belongs to.
+/// </remarks>
+public record EventFeatures(
+    PatternGroupingKey GroupingKey,
+    FacetValue CommandType,
+    InitiatorType InitiatorType,
+    FacetValue InitiatorId,
+    FacetValue OnBehalfOf,
+    FacetValue CausedByCommand,
+    FacetValue CorrelationRootId,
+    FacetValue AggregateType,
+    int Year,
+    int Month,
+    DayOfWeek Day,
+    TimeBucket TimeBucket,
+    DateTimeOffset Occurred)
+{
+    /// <summary>
+    /// Gets every facet the event carries, keyed by <see cref="FacetName"/>.
+    /// </summary>
+    /// <returns>A dictionary of every facet, including the ones holding no value.</returns>
+    /// <remarks>
+    /// Which of these take part in the mined itemset is a policy decision made further up, not here - this is the
+    /// full vocabulary an event contributes, and the miner selects from it.
+    /// </remarks>
+    public IReadOnlyDictionary<FacetName, FacetValue> AsFacets() => new Dictionary<FacetName, FacetValue>
+    {
+        [FacetName.CommandType] = CommandType,
+        [FacetName.InitiatorType] = new(InitiatorType.ToString()),
+        [FacetName.InitiatorId] = InitiatorId,
+        [FacetName.OnBehalfOf] = OnBehalfOf,
+        [FacetName.CausedByCommand] = CausedByCommand,
+        [FacetName.CorrelationRootId] = CorrelationRootId,
+        [FacetName.AggregateType] = AggregateType,
+        [FacetName.Year] = new(Year.ToString(CultureInfo.InvariantCulture)),
+        [FacetName.Month] = new(Month.ToString(CultureInfo.InvariantCulture)),
+        [FacetName.Day] = new(Day.ToString()),
+        [FacetName.TimeBucket] = new(TimeBucket.ToString())
+    };
+}

--- a/Source/Kernel/Concepts/Patterns/Facet.cs
+++ b/Source/Kernel/Concepts/Patterns/Facet.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents a single contextual dimension and the value it held.
+/// </summary>
+/// <param name="Name">The <see cref="FacetName"/>.</param>
+/// <param name="Value">The <see cref="FacetValue"/>.</param>
+public record Facet(FacetName Name, FacetValue Value);

--- a/Source/Kernel/Concepts/Patterns/FacetName.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetName.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the name of a facet - one contextual dimension a <see cref="BehaviorPattern"/> can be expressed in.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record FacetName(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Represents an unspecified <see cref="FacetName"/>.
+    /// </summary>
+    public static readonly FacetName Unspecified = new(string.Empty);
+
+    /// <summary>
+    /// The type of command - or, when nothing above the event named itself, the event type - that produced the event.
+    /// </summary>
+    public static readonly FacetName CommandType = new(nameof(CommandType));
+
+    /// <summary>
+    /// What kind of initiator caused the event - a user, an agent or the system itself.
+    /// </summary>
+    public static readonly FacetName InitiatorType = new(nameof(InitiatorType));
+
+    /// <summary>
+    /// The identifier of the initiator that caused the event.
+    /// </summary>
+    public static readonly FacetName InitiatorId = new(nameof(InitiatorId));
+
+    /// <summary>
+    /// The identity the initiator acted on behalf of, when it acted for someone else.
+    /// </summary>
+    public static readonly FacetName OnBehalfOf = new(nameof(OnBehalfOf));
+
+    /// <summary>
+    /// The command one level up the causation chain from the one that produced the event.
+    /// </summary>
+    public static readonly FacetName CausedByCommand = new(nameof(CausedByCommand));
+
+    /// <summary>
+    /// The correlation the event belongs to, identifying the flow it took part in.
+    /// </summary>
+    public static readonly FacetName CorrelationRootId = new(nameof(CorrelationRootId));
+
+    /// <summary>
+    /// The type of the event source the event was appended to.
+    /// </summary>
+    public static readonly FacetName AggregateType = new(nameof(AggregateType));
+
+    /// <summary>
+    /// The year the event occurred in.
+    /// </summary>
+    public static readonly FacetName Year = new(nameof(Year));
+
+    /// <summary>
+    /// The month the event occurred in.
+    /// </summary>
+    public static readonly FacetName Month = new(nameof(Month));
+
+    /// <summary>
+    /// The day of week the event occurred on.
+    /// </summary>
+    public static readonly FacetName Day = new(nameof(Day));
+
+    /// <summary>
+    /// The <see cref="Patterns.TimeBucket"/> the event occurred in.
+    /// </summary>
+    public static readonly FacetName TimeBucket = new(nameof(TimeBucket));
+
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="FacetName"/>.
+    /// </summary>
+    /// <param name="name">String to convert from.</param>
+    public static implicit operator FacetName(string name) => new(name);
+}

--- a/Source/Kernel/Concepts/Patterns/FacetSet.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetSet.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents an itemset of facets - the combination of contextual dimensions a pattern is expressed in.
+/// </summary>
+/// <remarks>
+/// A set is canonical: facets are ordered by name, at most one facet per name survives, and facets without a value
+/// are dropped. Two sets built from the same facts therefore carry the same <see cref="Key"/> and compare equal,
+/// which is what lets a mined pattern be counted once no matter which order its facets were extracted in.
+/// </remarks>
+public sealed record FacetSet
+{
+    /// <summary>
+    /// Represents the empty <see cref="FacetSet"/> - the set matching every context.
+    /// </summary>
+    public static readonly FacetSet Empty = new([]);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FacetSet"/> class.
+    /// </summary>
+    /// <param name="facets">The <see cref="Facet">facets</see> the set is made of.</param>
+    public FacetSet(IEnumerable<Facet> facets)
+    {
+        Facets = [.. facets
+            .Where(facet => facet.Value.IsSpecified)
+            .GroupBy(facet => facet.Name)
+            .Select(group => group.First())
+            .OrderBy(facet => facet.Name.Value, StringComparer.Ordinal)
+            .ThenBy(facet => facet.Value.Value, StringComparer.Ordinal)];
+
+        Key = BuildKey(Facets);
+    }
+
+    /// <summary>
+    /// Gets the facets the set is made of, ordered canonically.
+    /// </summary>
+    public IReadOnlyList<Facet> Facets { get; }
+
+    /// <summary>
+    /// Gets the canonical <see cref="FacetSetKey"/> identifying the set.
+    /// </summary>
+    public FacetSetKey Key { get; }
+
+    /// <summary>
+    /// Gets how specific the set is - the number of facets it constrains.
+    /// </summary>
+    public int Specificity => Facets.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the set constrains nothing.
+    /// </summary>
+    public bool IsEmpty => Facets.Count == 0;
+
+    /// <summary>
+    /// Creates a <see cref="FacetSet"/> from name and value pairs.
+    /// </summary>
+    /// <param name="facets">The pairs to create from.</param>
+    /// <returns>A new <see cref="FacetSet"/>.</returns>
+    public static FacetSet From(IEnumerable<KeyValuePair<FacetName, FacetValue>> facets) =>
+        new(facets.Select(pair => new Facet(pair.Key, pair.Value)));
+
+    /// <summary>
+    /// Creates a copy of the set with a facet added or replaced.
+    /// </summary>
+    /// <param name="name">The <see cref="FacetName"/> to set.</param>
+    /// <param name="value">The <see cref="FacetValue"/> to set it to.</param>
+    /// <returns>A new <see cref="FacetSet"/>.</returns>
+    /// <remarks>
+    /// Replacing rather than adding: a set holds at most one value per facet, and silently keeping whichever one
+    /// arrived first would make a context built up in steps depend on the order it was written in.
+    /// </remarks>
+    public FacetSet With(FacetName name, FacetValue value) =>
+        new(Facets.Where(facet => facet.Name != name).Append(new Facet(name, value)));
+
+    /// <summary>
+    /// Gets the value of a specific facet.
+    /// </summary>
+    /// <param name="name">The <see cref="FacetName"/> to get the value for.</param>
+    /// <returns>The <see cref="FacetValue"/>, or <see cref="FacetValue.Unspecified"/> when the set does not constrain it.</returns>
+    public FacetValue ValueOf(FacetName name) =>
+        Facets.FirstOrDefault(facet => facet.Name == name)?.Value ?? FacetValue.Unspecified;
+
+    /// <summary>
+    /// Check whether the set constrains a specific facet.
+    /// </summary>
+    /// <param name="name">The <see cref="FacetName"/> to check for.</param>
+    /// <returns>True when the set constrains it, false when not.</returns>
+    public bool Constrains(FacetName name) => Facets.Any(facet => facet.Name == name);
+
+    /// <summary>
+    /// Check whether every facet in this set is also in another set.
+    /// </summary>
+    /// <param name="other">The <see cref="FacetSet"/> to check against.</param>
+    /// <returns>True when this set is a subset of the other, false when not.</returns>
+    public bool IsSubsetOf(FacetSet other) => Facets.All(other.Facets.Contains);
+
+    /// <summary>
+    /// Gets the set as a dictionary of names to values.
+    /// </summary>
+    /// <returns>A dictionary holding every facet in the set.</returns>
+    public IReadOnlyDictionary<FacetName, FacetValue> AsDictionary() =>
+        Facets.ToDictionary(facet => facet.Name, facet => facet.Value);
+
+    /// <inheritdoc/>
+    public bool Equals(FacetSet? other) => other is not null && Key == other.Key;
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Key.GetHashCode();
+
+    /// <inheritdoc/>
+    public override string ToString() => Key.Value;
+
+    static FacetSetKey BuildKey(IReadOnlyList<Facet> facets)
+    {
+        if (facets.Count == 0)
+        {
+            return FacetSetKey.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < facets.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(';');
+            }
+
+            Escape(builder, facets[index].Name.Value);
+            builder.Append('=');
+            Escape(builder, facets[index].Value.Value);
+        }
+
+        return new(builder.ToString());
+    }
+
+    static void Escape(StringBuilder builder, string value)
+    {
+        foreach (var character in value)
+        {
+            if (character is '\\' or ';' or '=')
+            {
+                builder.Append('\\');
+            }
+
+            builder.Append(character);
+        }
+    }
+}

--- a/Source/Kernel/Concepts/Patterns/FacetSetKey.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetSetKey.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the canonical, stable identity of a <see cref="FacetSet"/>.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+/// <remarks>
+/// The key is what a mined pattern is counted, stored and looked up by, so it has to mean the same thing on every
+/// silo and across restarts. It is built by <see cref="FacetSet"/> from ordered, escaped facets rather than from a
+/// hash - two sets are the same pattern exactly when they read the same, and the key stays legible in storage.
+/// </remarks>
+public record FacetSetKey(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Represents the key of the empty <see cref="FacetSet"/>.
+    /// </summary>
+    public static readonly FacetSetKey Empty = new(string.Empty);
+
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="FacetSetKey"/>.
+    /// </summary>
+    /// <param name="key">String to convert from.</param>
+    public static implicit operator FacetSetKey(string key) => new(key);
+}

--- a/Source/Kernel/Concepts/Patterns/FacetValue.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetValue.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the value a facet holds for a single event or pattern.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record FacetValue(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Represents an unspecified <see cref="FacetValue"/>.
+    /// </summary>
+    /// <remarks>
+    /// A facet the event carries nothing for is unspecified rather than null - a fact that is absent should never
+    /// take part in a mined pattern, and a sentinel keeps every consumer from having to null-check its way there.
+    /// </remarks>
+    public static readonly FacetValue Unspecified = new(string.Empty);
+
+    /// <summary>
+    /// Gets a value indicating whether the facet holds a value.
+    /// </summary>
+    public bool IsSpecified => !string.IsNullOrEmpty(Value);
+
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="FacetValue"/>.
+    /// </summary>
+    /// <param name="value">String to convert from.</param>
+    public static implicit operator FacetValue(string? value) => value is null ? Unspecified : new(value);
+}

--- a/Source/Kernel/Concepts/Patterns/InitiatorType.cs
+++ b/Source/Kernel/Concepts/Patterns/InitiatorType.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents what kind of initiator caused an event.
+/// </summary>
+public enum InitiatorType
+{
+    /// <summary>
+    /// The initiator could not be determined.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// A person caused the event.
+    /// </summary>
+    User = 1,
+
+    /// <summary>
+    /// An autonomous agent caused the event, possibly on behalf of a person.
+    /// </summary>
+    Agent = 2,
+
+    /// <summary>
+    /// Chronicle itself, or the hosting application, caused the event with nobody behind it.
+    /// </summary>
+    System = 3
+}

--- a/Source/Kernel/Concepts/Patterns/PatternConfidence.cs
+++ b/Source/Kernel/Concepts/Patterns/PatternConfidence.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents how often a pattern holds when the context it constrains is present, in the range 0 to 1.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record PatternConfidence(double Value) : ConceptAs<double>(Value)
+{
+    /// <summary>
+    /// Represents no confidence at all.
+    /// </summary>
+    public static readonly PatternConfidence None = new(0d);
+
+    /// <summary>
+    /// Represents full confidence.
+    /// </summary>
+    public static readonly PatternConfidence Certain = new(1d);
+
+    /// <summary>
+    /// Implicitly convert from a double to <see cref="PatternConfidence"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    public static implicit operator PatternConfidence(double value) => new(value);
+}

--- a/Source/Kernel/Concepts/Patterns/PatternGroupingKey.cs
+++ b/Source/Kernel/Concepts/Patterns/PatternGroupingKey.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the scope patterns are mined and looked up within - typically the identity of the user the behavior
+/// belongs to.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record PatternGroupingKey(string Value) : ConceptAs<string>(Value)
+{
+    /// <summary>
+    /// Represents an unspecified <see cref="PatternGroupingKey"/>.
+    /// </summary>
+    public static readonly PatternGroupingKey Unspecified = new(string.Empty);
+
+    /// <summary>
+    /// Gets a value indicating whether the key identifies a scope.
+    /// </summary>
+    public bool IsSpecified => !string.IsNullOrEmpty(Value);
+
+    /// <summary>
+    /// Implicitly convert from a string to <see cref="PatternGroupingKey"/>.
+    /// </summary>
+    /// <param name="key">String to convert from.</param>
+    public static implicit operator PatternGroupingKey(string? key) => key is null ? Unspecified : new(key);
+}

--- a/Source/Kernel/Concepts/Patterns/PatternOccurrences.cs
+++ b/Source/Kernel/Concepts/Patterns/PatternOccurrences.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents how many times a pattern has been observed.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record PatternOccurrences(long Value) : ConceptAs<long>(Value)
+{
+    /// <summary>
+    /// Represents no occurrences at all.
+    /// </summary>
+    public static readonly PatternOccurrences None = new(0L);
+
+    /// <summary>
+    /// Implicitly convert from a long to <see cref="PatternOccurrences"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    public static implicit operator PatternOccurrences(long value) => new(value);
+
+    /// <summary>
+    /// Implicitly convert from an int to <see cref="PatternOccurrences"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    public static implicit operator PatternOccurrences(int value) => new((long)value);
+
+    /// <summary>
+    /// Increase the number of occurrences.
+    /// </summary>
+    /// <returns>A new instance with the increased count.</returns>
+    public PatternOccurrences Increase() => new(Value + 1);
+}

--- a/Source/Kernel/Concepts/Patterns/PatternSupport.cs
+++ b/Source/Kernel/Concepts/Patterns/PatternSupport.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the share of all observed events a pattern was seen in, in the range 0 to 1.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record PatternSupport(double Value) : ConceptAs<double>(Value)
+{
+    /// <summary>
+    /// Represents no support at all.
+    /// </summary>
+    public static readonly PatternSupport None = new(0d);
+
+    /// <summary>
+    /// Implicitly convert from a double to <see cref="PatternSupport"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    public static implicit operator PatternSupport(double value) => new(value);
+}

--- a/Source/Kernel/Concepts/Patterns/PatternWeight.cs
+++ b/Source/Kernel/Concepts/Patterns/PatternWeight.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the recency-weighted strength of a pattern.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+/// <remarks>
+/// Unlike <see cref="PatternOccurrences"/>, weight decays as a pattern goes unseen, so a behavior somebody stopped
+/// months ago sinks below the threshold and is pruned instead of competing forever with what they do now.
+/// </remarks>
+public record PatternWeight(double Value) : ConceptAs<double>(Value)
+{
+    /// <summary>
+    /// Represents no weight at all.
+    /// </summary>
+    public static readonly PatternWeight None = new(0d);
+
+    /// <summary>
+    /// Implicitly convert from a double to <see cref="PatternWeight"/>.
+    /// </summary>
+    /// <param name="value">Value to convert from.</param>
+    public static implicit operator PatternWeight(double value) => new(value);
+}

--- a/Source/Kernel/Concepts/Patterns/TimeBucket.cs
+++ b/Source/Kernel/Concepts/Patterns/TimeBucket.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Represents the part of the day an event occurred in.
+/// </summary>
+/// <remarks>
+/// Buckets rather than hours: "approves expenses on Monday mornings" is a pattern a person recognizes, while
+/// "approves expenses on Mondays at 09" splits the same behavior across as many patterns as there are hours it
+/// happens to land on, and none of them clears a support threshold.
+/// </remarks>
+public enum TimeBucket
+{
+    /// <summary>
+    /// From 05:00 up to 08:00.
+    /// </summary>
+    EarlyMorning = 0,
+
+    /// <summary>
+    /// From 08:00 up to 11:00.
+    /// </summary>
+    Morning = 1,
+
+    /// <summary>
+    /// From 11:00 up to 14:00.
+    /// </summary>
+    Midday = 2,
+
+    /// <summary>
+    /// From 14:00 up to 17:00.
+    /// </summary>
+    Afternoon = 3,
+
+    /// <summary>
+    /// From 17:00 up to 22:00.
+    /// </summary>
+    Evening = 4,
+
+    /// <summary>
+    /// From 22:00 up to 05:00.
+    /// </summary>
+    Night = 5
+}

--- a/Source/Kernel/Concepts/Patterns/WellKnownCausationProperties.cs
+++ b/Source/Kernel/Concepts/Patterns/WellKnownCausationProperties.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns;
+
+/// <summary>
+/// Holds the causation property names pattern mining reads when they are present.
+/// </summary>
+/// <remarks>
+/// A causation's type says what kind of link it is - an HTTP request, a reactor, a command - and every command
+/// shares the one type. What behavior is mined by is which command, so mining prefers a property naming it and
+/// falls back to the type when nothing named itself. The names are a convention shared with the layer above
+/// Chronicle: Arc's command pipeline records them, and anything else that executes named work can too.
+/// </remarks>
+public static class WellKnownCausationProperties
+{
+    /// <summary>
+    /// The property naming the command a causation link represents.
+    /// </summary>
+    public const string CommandType = "commandType";
+}

--- a/Source/Kernel/Contracts/IServices.cs
+++ b/Source/Kernel/Contracts/IServices.cs
@@ -18,6 +18,7 @@ using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Contracts.Observation.Reactors;
 using Cratis.Chronicle.Contracts.Observation.Reducers;
 using Cratis.Chronicle.Contracts.Observation.Webhooks;
+using Cratis.Chronicle.Contracts.Patterns;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
 using Cratis.Chronicle.Contracts.Recommendations;
@@ -50,6 +51,11 @@ public interface IServices
     /// Gets the <see cref="IRecommendations"/> service.
     /// </summary>
     IRecommendations Recommendations { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IPatterns"/> service.
+    /// </summary>
+    IPatterns Patterns { get; }
 
     /// <summary>
     /// Gets the <see cref="IIdentities"/> service.

--- a/Source/Kernel/Contracts/Patterns/GetPatternsForScopeRequest.cs
+++ b/Source/Kernel/Contracts/Patterns/GetPatternsForScopeRequest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Patterns;
+
+/// <summary>
+/// Represents the request for getting every pattern held for a scope.
+/// </summary>
+[ProtoContract]
+public class GetPatternsForScopeRequest
+{
+    /// <summary>
+    /// Gets or sets the event store to get patterns for.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the namespace to get patterns for.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the scope to get patterns for.
+    /// </summary>
+    [ProtoMember(3)]
+    public string GroupingKey { get; set; } = string.Empty;
+}

--- a/Source/Kernel/Contracts/Patterns/GetPatternsRequest.cs
+++ b/Source/Kernel/Contracts/Patterns/GetPatternsRequest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Patterns;
+
+/// <summary>
+/// Represents the request for getting the patterns that apply to a context.
+/// </summary>
+[ProtoContract]
+public class GetPatternsRequest
+{
+    /// <summary>
+    /// Gets or sets the event store to get patterns for.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the namespace to get patterns for.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the scope to get patterns within.
+    /// </summary>
+    /// <remarks>
+    /// The scope is a field of its own rather than an entry in <see cref="Context"/>: it selects which behavior is
+    /// being asked about, whereas the context describes the situation. Folding the two together would make it
+    /// possible to ask for a pattern with no scope at all, which has no answer.
+    /// </remarks>
+    [ProtoMember(3)]
+    public string GroupingKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the partial context to match against, keyed by facet name.
+    /// </summary>
+    [ProtoMember(4, IsRequired = true)]
+    public IDictionary<string, string> Context { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets or sets the lowest confidence a returned pattern may hold.
+    /// </summary>
+    [ProtoMember(5)]
+    public double MinimumConfidence { get; set; }
+
+    /// <summary>
+    /// Gets or sets the largest number of patterns to return.
+    /// </summary>
+    [ProtoMember(6)]
+    public int MaximumResults { get; set; }
+}

--- a/Source/Kernel/Contracts/Patterns/IPatterns.cs
+++ b/Source/Kernel/Contracts/Patterns/IPatterns.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Patterns;
+
+/// <summary>
+/// Defines the contract for querying the behavior patterns mined from event history.
+/// </summary>
+[Service]
+public interface IPatterns
+{
+    /// <summary>
+    /// Get the patterns that apply to a partial context, ranked by specificity and confidence.
+    /// </summary>
+    /// <param name="request">The <see cref="GetPatternsRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns><see cref="IEnumerable{T}"/> of <see cref="Pattern"/>, empty when nothing clears the confidence bar.</returns>
+    [Operation]
+    Task<IEnumerable<Pattern>> GetPatterns(GetPatternsRequest request, CallContext context = default);
+
+    /// <summary>
+    /// Get every pattern held for a scope.
+    /// </summary>
+    /// <param name="request">The <see cref="GetPatternsForScopeRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns><see cref="IEnumerable{T}"/> of <see cref="Pattern"/>.</returns>
+    /// <remarks>
+    /// This is the browsing call - everything a scope has established, unfiltered - as opposed to
+    /// <see cref="GetPatterns"/>, which answers a question about one situation.
+    /// </remarks>
+    [Operation]
+    Task<IEnumerable<Pattern>> GetPatternsForScope(GetPatternsForScopeRequest request, CallContext context = default);
+}

--- a/Source/Kernel/Contracts/Patterns/Pattern.cs
+++ b/Source/Kernel/Contracts/Patterns/Pattern.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Patterns;
+
+/// <summary>
+/// Represents a recurring combination of facets that was mined from event history.
+/// </summary>
+[ProtoContract]
+public class Pattern
+{
+    /// <summary>
+    /// Gets or sets the scope the pattern belongs to.
+    /// </summary>
+    [ProtoMember(1)]
+    public string GroupingKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the facets the pattern is expressed in, keyed by facet name.
+    /// </summary>
+    [ProtoMember(2, IsRequired = true)]
+    public IDictionary<string, string> Facets { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets or sets how often the pattern holds when its context is present, in the range 0 to 1.
+    /// </summary>
+    [ProtoMember(3)]
+    public double Confidence { get; set; }
+
+    /// <summary>
+    /// Gets or sets the share of all observed events the pattern was seen in, in the range 0 to 1.
+    /// </summary>
+    [ProtoMember(4)]
+    public double Support { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many times the pattern has been observed.
+    /// </summary>
+    [ProtoMember(5)]
+    public long Occurrences { get; set; }
+
+    /// <summary>
+    /// Gets or sets the recency-weighted strength of the pattern.
+    /// </summary>
+    /// <remarks>
+    /// Carried alongside <see cref="Occurrences"/> because the two answer different questions: occurrences is how
+    /// often this has ever happened, weight is how much of that is still recent. A caller ordering by recency
+    /// needs it, and leaving it off the wire would make the client's copy of the pattern quietly incomplete.
+    /// </remarks>
+    [ProtoMember(6)]
+    public double Weight { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the pattern was first observed.
+    /// </summary>
+    [ProtoMember(7)]
+    public SerializableDateTimeOffset FirstSeen { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the pattern was last observed.
+    /// </summary>
+    [ProtoMember(8)]
+    public SerializableDateTimeOffset LastSeen { get; set; }
+}

--- a/Source/Kernel/Contracts/Services.cs
+++ b/Source/Kernel/Contracts/Services.cs
@@ -18,6 +18,7 @@ using Cratis.Chronicle.Contracts.Observation.EventStoreSubscriptions;
 using Cratis.Chronicle.Contracts.Observation.Reactors;
 using Cratis.Chronicle.Contracts.Observation.Reducers;
 using Cratis.Chronicle.Contracts.Observation.Webhooks;
+using Cratis.Chronicle.Contracts.Patterns;
 using Cratis.Chronicle.Contracts.Projections;
 using Cratis.Chronicle.Contracts.ReadModels;
 using Cratis.Chronicle.Contracts.Recommendations;
@@ -33,6 +34,7 @@ namespace Cratis.Chronicle.Contracts;
 /// <param name="EventStores"><see cref="IEventStores"/> instance.</param>
 /// <param name="Namespaces"><see cref="INamespaces"/> instance.</param>
 /// <param name="Recommendations"><see cref="IRecommendations"/> instance.</param>
+/// <param name="Patterns"><see cref="IPatterns"/> instance.</param>
 /// <param name="Identities"><see cref="IIdentities"/> instance.</param>
 /// <param name="EventSequences"><see cref="IEventSequences"/> instance.</param>
 /// <param name="EventTypes"><see cref="IEventTypes"/> instance.</param>
@@ -59,6 +61,7 @@ public sealed record Services(
     IEventStores EventStores,
     INamespaces Namespaces,
     IRecommendations Recommendations,
+    IPatterns Patterns,
     IIdentities Identities,
     IEventSequences EventSequences,
     IEventTypes EventTypes,

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/given/an_extractor.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/given/an_extractor.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.given;
+
+public class an_extractor : Specification
+{
+    protected static readonly DateTimeOffset Occurred = new(2026, 8, 24, 9, 15, 0, TimeSpan.Zero);
+    protected static readonly CorrelationId Correlation = CorrelationId.New();
+
+    protected EventFeatureExtractor _extractor;
+
+    void Establish() => _extractor = new(new TimeBucketResolver());
+
+    protected static AppendedEvent AnEvent(
+        Identity? causedBy = null,
+        IEnumerable<Causation>? causation = null,
+        EventSourceType? eventSourceType = null,
+        DateTimeOffset? occurred = null) =>
+        new(
+            new EventContext(
+                new EventType("ExpenseReportApproved", EventTypeGeneration.First),
+                eventSourceType ?? EventSourceType.Default,
+                "expense-1",
+                EventStreamType.All,
+                EventStreamId.Default,
+                EventSequenceNumber.First,
+                occurred ?? Occurred,
+                "some-store",
+                EventStoreNamespaceName.Default,
+                Correlation,
+                causation ?? [],
+                causedBy ?? Identity.NotSet,
+                [],
+                EventHash.NotSet),
+            new ExpandoObject());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_backdated_event.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_backdated_event.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+/// <summary>
+/// Time facets come from the event's own occurred timestamp, never from the clock at processing time. A seeded
+/// history and a replay both have to land in the buckets the events actually belong to, or the mined patterns
+/// describe when the store was loaded rather than when the behavior happened.
+/// </summary>
+public class from_a_backdated_event : given.an_extractor
+{
+    static readonly DateTimeOffset _backdated = new(2024, 3, 6, 20, 45, 0, TimeSpan.Zero);
+
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(occurred: _backdated));
+
+    [Fact] void should_take_the_year_from_the_event() => _result.Year.ShouldEqual(2024);
+    [Fact] void should_take_the_month_from_the_event() => _result.Month.ShouldEqual(3);
+    [Fact] void should_take_the_day_of_week_from_the_event() => _result.Day.ShouldEqual(DayOfWeek.Wednesday);
+    [Fact] void should_take_the_time_bucket_from_the_event() => _result.TimeBucket.ShouldEqual(TimeBucket.Evening);
+    [Fact] void should_carry_the_occurred_timestamp() => _result.Occurred.ShouldEqual(_backdated);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_system_event.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_system_event.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+public class from_a_system_event : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causedBy: Identity.System));
+
+    [Fact] void should_recognize_the_system() => _result.InitiatorType.ShouldEqual(InitiatorType.System);
+    [Fact] void should_group_by_the_system_identity() => _result.GroupingKey.Value.ShouldEqual(Identity.System.Subject);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_user_initiated_event.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_a_user_initiated_event.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+public class from_a_user_initiated_event : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(
+        causedBy: new Identity("user-42", "Ada"),
+        causation: [new Causation(Occurred, "ApproveExpenseReport", new Dictionary<string, string>())],
+        eventSourceType: new EventSourceType("ExpenseReport")));
+
+    [Fact] void should_group_by_the_user() => _result.GroupingKey.Value.ShouldEqual("user-42");
+    [Fact] void should_recognize_a_user() => _result.InitiatorType.ShouldEqual(InitiatorType.User);
+    [Fact] void should_carry_the_initiator() => _result.InitiatorId.Value.ShouldEqual("user-42");
+    [Fact] void should_not_carry_an_on_behalf_of() => _result.OnBehalfOf.ShouldEqual(FacetValue.Unspecified);
+    [Fact] void should_take_the_command_type_from_the_causation() => _result.CommandType.Value.ShouldEqual("ApproveExpenseReport");
+    [Fact] void should_not_carry_a_command_a_level_up() => _result.CausedByCommand.ShouldEqual(FacetValue.Unspecified);
+    [Fact] void should_carry_the_aggregate_type() => _result.AggregateType.Value.ShouldEqual("ExpenseReport");
+    [Fact] void should_carry_the_correlation() => _result.CorrelationRootId.Value.ShouldEqual(Correlation.ToString());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_agent_acting_for_a_user.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_agent_acting_for_a_user.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+/// <summary>
+/// An agent acting for somebody contributes to that person's behavior, not to its own - otherwise the same habit
+/// would be split across every agent that happened to carry it out.
+/// </summary>
+public class from_an_agent_acting_for_a_user : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(
+        causedBy: new Identity("agent-7", "Assistant", OnBehalfOf: new Identity("user-42", "Ada"))));
+
+    [Fact] void should_group_by_the_person_behind_the_agent() => _result.GroupingKey.Value.ShouldEqual("user-42");
+    [Fact] void should_recognize_an_agent() => _result.InitiatorType.ShouldEqual(InitiatorType.Agent);
+    [Fact] void should_carry_the_agent_as_the_initiator() => _result.InitiatorId.Value.ShouldEqual("agent-7");
+    [Fact] void should_carry_who_it_acted_for() => _result.OnBehalfOf.Value.ShouldEqual("user-42");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_caused_by_a_single_named_command.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_caused_by_a_single_named_command.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+public class from_an_event_caused_by_a_single_named_command : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causation:
+    [
+        new Causation(Occurred, CausationType.Root, new Dictionary<string, string>()),
+        new Causation(Occurred, "ASP.NET Request", new Dictionary<string, string>()),
+        new Causation(Occurred, "Command", new Dictionary<string, string>
+        {
+            { WellKnownCausationProperties.CommandType, "ApproveExpenseReport" }
+        })
+    ]));
+
+    [Fact] void should_name_the_command() => _result.CommandType.Value.ShouldEqual("ApproveExpenseReport");
+    [Fact] void should_read_the_request_as_the_link_above_it() => _result.CausedByCommand.Value.ShouldEqual("ASP.NET Request");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_caused_by_named_commands.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_caused_by_named_commands.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+/// <summary>
+/// Every command shares one causation type, so a link that names the command it stands for is read by that name.
+/// Reading the type instead would file every command in the store under a single value and there would be no
+/// behavior left to mine.
+/// </summary>
+public class from_an_event_caused_by_named_commands : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causation:
+    [
+        new Causation(Occurred, CausationType.Root, new Dictionary<string, string>()),
+        new Causation(Occurred, "ASP.NET Request", new Dictionary<string, string>()),
+        new Causation(Occurred, "Command", new Dictionary<string, string>
+        {
+            { WellKnownCausationProperties.CommandType, "SubmitExpenseReport" }
+        }),
+        new Causation(Occurred, "Command", new Dictionary<string, string>
+        {
+            { WellKnownCausationProperties.CommandType, "ApproveExpenseReport" }
+        })
+    ]));
+
+    [Fact] void should_name_the_command_that_produced_the_event() => _result.CommandType.Value.ShouldEqual("ApproveExpenseReport");
+    [Fact] void should_name_the_command_one_level_up() => _result.CausedByCommand.Value.ShouldEqual("SubmitExpenseReport");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_nobody_can_be_named_for.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_nobody_can_be_named_for.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+public class from_an_event_nobody_can_be_named_for : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causedBy: Identity.NotSet));
+
+    [Fact] void should_not_produce_a_scope() => _result.GroupingKey.IsSpecified.ShouldBeFalse();
+    [Fact] void should_not_claim_to_know_the_initiator_type() => _result.InitiatorType.ShouldEqual(InitiatorType.Unknown);
+    [Fact] void should_not_carry_an_initiator() => _result.InitiatorId.ShouldEqual(FacetValue.Unspecified);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_nothing_above_it_named.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_nothing_above_it_named.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+/// <summary>
+/// In an event-sourced store the fact that was recorded is itself the action, so an event with nothing named above
+/// it still has an action worth mining - its own type.
+/// </summary>
+public class from_an_event_nothing_above_it_named : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causation:
+    [
+        new Causation(Occurred, CausationType.Root, new Dictionary<string, string>()),
+        new Causation(Occurred, CausationType.Unknown, new Dictionary<string, string>())
+    ]));
+
+    [Fact] void should_fall_back_to_the_event_type() => _result.CommandType.Value.ShouldEqual("ExpenseReportApproved");
+    [Fact] void should_not_invent_a_command_a_level_up() => _result.CausedByCommand.ShouldEqual(FacetValue.Unspecified);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_on_a_default_event_source_type.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_on_a_default_event_source_type.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+/// <summary>
+/// "Default" is the absence of an event source type, not a type worth mining - carrying it as a facet would put
+/// every store that never named its event source types under one meaningless value.
+/// </summary>
+public class from_an_event_on_a_default_event_source_type : given.an_extractor
+{
+    EventFeatures _default;
+    EventFeatures _unspecified;
+
+    void Because()
+    {
+        _default = _extractor.Extract(AnEvent(eventSourceType: EventSourceType.Default));
+        _unspecified = _extractor.Extract(AnEvent(eventSourceType: EventSourceType.Unspecified));
+    }
+
+    [Fact] void should_not_carry_an_aggregate_type_for_the_default() => _default.AggregateType.ShouldEqual(FacetValue.Unspecified);
+    [Fact] void should_not_carry_an_aggregate_type_for_the_unspecified() => _unspecified.AggregateType.ShouldEqual(FacetValue.Unspecified);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_with_a_causation_chain.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_EventFeatureExtractor/when_extracting/from_an_event_with_a_causation_chain.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_EventFeatureExtractor.when_extracting;
+
+public class from_an_event_with_a_causation_chain : given.an_extractor
+{
+    EventFeatures _result;
+
+    void Because() => _result = _extractor.Extract(AnEvent(causation:
+    [
+        new Causation(Occurred, CausationType.Root, new Dictionary<string, string>()),
+        new Causation(Occurred, "SubmitExpenseReport", new Dictionary<string, string>()),
+        new Causation(Occurred, "ApproveExpenseReport", new Dictionary<string, string>())
+    ]));
+
+    [Fact] void should_take_the_command_type_from_the_most_recent_named_link() => _result.CommandType.Value.ShouldEqual("ApproveExpenseReport");
+    [Fact] void should_take_the_caused_by_command_from_one_level_up() => _result.CausedByCommand.Value.ShouldEqual("SubmitExpenseReport");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/from_nothing_to_combine.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/from_nothing_to_combine.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_FacetSetGenerator.when_generating;
+
+public class from_nothing_to_combine : Specification
+{
+    FacetSetGenerator _generator;
+    FacetSet _oneFacet;
+
+    void Establish()
+    {
+        _generator = new();
+        _oneFacet = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+    }
+
+    [Fact] void should_produce_nothing_from_an_empty_set() => _generator.Generate(FacetSet.Empty, 3).ShouldBeEmpty();
+    [Fact] void should_produce_nothing_for_a_zero_cap() => _generator.Generate(_oneFacet, 0).ShouldBeEmpty();
+    [Fact] void should_produce_nothing_for_a_negative_cap() => _generator.Generate(_oneFacet, -1).ShouldBeEmpty();
+    [Fact] void should_produce_the_single_facet_when_the_cap_is_larger_than_the_set() => _generator.Generate(_oneFacet, 3).Count().ShouldEqual(1);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/from_three_facets.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/from_three_facets.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_FacetSetGenerator.when_generating;
+
+public class from_three_facets : Specification
+{
+    FacetSet _source;
+    IEnumerable<FacetSet> _result;
+
+    void Establish() => _source = new FacetSet(
+    [
+        new Facet(FacetName.CommandType, "ApproveExpenseReport"),
+        new Facet(FacetName.Day, "Monday"),
+        new Facet(FacetName.TimeBucket, "Morning")
+    ]);
+
+    void Because() => _result = new FacetSetGenerator().Generate(_source, 3);
+
+    [Fact] void should_produce_every_non_empty_combination() => _result.Count().ShouldEqual(7);
+    [Fact] void should_produce_each_single_facet() => _result.Count(_ => _.Specificity == 1).ShouldEqual(3);
+    [Fact] void should_produce_each_pair() => _result.Count(_ => _.Specificity == 2).ShouldEqual(3);
+    [Fact] void should_produce_the_full_combination() => _result.Count(_ => _.Specificity == 3).ShouldEqual(1);
+    [Fact] void should_produce_distinct_combinations() => _result.Select(_ => _.Key).Distinct().Count().ShouldEqual(7);
+    [Fact] void should_not_produce_the_empty_combination() => _result.Any(_ => _.IsEmpty).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/with_a_cap_below_the_facet_count.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_FacetSetGenerator/when_generating/with_a_cap_below_the_facet_count.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_FacetSetGenerator.when_generating;
+
+/// <summary>
+/// The cap is what keeps the candidate space polynomial rather than exponential in the number of facets, so it has
+/// to actually bind: four facets capped at two is ten combinations, not fifteen.
+/// </summary>
+public class with_a_cap_below_the_facet_count : Specification
+{
+    FacetSet _source;
+    IEnumerable<FacetSet> _result;
+
+    void Establish() => _source = new FacetSet(
+    [
+        new Facet(FacetName.CommandType, "ApproveExpenseReport"),
+        new Facet(FacetName.Day, "Monday"),
+        new Facet(FacetName.TimeBucket, "Morning"),
+        new Facet(FacetName.AggregateType, "ExpenseReport")
+    ]);
+
+    void Because() => _result = new FacetSetGenerator().Generate(_source, 2);
+
+    [Fact] void should_produce_only_combinations_up_to_the_cap() => _result.Count().ShouldEqual(10);
+    [Fact] void should_not_produce_anything_above_the_cap() => _result.Any(_ => _.Specificity > 2).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_creating/with_an_error_parameter_outside_the_range.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_creating/with_an_error_parameter_outside_the_range.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_creating;
+
+/// <summary>
+/// The error parameter is what bounds the sketch's memory. A value outside zero to one is not a slow sketch, it is
+/// one whose bucket width is meaningless - so it fails at construction rather than mining nonsense quietly.
+/// </summary>
+public class with_an_error_parameter_outside_the_range : Specification
+{
+    static LossyCountingSketch _created;
+
+    static Exception CreatingWith(double error) => Catch.Exception(() => _created = new LossyCountingSketch(error, 1d));
+
+    [Fact] void should_reject_zero() => CreatingWith(0d).ShouldNotBeNull();
+    [Fact] void should_reject_a_negative_value() => CreatingWith(-0.1d).ShouldNotBeNull();
+    [Fact] void should_reject_one() => CreatingWith(1d).ShouldNotBeNull();
+    [Fact] void should_accept_a_value_between_zero_and_one() => CreatingWith(0.001d).ShouldBeNull();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_decaying/an_itemset_that_has_gone_unseen.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_decaying/an_itemset_that_has_gone_unseen.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_decaying;
+
+public class an_itemset_that_has_gone_unseen : Specification
+{
+    static readonly DateTimeOffset _occurred = new(2026, 8, 24, 9, 0, 0, TimeSpan.Zero);
+
+    LossyCountingSketch _sketch;
+    FacetSet _itemset;
+    double _weightBefore;
+    double _weightAfter;
+
+    void Establish()
+    {
+        _sketch = new(0.01d, 0.5d);
+        _itemset = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+        _sketch.Observe([_itemset], _occurred);
+        _weightBefore = _sketch.Entries.Single().Weight;
+    }
+
+    void Because()
+    {
+        _sketch.Decay(_occurred.AddDays(3));
+        _weightAfter = _sketch.Entries.Single().Weight;
+    }
+
+    [Fact] void should_start_at_a_full_weight() => _weightBefore.ShouldEqual(1d);
+    [Fact] void should_halve_the_weight_for_every_day_unseen() => Math.Round(_weightAfter, 6).ShouldEqual(0.125d);
+    [Fact] void should_not_change_when_it_was_last_observed() => _sketch.Entries.Single().LastSeen.ShouldEqual(_occurred);
+    [Fact] void should_not_change_how_often_it_occurred() => _sketch.Entries.Single().Frequency.ShouldEqual(1L);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_decaying/twice_over_the_same_interval.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_decaying/twice_over_the_same_interval.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_decaying;
+
+/// <summary>
+/// The background decay pass runs on a schedule, and a schedule fires more than once. Decaying to a moment the
+/// weight is already decayed to must be a no-op, or how fast behavior is forgotten would depend on how often the
+/// pass happens to run rather than on the configured factor.
+/// </summary>
+public class twice_over_the_same_interval : Specification
+{
+    static readonly DateTimeOffset _occurred = new(2026, 8, 24, 9, 0, 0, TimeSpan.Zero);
+
+    LossyCountingSketch _sketch;
+    double _afterFirstPass;
+    double _afterSecondPass;
+
+    void Establish()
+    {
+        _sketch = new(0.01d, 0.5d);
+        _sketch.Observe([new FacetSet([new Facet(FacetName.Day, "Monday")])], _occurred);
+    }
+
+    void Because()
+    {
+        _sketch.Decay(_occurred.AddDays(2));
+        _afterFirstPass = _sketch.Entries.Single().Weight;
+
+        _sketch.Decay(_occurred.AddDays(2));
+        _afterSecondPass = _sketch.Entries.Single().Weight;
+    }
+
+    [Fact] void should_decay_on_the_first_pass() => Math.Round(_afterFirstPass, 6).ShouldEqual(0.25d);
+    [Fact] void should_not_decay_again_on_the_second() => _afterSecondPass.ShouldEqual(_afterFirstPass);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/a_long_stream_of_mostly_unique_itemsets.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/a_long_stream_of_mostly_unique_itemsets.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_observing;
+
+/// <summary>
+/// The whole point of the sketch is that memory does not grow with the stream. Ten thousand one-off itemsets and
+/// one recurring one must leave the recurring one standing and almost nothing else - if the sketch simply
+/// remembered everything, it would be a dictionary with extra steps and would not survive a real event store.
+/// </summary>
+public class a_long_stream_of_mostly_unique_itemsets : Specification
+{
+    const int Observations = 10_000;
+
+    static readonly DateTimeOffset _occurred = new(2026, 8, 24, 9, 0, 0, TimeSpan.Zero);
+
+    LossyCountingSketch _sketch;
+    FacetSet _recurring;
+
+    void Establish()
+    {
+        _sketch = new(0.001d, 1d);
+        _recurring = new FacetSet([new Facet(FacetName.CommandType, "ApproveExpenseReport")]);
+    }
+
+    void Because()
+    {
+        for (var count = 0; count < Observations; count++)
+        {
+            var oneOff = new FacetSet([new Facet(FacetName.CorrelationRootId, count.ToString(CultureInfo.InvariantCulture))]);
+            _sketch.Observe([_recurring, oneOff], _occurred);
+        }
+    }
+
+    [Fact] void should_have_seen_every_observation() => _sketch.Observed.ShouldEqual(Observations);
+    [Fact] void should_keep_the_recurring_itemset() => _sketch.GetFrequency(_recurring.Key).ShouldEqual(Observations);
+    [Fact] void should_not_grow_with_the_stream() => _sketch.Count.ShouldBeLessThan(Observations / 2);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/one_event_contributing_several_itemsets.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/one_event_contributing_several_itemsets.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_observing;
+
+/// <summary>
+/// Support is a share of events, so an event that contributes several itemsets is still one observation. Counting
+/// each itemset as an observation would divide every frequency by a denominator many times too large and nothing
+/// would ever clear the support threshold.
+/// </summary>
+public class one_event_contributing_several_itemsets : Specification
+{
+    static readonly DateTimeOffset _occurred = new(2026, 8, 24, 9, 0, 0, TimeSpan.Zero);
+
+    LossyCountingSketch _sketch;
+
+    void Establish() => _sketch = new(0.01d, 1d);
+
+    void Because() => _sketch.Observe(
+    [
+        new FacetSet([new Facet(FacetName.Day, "Monday")]),
+        new FacetSet([new Facet(FacetName.TimeBucket, "Morning")]),
+        new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")])
+    ],
+    _occurred);
+
+    [Fact] void should_count_a_single_observation() => _sketch.Observed.ShouldEqual(1L);
+    [Fact] void should_retain_every_itemset() => _sketch.Count.ShouldEqual(3);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/the_same_itemset_repeatedly.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_LossyCountingSketch/when_observing/the_same_itemset_repeatedly.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_LossyCountingSketch.when_observing;
+
+public class the_same_itemset_repeatedly : Specification
+{
+    static readonly DateTimeOffset _occurred = new(2026, 8, 24, 9, 0, 0, TimeSpan.Zero);
+
+    LossyCountingSketch _sketch;
+    FacetSet _itemset;
+
+    void Establish()
+    {
+        _sketch = new(0.01d, 1d);
+        _itemset = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+    }
+
+    void Because()
+    {
+        for (var count = 0; count < 5; count++)
+        {
+            _sketch.Observe([_itemset], _occurred);
+        }
+    }
+
+    [Fact] void should_count_one_observation_per_event() => _sketch.Observed.ShouldEqual(5L);
+    [Fact] void should_count_the_itemset_once_per_observation() => _sketch.GetFrequency(_itemset.Key).ShouldEqual(5L);
+    [Fact] void should_retain_only_the_one_itemset() => _sketch.Count.ShouldEqual(1);
+    [Fact] void should_have_no_error_for_an_itemset_that_was_there_from_the_start() => _sketch.Entries.Single().Error.ShouldEqual(0L);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/a_context_nothing_clears_the_bar_for.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/a_context_nothing_clears_the_bar_for.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching;
+
+/// <summary>
+/// Nothing clearing the confidence bar returns nothing. An empty answer is a true statement about a context with
+/// no established behavior; the best of a bad set reads to a caller exactly like a real pattern.
+/// </summary>
+public class a_context_nothing_clears_the_bar_for : Specification
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    void Because() => _result = new PatternMatcher().Match(
+        [
+            new BehaviorPattern(
+                "user-42",
+                new FacetSet([new Facet(FacetName.Day, "Monday")]),
+                3,
+                0.2d,
+                0.1d,
+                1d,
+                DateTimeOffset.UnixEpoch,
+                DateTimeOffset.UnixEpoch)
+        ],
+        new FacetSet([new Facet(FacetName.Day, "Monday")]),
+        new PatternConfidence(0.5d),
+        10);
+
+    [Fact] void should_return_nothing() => _result.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/a_context_several_patterns_apply_to.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/a_context_several_patterns_apply_to.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching;
+
+/// <summary>
+/// Specificity outranks confidence. A pattern that constrains everything the caller asked about answers their
+/// question; a broader, more confident one answers a question they did not ask, and putting it first is how a
+/// recommendation ends up stating the obvious.
+/// </summary>
+public class a_context_several_patterns_apply_to : Specification
+{
+    BehaviorPattern _broadAndCertain;
+    BehaviorPattern _specific;
+    BehaviorPattern _elsewhere;
+    FacetSet _context;
+    IEnumerable<BehaviorPattern> _result;
+
+    void Establish()
+    {
+        _broadAndCertain = Pattern([new Facet(FacetName.Day, "Monday")], confidence: 1d);
+        _specific = Pattern([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")], confidence: 0.7d);
+        _elsewhere = Pattern([new Facet(FacetName.Day, "Friday")], confidence: 1d);
+
+        _context = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+    }
+
+    void Because() => _result = new PatternMatcher().Match(
+        [_broadAndCertain, _specific, _elsewhere],
+        _context,
+        PatternConfidence.None,
+        10);
+
+    [Fact] void should_return_only_the_patterns_that_apply() => _result.Count().ShouldEqual(2);
+    [Fact] void should_rank_the_most_specific_first() => _result.First().ShouldEqual(_specific);
+    [Fact] void should_rank_the_broader_one_after_it() => _result.Last().ShouldEqual(_broadAndCertain);
+    [Fact] void should_not_return_a_pattern_for_another_context() => _result.ShouldNotContain(_elsewhere);
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new("user-42", new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/with_a_result_limit.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching/with_a_result_limit.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching;
+
+public class with_a_result_limit : Specification
+{
+    PatternMatcher _matcher;
+    BehaviorPattern[] _patterns;
+    FacetSet _context;
+
+    void Establish()
+    {
+        _matcher = new();
+        _context = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _patterns =
+        [
+            Pattern([new Facet(FacetName.Day, "Monday")]),
+            Pattern([new Facet(FacetName.TimeBucket, "Morning")]),
+            Pattern([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")])
+        ];
+    }
+
+    [Fact] void should_return_at_most_the_limit() => _matcher.Match(_patterns, _context, PatternConfidence.None, 2).Count().ShouldEqual(2);
+    [Fact] void should_keep_the_most_specific_within_the_limit() => _matcher.Match(_patterns, _context, PatternConfidence.None, 1).Single().Specificity.ShouldEqual(2);
+    [Fact] void should_return_nothing_for_a_limit_of_zero() => _matcher.Match(_patterns, _context, PatternConfidence.None, 0).ShouldBeEmpty();
+    [Fact] void should_return_nothing_for_a_negative_limit() => _matcher.Match(_patterns, _context, PatternConfidence.None, -1).ShouldBeEmpty();
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets) =>
+        new("user-42", new FacetSet(facets), 10, 0.9d, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/given/a_pattern_miner.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/given/a_pattern_miner.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.given;
+
+public class a_pattern_miner : Specification
+{
+    protected static readonly DateTimeOffset Occurred = new(2026, 8, 24, 9, 15, 0, TimeSpan.Zero);
+
+    protected PatternMiner _miner;
+
+    void Establish()
+    {
+        var options = Options.Create(new ChronicleOptions
+        {
+            PatternDetection = new PatternDetection
+            {
+                Error = 0.001d,
+                MinimumSupport = 0.1d,
+                MinimumConfidence = 0.5d,
+                DecayFactor = 1d
+            }
+        });
+
+        _miner = new(new FacetVocabulary(options), new FacetSetGenerator(), options);
+    }
+
+    protected static EventFeatures Features(
+        string groupingKey,
+        string commandType,
+        DayOfWeek day = DayOfWeek.Monday,
+        TimeBucket timeBucket = TimeBucket.Morning,
+        DateTimeOffset? occurred = null) =>
+        new(
+            groupingKey,
+            commandType,
+            InitiatorType.User,
+            groupingKey,
+            FacetValue.Unspecified,
+            FacetValue.Unspecified,
+            FacetValue.Unspecified,
+            "ExpenseReport",
+            2026,
+            8,
+            day,
+            timeBucket,
+            occurred ?? Occurred);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/a_recurring_behavior.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/a_recurring_behavior.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// Somebody who always approves expense reports on Monday mornings should come out as exactly that, with full
+/// confidence: in that context, the action always follows.
+/// </summary>
+public class a_recurring_behavior : given.a_pattern_miner
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    void Because()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+        }
+
+        _result = _miner.GetSurvivingPatterns("user-42");
+    }
+
+    [Fact] void should_mine_the_full_combination() =>
+        _result.Any(_ =>
+            _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport" &&
+            _.Facets.ValueOf(FacetName.Day).Value == "Monday" &&
+            _.Facets.ValueOf(FacetName.TimeBucket).Value == "Morning").ShouldBeTrue();
+
+    [Fact] void should_be_fully_confident() => _result.All(_ => _.Confidence.Value == 1d).ShouldBeTrue();
+    [Fact] void should_have_full_support() => _result.All(_ => _.Support.Value == 1d).ShouldBeTrue();
+    [Fact] void should_count_every_occurrence() => _result.All(_ => _.Occurrences.Value == 20L).ShouldBeTrue();
+    [Fact] void should_scope_every_pattern_to_the_user() => _result.All(_ => _.GroupingKey.Value == "user-42").ShouldBeTrue();
+    [Fact] void should_not_mine_more_than_the_capped_combinations() => _result.All(_ => _.Specificity <= 3).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/an_event_nobody_can_be_named_for.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/an_event_nobody_can_be_named_for.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// Behavior belongs to somebody. An event with no scope could only be counted into a catch-all that every
+/// unattributed append in the store pours into, which is noise rather than a pattern.
+/// </summary>
+public class an_event_nobody_can_be_named_for : given.a_pattern_miner
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    void Because()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(Features(PatternGroupingKey.Unspecified, "ApproveExpenseReport"));
+        }
+
+        _result = _miner.GetSurvivingPatterns();
+    }
+
+    [Fact] void should_not_mine_anything() => _result.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_for_two_users.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_for_two_users.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// A habit is a person's. Mining both users into one sketch would let the busier one's routine outvote the other's
+/// and would make "what does this user usually do" unanswerable.
+/// </summary>
+public class behavior_for_two_users : given.a_pattern_miner
+{
+    IEnumerable<BehaviorPattern> _forFirstUser;
+    IEnumerable<BehaviorPattern> _forSecondUser;
+
+    void Because()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(Features("user-7", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+        }
+
+        _forFirstUser = _miner.GetSurvivingPatterns("user-42");
+        _forSecondUser = _miner.GetSurvivingPatterns("user-7");
+    }
+
+    [Fact] void should_mine_only_the_first_user_behavior_for_the_first_user() =>
+        _forFirstUser.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("SubmitExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_mine_only_the_second_user_behavior_for_the_second_user() =>
+        _forSecondUser.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("ApproveExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_hold_the_first_user_day() =>
+        _forFirstUser.Any(_ => _.Facets.ValueOf(FacetName.Day).Value == "Monday").ShouldBeTrue();
+
+    [Fact] void should_hold_the_second_user_day() =>
+        _forSecondUser.Any(_ => _.Facets.ValueOf(FacetName.Day).Value == "Friday").ShouldBeTrue();
+
+    [Fact] void should_be_fully_confident_for_each_user_on_their_own() =>
+        _forFirstUser.Concat(_forSecondUser).All(_ => _.Confidence.Value == 1d).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_that_only_sometimes_follows.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_that_only_sometimes_follows.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// Confidence is the rule "in this context, this action follows". Approving on three Monday mornings out of four
+/// is a real pattern held with three quarters confidence - not a certainty, and not noise.
+/// </summary>
+public class behavior_that_only_sometimes_follows : given.a_pattern_miner
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    void Because()
+    {
+        for (var count = 0; count < 15; count++)
+        {
+            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 5; count++)
+        {
+            _miner.Observe(Features("user-42", "RejectExpenseReport"));
+        }
+
+        _result = _miner.GetSurvivingPatterns("user-42");
+    }
+
+    BehaviorPattern Approving => _result.Single(_ =>
+        _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport" &&
+        _.Facets.ValueOf(FacetName.Day).Value == "Monday" &&
+        _.Facets.ValueOf(FacetName.TimeBucket).Value == "Morning");
+
+    [Fact] void should_hold_the_approving_pattern_with_three_quarters_confidence() => Math.Round(Approving.Confidence.Value, 6).ShouldEqual(0.75d);
+    [Fact] void should_hold_it_with_three_quarters_support() => Math.Round(Approving.Support.Value, 6).ShouldEqual(0.75d);
+    [Fact] void should_not_hold_the_rejecting_pattern() =>
+        _result.Any(_ => _.Facets.ValueOf(FacetName.CommandType).Value == "RejectExpenseReport").ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_TimeBucketResolver/when_resolving/a_moment_in_a_non_utc_offset.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_TimeBucketResolver/when_resolving/a_moment_in_a_non_utc_offset.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_TimeBucketResolver.when_resolving;
+
+/// <summary>
+/// Nine in the morning in Oslo is a morning, not the small hours of the preceding UTC day. Normalizing to UTC
+/// first would scatter one person's routine across buckets as their offset changed.
+/// </summary>
+public class a_moment_in_a_non_utc_offset : Specification
+{
+    TimeBucketResolver _resolver;
+    TimeBucket _result;
+
+    void Establish() => _resolver = new();
+
+    void Because() => _result = _resolver.Resolve(new DateTimeOffset(2026, 8, 24, 9, 0, 0, TimeSpan.FromHours(2)));
+
+    [Fact] void should_resolve_from_the_local_hour() => _result.ShouldEqual(TimeBucket.Morning);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_TimeBucketResolver/when_resolving/moments_across_a_day.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_TimeBucketResolver/when_resolving/moments_across_a_day.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_TimeBucketResolver.when_resolving;
+
+public class moments_across_a_day : Specification
+{
+    TimeBucketResolver _resolver;
+
+    void Establish() => _resolver = new();
+
+    static DateTimeOffset At(int hour) => new(2026, 8, 24, hour, 30, 0, TimeSpan.Zero);
+
+    [Fact] void should_put_six_in_the_early_morning() => _resolver.Resolve(At(6)).ShouldEqual(TimeBucket.EarlyMorning);
+    [Fact] void should_put_nine_in_the_morning() => _resolver.Resolve(At(9)).ShouldEqual(TimeBucket.Morning);
+    [Fact] void should_put_twelve_at_midday() => _resolver.Resolve(At(12)).ShouldEqual(TimeBucket.Midday);
+    [Fact] void should_put_fifteen_in_the_afternoon() => _resolver.Resolve(At(15)).ShouldEqual(TimeBucket.Afternoon);
+    [Fact] void should_put_nineteen_in_the_evening() => _resolver.Resolve(At(19)).ShouldEqual(TimeBucket.Evening);
+    [Fact] void should_put_twenty_three_at_night() => _resolver.Resolve(At(23)).ShouldEqual(TimeBucket.Night);
+    [Fact] void should_put_the_small_hours_at_night() => _resolver.Resolve(At(2)).ShouldEqual(TimeBucket.Night);
+    [Fact] void should_start_the_early_morning_at_five() => _resolver.Resolve(At(5)).ShouldEqual(TimeBucket.EarlyMorning);
+    [Fact] void should_end_the_night_just_before_five() => _resolver.Resolve(At(4)).ShouldEqual(TimeBucket.Night);
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/given/a_patterns_service.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/given/a_patterns_service.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Cratis.Chronicle.Patterns;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Patterns;
+using Microsoft.Extensions.Options;
+using KernelBehaviorPattern = Cratis.Chronicle.Concepts.Patterns.BehaviorPattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.given;
+
+public class a_patterns_service : Specification
+{
+    protected const string EventStore = "some-store";
+    protected const string Scope = "user-42";
+
+    private protected Chronicle.Services.Patterns.Patterns _service;
+
+    protected IBehaviorPatternStorage _patterns;
+    protected KernelBehaviorPattern _mondayMorning;
+    protected KernelBehaviorPattern _monday;
+    protected KernelBehaviorPattern _lowConfidence;
+
+    void Establish()
+    {
+        _mondayMorning = Pattern([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")], 0.9d);
+        _monday = Pattern([new Facet(FacetName.Day, "Monday")], 0.8d);
+        _lowConfidence = Pattern([new Facet(FacetName.TimeBucket, "Morning")], 0.2d);
+
+        KernelBehaviorPattern[] held = [_mondayMorning, _monday, _lowConfidence];
+
+        _patterns = Substitute.For<IBehaviorPatternStorage>();
+        _patterns
+            .GetMatching(new PatternGroupingKey(Scope), Arg.Any<IEnumerable<FacetSetKey>>())
+            .Returns(call => held.Where(pattern => call.Arg<IEnumerable<FacetSetKey>>().Contains(pattern.Facets.Key)));
+        _patterns.GetForScope(new PatternGroupingKey(Scope)).Returns(held);
+
+        var storage = Substitute.For<IStorage>();
+        var eventStore = Substitute.For<IEventStoreStorage>();
+        var @namespace = Substitute.For<IEventStoreNamespaceStorage>();
+        storage.GetEventStore(new EventStoreName(EventStore)).Returns(eventStore);
+        eventStore.GetNamespace(EventStoreNamespaceName.Default).Returns(@namespace);
+        @namespace.Patterns.Returns(_patterns);
+
+        var options = Options.Create(new ChronicleOptions
+        {
+            PatternDetection = new PatternDetection { MinimumConfidence = 0.5d }
+        });
+
+        _service = new(storage, new FacetVocabulary(options), new FacetSetGenerator(), new PatternMatcher(), options);
+    }
+
+    static KernelBehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new(Scope, new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/for_a_partial_context.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/for_a_partial_context.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns;
+
+public class for_a_partial_context : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetPatterns(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = Scope,
+        Context = new Dictionary<string, string>
+        {
+            { FacetName.Day.Value, "Monday" },
+            { FacetName.TimeBucket.Value, "Morning" }
+        }
+    });
+
+    [Fact] void should_return_the_patterns_clearing_the_configured_threshold() => _result.Count().ShouldEqual(2);
+    [Fact] void should_rank_the_most_specific_first() => _result.First().Facets.Count.ShouldEqual(2);
+    [Fact] void should_carry_the_facets_the_pattern_constrains() => _result.First().Facets[FacetName.Day.Value].ShouldEqual("Monday");
+    [Fact] void should_carry_the_confidence() => _result.First().Confidence.ShouldEqual(0.9d);
+    [Fact] void should_carry_the_occurrences() => _result.First().Occurrences.ShouldEqual(10L);
+    [Fact] void should_carry_the_weight() => _result.First().Weight.ShouldEqual(1d);
+    [Fact] void should_carry_the_scope() => _result.First().GroupingKey.ShouldEqual(Scope);
+    [Fact] void should_not_return_a_pattern_below_the_threshold() => _result.Any(_ => _.Confidence < 0.5d).ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/with_a_confidence_higher_than_anything_held.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/with_a_confidence_higher_than_anything_held.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns;
+
+public class with_a_confidence_higher_than_anything_held : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetPatterns(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = Scope,
+        Context = new Dictionary<string, string> { { FacetName.Day.Value, "Monday" } },
+        MinimumConfidence = 0.95d
+    });
+
+    [Fact] void should_return_nothing_rather_than_the_best_of_a_bad_set() => _result.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/with_a_context_holding_a_facet_that_is_not_mined.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/with_a_context_holding_a_facet_that_is_not_mined.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns;
+
+/// <summary>
+/// A caller can describe its situation in whatever terms it has. Facets the store does not mine are discarded
+/// rather than narrowing the lookup to nothing - the question is still answerable from the parts that are mined.
+/// </summary>
+public class with_a_context_holding_a_facet_that_is_not_mined : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetPatterns(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = Scope,
+        Context = new Dictionary<string, string>
+        {
+            { FacetName.Day.Value, "Monday" },
+            { FacetName.CorrelationRootId.Value, "correlation-1" },
+            { "SomethingNobodyMines", "whatever" }
+        }
+    });
+
+    [Fact] void should_still_answer_from_the_mined_facets() => _result.Count().ShouldEqual(1);
+    [Fact] void should_answer_with_the_pattern_for_the_mined_facet() => _result.Single().Facets[FacetName.Day.Value].ShouldEqual("Monday");
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/without_a_scope.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns/without_a_scope.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns;
+
+/// <summary>
+/// The scope selects whose behavior is being asked about. Without one there is no question to answer, so the
+/// answer is nothing rather than everybody's patterns at once.
+/// </summary>
+public class without_a_scope : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetPatterns(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = PatternGroupingKey.Unspecified,
+        Context = new Dictionary<string, string> { { FacetName.Day.Value, "Monday" } }
+    });
+
+    [Fact] void should_return_nothing() => _result.ShouldBeEmpty();
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns_for_scope/everything_a_scope_established.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns_for_scope/everything_a_scope_established.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns_for_scope;
+
+/// <summary>
+/// Browsing a scope is a different question from asking about a situation: it lists what the scope established,
+/// unfiltered, so a view can show weak patterns alongside strong ones.
+/// </summary>
+public class everything_a_scope_established : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetPatternsForScope(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = Scope
+    });
+
+    [Fact] void should_return_every_pattern_held() => _result.Count().ShouldEqual(3);
+    [Fact] void should_include_the_ones_below_the_confidence_threshold() => _result.Any(_ => _.Confidence < 0.5d).ShouldBeTrue();
+}

--- a/Source/Kernel/Core/Configuration/ChronicleOptions.cs
+++ b/Source/Kernel/Core/Configuration/ChronicleOptions.cs
@@ -119,6 +119,11 @@ public class ChronicleOptions
     public EncryptionCertificate EncryptionCertificate { get; init; } = new();
 
     /// <summary>
+    /// Gets the pattern detection configuration.
+    /// </summary>
+    public PatternDetection PatternDetection { get; init; } = new PatternDetection();
+
+    /// <summary>
     /// Gets or inits the TLS configuration.
     /// </summary>
     public Tls Tls { get; init; } = new Tls();

--- a/Source/Kernel/Core/Configuration/PatternDetection.cs
+++ b/Source/Kernel/Core/Configuration/PatternDetection.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Configuration;
+
+/// <summary>
+/// Represents the configuration for pattern detection.
+/// </summary>
+public class PatternDetection
+{
+    /// <summary>
+    /// Gets the facets that take part in the mined itemset key.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="FacetName.Year"/> and <see cref="FacetName.Month"/> are deliberately absent: they are kept on a
+    /// surviving pattern for recency, but combining them multiplies the candidate space by every month the store
+    /// has been running while splitting one behavior across all of them. Add them here when a deployment wants to
+    /// mine seasonality and can afford the cardinality.
+    /// </remarks>
+    public IReadOnlyList<string> Facets { get; init; } =
+    [
+        FacetName.CommandType.Value,
+        FacetName.InitiatorType.Value,
+        FacetName.CausedByCommand.Value,
+        FacetName.AggregateType.Value,
+        FacetName.Day.Value,
+        FacetName.TimeBucket.Value
+    ];
+
+    /// <summary>
+    /// Gets the largest number of facets a mined itemset may combine.
+    /// </summary>
+    /// <remarks>
+    /// The candidate space grows as the binomial coefficient of the facet count over this, so it is what keeps
+    /// mining polynomial rather than exponential in the number of facets.
+    /// </remarks>
+    public int MaximumCombinationSize { get; init; } = 3;
+
+    /// <summary>
+    /// Gets the Lossy Counting error parameter, bounding how far a counted frequency may lag the true one.
+    /// </summary>
+    /// <remarks>
+    /// Memory is bounded at roughly the logarithm of the observed count over this value, so a smaller value buys
+    /// accuracy with memory. It must be greater than zero and smaller than <see cref="MinimumSupport"/> for the
+    /// guarantee to mean anything.
+    /// </remarks>
+    public double Error { get; init; } = 0.001;
+
+    /// <summary>
+    /// Gets the smallest share of observed events an itemset must hold to survive as a pattern.
+    /// </summary>
+    public double MinimumSupport { get; init; } = 0.01;
+
+    /// <summary>
+    /// Gets the smallest confidence an itemset must hold to survive as a pattern.
+    /// </summary>
+    public double MinimumConfidence { get; init; } = 0.5;
+
+    /// <summary>
+    /// Gets the daily decay applied to the weight of an itemset that has gone unseen.
+    /// </summary>
+    /// <remarks>
+    /// Applied as weight multiplied by this raised to the number of days since the itemset was last seen, so a
+    /// value of 1 disables decay entirely and a smaller value forgets faster.
+    /// </remarks>
+    public double DecayFactor { get; init; } = 0.99;
+}

--- a/Source/Kernel/Core/Patterns/EventFeatureExtractor.cs
+++ b/Source/Kernel/Core/Patterns/EventFeatureExtractor.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Auditing;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Identities;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.DependencyInjection;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IEventFeatureExtractor"/>.
+/// </summary>
+/// <param name="timeBucketResolver"><see cref="ITimeBucketResolver"/> for resolving the part of the day.</param>
+/// <remarks>
+/// Nothing here reads the event's content. Patterns are mined from the context an event was appended in - who, on
+/// whose behalf, caused by what, against what kind of event source, when - which is the same vocabulary for every
+/// event type in every event store, and is exactly what makes the mined patterns comparable across a store.
+/// </remarks>
+[Singleton]
+public class EventFeatureExtractor(ITimeBucketResolver timeBucketResolver) : IEventFeatureExtractor
+{
+    /// <inheritdoc/>
+    public EventFeatures Extract(AppendedEvent @event)
+    {
+        var context = @event.Context;
+        var causedBy = context.CausedBy ?? Identity.NotSet;
+        var rootIdentity = GetRootIdentity(causedBy);
+        var (commandType, causedByCommand) = GetCommandTypes(context);
+
+        return new EventFeatures(
+            GetGroupingKey(rootIdentity),
+            commandType,
+            GetInitiatorType(causedBy),
+            GetIdentitySubject(causedBy),
+            GetIdentitySubject(causedBy.OnBehalfOf),
+            causedByCommand,
+            context.CorrelationId.ToString(),
+            context.EventSourceType.IsDefaultOrUnspecified ? FacetValue.Unspecified : context.EventSourceType.Value,
+            context.Occurred.Year,
+            context.Occurred.Month,
+            context.Occurred.DayOfWeek,
+            timeBucketResolver.Resolve(context.Occurred),
+            context.Occurred);
+    }
+
+    /// <summary>
+    /// Gets the command types for an event - the one that caused it and the one a level above that.
+    /// </summary>
+    /// <param name="context">The <see cref="EventContext"/> to read the causation chain from.</param>
+    /// <returns>The command type and the command that caused it.</returns>
+    /// <remarks>
+    /// The causation chain is ordered from the root outwards, so the last named link is what directly produced the
+    /// event and the one before it is a level up. Links the client stack could not name - <see cref="CausationType.Root"/>
+    /// and <see cref="CausationType.Unknown"/> - carry no behavior worth mining and are skipped. When nothing above
+    /// the event named itself, the event type stands in: in an event-sourced store the fact that was recorded is
+    /// itself the action.
+    /// </remarks>
+    static (FacetValue CommandType, FacetValue CausedByCommand) GetCommandTypes(EventContext context)
+    {
+        var named = context.Causation?
+            .Where(causation => IsNamed(causation.Type))
+            .Select(causation => causation.Type.Value)
+            .ToArray() ?? [];
+
+        FacetValue commandType = named.Length > 0 ? named[^1] : context.EventType.Id.Value;
+        var causedByCommand = named.Length > 1 ? new FacetValue(named[^2]) : FacetValue.Unspecified;
+
+        return (commandType, causedByCommand);
+    }
+
+    static bool IsNamed(CausationType type) =>
+        !string.IsNullOrEmpty(type?.Value) && type != CausationType.Root && type != CausationType.Unknown;
+
+    /// <summary>
+    /// Gets the scope the behavior belongs to.
+    /// </summary>
+    /// <param name="rootIdentity">The identity at the root of the on-behalf-of chain.</param>
+    /// <returns>The <see cref="PatternGroupingKey"/>.</returns>
+    /// <remarks>
+    /// An agent acting for a person contributes to that person's behavior, not to its own - otherwise the same
+    /// habit would be mined once per agent that happened to carry it out, and none of the halves would clear the
+    /// support threshold.
+    /// </remarks>
+    static PatternGroupingKey GetGroupingKey(Identity rootIdentity) =>
+        IsAnonymous(rootIdentity) ? PatternGroupingKey.Unspecified : rootIdentity.Subject;
+
+    static Identity GetRootIdentity(Identity identity)
+    {
+        var current = identity;
+        while (current.OnBehalfOf is not null)
+        {
+            current = current.OnBehalfOf;
+        }
+
+        return current;
+    }
+
+    static FacetValue GetIdentitySubject(Identity? identity) =>
+        identity is null || IsAnonymous(identity) ? FacetValue.Unspecified : identity.Subject;
+
+    static bool IsAnonymous(Identity identity) =>
+        identity == Identity.NotSet || identity == Identity.Unknown || string.IsNullOrEmpty(identity.Subject);
+
+    /// <summary>
+    /// Gets what kind of initiator caused the event.
+    /// </summary>
+    /// <param name="causedBy">The <see cref="Identity"/> that caused it.</param>
+    /// <returns>The <see cref="InitiatorType"/>.</returns>
+    /// <remarks>
+    /// Acting on behalf of somebody is what separates an agent from a user: a person acts as themselves, whereas
+    /// anything carrying a delegation chain is standing in for one.
+    /// </remarks>
+    static InitiatorType GetInitiatorType(Identity causedBy) => causedBy switch
+    {
+        _ when causedBy == Identity.System => InitiatorType.System,
+        _ when IsAnonymous(causedBy) => InitiatorType.Unknown,
+        { OnBehalfOf: not null } => InitiatorType.Agent,
+        _ => InitiatorType.User
+    };
+}

--- a/Source/Kernel/Core/Patterns/EventFeatureExtractor.cs
+++ b/Source/Kernel/Core/Patterns/EventFeatureExtractor.cs
@@ -53,15 +53,17 @@ public class EventFeatureExtractor(ITimeBucketResolver timeBucketResolver) : IEv
     /// <remarks>
     /// The causation chain is ordered from the root outwards, so the last named link is what directly produced the
     /// event and the one before it is a level up. Links the client stack could not name - <see cref="CausationType.Root"/>
-    /// and <see cref="CausationType.Unknown"/> - carry no behavior worth mining and are skipped. When nothing above
-    /// the event named itself, the event type stands in: in an event-sourced store the fact that was recorded is
-    /// itself the action.
+    /// and <see cref="CausationType.Unknown"/> - carry no behavior worth mining and are skipped. A link that names
+    /// the command it stands for is read by that name rather than by its causation type, because every command
+    /// shares one type and mining by it would put every command in the store under a single value. When nothing
+    /// above the event named itself, the event type stands in: in an event-sourced store the fact that was recorded
+    /// is itself the action.
     /// </remarks>
     static (FacetValue CommandType, FacetValue CausedByCommand) GetCommandTypes(EventContext context)
     {
         var named = context.Causation?
             .Where(causation => IsNamed(causation.Type))
-            .Select(causation => causation.Type.Value)
+            .Select(NameOf)
             .ToArray() ?? [];
 
         FacetValue commandType = named.Length > 0 ? named[^1] : context.EventType.Id.Value;
@@ -69,6 +71,13 @@ public class EventFeatureExtractor(ITimeBucketResolver timeBucketResolver) : IEv
 
         return (commandType, causedByCommand);
     }
+
+    static string NameOf(Causation causation) =>
+        causation.Properties is not null &&
+        causation.Properties.TryGetValue(WellKnownCausationProperties.CommandType, out var commandType) &&
+        !string.IsNullOrEmpty(commandType)
+            ? commandType
+            : causation.Type.Value;
 
     static bool IsNamed(CausationType type) =>
         !string.IsNullOrEmpty(type?.Value) && type != CausationType.Root && type != CausationType.Unknown;

--- a/Source/Kernel/Core/Patterns/FacetSetGenerator.cs
+++ b/Source/Kernel/Core/Patterns/FacetSetGenerator.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.DependencyInjection;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IFacetSetGenerator"/>.
+/// </summary>
+/// <remarks>
+/// Combinations are capped rather than exhaustive on purpose. Every subset of a facet set is a candidate the sketch
+/// has to count, and the number of subsets doubles with each facet; capping the size at k leaves a polynomial
+/// number of candidates - the sum of the binomial coefficients up to k - which is what keeps mining affordable per
+/// event.
+/// </remarks>
+[Singleton]
+public class FacetSetGenerator : IFacetSetGenerator
+{
+    /// <inheritdoc/>
+    public IEnumerable<FacetSet> Generate(FacetSet source, int maximumCombinationSize)
+    {
+        if (source.IsEmpty || maximumCombinationSize <= 0)
+        {
+            return [];
+        }
+
+        var facets = source.Facets;
+        var largest = Math.Min(maximumCombinationSize, facets.Count);
+        var combinations = new List<FacetSet>();
+
+        for (var length = 1; length <= largest; length++)
+        {
+            Build(facets, new Facet[length], 0, 0, combinations);
+        }
+
+        return combinations;
+    }
+
+    static void Build(IReadOnlyList<Facet> facets, Facet[] buffer, int index, int start, List<FacetSet> combinations)
+    {
+        if (index == buffer.Length)
+        {
+            combinations.Add(new FacetSet(buffer));
+            return;
+        }
+
+        for (var current = start; current <= facets.Count - (buffer.Length - index); current++)
+        {
+            buffer[index] = facets[current];
+            Build(facets, buffer, index + 1, current + 1, combinations);
+        }
+    }
+}

--- a/Source/Kernel/Core/Patterns/FacetVocabulary.cs
+++ b/Source/Kernel/Core/Patterns/FacetVocabulary.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Cratis.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IFacetVocabulary"/> driven by <see cref="PatternDetection"/>.
+/// </summary>
+/// <param name="options">The <see cref="IOptions{TOptions}"/> holding the <see cref="ChronicleOptions"/>.</param>
+[Singleton]
+public class FacetVocabulary(IOptions<ChronicleOptions> options) : IFacetVocabulary
+{
+    /// <inheritdoc/>
+    public IReadOnlyList<FacetName> Facets { get; } =
+        [.. options.Value.PatternDetection.Facets.Select(facet => new FacetName(facet))];
+
+    /// <inheritdoc/>
+    public FacetSet Select(EventFeatures features)
+    {
+        var facets = features.AsFacets();
+        return new FacetSet(Facets
+            .Where(facets.ContainsKey)
+            .Select(name => new Facet(name, facets[name])));
+    }
+
+    /// <inheritdoc/>
+    public FacetSet Select(FacetSet context) =>
+        new(context.Facets.Where(facet => Facets.Contains(facet.Name)));
+}

--- a/Source/Kernel/Core/Patterns/IEventFeatureExtractor.cs
+++ b/Source/Kernel/Core/Patterns/IEventFeatureExtractor.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system that extracts the contextual facts pattern mining works on from an event.
+/// </summary>
+public interface IEventFeatureExtractor
+{
+    /// <summary>
+    /// Extract the <see cref="EventFeatures"/> from an event.
+    /// </summary>
+    /// <param name="event">The <see cref="AppendedEvent"/> to extract from.</param>
+    /// <returns>The extracted <see cref="EventFeatures"/>.</returns>
+    EventFeatures Extract(AppendedEvent @event);
+}

--- a/Source/Kernel/Core/Patterns/IFacetSetGenerator.cs
+++ b/Source/Kernel/Core/Patterns/IFacetSetGenerator.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system that expands a set of facets into the candidate itemsets mining counts.
+/// </summary>
+public interface IFacetSetGenerator
+{
+    /// <summary>
+    /// Generate every non-empty combination of facets up to a given size.
+    /// </summary>
+    /// <param name="source">The <see cref="FacetSet"/> to combine facets from.</param>
+    /// <param name="maximumCombinationSize">The largest number of facets a combination may hold.</param>
+    /// <returns>The candidate <see cref="FacetSet">itemsets</see>, ordered from least to most specific.</returns>
+    IEnumerable<FacetSet> Generate(FacetSet source, int maximumCombinationSize);
+}

--- a/Source/Kernel/Core/Patterns/IFacetVocabulary.cs
+++ b/Source/Kernel/Core/Patterns/IFacetVocabulary.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines the facets that take part in mining, and how to read them off an event.
+/// </summary>
+public interface IFacetVocabulary
+{
+    /// <summary>
+    /// Gets the facets that take part in the mined itemset key.
+    /// </summary>
+    IReadOnlyList<FacetName> Facets { get; }
+
+    /// <summary>
+    /// Select the facets an event contributes to mining.
+    /// </summary>
+    /// <param name="features">The <see cref="EventFeatures"/> to select from.</param>
+    /// <returns>A <see cref="FacetSet"/> holding the participating facets the event carries a value for.</returns>
+    FacetSet Select(EventFeatures features);
+
+    /// <summary>
+    /// Select the facets of a context that take part in mining, discarding any the vocabulary does not mine.
+    /// </summary>
+    /// <param name="context">The <see cref="FacetSet"/> describing the context.</param>
+    /// <returns>A <see cref="FacetSet"/> holding only the participating facets.</returns>
+    FacetSet Select(FacetSet context);
+}

--- a/Source/Kernel/Core/Patterns/IPatternMatcher.cs
+++ b/Source/Kernel/Core/Patterns/IPatternMatcher.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system that answers what usually happens in a given context.
+/// </summary>
+public interface IPatternMatcher
+{
+    /// <summary>
+    /// Rank the patterns that apply to a context.
+    /// </summary>
+    /// <param name="patterns">The <see cref="BehaviorPattern">patterns</see> to consider.</param>
+    /// <param name="context">The <see cref="FacetSet"/> describing the context, which may be partial.</param>
+    /// <param name="minimumConfidence">The lowest <see cref="PatternConfidence"/> a match may hold.</param>
+    /// <param name="maximumResults">The largest number of matches to return.</param>
+    /// <returns>The matching patterns, most specific and most confident first.</returns>
+    IEnumerable<BehaviorPattern> Match(
+        IEnumerable<BehaviorPattern> patterns,
+        FacetSet context,
+        PatternConfidence minimumConfidence,
+        int maximumResults);
+}

--- a/Source/Kernel/Core/Patterns/IPatternMiner.cs
+++ b/Source/Kernel/Core/Patterns/IPatternMiner.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system that mines recurring behavior from a stream of events.
+/// </summary>
+public interface IPatternMiner
+{
+    /// <summary>
+    /// Mine the facts extracted from one event.
+    /// </summary>
+    /// <param name="features">The <see cref="EventFeatures"/> to mine.</param>
+    void Observe(EventFeatures features);
+
+    /// <summary>
+    /// Decay every mined itemset as of a point in time.
+    /// </summary>
+    /// <param name="asOf"><see cref="DateTimeOffset">When</see> to decay as of.</param>
+    void Decay(DateTimeOffset asOf);
+
+    /// <summary>
+    /// Gets every itemset that currently clears the support and confidence thresholds, across all scopes.
+    /// </summary>
+    /// <returns>The surviving <see cref="BehaviorPattern">patterns</see>.</returns>
+    IEnumerable<BehaviorPattern> GetSurvivingPatterns();
+
+    /// <summary>
+    /// Gets every itemset that currently clears the support and confidence thresholds for one scope.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to get for.</param>
+    /// <returns>The surviving <see cref="BehaviorPattern">patterns</see>.</returns>
+    IEnumerable<BehaviorPattern> GetSurvivingPatterns(PatternGroupingKey groupingKey);
+}

--- a/Source/Kernel/Core/Patterns/ITimeBucketResolver.cs
+++ b/Source/Kernel/Core/Patterns/ITimeBucketResolver.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Defines a system that resolves which part of the day a moment belongs to.
+/// </summary>
+public interface ITimeBucketResolver
+{
+    /// <summary>
+    /// Resolve the <see cref="TimeBucket"/> a moment belongs to.
+    /// </summary>
+    /// <param name="occurred">When it occurred.</param>
+    /// <returns>The <see cref="TimeBucket"/>.</returns>
+    TimeBucket Resolve(DateTimeOffset occurred);
+}

--- a/Source/Kernel/Core/Patterns/LossyCountingEntry.cs
+++ b/Source/Kernel/Core/Patterns/LossyCountingEntry.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents what a <see cref="LossyCountingSketch"/> holds for one candidate itemset.
+/// </summary>
+/// <param name="Itemset">The <see cref="FacetSet"/> being counted.</param>
+/// <param name="Frequency">How many times the itemset has been counted since it entered the sketch.</param>
+/// <param name="Error">The largest number of occurrences that could have been missed before it entered.</param>
+/// <param name="Weight">The recency-weighted strength of the itemset.</param>
+/// <param name="FirstSeen">When the itemset was first counted.</param>
+/// <param name="LastSeen">When the itemset was last counted.</param>
+/// <remarks>
+/// <see cref="Frequency"/> and <see cref="Error"/> are the Lossy Counting pair: the true count of an itemset in
+/// the sketch is at least <see cref="Frequency"/> and at most <see cref="Frequency"/> plus <see cref="Error"/>.
+/// An itemset that entered late carries a large error, which is what stops a newcomer from being mistaken for a
+/// long-standing habit.
+/// </remarks>
+public record LossyCountingEntry(
+    FacetSet Itemset,
+    long Frequency,
+    long Error,
+    double Weight,
+    DateTimeOffset FirstSeen,
+    DateTimeOffset LastSeen)
+{
+    /// <summary>
+    /// Gets the largest the true count of the itemset could be.
+    /// </summary>
+    public long MaximumFrequency => Frequency + Error;
+}

--- a/Source/Kernel/Core/Patterns/LossyCountingSketch.cs
+++ b/Source/Kernel/Core/Patterns/LossyCountingSketch.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents a Lossy Counting sketch over candidate itemsets, holding bounded state no matter how many events
+/// flow through it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lossy Counting (Manku and Motwani) divides the stream into buckets of width one over the error parameter. An
+/// itemset already in the sketch has its frequency incremented; a new one enters carrying the current bucket
+/// number minus one as its error, which is the most it could have occurred before anyone was watching. At a bucket
+/// boundary every itemset whose frequency plus error has not kept up with the bucket number is dropped.
+/// </para>
+/// <para>
+/// The guarantee that buys: nothing with true frequency above the support threshold is ever missed, nothing
+/// reported is off by more than the error parameter times the number of observations, and the number of retained
+/// itemsets is bounded regardless of stream length. That last part is the point - the whole feature exists to
+/// summarize an unbounded event history in memory that does not grow with it.
+/// </para>
+/// <para>
+/// The sketch is not thread-safe. It is owned by whatever mines a single grouping scope, and that owner serializes
+/// access - see <see cref="PatternMiner"/>.
+/// </para>
+/// </remarks>
+public sealed class LossyCountingSketch
+{
+    readonly Dictionary<FacetSetKey, MutableEntry> _entries = [];
+    readonly double _error;
+    readonly double _decayFactor;
+    readonly long _bucketWidth;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LossyCountingSketch"/> class.
+    /// </summary>
+    /// <param name="error">The error parameter, bounding how far a counted frequency may lag the true one.</param>
+    /// <param name="decayFactor">The daily decay applied to the weight of an itemset that has gone unseen.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the error parameter is not between zero and one, exclusive.</exception>
+    public LossyCountingSketch(double error, double decayFactor)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(error, 0d);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(error, 1d);
+
+        _error = error;
+        _decayFactor = decayFactor;
+        _bucketWidth = (long)Math.Ceiling(1d / error);
+    }
+
+    /// <summary>
+    /// Gets how many observations the sketch has seen. One event is one observation, however many itemsets it
+    /// contributed.
+    /// </summary>
+    public long Observed { get; private set; }
+
+    /// <summary>
+    /// Gets how many itemsets the sketch currently retains.
+    /// </summary>
+    public int Count => _entries.Count;
+
+    /// <summary>
+    /// Gets the entries the sketch currently retains.
+    /// </summary>
+    public IEnumerable<LossyCountingEntry> Entries => _entries.Values.Select(entry => entry.ToEntry());
+
+    long CurrentBucket => (long)Math.Ceiling(Observed * _error);
+
+    /// <summary>
+    /// Count one observation and the itemsets it contributed.
+    /// </summary>
+    /// <param name="itemsets">The candidate <see cref="FacetSet">itemsets</see> the observation contributed.</param>
+    /// <param name="occurred"><see cref="DateTimeOffset">When</see> the observation occurred.</param>
+    /// <remarks>
+    /// The number of observations grows by one, not by the number of itemsets. Support is a share of events, so
+    /// counting each of an event's itemsets as an observation would divide every frequency by a denominator many
+    /// times too large and no pattern would ever clear the threshold.
+    /// </remarks>
+    public void Observe(IEnumerable<FacetSet> itemsets, DateTimeOffset occurred)
+    {
+        Observed++;
+        var bucket = CurrentBucket;
+
+        foreach (var itemset in itemsets)
+        {
+            if (_entries.TryGetValue(itemset.Key, out var existing))
+            {
+                existing.Count(occurred, _decayFactor);
+            }
+            else
+            {
+                _entries[itemset.Key] = new MutableEntry(itemset, bucket - 1, occurred);
+            }
+        }
+
+        if (Observed % _bucketWidth == 0)
+        {
+            Prune();
+        }
+    }
+
+    /// <summary>
+    /// Drop every itemset that has not kept up with the stream.
+    /// </summary>
+    /// <remarks>
+    /// Called automatically at each bucket boundary, and exposed so an owner can prune on its own cadence - a
+    /// low-throughput scope may take a long time to fill a bucket, and its dormant itemsets should still decay out
+    /// rather than sit there forever.
+    /// </remarks>
+    public void Prune()
+    {
+        var bucket = CurrentBucket;
+        var stale = _entries
+            .Where(pair => pair.Value.Frequency + pair.Value.Error <= bucket)
+            .Select(pair => pair.Key)
+            .ToArray();
+
+        foreach (var key in stale)
+        {
+            _entries.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Apply decay to every itemset as of a point in time, without counting an observation.
+    /// </summary>
+    /// <param name="asOf"><see cref="DateTimeOffset">When</see> to decay as of.</param>
+    /// <remarks>
+    /// Decay is otherwise only applied when an itemset is counted again, so a scope that has gone quiet would keep
+    /// the weight it had on its last good day forever. This is the background pass that lets dormant behavior fade.
+    /// </remarks>
+    public void Decay(DateTimeOffset asOf)
+    {
+        foreach (var entry in _entries.Values)
+        {
+            entry.DecayTo(asOf, _decayFactor);
+        }
+    }
+
+    /// <summary>
+    /// Try to get the entry for a specific itemset.
+    /// </summary>
+    /// <param name="key">The <see cref="FacetSetKey"/> to get for.</param>
+    /// <param name="entry">The <see cref="LossyCountingEntry"/> when found.</param>
+    /// <returns>True when the sketch retains the itemset, false when not.</returns>
+    public bool TryGet(FacetSetKey key, out LossyCountingEntry entry)
+    {
+        if (_entries.TryGetValue(key, out var existing))
+        {
+            entry = existing.ToEntry();
+            return true;
+        }
+
+        entry = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the frequency counted for a specific itemset.
+    /// </summary>
+    /// <param name="key">The <see cref="FacetSetKey"/> to get for.</param>
+    /// <returns>The counted frequency, or zero when the sketch does not retain the itemset.</returns>
+    public long GetFrequency(FacetSetKey key) =>
+        _entries.TryGetValue(key, out var existing) ? existing.Frequency : 0L;
+
+    /// <summary>
+    /// Represents the mutable state the sketch keeps per itemset.
+    /// </summary>
+    /// <param name="itemset">The <see cref="FacetSet"/> being counted.</param>
+    /// <param name="error">The largest number of occurrences that could have been missed before it entered.</param>
+    /// <param name="occurred">When the observation that created the entry occurred.</param>
+    /// <remarks>
+    /// <c>LastSeen</c> answers "when did this behavior last happen" and only ever moves on an observation. The
+    /// moment the weight is decayed to is tracked separately, because it also moves on a background decay pass.
+    /// Collapsing the two would make a decay pass look like an occurrence in the stored pattern, and would let two
+    /// passes over the same interval decay it twice.
+    /// </remarks>
+    sealed class MutableEntry(FacetSet itemset, long error, DateTimeOffset occurred)
+    {
+        DateTimeOffset _weightAsOf = occurred;
+
+        public long Frequency { get; private set; } = 1;
+
+        public long Error { get; } = error;
+
+        public double Weight { get; private set; } = 1d;
+
+        public DateTimeOffset FirstSeen { get; private set; } = occurred;
+
+        public DateTimeOffset LastSeen { get; private set; } = occurred;
+
+        public void Count(DateTimeOffset occurred, double decayFactor)
+        {
+            Frequency++;
+            Weight = Decayed(occurred, decayFactor) + 1d;
+
+            if (occurred > _weightAsOf)
+            {
+                _weightAsOf = occurred;
+            }
+
+            if (occurred < FirstSeen)
+            {
+                FirstSeen = occurred;
+            }
+
+            if (occurred > LastSeen)
+            {
+                LastSeen = occurred;
+            }
+        }
+
+        public void DecayTo(DateTimeOffset asOf, double decayFactor)
+        {
+            if (asOf <= _weightAsOf)
+            {
+                return;
+            }
+
+            Weight = Decayed(asOf, decayFactor);
+            _weightAsOf = asOf;
+        }
+
+        public LossyCountingEntry ToEntry() => new(itemset, Frequency, Error, Weight, FirstSeen, LastSeen);
+
+        double Decayed(DateTimeOffset asOf, double decayFactor)
+        {
+            var days = (asOf - _weightAsOf).TotalDays;
+            return days <= 0d ? Weight : Weight * Math.Pow(decayFactor, days);
+        }
+    }
+}

--- a/Source/Kernel/Core/Patterns/PatternMatcher.cs
+++ b/Source/Kernel/Core/Patterns/PatternMatcher.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.DependencyInjection;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IPatternMatcher"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Specificity outranks confidence. A pattern that constrains everything the caller asked about is an answer to
+/// their question; a broader one that happens to be more confident is an answer to a question they did not ask, and
+/// putting it first is how a recommendation engine ends up stating the obvious.
+/// </para>
+/// <para>
+/// Nothing clearing the confidence bar returns nothing. An empty answer is a true statement about a context with no
+/// established behavior, whereas the best of a bad set reads to a caller exactly like a real pattern.
+/// </para>
+/// </remarks>
+[Singleton]
+public class PatternMatcher : IPatternMatcher
+{
+    /// <inheritdoc/>
+    public IEnumerable<BehaviorPattern> Match(
+        IEnumerable<BehaviorPattern> patterns,
+        FacetSet context,
+        PatternConfidence minimumConfidence,
+        int maximumResults)
+    {
+        if (maximumResults <= 0)
+        {
+            return [];
+        }
+
+        return
+        [
+            .. patterns
+                .Where(pattern => pattern.Matches(context) && pattern.Confidence.Value >= minimumConfidence.Value)
+                .OrderByDescending(pattern => pattern.Specificity)
+                .ThenByDescending(pattern => pattern.Confidence.Value)
+                .ThenByDescending(pattern => pattern.Support.Value)
+                .ThenBy(pattern => pattern.Facets.Key.Value, StringComparer.Ordinal)
+                .Take(maximumResults)
+        ];
+    }
+}

--- a/Source/Kernel/Core/Patterns/PatternMiner.cs
+++ b/Source/Kernel/Core/Patterns/PatternMiner.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Cratis.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IPatternMiner"/> backed by a <see cref="LossyCountingSketch"/> per
+/// scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One sketch per grouping key rather than one for everybody: a habit is a person's, and a shared sketch would let
+/// a busy user's routine outvote everyone else's while making "what does this user usually do" unanswerable.
+/// Whether a global sketch should exist alongside these, for org-wide behavior, is deliberately left open.
+/// </para>
+/// <para>
+/// An event nobody can be named for is not mined at all. Its behavior belongs to no scope, so it could only be
+/// counted into a catch-all that every unattributed append in the store would pour into - which is noise, not a
+/// pattern.
+/// </para>
+/// </remarks>
+/// <param name="vocabulary">The <see cref="IFacetVocabulary"/> deciding which facets take part.</param>
+/// <param name="generator">The <see cref="IFacetSetGenerator"/> expanding facets into candidate itemsets.</param>
+/// <param name="options">The <see cref="IOptions{TOptions}"/> holding the <see cref="ChronicleOptions"/>.</param>
+[Singleton]
+public class PatternMiner(
+    IFacetVocabulary vocabulary,
+    IFacetSetGenerator generator,
+    IOptions<ChronicleOptions> options) : IPatternMiner
+{
+    readonly Dictionary<PatternGroupingKey, LossyCountingSketch> _sketches = [];
+    readonly Lock _lock = new();
+    readonly PatternDetection _configuration = options.Value.PatternDetection;
+
+    /// <inheritdoc/>
+    public void Observe(EventFeatures features)
+    {
+        if (!features.GroupingKey.IsSpecified)
+        {
+            return;
+        }
+
+        var facets = vocabulary.Select(features);
+        if (facets.IsEmpty)
+        {
+            return;
+        }
+
+        var itemsets = generator.Generate(facets, _configuration.MaximumCombinationSize);
+
+        lock (_lock)
+        {
+            GetSketch(features.GroupingKey).Observe(itemsets, features.Occurred);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Decay(DateTimeOffset asOf)
+    {
+        lock (_lock)
+        {
+            foreach (var sketch in _sketches.Values)
+            {
+                sketch.Decay(asOf);
+                sketch.Prune();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<BehaviorPattern> GetSurvivingPatterns()
+    {
+        lock (_lock)
+        {
+            return [.. _sketches.SelectMany(pair => Surviving(pair.Key, pair.Value))];
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<BehaviorPattern> GetSurvivingPatterns(PatternGroupingKey groupingKey)
+    {
+        lock (_lock)
+        {
+            return _sketches.TryGetValue(groupingKey, out var sketch)
+                ? [.. Surviving(groupingKey, sketch)]
+                : [];
+        }
+    }
+
+    LossyCountingSketch GetSketch(PatternGroupingKey groupingKey)
+    {
+        if (!_sketches.TryGetValue(groupingKey, out var sketch))
+        {
+            sketch = new LossyCountingSketch(_configuration.Error, _configuration.DecayFactor);
+            _sketches[groupingKey] = sketch;
+        }
+
+        return sketch;
+    }
+
+    /// <summary>
+    /// Gets the patterns of a scope that clear both thresholds.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> the sketch belongs to.</param>
+    /// <param name="sketch">The <see cref="LossyCountingSketch"/> to read.</param>
+    /// <returns>The surviving <see cref="BehaviorPattern">patterns</see>.</returns>
+    /// <remarks>
+    /// Confidence is read as the rule "in this context, this action follows": the frequency of the whole itemset
+    /// over the frequency of the same itemset without its action facet. An itemset that names no action is pure
+    /// context, and the only honest answer to "how often does this hold" is its support.
+    /// </remarks>
+    IEnumerable<BehaviorPattern> Surviving(PatternGroupingKey groupingKey, LossyCountingSketch sketch)
+    {
+        if (sketch.Observed == 0)
+        {
+            yield break;
+        }
+
+        foreach (var entry in sketch.Entries)
+        {
+            var support = (double)entry.Frequency / sketch.Observed;
+            if (support < _configuration.MinimumSupport)
+            {
+                continue;
+            }
+
+            var confidence = ConfidenceOf(entry, sketch, support);
+            if (confidence < _configuration.MinimumConfidence)
+            {
+                continue;
+            }
+
+            yield return new BehaviorPattern(
+                groupingKey,
+                entry.Itemset,
+                entry.Frequency,
+                confidence,
+                support,
+                entry.Weight,
+                entry.FirstSeen,
+                entry.LastSeen);
+        }
+    }
+
+    double ConfidenceOf(LossyCountingEntry entry, LossyCountingSketch sketch, double support)
+    {
+        if (!entry.Itemset.Constrains(FacetName.CommandType))
+        {
+            return support;
+        }
+
+        var context = new FacetSet(entry.Itemset.Facets.Where(facet => facet.Name != FacetName.CommandType));
+        if (context.IsEmpty)
+        {
+            return support;
+        }
+
+        var contextFrequency = sketch.GetFrequency(context.Key);
+        return contextFrequency == 0 ? 0d : (double)entry.Frequency / contextFrequency;
+    }
+}

--- a/Source/Kernel/Core/Patterns/TimeBucketResolver.cs
+++ b/Source/Kernel/Core/Patterns/TimeBucketResolver.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.DependencyInjection;
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="ITimeBucketResolver"/>.
+/// </summary>
+/// <remarks>
+/// Buckets are resolved from the offset the event was appended with, not from UTC. A person who approves expenses
+/// at nine in the morning does so at nine in their own morning, and normalizing to UTC first would scatter that one
+/// behavior across buckets as they travel or as daylight saving shifts.
+/// </remarks>
+[Singleton]
+public class TimeBucketResolver : ITimeBucketResolver
+{
+    /// <inheritdoc/>
+    public TimeBucket Resolve(DateTimeOffset occurred) => occurred.Hour switch
+    {
+        >= 5 and < 8 => TimeBucket.EarlyMorning,
+        >= 8 and < 11 => TimeBucket.Morning,
+        >= 11 and < 14 => TimeBucket.Midday,
+        >= 14 and < 17 => TimeBucket.Afternoon,
+        >= 17 and < 22 => TimeBucket.Evening,
+        _ => TimeBucket.Night
+    };
+}

--- a/Source/Kernel/Core/Services/Patterns/PatternConverters.cs
+++ b/Source/Kernel/Core/Services/Patterns/PatternConverters.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Services.Patterns;
+
+/// <summary>
+/// Extension methods for converting patterns between their kernel and contract representations.
+/// </summary>
+public static class PatternConverters
+{
+    /// <summary>
+    /// Convert a kernel <see cref="BehaviorPattern"/> to its contract representation.
+    /// </summary>
+    /// <param name="pattern">The pattern to convert.</param>
+    /// <returns>The converted <see cref="Contract.Pattern"/>.</returns>
+    public static Contract.Pattern ToContract(this BehaviorPattern pattern) => new()
+    {
+        GroupingKey = pattern.GroupingKey.Value,
+        Facets = pattern.Facets.Facets.ToDictionary(facet => facet.Name.Value, facet => facet.Value.Value),
+        Confidence = pattern.Confidence.Value,
+        Support = pattern.Support.Value,
+        Occurrences = pattern.Occurrences.Value,
+        Weight = pattern.Weight.Value,
+        FirstSeen = pattern.FirstSeen,
+        LastSeen = pattern.LastSeen
+    };
+
+    /// <summary>
+    /// Convert a contract facet map to a <see cref="FacetSet"/>.
+    /// </summary>
+    /// <param name="facets">The facets to convert.</param>
+    /// <returns>The converted <see cref="FacetSet"/>.</returns>
+    public static FacetSet ToFacetSet(this IEnumerable<KeyValuePair<string, string>> facets) =>
+        new(facets.Select(pair => new Facet(new FacetName(pair.Key), new FacetValue(pair.Value))));
+}

--- a/Source/Kernel/Core/Services/Patterns/Patterns.cs
+++ b/Source/Kernel/Core/Services/Patterns/Patterns.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Cratis.Chronicle.Patterns;
+using Cratis.Chronicle.Storage;
+using Microsoft.Extensions.Options;
+using ProtoBuf.Grpc;
+using ContractIPatterns = Cratis.Chronicle.Contracts.Patterns.IPatterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="ContractIPatterns"/>.
+/// </summary>
+/// <param name="storage"><see cref="IStorage"/> for getting the mined patterns.</param>
+/// <param name="vocabulary"><see cref="IFacetVocabulary"/> for discarding facets that are not mined.</param>
+/// <param name="generator"><see cref="IFacetSetGenerator"/> for expanding a context into candidate itemsets.</param>
+/// <param name="matcher"><see cref="IPatternMatcher"/> for ranking the matches.</param>
+/// <param name="options">The <see cref="IOptions{TOptions}"/> holding the <see cref="ChronicleOptions"/>.</param>
+internal sealed class Patterns(
+    IStorage storage,
+    IFacetVocabulary vocabulary,
+    IFacetSetGenerator generator,
+    IPatternMatcher matcher,
+    IOptions<ChronicleOptions> options) : ContractIPatterns
+{
+    /// <summary>
+    /// The number of matches returned when the caller does not ask for a specific number.
+    /// </summary>
+    /// <remarks>
+    /// Small on purpose. The question is "what usually happens here", and an answer long enough to scroll is not
+    /// one - the ranking already puts the most specific, most confident patterns first.
+    /// </remarks>
+    const int DefaultMaximumResults = 10;
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Pattern>> GetPatterns(Contracts.Patterns.GetPatternsRequest request, CallContext context = default)
+    {
+        var groupingKey = new PatternGroupingKey(request.GroupingKey);
+        if (!groupingKey.IsSpecified)
+        {
+            return [];
+        }
+
+        var configuration = options.Value.PatternDetection;
+        var requested = vocabulary.Select(request.Context.ToFacetSet());
+
+        // The stored patterns are combinations of facets, so a context is answered by looking up the same
+        // combinations it can form - which is a bounded, keyed read rather than a scan of the scope.
+        var candidates = generator
+            .Generate(requested, configuration.MaximumCombinationSize)
+            .Select(itemset => itemset.Key);
+
+        var patterns = await storage
+            .GetEventStore(request.EventStore)
+            .GetNamespace(request.Namespace)
+            .Patterns
+            .GetMatching(groupingKey, candidates);
+
+        var minimumConfidence = request.MinimumConfidence > 0d
+            ? new PatternConfidence(request.MinimumConfidence)
+            : new PatternConfidence(configuration.MinimumConfidence);
+
+        var maximumResults = request.MaximumResults > 0 ? request.MaximumResults : DefaultMaximumResults;
+
+        return matcher
+            .Match(patterns, requested, minimumConfidence, maximumResults)
+            .Select(pattern => pattern.ToContract())
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Pattern>> GetPatternsForScope(Contracts.Patterns.GetPatternsForScopeRequest request, CallContext context = default)
+    {
+        var patterns = await storage
+            .GetEventStore(request.EventStore)
+            .GetNamespace(request.Namespace)
+            .Patterns
+            .GetForScope(new PatternGroupingKey(request.GroupingKey));
+
+        return patterns.Select(pattern => pattern.ToContract()).ToArray();
+    }
+}

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -123,6 +123,12 @@ public static class ChronicleServerSiloBuilderExtensions
                     sp.GetRequiredService<Cratis.Chronicle.Observation.Reactors.Kernel.IReactors>()),
                 new Cratis.Chronicle.Services.Namespaces(grainFactory, storage),
                 new Cratis.Chronicle.Services.Recommendations.Recommendations(grainFactory, storage),
+                new Cratis.Chronicle.Services.Patterns.Patterns(
+                    storage,
+                    sp.GetRequiredService<Cratis.Chronicle.Patterns.IFacetVocabulary>(),
+                    sp.GetRequiredService<Cratis.Chronicle.Patterns.IFacetSetGenerator>(),
+                    sp.GetRequiredService<Cratis.Chronicle.Patterns.IPatternMatcher>(),
+                    sp.GetRequiredService<IOptions<ChronicleOptions>>()),
                 new Cratis.Chronicle.Services.Identities.Identities(storage),
                 new EventSequences(
                     grainFactory,

--- a/Source/Kernel/Protobuf/patterns.proto
+++ b/Source/Kernel/Protobuf/patterns.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+package Cratis.Chronicle.Contracts.Patterns;
+
+// NOTE: This file was written by hand rather than by Source/Kernel/Protobuf/generate-protos.sh, because the
+// generator currently cannot emit this package at all - it aborts for Cratis.Chronicle.Contracts.Patterns (and 21
+// other packages) on a reserved-field error raised for
+// Cratis.Chronicle.Contracts.Events.Constraints.UniqueEventTypeConstraintDefinition, and exits 0 while doing so,
+// which is why CI never reported it. Tracked as Cratis/Chronicle#3712. Every message below matches what
+// protobuf-net would emit for the [ProtoMember] declarations in Source/Kernel/Contracts/Patterns.
+// Re-run the generator and drop this comment once #3712 is fixed.
+
+message GetPatternsForScopeRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string GroupingKey = 3;
+}
+message GetPatternsRequest {
+   string EventStore = 1;
+   string Namespace = 2;
+   string GroupingKey = 3;
+   map<string,string> Context = 4;
+   double MinimumConfidence = 5;
+   int32 MaximumResults = 6;
+}
+message IEnumerable_Pattern {
+   repeated Pattern items = 1;
+}
+message Pattern {
+   string GroupingKey = 1;
+   map<string,string> Facets = 2;
+   double Confidence = 3;
+   double Support = 4;
+   int64 Occurrences = 5;
+   double Weight = 6;
+   SerializableDateTimeOffset FirstSeen = 7;
+   SerializableDateTimeOffset LastSeen = 8;
+}
+// Represents a DateTimeOffset value as an ISO 8601 string (e.g., "2024-01-15T12:30:00.0000000+02:00").
+message SerializableDateTimeOffset {
+   string Value = 1;
+}
+service Patterns {
+   rpc GetPatterns (GetPatternsRequest) returns (IEnumerable_Pattern);
+   rpc GetPatternsForScope (GetPatternsForScopeRequest) returns (IEnumerable_Pattern);
+}

--- a/Source/Kernel/Server/GrpcServiceRegistrations.cs
+++ b/Source/Kernel/Server/GrpcServiceRegistrations.cs
@@ -23,6 +23,7 @@ public static class GrpcServiceRegistrations
         services.AddSingleton<Contracts.EventStores.IEventStores, Services.EventStores>();
         services.AddSingleton<Contracts.Namespaces.INamespaces, Services.Namespaces>();
         services.AddSingleton<Contracts.Recommendations.IRecommendations, Services.Recommendations.Recommendations>();
+        services.AddSingleton<Contracts.Patterns.IPatterns, Services.Patterns.Patterns>();
         services.AddSingleton<Contracts.Identities.IIdentities, Services.Identities.Identities>();
         services.AddSingleton<Contracts.EventSequences.IEventSequences, Services.EventSequences.EventSequences>();
         services.AddSingleton<Contracts.Events.IEventTypes, Services.Events.EventTypes>();
@@ -62,6 +63,7 @@ public static class GrpcServiceRegistrations
             _.MapGrpcService<Services.EventStores>();
             _.MapGrpcService<Services.Namespaces>();
             _.MapGrpcService<Services.Recommendations.Recommendations>();
+            _.MapGrpcService<Services.Patterns.Patterns>();
             _.MapGrpcService<Services.Identities.Identities>();
             _.MapGrpcService<Services.EventSequences.EventSequences>();
             _.MapGrpcService<Services.Events.EventTypes>();

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/given/a_storage_with_patterns_for_two_scopes.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/given/a_storage_with_patterns_for_two_scopes.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.given;
+
+public class a_storage_with_patterns_for_two_scopes : Specification
+{
+    protected BehaviorPatternStorage _storage;
+    protected BehaviorPattern _mondayMorning;
+    protected BehaviorPattern _monday;
+    protected BehaviorPattern _forSomebodyElse;
+
+    async Task Establish()
+    {
+        _storage = new();
+
+        _mondayMorning = Pattern("user-42", [new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "Morning")]);
+        _monday = Pattern("user-42", [new Facet(FacetName.Day, "Monday")]);
+        _forSomebodyElse = Pattern("user-7", [new Facet(FacetName.Day, "Monday")]);
+
+        await _storage.Save([_mondayMorning, _monday, _forSomebodyElse]);
+    }
+
+    protected static BehaviorPattern Pattern(PatternGroupingKey groupingKey, IEnumerable<Facet> facets, double confidence = 0.9d) =>
+        new(groupingKey, new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/candidates_for_a_scope.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/candidates_for_a_scope.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_getting_matching;
+
+public class candidates_for_a_scope : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    async Task Because() => _result = await _storage.GetMatching(
+        "user-42",
+        [_mondayMorning.Facets.Key, _monday.Facets.Key, new FacetSetKey("Day=Tuesday")]);
+
+    [Fact] void should_return_the_candidates_it_holds() => _result.Count().ShouldEqual(2);
+    [Fact] void should_return_the_more_specific_one() => _result.ShouldContain(_mondayMorning);
+    [Fact] void should_return_the_broader_one() => _result.ShouldContain(_monday);
+    [Fact] void should_not_return_a_candidate_it_does_not_hold() => _result.Any(_ => _.Facets.Key.Value == "Day=Tuesday").ShouldBeFalse();
+    [Fact] void should_not_reach_into_another_scope() => _result.ShouldNotContain(_forSomebodyElse);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/candidates_for_a_scope_that_holds_nothing.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/candidates_for_a_scope_that_holds_nothing.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_getting_matching;
+
+public class candidates_for_a_scope_that_holds_nothing : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _matching;
+    IEnumerable<BehaviorPattern> _all;
+
+    async Task Because()
+    {
+        _matching = await _storage.GetMatching("user-nobody", [_monday.Facets.Key]);
+        _all = await _storage.GetForScope("user-nobody");
+    }
+
+    [Fact] void should_return_nothing_for_a_lookup() => _matching.ShouldBeEmpty();
+    [Fact] void should_return_nothing_for_the_whole_scope() => _all.ShouldBeEmpty();
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/no_candidates_at_all.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_getting_matching/no_candidates_at_all.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_getting_matching;
+
+/// <summary>
+/// An empty candidate set asks for nothing, and must therefore return nothing. Treating it as "do not narrow" -
+/// the way a query criteria sentinel would - would hand back everything the scope has ever done in answer to a
+/// question about no context at all.
+/// </summary>
+public class no_candidates_at_all : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    async Task Because() => _result = await _storage.GetMatching("user-42", []);
+
+    [Fact] void should_return_nothing() => _result.ShouldBeEmpty();
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_removing/everything_because_nothing_survived.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_removing/everything_because_nothing_survived.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_removing;
+
+/// <summary>
+/// A scope whose behavior has all decayed below the threshold survives with nothing, and an empty surviving set
+/// has to mean exactly that. Reading it as "nothing to remove" would leave stale behavior on record forever.
+/// </summary>
+public class everything_because_nothing_survived : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _remaining;
+    IEnumerable<PatternGroupingKey> _scopes;
+
+    async Task Because()
+    {
+        await _storage.RemoveAllExcept("user-42", []);
+        _remaining = await _storage.GetForScope("user-42");
+        _scopes = await _storage.GetScopes();
+    }
+
+    [Fact] void should_remove_everything_for_the_scope() => _remaining.ShouldBeEmpty();
+    [Fact] void should_leave_the_other_scope_listed() => _scopes.ShouldContain(new PatternGroupingKey("user-7"));
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_removing/everything_except_the_surviving_patterns.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_removing/everything_except_the_surviving_patterns.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_removing;
+
+public class everything_except_the_surviving_patterns : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _remaining;
+    IEnumerable<BehaviorPattern> _otherScope;
+
+    async Task Because()
+    {
+        await _storage.RemoveAllExcept("user-42", [_mondayMorning.Facets.Key]);
+        _remaining = await _storage.GetForScope("user-42");
+        _otherScope = await _storage.GetForScope("user-7");
+    }
+
+    [Fact] void should_keep_the_surviving_pattern() => _remaining.ShouldContainOnly(_mondayMorning);
+    [Fact] void should_leave_another_scope_alone() => _otherScope.ShouldContainOnly(_forSomebodyElse);
+}

--- a/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_saving/a_pattern_that_is_already_held.cs
+++ b/Source/Kernel/Storage.InMemory.Specs/Patterns/for_BehaviorPatternStorage/when_saving/a_pattern_that_is_already_held.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns.for_BehaviorPatternStorage.when_saving;
+
+/// <summary>
+/// Mining reports what a scope's behavior currently is, not what changed. Saving is therefore a replace: a scope
+/// that keeps doing the same thing must not accumulate a row per flush.
+/// </summary>
+public class a_pattern_that_is_already_held : given.a_storage_with_patterns_for_two_scopes
+{
+    IEnumerable<BehaviorPattern> _result;
+
+    async Task Because()
+    {
+        await _storage.Save([Pattern("user-42", [new Facet(FacetName.Day, "Monday")], confidence: 0.42d)]);
+        _result = await _storage.GetForScope("user-42");
+    }
+
+    [Fact] void should_not_add_a_second_row_for_it() => _result.Count().ShouldEqual(2);
+    [Fact] void should_hold_the_new_confidence() =>
+        _result.Single(_ => _.Specificity == 1).Confidence.Value.ShouldEqual(0.42d);
+}

--- a/Source/Kernel/Storage.InMemory/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.InMemory/EventStoreNamespaceStorage.cs
@@ -16,12 +16,14 @@ using Cratis.Chronicle.Storage.InMemory.Identities;
 using Cratis.Chronicle.Storage.InMemory.Jobs;
 using Cratis.Chronicle.Storage.InMemory.Keys;
 using Cratis.Chronicle.Storage.InMemory.Observation;
+using Cratis.Chronicle.Storage.InMemory.Patterns;
 using Cratis.Chronicle.Storage.InMemory.Projections;
 using Cratis.Chronicle.Storage.InMemory.Recommendations;
 using Cratis.Chronicle.Storage.InMemory.Seeding;
 using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Keys;
 using Cratis.Chronicle.Storage.Observation;
+using Cratis.Chronicle.Storage.Patterns;
 using Cratis.Chronicle.Storage.Projections;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Recommendations;
@@ -76,6 +78,9 @@ public sealed class EventStoreNamespaceStorage(
 
     /// <inheritdoc/>
     public IRecommendationStorage Recommendations { get; } = new RecommendationStorage();
+
+    /// <inheritdoc/>
+    public IBehaviorPatternStorage Patterns { get; } = new BehaviorPatternStorage();
 
     /// <inheritdoc/>
     public IObserverKeyIndexes ObserverKeyIndexes { get; } = new ObserverKeyIndexes();

--- a/Source/Kernel/Storage.InMemory/Patterns/BehaviorPatternStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Patterns/BehaviorPatternStorage.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Storage.Patterns;
+
+namespace Cratis.Chronicle.Storage.InMemory.Patterns;
+
+/// <summary>
+/// Represents an in-memory implementation of <see cref="IBehaviorPatternStorage"/>.
+/// </summary>
+public class BehaviorPatternStorage : IBehaviorPatternStorage
+{
+    readonly ConcurrentDictionary<PatternGroupingKey, ConcurrentDictionary<FacetSetKey, BehaviorPattern>> _patterns = new();
+
+    /// <inheritdoc/>
+    public Task Save(IEnumerable<BehaviorPattern> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            ForScope(pattern.GroupingKey)[pattern.Facets.Key] = pattern;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<BehaviorPattern>> GetForScope(PatternGroupingKey groupingKey) =>
+        Task.FromResult<IEnumerable<BehaviorPattern>>(
+            _patterns.TryGetValue(groupingKey, out var forScope) ? [.. forScope.Values] : []);
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<BehaviorPattern>> GetMatching(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> candidates)
+    {
+        if (!_patterns.TryGetValue(groupingKey, out var forScope))
+        {
+            return Task.FromResult<IEnumerable<BehaviorPattern>>([]);
+        }
+
+        var matching = candidates
+            .Distinct()
+            .Where(forScope.ContainsKey)
+            .Select(key => forScope[key])
+            .ToArray();
+
+        return Task.FromResult<IEnumerable<BehaviorPattern>>(matching);
+    }
+
+    /// <inheritdoc/>
+    public Task<IEnumerable<PatternGroupingKey>> GetScopes() =>
+        Task.FromResult<IEnumerable<PatternGroupingKey>>([.. _patterns.Keys]);
+
+    /// <inheritdoc/>
+    public Task RemoveAllExcept(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> surviving)
+    {
+        if (!_patterns.TryGetValue(groupingKey, out var forScope))
+        {
+            return Task.CompletedTask;
+        }
+
+        var keep = surviving.ToHashSet();
+        foreach (var key in forScope.Keys.Where(key => !keep.Contains(key)))
+        {
+            forScope.TryRemove(key, out _);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    ConcurrentDictionary<FacetSetKey, BehaviorPattern> ForScope(PatternGroupingKey groupingKey) =>
+        _patterns.GetOrAdd(groupingKey, _ => new ConcurrentDictionary<FacetSetKey, BehaviorPattern>());
+}

--- a/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
@@ -21,9 +21,11 @@ using Cratis.Chronicle.Storage.MongoDB.Identities;
 using Cratis.Chronicle.Storage.MongoDB.Jobs;
 using Cratis.Chronicle.Storage.MongoDB.Keys;
 using Cratis.Chronicle.Storage.MongoDB.Observation;
+using Cratis.Chronicle.Storage.MongoDB.Patterns;
 using Cratis.Chronicle.Storage.MongoDB.ReadModels;
 using Cratis.Chronicle.Storage.MongoDB.Recommendations;
 using Cratis.Chronicle.Storage.Observation;
+using Cratis.Chronicle.Storage.Patterns;
 using Cratis.Chronicle.Storage.Projections;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Recommendations;
@@ -99,6 +101,7 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
         InFlightEvents = new InFlightEventsStorage(eventStoreNamespaceDatabase);
         ObserverHandledCounts = new ObserverHandledCountsStorage(eventStoreNamespaceDatabase);
         Recommendations = new RecommendationStorage(eventStoreNamespaceDatabase);
+        Patterns = new BehaviorPatternStorage(eventStoreNamespaceDatabase);
         ObserverKeyIndexes = new ObserverKeyIndexes(eventStoreNamespaceDatabase, observerDefinitionsStorage);
         Sinks = sinks;
         ReplayContexts = new ReplayContexts(new ReplayContextsStorage(eventStoreNamespaceDatabase));
@@ -140,6 +143,9 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
 
     /// <inheritdoc/>
     public IRecommendationStorage Recommendations { get; }
+
+    /// <inheritdoc/>
+    public IBehaviorPatternStorage Patterns { get; }
 
     /// <inheritdoc/>
     public IObserverKeyIndexes ObserverKeyIndexes { get; }

--- a/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPattern.cs
+++ b/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPattern.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Patterns;
+
+/// <summary>
+/// Represents the MongoDB representation of a <see cref="Concepts.Patterns.BehaviorPattern"/>.
+/// </summary>
+/// <remarks>
+/// The facet set is stored as its canonical key alongside the facets it is made of. The key is what lookups filter
+/// on, and the facets are what a caller reads - deriving one from the other on every read would make the lookup a
+/// scan, and storing only the key would make the pattern unreadable.
+/// </remarks>
+public class BehaviorPattern
+{
+    /// <summary>
+    /// Gets or sets the identifier of the pattern, unique across scopes.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the <see cref="PatternGroupingKey"/> the pattern belongs to.
+    /// </summary>
+    public PatternGroupingKey GroupingKey { get; set; } = PatternGroupingKey.Unspecified;
+
+    /// <summary>
+    /// Gets or sets the <see cref="FacetSetKey"/> identifying the facet combination.
+    /// </summary>
+    public FacetSetKey FacetSetKey { get; set; } = FacetSetKey.Empty;
+
+    /// <summary>
+    /// Gets or sets the facets the pattern is expressed in.
+    /// </summary>
+    public IList<PatternFacet> Facets { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets how many times the pattern has been observed.
+    /// </summary>
+    public long Occurrences { get; set; }
+
+    /// <summary>
+    /// Gets or sets how often the pattern holds when its context is present.
+    /// </summary>
+    public double Confidence { get; set; }
+
+    /// <summary>
+    /// Gets or sets the share of all observed events the pattern was seen in.
+    /// </summary>
+    public double Support { get; set; }
+
+    /// <summary>
+    /// Gets or sets the recency-weighted strength of the pattern.
+    /// </summary>
+    public double Weight { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the pattern was first observed.
+    /// </summary>
+    public DateTimeOffset FirstSeen { get; set; }
+
+    /// <summary>
+    /// Gets or sets when the pattern was last observed.
+    /// </summary>
+    public DateTimeOffset LastSeen { get; set; }
+}

--- a/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPatternConverters.cs
+++ b/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPatternConverters.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using KernelBehaviorPattern = Cratis.Chronicle.Concepts.Patterns.BehaviorPattern;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Patterns;
+
+/// <summary>
+/// Extension methods for converting patterns between their kernel and MongoDB representations.
+/// </summary>
+public static class BehaviorPatternConverters
+{
+    /// <summary>
+    /// Convert a kernel <see cref="KernelBehaviorPattern"/> to its MongoDB representation.
+    /// </summary>
+    /// <param name="pattern">The pattern to convert.</param>
+    /// <returns>The converted <see cref="BehaviorPattern"/>.</returns>
+    public static BehaviorPattern ToMongoDB(this KernelBehaviorPattern pattern) => new()
+    {
+        Id = IdFor(pattern.GroupingKey, pattern.Facets.Key),
+        GroupingKey = pattern.GroupingKey,
+        FacetSetKey = pattern.Facets.Key,
+        Facets = [.. pattern.Facets.Facets.Select(facet => new PatternFacet { Name = facet.Name, Value = facet.Value })],
+        Occurrences = pattern.Occurrences.Value,
+        Confidence = pattern.Confidence.Value,
+        Support = pattern.Support.Value,
+        Weight = pattern.Weight.Value,
+        FirstSeen = pattern.FirstSeen,
+        LastSeen = pattern.LastSeen
+    };
+
+    /// <summary>
+    /// Convert a MongoDB <see cref="BehaviorPattern"/> to its kernel representation.
+    /// </summary>
+    /// <param name="pattern">The pattern to convert.</param>
+    /// <returns>The converted <see cref="KernelBehaviorPattern"/>.</returns>
+    public static KernelBehaviorPattern ToKernel(this BehaviorPattern pattern) => new(
+        pattern.GroupingKey,
+        new FacetSet(pattern.Facets.Select(facet => new Facet(facet.Name, facet.Value))),
+        pattern.Occurrences,
+        pattern.Confidence,
+        pattern.Support,
+        pattern.Weight,
+        pattern.FirstSeen,
+        pattern.LastSeen);
+
+    /// <summary>
+    /// Gets the identifier a pattern is stored under.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> the pattern belongs to.</param>
+    /// <param name="facetSetKey">The <see cref="FacetSetKey"/> identifying the facet combination.</param>
+    /// <returns>The identifier.</returns>
+    /// <remarks>
+    /// A pattern is one facet combination within one scope, so the identity is the pair. Making that the document
+    /// identifier is what lets a mining flush be an upsert rather than a read-compare-write.
+    /// </remarks>
+    public static string IdFor(PatternGroupingKey groupingKey, FacetSetKey facetSetKey) =>
+        $"{groupingKey.Value}|{facetSetKey.Value}";
+}

--- a/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPatternStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/Patterns/BehaviorPatternStorage.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Storage.Patterns;
+using MongoDB.Driver;
+using KernelBehaviorPattern = Cratis.Chronicle.Concepts.Patterns.BehaviorPattern;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Patterns;
+
+/// <summary>
+/// Represents a MongoDB implementation of <see cref="IBehaviorPatternStorage"/>.
+/// </summary>
+/// <param name="database">The <see cref="IEventStoreNamespaceDatabase"/> the patterns are held in.</param>
+public class BehaviorPatternStorage(IEventStoreNamespaceDatabase database) : IBehaviorPatternStorage
+{
+    IMongoCollection<BehaviorPattern> Collection => database.GetCollection<BehaviorPattern>(WellKnownCollectionNames.BehaviorPatterns);
+
+    /// <inheritdoc/>
+    public async Task Save(IEnumerable<KernelBehaviorPattern> patterns)
+    {
+        var writes = patterns
+            .Select(pattern => pattern.ToMongoDB())
+            .Select(document => new ReplaceOneModel<BehaviorPattern>(
+                Builders<BehaviorPattern>.Filter.Eq(_ => _.Id, document.Id),
+                document)
+            {
+                IsUpsert = true
+            })
+            .ToArray();
+
+        if (writes.Length == 0)
+        {
+            return;
+        }
+
+        await Collection.BulkWriteAsync(writes);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<KernelBehaviorPattern>> GetForScope(PatternGroupingKey groupingKey)
+    {
+        using var cursor = await Collection.FindAsync(Builders<BehaviorPattern>.Filter.Eq(_ => _.GroupingKey, groupingKey));
+        var patterns = await cursor.ToListAsync();
+        return [.. patterns.Select(pattern => pattern.ToKernel())];
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<KernelBehaviorPattern>> GetMatching(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> candidates)
+    {
+        var keys = candidates.Distinct().ToArray();
+        if (keys.Length == 0)
+        {
+            return [];
+        }
+
+        var filter = Builders<BehaviorPattern>.Filter.And(
+            Builders<BehaviorPattern>.Filter.Eq(_ => _.GroupingKey, groupingKey),
+            Builders<BehaviorPattern>.Filter.In(_ => _.FacetSetKey, keys));
+
+        using var cursor = await Collection.FindAsync(filter);
+        var patterns = await cursor.ToListAsync();
+        return [.. patterns.Select(pattern => pattern.ToKernel())];
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<PatternGroupingKey>> GetScopes()
+    {
+        using var cursor = await Collection.DistinctAsync(_ => _.GroupingKey, FilterDefinition<BehaviorPattern>.Empty);
+        return await cursor.ToListAsync();
+    }
+
+    /// <inheritdoc/>
+    public Task RemoveAllExcept(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> surviving)
+    {
+        var filter = Builders<BehaviorPattern>.Filter.And(
+            Builders<BehaviorPattern>.Filter.Eq(_ => _.GroupingKey, groupingKey),
+            Builders<BehaviorPattern>.Filter.Nin(_ => _.FacetSetKey, surviving.Distinct()));
+
+        return Collection.DeleteManyAsync(filter);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB/Patterns/PatternFacet.cs
+++ b/Source/Kernel/Storage.MongoDB/Patterns/PatternFacet.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Patterns;
+
+/// <summary>
+/// Represents the MongoDB representation of a <see cref="Facet"/>.
+/// </summary>
+public class PatternFacet
+{
+    /// <summary>
+    /// Gets or sets the <see cref="FacetName"/>.
+    /// </summary>
+    public FacetName Name { get; set; } = FacetName.Unspecified;
+
+    /// <summary>
+    /// Gets or sets the <see cref="FacetValue"/>.
+    /// </summary>
+    public FacetValue Value { get; set; } = FacetValue.Unspecified;
+}

--- a/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
+++ b/Source/Kernel/Storage.MongoDB/WellKnownCollectionNames.cs
@@ -94,6 +94,11 @@ public static class WellKnownCollectionNames
     public const string Recommendations = "recommendations";
 
     /// <summary>
+    /// The collection that holds the behavior patterns that survived mining.
+    /// </summary>
+    public const string BehaviorPatterns = "behavior-patterns";
+
+    /// <summary>
     /// The collection that holds reactor definitions.
     /// </summary>
     public const string ReactorDefinitions = "reactors";

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
@@ -12,6 +12,7 @@ using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Keys;
 using Cratis.Chronicle.Storage.Observation;
+using Cratis.Chronicle.Storage.Patterns;
 using Cratis.Chronicle.Storage.Projections;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Recommendations;
@@ -63,6 +64,9 @@ public class EventStoreNamespaceStorage(EventStoreName eventStore, EventStoreNam
 
     /// <inheritdoc/>
     public IRecommendationStorage Recommendations { get; } = new Recommendations.RecommendationStorage(eventStore, @namespace, database);
+
+    /// <inheritdoc/>
+    public IBehaviorPatternStorage Patterns { get; } = new Patterns.BehaviorPatternStorage(eventStore, @namespace, database);
 
     /// <inheritdoc/>
     public IObserverKeyIndexes ObserverKeyIndexes { get; } = new ObserverKeyIndexes.ObserverKeyIndexes(eventStore, @namespace, database, observerDefinitionsStorage);

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceDbContext.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceDbContext.cs
@@ -49,6 +49,11 @@ public class NamespaceDbContext(DbContextOptions<NamespaceDbContext> options) : 
     public DbSet<Recommendations.Recommendation> Recommendations { get; set; } = null!;
 
     /// <summary>
+    /// Gets or sets the behavior patterns DbSet.
+    /// </summary>
+    public DbSet<Patterns.BehaviorPattern> BehaviorPatterns { get; set; } = null!;
+
+    /// <summary>
     /// Gets or sets the replay contexts DbSet.
     /// </summary>
     public DbSet<ReplayContexts.ReplayContextEntry> ReplayContexts { get; set; } = null!;
@@ -93,11 +98,17 @@ public class NamespaceDbContext(DbContextOptions<NamespaceDbContext> options) : 
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.Entity<ClosedStreamEntry>(entity =>
-        {
-            entity.ToTable(WellKnownTableNames.ClosedStreams);
-            entity.HasKey(e => new { e.EventSequenceId, e.StreamType, e.StreamId });
-        });
+        modelBuilder
+            .Entity<ClosedStreamEntry>(entity =>
+            {
+                entity.ToTable(WellKnownTableNames.ClosedStreams);
+                entity.HasKey(e => new { e.EventSequenceId, e.StreamType, e.StreamId });
+            })
+            .Entity<Patterns.BehaviorPattern>(entity =>
+            {
+                entity.ToTable(WellKnownTableNames.BehaviorPatterns);
+                entity.HasKey(e => new { e.GroupingKey, e.FacetSetHash });
+            });
 
         // Match the column mappings to the provider-native JSON type the migrations create
         // (jsonb on Npgsql), so EF Core sends parameters with the correct OID. PostgreSQL is

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceJsonStringColumns.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceJsonStringColumns.cs
@@ -22,6 +22,7 @@ internal static class NamespaceJsonStringColumns
         (typeof(JobSteps.JobStep), "StateJson"),
         (typeof(FailedPartitions.FailedPartition), "StateJson"),
         (typeof(Recommendations.Recommendation), "RequestJson"),
+        (typeof(Patterns.BehaviorPattern), "FacetsJson"),
         (typeof(Projections.ProjectionFutureEntity), "EventContentJson"),
         (typeof(Projections.ProjectionFutureEntity), "ParentKeyJson"),
         (typeof(Changesets.Changeset), "ChangesetData"),

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPattern.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPattern.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Patterns;
+
+/// <summary>
+/// Represents a behavior pattern that survived mining, as stored in SQL.
+/// </summary>
+/// <remarks>
+/// The row is keyed by the scope and a fixed-width hash of the facet set rather than by the facet set key itself.
+/// The key is a readable, unbounded string - fine as a value, but a primary key made of it would grow past the
+/// index key size limits of the supported providers as soon as a pattern combined a few long-named facets.
+/// </remarks>
+[Table("BehaviorPatterns")]
+public record BehaviorPattern
+{
+    /// <summary>
+    /// Gets the scope the pattern belongs to.
+    /// </summary>
+    [StringLength(200)]
+    public string GroupingKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the fixed-width hash of <see cref="FacetSetKey"/> the row is keyed by.
+    /// </summary>
+    [StringLength(64)]
+    public string FacetSetHash { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the canonical key of the facet set the pattern is expressed in.
+    /// </summary>
+    public string FacetSetKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the JSON representation of the facets, keyed by facet name.
+    /// </summary>
+    public string FacetsJson { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets how many times the pattern has been observed.
+    /// </summary>
+    public long Occurrences { get; init; }
+
+    /// <summary>
+    /// Gets how often the pattern holds when its context is present.
+    /// </summary>
+    public double Confidence { get; init; }
+
+    /// <summary>
+    /// Gets the share of all observed events the pattern was seen in.
+    /// </summary>
+    public double Support { get; init; }
+
+    /// <summary>
+    /// Gets the recency-weighted strength of the pattern.
+    /// </summary>
+    public double Weight { get; init; }
+
+    /// <summary>
+    /// Gets when the pattern was first observed.
+    /// </summary>
+    public DateTimeOffset FirstSeen { get; init; }
+
+    /// <summary>
+    /// Gets when the pattern was last observed.
+    /// </summary>
+    public DateTimeOffset LastSeen { get; init; }
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPatternConverter.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPatternConverter.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Cratis.Chronicle.Concepts.Patterns;
+using KernelBehaviorPattern = Cratis.Chronicle.Concepts.Patterns.BehaviorPattern;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Patterns;
+
+/// <summary>
+/// Converts between <see cref="BehaviorPattern"/> and <see cref="KernelBehaviorPattern"/>.
+/// </summary>
+public class BehaviorPatternConverter
+{
+    /// <summary>
+    /// Converts a <see cref="KernelBehaviorPattern"/> to a <see cref="BehaviorPattern"/>.
+    /// </summary>
+    /// <param name="pattern">The pattern to convert.</param>
+    /// <returns>The pattern entity.</returns>
+    public BehaviorPattern ToEntity(KernelBehaviorPattern pattern) => new()
+    {
+        GroupingKey = pattern.GroupingKey.Value,
+        FacetSetHash = FacetSetHash.Of(pattern.Facets.Key),
+        FacetSetKey = pattern.Facets.Key.Value,
+        FacetsJson = JsonSerializer.Serialize(
+            pattern.Facets.Facets.ToDictionary(facet => facet.Name.Value, facet => facet.Value.Value)),
+        Occurrences = pattern.Occurrences.Value,
+        Confidence = pattern.Confidence.Value,
+        Support = pattern.Support.Value,
+        Weight = pattern.Weight.Value,
+        FirstSeen = pattern.FirstSeen,
+        LastSeen = pattern.LastSeen
+    };
+
+    /// <summary>
+    /// Converts a <see cref="BehaviorPattern"/> to a <see cref="KernelBehaviorPattern"/>.
+    /// </summary>
+    /// <param name="entity">The pattern entity.</param>
+    /// <returns>The kernel pattern.</returns>
+    public KernelBehaviorPattern ToKernel(BehaviorPattern entity)
+    {
+        var facets = string.IsNullOrEmpty(entity.FacetsJson)
+            ? []
+            : JsonSerializer.Deserialize<Dictionary<string, string>>(entity.FacetsJson) ?? [];
+
+        return new KernelBehaviorPattern(
+            entity.GroupingKey,
+            new FacetSet(facets.Select(pair => new Facet(new FacetName(pair.Key), new FacetValue(pair.Value)))),
+            entity.Occurrences,
+            entity.Confidence,
+            entity.Support,
+            entity.Weight,
+            entity.FirstSeen,
+            entity.LastSeen);
+    }
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPatternStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/BehaviorPatternStorage.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Storage.Patterns;
+using Microsoft.EntityFrameworkCore;
+using KernelBehaviorPattern = Cratis.Chronicle.Concepts.Patterns.BehaviorPattern;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Patterns;
+
+/// <summary>
+/// Represents an implementation of <see cref="IBehaviorPatternStorage"/> for SQL.
+/// </summary>
+/// <param name="eventStore">The name of the event store.</param>
+/// <param name="namespace">The name of the namespace.</param>
+/// <param name="database">The <see cref="IDatabase"/> to use for storage operations.</param>
+public class BehaviorPatternStorage(EventStoreName eventStore, EventStoreNamespaceName @namespace, IDatabase database) : IBehaviorPatternStorage
+{
+    readonly BehaviorPatternConverter _converter = new();
+
+    /// <inheritdoc/>
+    public async Task Save(IEnumerable<KernelBehaviorPattern> patterns)
+    {
+        var entities = patterns.Select(_converter.ToEntity).ToArray();
+        if (entities.Length == 0)
+        {
+            return;
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        foreach (var entity in entities)
+        {
+            await scope.DbContext.BehaviorPatterns.Upsert(entity);
+        }
+
+        await scope.DbContext.SaveChangesAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<KernelBehaviorPattern>> GetForScope(PatternGroupingKey groupingKey)
+    {
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var entities = await scope.DbContext.BehaviorPatterns
+            .Where(pattern => pattern.GroupingKey == groupingKey.Value)
+            .ToListAsync();
+
+        return [.. entities.Select(_converter.ToKernel)];
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<KernelBehaviorPattern>> GetMatching(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> candidates)
+    {
+        var hashes = candidates.Distinct().Select(FacetSetHash.Of).ToArray();
+        if (hashes.Length == 0)
+        {
+            return [];
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var entities = await scope.DbContext.BehaviorPatterns
+            .Where(pattern => pattern.GroupingKey == groupingKey.Value && hashes.Contains(pattern.FacetSetHash))
+            .ToListAsync();
+
+        return [.. entities.Select(_converter.ToKernel)];
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<PatternGroupingKey>> GetScopes()
+    {
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var keys = await scope.DbContext.BehaviorPatterns
+            .Select(pattern => pattern.GroupingKey)
+            .Distinct()
+            .ToListAsync();
+
+        return [.. keys.Select(key => new PatternGroupingKey(key))];
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveAllExcept(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> surviving)
+    {
+        var hashes = surviving.Distinct().Select(FacetSetHash.Of).ToArray();
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var doomed = await scope.DbContext.BehaviorPatterns
+            .Where(pattern => pattern.GroupingKey == groupingKey.Value && !hashes.Contains(pattern.FacetSetHash))
+            .ToListAsync();
+
+        if (doomed.Count == 0)
+        {
+            return;
+        }
+
+        scope.DbContext.BehaviorPatterns.RemoveRange(doomed);
+        await scope.DbContext.SaveChangesAsync();
+    }
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/FacetSetHash.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/FacetSetHash.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Patterns;
+
+/// <summary>
+/// Provides the fixed-width hash a behavior pattern row is keyed by.
+/// </summary>
+/// <remarks>
+/// SHA-256 rather than a cheaper non-cryptographic hash: this is a primary key, and two distinct facet sets
+/// colliding would silently overwrite one pattern with another. It is not a security boundary - the property that
+/// matters is that the value is stable across processes, runtimes and restarts, which rules out
+/// <see cref="string.GetHashCode()"/>.
+/// </remarks>
+public static class FacetSetHash
+{
+    /// <summary>
+    /// Gets the hash of a facet set key.
+    /// </summary>
+    /// <param name="key">The <see cref="FacetSetKey"/> to hash.</param>
+    /// <returns>The lowercase hexadecimal hash.</returns>
+    public static string Of(FacetSetKey key) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(key.Value)));
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/Migrations/v16_39_0.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/Patterns/Migrations/v16_39_0.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.EntityFrameworkCore;
+using Cratis.Arc.EntityFrameworkCore.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.Patterns.Migrations;
+
+#nullable disable
+#pragma warning disable SA1600, SA1402, MA0048
+
+[DbContext(typeof(NamespaceDbContext))]
+[Migration($"NS-{WellKnownTableNames.BehaviorPatterns}-{nameof(v16_39_0)}")]
+public class v16_39_0 : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: WellKnownTableNames.BehaviorPatterns,
+            columns: table => new
+            {
+                GroupingKey = table.StringColumn(migrationBuilder, maxLength: 200, nullable: false),
+                FacetSetHash = table.StringColumn(migrationBuilder, maxLength: 64, nullable: false),
+                FacetSetKey = table.StringColumn(migrationBuilder),
+                FacetsJson = table.JsonColumn<string>(migrationBuilder),
+                Occurrences = table.NumberColumn<long>(migrationBuilder, nullable: false),
+                Confidence = table.NumberColumn<double>(migrationBuilder, nullable: false),
+                Support = table.NumberColumn<double>(migrationBuilder, nullable: false),
+                Weight = table.NumberColumn<double>(migrationBuilder, nullable: false),
+                FirstSeen = table.Column<DateTimeOffset>(nullable: false),
+                LastSeen = table.Column<DateTimeOffset>(nullable: false)
+            },
+            constraints: table => table.PrimaryKey(
+                $"PK_{WellKnownTableNames.BehaviorPatterns}",
+                x => new { x.GroupingKey, x.FacetSetHash }));
+
+        migrationBuilder.CreateIndex(
+            name: $"IX_{WellKnownTableNames.BehaviorPatterns}_LastSeen",
+            table: WellKnownTableNames.BehaviorPatterns,
+            column: "LastSeen");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: WellKnownTableNames.BehaviorPatterns);
+    }
+}

--- a/Source/Kernel/Storage.Sql/WellKnownTableNames.cs
+++ b/Source/Kernel/Storage.Sql/WellKnownTableNames.cs
@@ -89,6 +89,11 @@ public static class WellKnownTableNames
     public const string Recommendations = "Recommendations";
 
     /// <summary>
+    /// The table that holds the behavior patterns that survived mining.
+    /// </summary>
+    public const string BehaviorPatterns = "BehaviorPatterns";
+
+    /// <summary>
     /// The table that holds observer definitions.
     /// </summary>
     public const string ObserverDefinitions = "ObserverDefinitions";

--- a/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
@@ -9,6 +9,7 @@ using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Keys;
 using Cratis.Chronicle.Storage.Observation;
+using Cratis.Chronicle.Storage.Patterns;
 using Cratis.Chronicle.Storage.Projections;
 using Cratis.Chronicle.Storage.ReadModels;
 using Cratis.Chronicle.Storage.Recommendations;
@@ -66,6 +67,11 @@ public interface IEventStoreNamespaceStorage
     /// Gets the <see cref="IRecommendationStorage"/> for the event store namespace.
     /// </summary>
     IRecommendationStorage Recommendations { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IBehaviorPatternStorage"/> for the event store namespace.
+    /// </summary>
+    IBehaviorPatternStorage Patterns { get; }
 
     /// <summary>
     /// Gets the <see cref="IObserverKeyIndexes"/>  for the event store namespace.

--- a/Source/Kernel/Storage/Patterns/IBehaviorPatternStorage.cs
+++ b/Source/Kernel/Storage/Patterns/IBehaviorPatternStorage.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Storage.Patterns;
+
+/// <summary>
+/// Defines a system for working with the <see cref="BehaviorPattern">patterns</see> that survived mining.
+/// </summary>
+/// <remarks>
+/// Only surviving patterns reach storage, so what is held here scales with distinct recurring behavior rather than
+/// with event volume. Nothing per-event is ever written.
+/// </remarks>
+public interface IBehaviorPatternStorage
+{
+    /// <summary>
+    /// Save patterns, replacing any already held for the same scope and facet set.
+    /// </summary>
+    /// <param name="patterns">The <see cref="BehaviorPattern">patterns</see> to save.</param>
+    /// <returns>Awaitable task.</returns>
+    Task Save(IEnumerable<BehaviorPattern> patterns);
+
+    /// <summary>
+    /// Get every pattern held for a scope.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to get for.</param>
+    /// <returns>The <see cref="BehaviorPattern">patterns</see> held for the scope.</returns>
+    Task<IEnumerable<BehaviorPattern>> GetForScope(PatternGroupingKey groupingKey);
+
+    /// <summary>
+    /// Get the patterns of a scope whose facet set is one of a set of candidates.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to get for.</param>
+    /// <param name="candidates">The candidate <see cref="FacetSetKey">facet set keys</see> to look up.</param>
+    /// <returns>The <see cref="BehaviorPattern">patterns</see> matching any of the candidates.</returns>
+    /// <remarks>
+    /// A partial context expands to a bounded set of candidate keys, so answering "what usually happens here" is a
+    /// keyed lookup rather than a scan over everything the scope has ever done.
+    /// </remarks>
+    Task<IEnumerable<BehaviorPattern>> GetMatching(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> candidates);
+
+    /// <summary>
+    /// Get every scope that holds patterns.
+    /// </summary>
+    /// <returns>The <see cref="PatternGroupingKey">scopes</see> held.</returns>
+    Task<IEnumerable<PatternGroupingKey>> GetScopes();
+
+    /// <summary>
+    /// Remove every pattern held for a scope that is not among the given facet sets.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to remove within.</param>
+    /// <param name="surviving">The <see cref="FacetSetKey">facet set keys</see> that should remain.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// This is how a pattern that decayed below the threshold leaves storage. Mining reports what survives, not
+    /// what died, so the pruning step is expressed as "keep only these" rather than as a list of removals.
+    /// </remarks>
+    Task RemoveAllExcept(PatternGroupingKey groupingKey, IEnumerable<FacetSetKey> surviving);
+}


### PR DESCRIPTION
# Summary

The first slice of pattern detection: Chronicle mines its event history for recurring behavior and can answer "what usually happens in this context?" with something backed by what actually happened. This covers the mining engine, storage, the gRPC and .NET client surfaces, and the documentation. The kernel reactor that feeds it, the Workbench views and the demo sample set follow.

## Added

- Behavior pattern detection in the kernel: contextual facets are read off each event, mined into recurring combinations with a bounded Lossy Counting sketch, and only combinations clearing the support and confidence thresholds are persisted. Storage scales with distinct recurring behavior rather than with event volume. (#3857)
- `Patterns` gRPC service with `GetPatterns`, which answers a partial context ranked by specificity and then confidence, and `GetPatternsForScope`, which lists everything a scope has established. (#3857)
- `IEventStore.Patterns` on the .NET client for asking what a scope usually does in a context, and for browsing everything it has established. Nothing clearing the confidence bar returns nothing rather than the best of a bad set. (#3857)
- `Cratis:Chronicle:PatternDetection` configuration for which facets participate, the largest combination size, the Lossy Counting error parameter, the support and confidence thresholds, and the daily decay factor. (#3857)
- `ICausationManager.BeginScope`, which puts a causation on the chain and takes it off again when disposed. `Add` is append-only, which is right for a link describing how work arrived and wrong for one describing a bounded piece of work — two such pieces done one after the other would leave the second reading as caused by the first. (#3857)
- Documentation for behavior patterns and for the .NET pattern API.

## Changed

- Pattern mining reads a causation that carries a `commandType` property by that name rather than by its causation type, so commands are distinguishable from each other instead of sharing one value.
