### PR TITLE
Declare System.Collections.Immutable for net8.0 in Cratis.Chronicle client

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,9 @@
   <ItemGroup>
     <!-- System -->
     <PackageVersion Include="System.Reactive" Version="7.0.0" />
+    <!-- net8.0 only: the client compiles against System.Collections.Immutable 10.0.0 transitively, but the SDK
+         prunes it from declared dependencies. Declare it explicitly so consumers do not hit missing types. -->
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.11" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/Source/Clients/DotNET/DotNET.csproj
+++ b/Source/Clients/DotNET/DotNET.csproj
@@ -54,6 +54,12 @@
         <PackageReference Include="System.Reactive" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+        <!-- On net8.0 the package otherwise ships without declaring System.Collections.Immutable, while the
+             assembly is compiled against version 10.0.0. Declare it explicitly so consumers get the types. -->
+        <PackageReference Include="System.Collections.Immutable" />
+    </ItemGroup>
+
     <ItemGroup>
       <PackageReference Include="Cratis.Metrics.Roslyn" />
       <PackageReference Include="OpenTelemetry" />


### PR DESCRIPTION
## Summary

Cratis.Chronicle on net8.0 shipped without declaring a dependency on System.Collections.Immutable while the assembly is compiled against version 10.0.0 transitively — the SDK prunes it from the declared package dependencies. Consumers on net8.0 hit missing types until they add the package reference manually.

## Changes

- Add a central `PackageVersion` for `System.Collections.Immutable` 10.0.0 in `Directory.Packages.props`.
- Add a net8.0-conditional `PackageReference` in `Source/Clients/DotNET/DotNET.csproj` so the NuGet package declares the dependency.

## Verification

- `dotnet build Source/Clients/DotNET/DotNET.csproj -p:IsPackaging=true -c Release -m:1` builds all three targets (net8.0, net9.0, net10.0) with 0 warnings, 0 errors.