### PR TITLE
Make IEventStore.Patterns optional so existing implementers keep loading

### DIFF
--- a/Source/Clients/DotNET.Specs/Patterns/for_IEventStore/when_an_implementation_does_not_support_patterns.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_IEventStore/when_an_implementation_does_not_support_patterns.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Compliance.GDPR;
+using Cratis.Chronicle.Connections;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventStoreSubscriptions;
+using Cratis.Chronicle.ExternalServices;
+using Cratis.Chronicle.Identities;
+using Cratis.Chronicle.Jobs;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Reactors;
+using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Reducers;
+using Cratis.Chronicle.Registrations;
+using Cratis.Chronicle.Seeding;
+using Cratis.Chronicle.Transactions;
+using Cratis.Chronicle.Webhooks;
+
+namespace Cratis.Chronicle.Patterns.for_IEventStore;
+
+/// <summary>
+/// An event store written before patterns existed - a test double, a scenario harness in a consuming framework -
+/// must keep compiling and loading. It says it does not support patterns by throwing, never by answering with
+/// something that looks like an absence of behavior.
+/// </summary>
+public class when_an_implementation_does_not_support_patterns : Specification
+{
+    Exception _exception;
+    IPatterns _resolved;
+
+    IEventStore _eventStore;
+
+    void Establish() => _eventStore = new an_event_store_from_before_patterns();
+
+    void Because() => _exception = Catch.Exception(() => _resolved = _eventStore.Patterns);
+
+    [Fact] void should_throw_that_patterns_are_not_supported() => _exception.ShouldBeOfExactType<PatternsNotSupported>();
+
+    class an_event_store_from_before_patterns : IEventStore
+    {
+        public EventStoreName Name => EventStoreName.NotSet;
+        public EventStoreNamespaceName Namespace => EventStoreNamespaceName.NotSet;
+        public IChronicleConnection Connection => throw new NotSupportedException();
+        public IUnitOfWorkManager UnitOfWorkManager => throw new NotSupportedException();
+        public IEventTypes EventTypes => throw new NotSupportedException();
+        public IConstraints Constraints => throw new NotSupportedException();
+        public IEventLog EventLog => throw new NotSupportedException();
+        public IJobs Jobs => throw new NotSupportedException();
+        public IReactors Reactors => throw new NotSupportedException();
+        public IReducers Reducers => throw new NotSupportedException();
+        public IProjections Projections => throw new NotSupportedException();
+        public IWebhooks Webhooks => throw new NotSupportedException();
+        public IExternalServices ExternalServices => throw new NotSupportedException();
+        public IEventStoreSubscriptions Subscriptions => throw new NotSupportedException();
+        public IFailedPartitions FailedPartitions => throw new NotSupportedException();
+        public IReadModels ReadModels => throw new NotSupportedException();
+        public IReadModelReactors ReadModelReactors => throw new NotSupportedException();
+        public IEventSeeding Seeding => throw new NotSupportedException();
+        public IPIIManager PII => throw new NotSupportedException();
+        public IIdentityManager Identities => throw new NotSupportedException();
+        public RegistrationOutcome Registration => RegistrationOutcome.NotRun;
+
+        public Task DiscoverAll() => Task.CompletedTask;
+        public Task RegisterAll() => Task.CompletedTask;
+        public IEventSequence GetEventSequence(EventSequenceId id) => throw new NotSupportedException();
+        public Task<IEnumerable<EventStoreNamespaceName>> GetNamespaces(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/Source/Clients/DotNET/IEventStore.cs
+++ b/Source/Clients/DotNET/IEventStore.cs
@@ -121,7 +121,14 @@ public interface IEventStore
     /// <summary>
     /// Gets the <see cref="IPatterns"/> for the event store.
     /// </summary>
-    IPatterns Patterns { get; }
+    /// <remarks>
+    /// Optional, so that an existing implementation of this interface - a test double, a scenario harness in a
+    /// consuming framework - keeps compiling and loading without change. Adding a required member to an interface
+    /// this widely implemented breaks every implementer at type-load time, before any of their code runs. The real
+    /// event store implements it; anything that does not says so by throwing rather than by quietly answering.
+    /// </remarks>
+    /// <exception cref="PatternsNotSupported">Thrown when the implementation does not support behavior patterns.</exception>
+    IPatterns Patterns => throw new PatternsNotSupported(GetType());
 
     /// <summary>
     /// Gets the <see cref="IPIIManager"/> for managing PII encryption keys (GDPR right-to-erasure) for the event store.

--- a/Source/Clients/DotNET/Patterns/PatternsNotSupported.cs
+++ b/Source/Clients/DotNET/Patterns/PatternsNotSupported.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Patterns;
+
+/// <summary>
+/// The exception that is thrown when an event store implementation does not support behavior patterns.
+/// </summary>
+/// <param name="eventStoreType">The type of event store that does not support behavior patterns.</param>
+public class PatternsNotSupported(Type eventStoreType)
+    : Exception($"The event store implementation '{eventStoreType.FullName}' does not support behavior patterns.");


### PR DESCRIPTION
# Summary

`IEventStore` gained a `Patterns` member in 16.39.0. Adding a required member to an interface breaks every implementation of it at type-load time — before any consumer code runs — and Arc's scenario harness implements it. The consumer smoke gate caught this and stopped 16.39.0 from being pushed to NuGet, so no broken package reached anyone. This makes the member optional so the release can go out.

## Fixed

- An application installing Chronicle 16.39.0 alongside the current Arc packages failed on startup in `AddCratisArcCore` with a `TypeLoadException` for a missing `get_Patterns`. `IEventStore.Patterns` is now a default interface member, so an existing implementation of the interface keeps compiling and loading unchanged. An implementation that does not support behavior patterns throws `PatternsNotSupported` rather than answering with something that looks like an absence of behavior.
