### PR TITLE
Answer what usually happens in a context with the action taken in it

### DIFF
--- a/.github/workflows/publish-typescript-client.yml
+++ b/.github/workflows/publish-typescript-client.yml
@@ -107,6 +107,13 @@ jobs:
         working-directory: ./Source/Clients/TypeScript
         run: npm version ${{ inputs.version }} --no-git-tag-version
 
+      # --tag latest is explicit rather than implied. On 2026-08-25 a release accident published 17.0.0, and
+      # deleting the tag and the GitHub release put the series back on 16.x without taking the npm version with
+      # it - npm versions are immutable and the 72-hour unpublish window closed on 2026-08-28. npm refuses to
+      # move "latest" backwards implicitly, so every client publish since has failed with "Cannot implicitly
+      # apply the latest tag because previously published version 17.0.0 is higher". Naming the tag is the
+      # documented way to say the move is intended, and it is what makes `npm install` resolve to the series
+      # this repository actually releases instead of the ghost. See #3842.
       - name: Publish to npm
         working-directory: ./Source/Clients/TypeScript
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag latest

--- a/Documentation/clients/dotnet/patterns.md
+++ b/Documentation/clients/dotnet/patterns.md
@@ -10,8 +10,14 @@ description: Ask what a user usually does in a given context, from the .NET clie
 Most applications have one question: *what does this person normally do at this point in the week?* Every Chronicle client offers that as a single call — see [asking about a moment](/chronicle/patterns/) for the shared contract. In .NET it is `GetPatternsAt`, and it takes the scope and nothing else:
 
 ```csharp
-var patterns = await eventStore.Patterns.GetPatternsAt(userId);
+foreach (var pattern in await eventStore.Patterns.GetPatternsAt(userId))
+{
+    var command = pattern.Facets.ValueOf(FacetName.CommandType);
+    Console.WriteLine($"{command} — {pattern.Confidence.Value:P0} of the time");
+}
 ```
+
+Each answer names a **command**, and its `Confidence` is the chance of that command given the context it was established in. You get at most one answer per command, so a habit mined at several context sizes at once comes back once rather than three times.
 
 The day and the part of the day are read off the moment for you, using the same rule the engine bucketed events with when it mined them — so the answer is about the slot the behavior was actually learned in. Pass a moment to ask about a different one:
 
@@ -33,37 +39,53 @@ Derive the time bucket yourself and you own a copy of a rule the engine also own
 
 ## Asking about a context that is not a moment
 
-`GetPatterns` is the lower-level call underneath. Build a context from the facets you know and ask within a scope — normally the user whose behavior you are asking about:
+`GetUsualActions` is the call underneath. Build a context from the facets you know and ask within a scope — normally the user whose behavior you are asking about:
 
 ```csharp
 using Cratis.Chronicle.Concepts.Patterns;
 
-var patterns = await eventStore.Patterns.GetPatterns(
+var patterns = await eventStore.Patterns.GetUsualActions(
     groupingKey: userId,
     context: FacetSet.Empty
         .With(FacetName.Day, DayOfWeek.Monday.ToString())
-        .With(FacetName.TimeBucket, TimeBucket.Morning.ToString()));
+        .With(FacetName.AggregateType, "Invoice"));
 
 foreach (var pattern in patterns)
 {
-    Console.WriteLine($"{pattern.Facets} — {pattern.Confidence.Value:P0} confident, seen {pattern.Occurrences.Value} times");
+    Console.WriteLine($"{pattern.Facets.ValueOf(FacetName.CommandType)} — {pattern.Confidence.Value:P0} confident, seen {pattern.Occurrences.Value} times");
 }
 ```
 
 The context may constrain **any subset** of the facets. Facets the store does not mine are discarded rather than narrowing the lookup to nothing, so a caller can describe its situation in whatever terms it has.
 
-Results are ranked **most specific first**, then most confident. A pattern constraining everything you asked about answers your question; a broader, more confident one answers a question you did not ask.
+Results are ranked **most likely first**. Constraining `CommandType` here does nothing — it names the answer rather than the situation, and the answer is what you are asking for.
 
-:::caution
-A pattern matches when **its facets are a subset of the context you asked with**, so a query returns patterns describing the context you named — not the action taken in it. Asking about a day and a time tells you whether that slot is established; it does not yet tell you which command usually follows, because a pattern constraining `CommandType` is not a subset of a context that does not name one. Returning the action is tracked in [#3872](https://github.com/Cratis/Chronicle/issues/3872).
-:::
+## Checking whether an action is normal
+
+`GetPatterns` asks the opposite question: given a situation you can describe *completely*, including the command, which established patterns cover it? That is the check you make before flagging something as unusual, rather than the prediction above.
+
+```csharp
+var covering = await eventStore.Patterns.GetPatterns(
+    groupingKey: userId,
+    context: FacetSet.Empty
+        .With(FacetName.CommandType, "DeleteSupplier")
+        .With(FacetName.Day, DayOfWeek.Sunday.ToString())
+        .With(FacetName.TimeBucket, TimeBucket.Night.ToString()));
+
+if (!covering.Any(pattern => pattern.Facets.Constrains(FacetName.CommandType)))
+{
+    // Nothing established covers this person doing this, here.
+}
+```
+
+A pattern is returned when **its facets are a subset of the context you asked with**, so every result describes something you named. Results are ranked **most specific first**, then most confident: a pattern constraining everything you asked about describes your situation; a broader, more confident one describes a situation you did not ask about.
 
 ### An empty result is an answer
 
-`GetPatterns` returns nothing when no pattern clears the confidence bar. That is a true statement — this scope has no established behavior for this context — and it is deliberately not padded with the best of a bad set. Treat "no patterns" as "do not claim to know":
+Both calls return nothing when no pattern clears the confidence bar. That is a true statement — this scope has no established behavior for this context — and it is deliberately not padded with the best of a bad set. Treat "no patterns" as "do not claim to know":
 
 ```csharp
-var patterns = await eventStore.Patterns.GetPatterns(userId, context);
+var patterns = await eventStore.Patterns.GetUsualActions(userId, context);
 if (!patterns.Any())
 {
     return "I don't have enough history to say what usually happens here.";
@@ -73,7 +95,7 @@ if (!patterns.Any())
 ### Thresholds and limits
 
 ```csharp
-var patterns = await eventStore.Patterns.GetPatterns(
+var patterns = await eventStore.Patterns.GetUsualActions(
     groupingKey: userId,
     context: context,
     minimumConfidence: new PatternConfidence(0.8d),
@@ -85,7 +107,7 @@ Leave `minimumConfidence` and `maximumResults` unset to use whatever the **serve
 
 ## Browsing everything a scope established
 
-`GetPatternsForScope` is the listing call — everything held for a scope, unfiltered, including patterns below the confidence threshold. It is what a browsing view binds to, as opposed to `GetPatterns`, which answers a question about one situation.
+`GetPatternsForScope` is the listing call — everything held for a scope, unfiltered, including patterns below the confidence threshold. It is what a browsing view binds to, as opposed to the two calls above, which each answer a question about one situation.
 
 ```csharp
 var everything = await eventStore.Patterns.GetPatternsForScope(userId);
@@ -100,7 +122,7 @@ foreach (var scope in await eventStore.Patterns.GetScopes())
 }
 ```
 
-The scopes returned are the ones that actually hold patterns, not every identity that ever appeared in the store. A scope missing from the list has established no behavior yet — which is the same answer an empty `GetPatterns` gives, one level up.
+The scopes returned are the ones that actually hold patterns, not every identity that ever appeared in the store. A scope missing from the list has established no behavior yet — which is the same answer an empty `GetUsualActions` gives, one level up.
 
 ## What you get back
 

--- a/Documentation/patterns/index.md
+++ b/Documentation/patterns/index.md
@@ -89,19 +89,28 @@ Without such a link the mined `CommandType` falls back to the event type, which 
 
 Ask what usually happens with the [.NET client's pattern API](/chronicle/clients/dotnet/patterns/), or over gRPC through the `Patterns` service:
 
-- **`GetPatterns`** — given a partial context, the patterns that apply, ranked by specificity and then confidence.
+- **`GetUsualActions`** — given a situation, what is usually *done* in it, ranked by confidence.
+- **`GetPatterns`** — given a situation, the patterns that *describe* it, ranked by specificity and then confidence.
 - **`GetPatternsForScope`** — everything a scope has established, unfiltered, for browsing.
 - **`GetScopes`** — the scopes that hold any patterns at all, which is what a browsing view needs before it can offer one.
 
-Specificity outranks confidence in the ranking. A pattern constraining everything you asked about answers your question; a broader, more confident one answers a question you did not ask.
+### Two questions, and why they are different calls
 
-A pattern matches when **its facets are a subset of the asked context**. That means a query describes the context you named rather than the action taken in it: asking about a day and a part of the day says whether that slot is established, not which command usually follows. Returning the action is tracked in [#3872](https://github.com/Cratis/Chronicle/issues/3872).
+Most applications want the first one: *what does this person usually do here?* You describe the situation you are in — a day, a part of the day, the kind of thing being worked on — and the answer is the command.
+
+The second is the opposite question: *is what I am looking at normal?* There you already know the command, and you want the established patterns that cover it — which is what you check an action against before flagging it as unusual.
+
+They cannot be one call, because they compare different halves of a pattern. A pattern like `CommandType=RegisterInvoice; Day=Monday; TimeBucket=EarlyMorning` **describes** a situation only if everything it names was named in the question. But nobody asking what usually happens on a Monday morning can name the command — naming it is what they are asking for. So `GetUsualActions` compares only the *context* half of a pattern against your question and hands back the command as the answer, while `GetPatterns` compares the whole pattern and can only ever return facets you already named.
+
+`GetUsualActions` returns **at most one answer per action**. A habit is established at several context sizes at once — on a Monday, in the early morning, and on a Monday early morning are three mined combinations describing one behavior — and returning all three says the same thing three times while pushing the second-most-likely action out of a limited result set. The one kept is the one conditioned on most of your question.
+
+Ranking differs for the same reason. `GetPatterns` leads with specificity, because the pattern covering most of what you asked describes your situation best. `GetUsualActions` leads with **confidence**, which is already the chance of that action given the context it was established in — a number that compares directly between one answer and the next, where a facet count does not.
 
 **Nothing clearing the confidence bar returns nothing.** An empty answer is a true statement — this scope has no established behavior for this context — and is not padded with the best of a bad set.
 
 ## Asking about a moment
 
-The context an application usually has is a person and a point in time, so every client offers that as a single call on top of `GetPatterns`: **give it the scope, optionally give it a moment, and it fills in the rest**. The moment defaults to now.
+The context an application usually has is a person and a point in time, so every client offers that as a single call on top of `GetUsualActions`: **give it the scope, optionally give it a moment, and it fills in the rest**. The moment defaults to now.
 
 What it fills in is the `Day` and the `TimeBucket`, derived from the moment with **the same rule the engine used when it mined the events**. That rule is the load-bearing part. A caller deriving the bucket itself owns a second copy of it, and when the two drift nothing fails loudly — the query simply asks about a slot the mining never used and comes back empty. Each client therefore exposes the bucketing rule as well, so the copy never has to exist:
 
@@ -117,7 +126,7 @@ Two views under an event store's namespace read the same patterns from different
 
 **Behavior patterns** pivots every pattern in the namespace, with the scope as the first filter rather than a control above the viewer — so two people's behavior can be compared side by side instead of one being chosen before anything can be seen. The facets become the dimensions and filters, so the same set can be approached from whichever direction the question comes: by command, by who initiated it, by day or part of day, by aggregate, by what caused it, or by how specific the pattern is. Each card carries a confidence bar, so a well-established habit is distinguishable from a marginal one without reading numbers.
 
-**Pattern heatmap** answers the narrower question of *when*, for one scope at a time. It is a day-by-time-of-day grid where each cell is shaded by how much the scope does in that slot, with the current slot outlined. Activity rather than confidence, because confidence saturates — anything habitual sits at a hundred percent, so shading by it would make every slot a person works in look the same. Clicking a cell lists everything established for it. Above the grid, a panel names what the scope usually does *right now* — the same question [`GetPatterns`](/chronicle/clients/dotnet/patterns/) answers from code, asked with the current day and time bucket as the context.
+**Pattern heatmap** answers the narrower question of *when*, for one scope at a time. It is a day-by-time-of-day grid where each cell is shaded by how much the scope does in that slot, with the current slot outlined. Activity rather than confidence, because confidence saturates — anything habitual sits at a hundred percent, so shading by it would make every slot a person works in look the same. Clicking a cell lists everything established for it. Above the grid, a panel names what the scope usually does *right now* — the same question [`GetUsualActions`](/chronicle/clients/dotnet/patterns/) answers from code, asked with the current day and time bucket as the context.
 
 A pattern that constrains neither day nor time of day belongs to no cell and is left out of the grid rather than drawn somewhere arbitrary. It is still in the pivot view, which is the one that shows everything.
 

--- a/Samples/Backoffice/Program.cs
+++ b/Samples/Backoffice/Program.cs
@@ -158,9 +158,11 @@ async Task PredictNow(PatternGroupingKey? scope, DateTimeOffset? moment)
         return;
     }
 
+    // The answer names the command. What is left of the pattern once the command is taken off is the slice of the
+    // question it was established in - printed alongside, so it is visible how much of the moment each answer used.
     foreach (var pattern in patterns)
     {
-        Console.WriteLine($"  {pattern.Confidence.Value,6:P0}  {pattern.Facets}");
+        Console.WriteLine($"  {pattern.Confidence.Value,6:P0}  {pattern.Facets.ValueOf(FacetName.CommandType),-22}  ({pattern.Facets.WithoutActions()})");
     }
 }
 

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/and_further_facets_are_given.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/and_further_facets_are_given.cs
@@ -8,8 +8,8 @@ using Contract = Cratis.Chronicle.Contracts.Patterns;
 namespace Cratis.Chronicle.Patterns.for_Patterns.when_getting_patterns_at_a_moment;
 
 /// <summary>
-/// Asking about a moment and asking about a command are the same question, so the moment builds on whatever the
-/// caller already wanted to constrain rather than replacing it.
+/// Asking about a moment and asking about the kind of work are the same question, so the moment builds on whatever
+/// the caller already wanted to constrain rather than replacing it.
 /// </summary>
 public class and_further_facets_are_given : given.a_patterns_client
 {
@@ -19,15 +19,15 @@ public class and_further_facets_are_given : given.a_patterns_client
 
     void Establish() =>
         _patterns
-            .GetPatterns(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
+            .GetUsualActions(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
             .Returns([]);
 
     async Task Because() => await _client.GetPatternsAt(
         "user-42",
         _moment,
-        FacetSet.Empty.With(FacetName.CommandType, "RegisterInvoice"));
+        FacetSet.Empty.With(FacetName.AggregateType, "Invoice"));
 
-    [Fact] void should_keep_the_facet_the_caller_gave() => _request.Context["CommandType"].ShouldEqual("RegisterInvoice");
+    [Fact] void should_keep_the_facet_the_caller_gave() => _request.Context["AggregateType"].ShouldEqual("Invoice");
     [Fact] void should_add_the_day_of_the_moment() => _request.Context["Day"].ShouldEqual("Thursday");
     [Fact] void should_add_the_part_of_the_day() => _request.Context["TimeBucket"].ShouldEqual("Morning");
 }

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/and_the_question_is_what_usually_happens.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/and_the_question_is_what_usually_happens.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using ProtoBuf.Grpc;
+using Contract = Cratis.Chronicle.Contracts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_Patterns.when_getting_patterns_at_a_moment;
+
+/// <summary>
+/// "What does this person usually do right now" wants the command, not a restatement of the moment. Routed at the
+/// describing query instead, it can only ever come back with the day and the time it was handed - which is what it
+/// did before the answering query existed.
+/// </summary>
+public class and_the_question_is_what_usually_happens : given.a_patterns_client
+{
+    static readonly DateTimeOffset _moment = new(2026, 8, 27, 9, 30, 0, TimeSpan.Zero);
+
+    void Establish()
+    {
+        _patterns.GetUsualActions(Arg.Any<Contract.GetPatternsRequest>(), Arg.Any<CallContext>()).Returns([]);
+        _patterns.GetPatterns(Arg.Any<Contract.GetPatternsRequest>(), Arg.Any<CallContext>()).Returns([]);
+    }
+
+    async Task Because() => await _client.GetPatternsAt("user-42", _moment);
+
+    [Fact] async Task should_ask_what_usually_happens() =>
+        await _patterns.Received(1).GetUsualActions(Arg.Any<Contract.GetPatternsRequest>(), Arg.Any<CallContext>());
+
+    [Fact] async Task should_not_ask_which_patterns_describe_the_moment() =>
+        await _patterns.DidNotReceive().GetPatterns(Arg.Any<Contract.GetPatternsRequest>(), Arg.Any<CallContext>());
+}

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/for_a_given_moment.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/for_a_given_moment.cs
@@ -17,7 +17,7 @@ public class for_a_given_moment : given.a_patterns_client
 
     void Establish() =>
         _patterns
-            .GetPatterns(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
+            .GetUsualActions(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
             .Returns([]);
 
     async Task Because() => await _client.GetPatternsAt("user-42", _moment);

--- a/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/without_a_moment.cs
+++ b/Source/Clients/DotNET.Specs/Patterns/for_Patterns/when_getting_patterns_at_a_moment/without_a_moment.cs
@@ -17,7 +17,7 @@ public class without_a_moment : given.a_patterns_client
 
     void Establish() =>
         _patterns
-            .GetPatterns(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
+            .GetUsualActions(Arg.Do<Contract.GetPatternsRequest>(request => _request = request), Arg.Any<CallContext>())
             .Returns([]);
 
     async Task Because()

--- a/Source/Clients/DotNET/Patterns/IPatterns.cs
+++ b/Source/Clients/DotNET/Patterns/IPatterns.cs
@@ -32,7 +32,34 @@ public interface IPatterns
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get what a scope usually does at a moment, most specific and most confident first.
+    /// Get what usually happens in a context, most likely first, at most one answer per action.
+    /// </summary>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey">scope</see> to ask within - typically a user.</param>
+    /// <param name="context">The <see cref="FacetSet">context</see> describing the situation, which may constrain any subset of the facets.</param>
+    /// <param name="minimumConfidence">The lowest <see cref="PatternConfidence"/> an answer may hold. Defaults to the server's configured threshold.</param>
+    /// <param name="maximumResults">The largest number of answers to return. Defaults to the server's default.</param>
+    /// <param name="cancellationToken">Optional <see cref="CancellationToken"/>.</param>
+    /// <returns>The <see cref="BehaviorPattern">patterns</see> naming what usually happens, empty when nothing clears the bar.</returns>
+    /// <remarks>
+    /// <para>
+    /// Where <see cref="GetPatterns"/> returns patterns that <em>describe</em> a situation, this returns the ones
+    /// that say what is <em>done</em> in it. Read the action off a result with
+    /// <c>pattern.Facets.ValueOf(FacetName.CommandType)</c>, and its likelihood from <c>Confidence</c> - the chance
+    /// of that action given the context it was established in.
+    /// </para>
+    /// <para>
+    /// An empty result is an answer, not a failure: this scope has no established behavior for this context.
+    /// </para>
+    /// </remarks>
+    Task<IEnumerable<BehaviorPattern>> GetUsualActions(
+        PatternGroupingKey groupingKey,
+        FacetSet context,
+        PatternConfidence? minimumConfidence = default,
+        int maximumResults = 0,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get what a scope usually does at a moment, most likely first, at most one answer per action.
     /// </summary>
     /// <param name="groupingKey">The <see cref="PatternGroupingKey">scope</see> to ask about - typically a user.</param>
     /// <param name="moment">The moment to ask about. Defaults to now.</param>
@@ -46,8 +73,8 @@ public interface IPatterns
     /// question. The day and the part of the day are read off the moment using the same rule the engine bucketed
     /// events with when it mined them, so the answer is about the slot the behavior was actually learned in.
     /// <para>
-    /// <see cref="GetPatterns"/> remains for anything asking about a context that is not a moment - a command, an
-    /// aggregate, what caused what. Pass <paramref name="alsoConstraining"/> to ask about both at once.
+    /// Answers name what is done, through <see cref="GetUsualActions"/>. Pass <paramref name="alsoConstraining"/>
+    /// to narrow the moment with more of the situation - the kind of thing being worked on, what caused the work.
     /// </para>
     /// <para>
     /// An empty result is an answer, not a failure: this scope has no established behavior for this moment.

--- a/Source/Clients/DotNET/Patterns/Patterns.cs
+++ b/Source/Clients/DotNET/Patterns/Patterns.cs
@@ -44,6 +44,29 @@ public class Patterns(IEventStore eventStore) : IPatterns
     }
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<BehaviorPattern>> GetUsualActions(
+        PatternGroupingKey groupingKey,
+        FacetSet context,
+        PatternConfidence? minimumConfidence = default,
+        int maximumResults = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var patterns = await _servicesAccessor.Services.Patterns.GetUsualActions(
+            new()
+            {
+                EventStore = eventStore.Name,
+                Namespace = eventStore.Namespace,
+                GroupingKey = groupingKey,
+                Context = context.Facets.ToDictionary(facet => facet.Name.Value, facet => facet.Value.Value),
+                MinimumConfidence = minimumConfidence?.Value ?? 0d,
+                MaximumResults = maximumResults
+            },
+            new CallContext(new CallOptions(cancellationToken: cancellationToken)));
+
+        return patterns.ToClient();
+    }
+
+    /// <inheritdoc/>
     public Task<IEnumerable<BehaviorPattern>> GetPatternsAt(
         PatternGroupingKey groupingKey,
         DateTimeOffset? moment = default,
@@ -55,13 +78,13 @@ public class Patterns(IEventStore eventStore) : IPatterns
         var at = moment ?? DateTimeOffset.Now;
 
         // Built on top of whatever the caller already wanted to constrain, so asking about a moment and asking
-        // about a command are the same question rather than two competing ones. With() replaces, so a caller who
-        // constrained the day themselves gets the moment's day - which is the value they asked to be asked about.
+        // about the kind of work are the same question rather than two competing ones. With() replaces, so a caller
+        // who constrained the day themselves gets the moment's day - the value they asked to be asked about.
         var context = (alsoConstraining ?? FacetSet.Empty)
             .With(FacetName.Day, at.DayOfWeek.ToString())
             .With(FacetName.TimeBucket, at.ToTimeBucket().ToString());
 
-        return GetPatterns(groupingKey, context, minimumConfidence, maximumResults, cancellationToken);
+        return GetUsualActions(groupingKey, context, minimumConfidence, maximumResults, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_and_the_pattern_names_no_action.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_and_the_pattern_names_no_action.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_BehaviorPattern.when_answering_for;
+
+/// <summary>
+/// A pattern of pure context establishes that a situation recurs, not what is done in it. Letting it through as an
+/// answer is how a caller ends up being told "you are asking about an early morning" at some confidence, which is
+/// their own question handed back to them.
+/// </summary>
+public class a_context_and_the_pattern_names_no_action : Specification
+{
+    BehaviorPattern _theMomentItself;
+    FacetSet _theMomentAsked;
+
+    void Establish()
+    {
+        _theMomentItself = new BehaviorPattern(
+            "ingrid.holm",
+            new FacetSet([new Facet(FacetName.TimeBucket, "EarlyMorning")]),
+            1400,
+            0.53d,
+            0.53d,
+            5d,
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch);
+
+        _theMomentAsked = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "EarlyMorning")]);
+    }
+
+    [Fact] void should_not_answer_what_usually_happens() => _theMomentItself.AnswersFor(_theMomentAsked).ShouldBeFalse();
+    [Fact] void should_still_describe_the_context() => _theMomentItself.Matches(_theMomentAsked).ShouldBeTrue();
+    [Fact] void should_name_no_action() => _theMomentItself.Action.ShouldEqual(FacetValue.Unspecified);
+    [Fact] void should_count_all_of_its_facets_as_context() => _theMomentItself.ContextSpecificity.ShouldEqual(1);
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_the_action_is_established_in_no_part_of.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_the_action_is_established_in_no_part_of.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_BehaviorPattern.when_answering_for;
+
+/// <summary>
+/// An action established in no context at all is a base rate for the whole scope - "half of what this person ever
+/// does is post ledger entries" - and its empty context is a subset of every question there is. Left alone it
+/// answers a question about a Sunday night the scope has never worked with the same 52% it answers everything
+/// else, which makes "nothing is established here" unsayable for anybody who has a dominant action.
+/// </summary>
+public class a_context_the_action_is_established_in_no_part_of : Specification
+{
+    BehaviorPattern _whatTheyMostlyDo;
+    FacetSet _aMomentTheyNeverWork;
+    FacetSet _noQuestionAtAll;
+
+    void Establish()
+    {
+        _whatTheyMostlyDo = new BehaviorPattern(
+            "petter.aas",
+            new FacetSet([new Facet(FacetName.CommandType, "PostLedgerEntry")]),
+            649,
+            0.52d,
+            0.52d,
+            5d,
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch);
+
+        _aMomentTheyNeverWork = new FacetSet([new Facet(FacetName.Day, "Sunday"), new Facet(FacetName.TimeBucket, "Night")]);
+        _noQuestionAtAll = FacetSet.Empty;
+    }
+
+    [Fact] void should_not_answer_a_question_it_uses_no_part_of() => _whatTheyMostlyDo.AnswersFor(_aMomentTheyNeverWork).ShouldBeFalse();
+    [Fact] void should_answer_when_nothing_was_asked() => _whatTheyMostlyDo.AnswersFor(_noQuestionAtAll).ShouldBeTrue();
+    [Fact] void should_be_conditioned_on_nothing() => _whatTheyMostlyDo.ContextSpecificity.ShouldEqual(0);
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_the_action_was_established_in.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_BehaviorPattern/when_answering_for/a_context_the_action_was_established_in.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_BehaviorPattern.when_answering_for;
+
+/// <summary>
+/// The case the feature exists for, and the one plain subset matching cannot serve. A caller asking what somebody
+/// usually does on a Monday early morning names the day and the time and nothing else, because the command is the
+/// thing they are asking for. Requiring the whole pattern to be a subset of that question excludes precisely the
+/// pattern that answers it.
+/// </summary>
+public class a_context_the_action_was_established_in : Specification
+{
+    BehaviorPattern _registersInvoices;
+    FacetSet _theMomentAsked;
+    FacetSet _anotherDay;
+    FacetSet _theDayAlone;
+
+    void Establish()
+    {
+        _registersInvoices = new BehaviorPattern(
+            "ingrid.holm",
+            new FacetSet(
+            [
+                new Facet(FacetName.CommandType, "RegisterInvoice"),
+                new Facet(FacetName.Day, "Monday"),
+                new Facet(FacetName.TimeBucket, "EarlyMorning")
+            ]),
+            730,
+            1d,
+            0.2d,
+            5d,
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch);
+
+        _theMomentAsked = new FacetSet([new Facet(FacetName.Day, "Monday"), new Facet(FacetName.TimeBucket, "EarlyMorning")]);
+        _anotherDay = new FacetSet([new Facet(FacetName.Day, "Friday"), new Facet(FacetName.TimeBucket, "EarlyMorning")]);
+        _theDayAlone = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+    }
+
+    [Fact] void should_answer_the_moment_it_was_established_in() => _registersInvoices.AnswersFor(_theMomentAsked).ShouldBeTrue();
+    [Fact] void should_not_answer_a_moment_it_disagrees_with() => _registersInvoices.AnswersFor(_anotherDay).ShouldBeFalse();
+    [Fact] void should_not_answer_a_context_leaving_one_of_its_facets_open() => _registersInvoices.AnswersFor(_theDayAlone).ShouldBeFalse();
+    [Fact] void should_name_the_action_it_answers_with() => _registersInvoices.Action.ShouldEqual(new FacetValue("RegisterInvoice"));
+    [Fact] void should_report_how_much_of_the_question_it_uses() => _registersInvoices.ContextSpecificity.ShouldEqual(2);
+
+    [Fact] void should_still_not_match_that_moment_as_a_description() => _registersInvoices.Matches(_theMomentAsked).ShouldBeFalse();
+}

--- a/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_removing_the_actions/from_a_set_that_names_one.cs
+++ b/Source/Kernel/Concepts.Specs/Patterns/for_FacetSet/when_removing_the_actions/from_a_set_that_names_one.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Patterns.for_FacetSet.when_removing_the_actions;
+
+/// <summary>
+/// Splitting a mined itemset into the action and the context it was taken in is what both mining and answering are
+/// built on - confidence is the frequency of the whole over the frequency of this remainder, and an answer matches
+/// on this remainder rather than on the whole.
+/// </summary>
+public class from_a_set_that_names_one : Specification
+{
+    FacetSet _withAnAction;
+    FacetSet _pureContext;
+    FacetSet _actionOnly;
+
+    FacetSet _contextOfTheFirst;
+    FacetSet _contextOfTheSecond;
+    FacetSet _contextOfTheThird;
+
+    void Establish()
+    {
+        _withAnAction = new FacetSet(
+        [
+            new Facet(FacetName.CommandType, "RegisterInvoice"),
+            new Facet(FacetName.Day, "Monday"),
+            new Facet(FacetName.TimeBucket, "EarlyMorning")
+        ]);
+
+        _pureContext = new FacetSet([new Facet(FacetName.Day, "Monday")]);
+        _actionOnly = new FacetSet([new Facet(FacetName.CommandType, "RegisterInvoice")]);
+    }
+
+    void Because()
+    {
+        _contextOfTheFirst = _withAnAction.WithoutActions();
+        _contextOfTheSecond = _pureContext.WithoutActions();
+        _contextOfTheThird = _actionOnly.WithoutActions();
+    }
+
+    [Fact] void should_drop_the_action() => _contextOfTheFirst.ConstrainsAction.ShouldBeFalse();
+    [Fact] void should_keep_every_context_facet() => _contextOfTheFirst.Specificity.ShouldEqual(2);
+    [Fact] void should_keep_the_context_values() => _contextOfTheFirst.ValueOf(FacetName.Day).ShouldEqual(new FacetValue("Monday"));
+    [Fact] void should_leave_a_set_naming_no_action_alone() => _contextOfTheSecond.ShouldEqual(_pureContext);
+    [Fact] void should_reduce_a_set_that_is_only_an_action_to_nothing() => _contextOfTheThird.IsEmpty.ShouldBeTrue();
+
+    [Fact] void should_report_that_the_first_names_an_action() => _withAnAction.ConstrainsAction.ShouldBeTrue();
+    [Fact] void should_read_the_action_off_the_first() => _withAnAction.Action.ShouldEqual(new FacetValue("RegisterInvoice"));
+    [Fact] void should_report_no_action_for_pure_context() => _pureContext.Action.ShouldEqual(FacetValue.Unspecified);
+}

--- a/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
+++ b/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
@@ -35,9 +35,43 @@ public record BehaviorPattern(
     public int Specificity => Facets.Specificity;
 
     /// <summary>
+    /// Gets the action the pattern names, or <see cref="FacetValue.Unspecified"/> when it is pure context.
+    /// </summary>
+    public FacetValue Action => Facets.Action;
+
+    /// <summary>
+    /// Gets how much of an asked context the pattern's own context uses - the number of context facets it constrains.
+    /// </summary>
+    /// <remarks>
+    /// The specificity of an <em>answer</em>, as opposed to <see cref="Specificity"/>. Two patterns naming the same
+    /// action differ by how much of the question they were conditioned on, and the action facet they share tells
+    /// them apart in neither direction.
+    /// </remarks>
+    public int ContextSpecificity => Facets.Specificity - (Facets.ConstrainsAction ? 1 : 0);
+
+    /// <summary>
     /// Check whether the pattern applies to a context.
     /// </summary>
     /// <param name="context">The <see cref="FacetSet"/> describing the context, which may constrain more facets than the pattern does.</param>
     /// <returns>True when every facet the pattern constrains is present with the same value in the context, false when not.</returns>
+    /// <remarks>
+    /// This is the question "does this established pattern describe the situation I am in" - the one worth asking
+    /// about an action that already happened. It can never return a pattern naming an action the caller did not
+    /// name, because such a pattern is not a subset of what was asked. Use <see cref="AnswersFor"/> for the
+    /// question that has an action as its answer.
+    /// </remarks>
     public bool Matches(FacetSet context) => Facets.IsSubsetOf(context);
+
+    /// <summary>
+    /// Check whether the pattern answers what usually happens in a context.
+    /// </summary>
+    /// <param name="context">The <see cref="FacetSet"/> describing the situation being asked about.</param>
+    /// <returns>True when the pattern names an action and was established in a context the asked one covers, false when not.</returns>
+    /// <remarks>
+    /// The action facet is excluded from the comparison on purpose. A caller asking what somebody usually does on a
+    /// Monday morning cannot name the command in the question - naming it is what they are asking for - so requiring
+    /// the whole pattern to be a subset of the question excludes exactly the patterns that answer it.
+    /// </remarks>
+    public bool AnswersFor(FacetSet context) =>
+        Facets.ConstrainsAction && Facets.WithoutActions().IsSubsetOf(context);
 }

--- a/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
+++ b/Source/Kernel/Concepts/Patterns/BehaviorPattern.cs
@@ -68,10 +68,29 @@ public record BehaviorPattern(
     /// <param name="context">The <see cref="FacetSet"/> describing the situation being asked about.</param>
     /// <returns>True when the pattern names an action and was established in a context the asked one covers, false when not.</returns>
     /// <remarks>
+    /// <para>
     /// The action facet is excluded from the comparison on purpose. A caller asking what somebody usually does on a
     /// Monday morning cannot name the command in the question - naming it is what they are asking for - so requiring
     /// the whole pattern to be a subset of the question excludes exactly the patterns that answer it.
+    /// </para>
+    /// <para>
+    /// An answer must also use some of the question. A pattern established in no context at all - "half of what
+    /// this person ever does is post ledger entries" - is a subset of every context there is, so without this it
+    /// answers every question identically, including questions about moments the scope has never worked. That
+    /// would make "nothing is established here" unsayable for anyone with a dominant action, which is the one
+    /// answer this whole surface exists to be able to give honestly. When the caller names nothing, though, the
+    /// general behavior is precisely what they asked for, and it is returned.
+    /// </para>
     /// </remarks>
-    public bool AnswersFor(FacetSet context) =>
-        Facets.ConstrainsAction && Facets.WithoutActions().IsSubsetOf(context);
+    public bool AnswersFor(FacetSet context)
+    {
+        if (!Facets.ConstrainsAction)
+        {
+            return false;
+        }
+
+        var establishedIn = Facets.WithoutActions();
+
+        return establishedIn.IsSubsetOf(context) && (!establishedIn.IsEmpty || context.IsEmpty);
+    }
 }

--- a/Source/Kernel/Concepts/Patterns/FacetName.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetName.cs
@@ -70,6 +70,30 @@ public record FacetName(string Value) : ConceptAs<string>(Value)
     public static readonly FacetName TimeBucket = new(nameof(TimeBucket));
 
     /// <summary>
+    /// Gets a value indicating whether the facet names the action that was taken rather than the context it was
+    /// taken in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The distinction is what separates the question from its answer. A caller describing a situation can name
+    /// every context facet, because those are things they know - the day, the time of day, the kind of thing being
+    /// worked on. They cannot name the action, because the action is what they are asking about.
+    /// </para>
+    /// <para>
+    /// This is not a query-side convenience: confidence is already defined against it, as the frequency of an
+    /// itemset over the frequency of the same itemset with its action facets removed - the chance of the action
+    /// given the context. Naming another facet here therefore changes what confidence means for every pattern that
+    /// constrains it, so it is a modelling decision rather than a filter.
+    /// </para>
+    /// <para>
+    /// <see cref="CausedByCommand"/> is deliberately left as context. It reads as an answer to "what usually
+    /// follows this" and as context to "what does this person do on a Monday", and only one of those can be true
+    /// of a single definition.
+    /// </para>
+    /// </remarks>
+    public bool IsAction => this == CommandType;
+
+    /// <summary>
     /// Implicitly convert from a string to <see cref="FacetName"/>.
     /// </summary>
     /// <param name="name">String to convert from.</param>

--- a/Source/Kernel/Concepts/Patterns/FacetSet.cs
+++ b/Source/Kernel/Concepts/Patterns/FacetSet.cs
@@ -57,6 +57,17 @@ public sealed record FacetSet
     public bool IsEmpty => Facets.Count == 0;
 
     /// <summary>
+    /// Gets a value indicating whether the set names an action rather than only the context it was taken in.
+    /// </summary>
+    public bool ConstrainsAction => Facets.Any(facet => facet.Name.IsAction);
+
+    /// <summary>
+    /// Gets the action the set names, or <see cref="FacetValue.Unspecified"/> when it names none.
+    /// </summary>
+    public FacetValue Action =>
+        Facets.FirstOrDefault(facet => facet.Name.IsAction)?.Value ?? FacetValue.Unspecified;
+
+    /// <summary>
     /// Creates a <see cref="FacetSet"/> from name and value pairs.
     /// </summary>
     /// <param name="facets">The pairs to create from.</param>
@@ -98,6 +109,17 @@ public sealed record FacetSet
     /// <param name="other">The <see cref="FacetSet"/> to check against.</param>
     /// <returns>True when this set is a subset of the other, false when not.</returns>
     public bool IsSubsetOf(FacetSet other) => Facets.All(other.Facets.Contains);
+
+    /// <summary>
+    /// Creates a copy of the set with every action facet removed, leaving the context the action was taken in.
+    /// </summary>
+    /// <returns>A new <see cref="FacetSet"/> holding only the context facets.</returns>
+    /// <remarks>
+    /// This is the half of a pattern a caller can actually describe. Comparing it against an asked context is what
+    /// lets a pattern answer a question instead of restating it - see <see cref="FacetName.IsAction"/>.
+    /// </remarks>
+    public FacetSet WithoutActions() =>
+        ConstrainsAction ? new(Facets.Where(facet => !facet.Name.IsAction)) : this;
 
     /// <summary>
     /// Gets the set as a dictionary of names to values.

--- a/Source/Kernel/Contracts/Patterns/IPatterns.cs
+++ b/Source/Kernel/Contracts/Patterns/IPatterns.cs
@@ -19,6 +19,21 @@ public interface IPatterns
     Task<IEnumerable<Pattern>> GetPatterns(GetPatternsRequest request, CallContext context = default);
 
     /// <summary>
+    /// Get what usually happens in a context, ranked by confidence, at most one result per action.
+    /// </summary>
+    /// <param name="request">The <see cref="GetPatternsRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns><see cref="IEnumerable{T}"/> of <see cref="Pattern"/>, empty when nothing clears the confidence bar.</returns>
+    /// <remarks>
+    /// The question <see cref="GetPatterns"/> cannot answer. That one returns patterns describing the situation the
+    /// caller named, which can confirm a context is established but never says what is done in it - a pattern naming
+    /// a command is not a subset of a context that names none. This compares only the context half of a pattern, so
+    /// the command comes back as the answer.
+    /// </remarks>
+    [Operation]
+    Task<IEnumerable<Pattern>> GetUsualActions(GetPatternsRequest request, CallContext context = default);
+
+    /// <summary>
     /// Get every pattern held for a scope.
     /// </summary>
     /// <param name="request">The <see cref="GetPatternsForScopeRequest"/>.</param>

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_nothing_clears_the_bar_for.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_nothing_clears_the_bar_for.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching_actions;
+
+/// <summary>
+/// An empty answer is a true statement - this scope does nothing established here - and the best of a bad set reads
+/// to a caller exactly like a real habit. Nothing is promoted to fill the gap.
+/// </summary>
+public class a_context_nothing_clears_the_bar_for : Specification
+{
+    BehaviorPattern _tooUncertain;
+    FacetSet _context;
+    IEnumerable<BehaviorPattern> _result;
+    IEnumerable<BehaviorPattern> _resultWithoutRoom;
+
+    void Establish()
+    {
+        _tooUncertain = Pattern([new Facet(FacetName.CommandType, "RegisterInvoice"), Monday], confidence: 0.2d);
+        _context = new FacetSet([Monday]);
+    }
+
+    void Because()
+    {
+        var matcher = new PatternMatcher();
+        _result = matcher.MatchActions([_tooUncertain], _context, new PatternConfidence(0.5d), 10);
+        _resultWithoutRoom = matcher.MatchActions([_tooUncertain], _context, PatternConfidence.None, 0);
+    }
+
+    [Fact] void should_answer_with_nothing() => _result.ShouldBeEmpty();
+    [Fact] void should_answer_with_nothing_when_asked_for_no_results() => _resultWithoutRoom.ShouldBeEmpty();
+
+    static Facet Monday => new(FacetName.Day, "Monday");
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new("ingrid.holm", new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_only_a_scope_wide_habit_covers.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_only_a_scope_wide_habit_covers.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching_actions;
+
+/// <summary>
+/// The empty answer has to survive contact with a scope that has a dominant action. Asking about a moment nobody
+/// works must come back with nothing rather than with what the scope does the rest of the week, or "no established
+/// behavior here" stops being something the surface can say.
+/// </summary>
+public class a_context_only_a_scope_wide_habit_covers : Specification
+{
+    BehaviorPattern _whatTheyMostlyDo;
+    BehaviorPattern _whatTheyDoOnFridays;
+    IEnumerable<BehaviorPattern> _atAMomentTheyNeverWork;
+    IEnumerable<BehaviorPattern> _whenNothingIsAsked;
+
+    void Establish()
+    {
+        _whatTheyMostlyDo = Pattern([Action("PostLedgerEntry")], confidence: 0.52d);
+        _whatTheyDoOnFridays = Pattern([Action("ClosePeriod"), new Facet(FacetName.Day, "Friday")], confidence: 0.8d);
+    }
+
+    void Because()
+    {
+        var matcher = new PatternMatcher();
+        BehaviorPattern[] held = [_whatTheyMostlyDo, _whatTheyDoOnFridays];
+
+        _atAMomentTheyNeverWork = matcher.MatchActions(
+            held,
+            new FacetSet([new Facet(FacetName.Day, "Sunday"), new Facet(FacetName.TimeBucket, "Night")]),
+            PatternConfidence.None,
+            10);
+
+        _whenNothingIsAsked = matcher.MatchActions(held, FacetSet.Empty, PatternConfidence.None, 10);
+    }
+
+    [Fact] void should_answer_nothing_for_a_moment_no_habit_covers() => _atAMomentTheyNeverWork.ShouldBeEmpty();
+    [Fact] void should_answer_with_the_general_habit_when_nothing_is_asked() => _whenNothingIsAsked.ShouldContain(_whatTheyMostlyDo);
+    [Fact] void should_not_answer_with_a_narrower_habit_when_nothing_is_asked() => _whenNothingIsAsked.ShouldNotContain(_whatTheyDoOnFridays);
+
+    static Facet Action(string command) => new(FacetName.CommandType, command);
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new("petter.aas", new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_several_actions_are_established_in.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/a_context_several_actions_are_established_in.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching_actions;
+
+/// <summary>
+/// Confidence leads when ranking answers, where specificity leads when ranking descriptions. Confidence is already
+/// the chance of the action given the context it was established in, which compares directly between one answer and
+/// the next; a facet count does not.
+/// </summary>
+public class a_context_several_actions_are_established_in : Specification
+{
+    BehaviorPattern _almostAlways;
+    BehaviorPattern _sometimes;
+    BehaviorPattern _onAnotherDay;
+    BehaviorPattern _theMomentItself;
+    FacetSet _context;
+    IEnumerable<BehaviorPattern> _result;
+
+    void Establish()
+    {
+        _almostAlways = Pattern([Action("RegisterInvoice"), Monday, EarlyMorning], confidence: 0.95d);
+        _sometimes = Pattern([Action("MatchInvoice"), Monday], confidence: 0.4d);
+        _onAnotherDay = Pattern([Action("ReleasePayment"), new Facet(FacetName.Day, "Friday")], confidence: 1d);
+        _theMomentItself = Pattern([EarlyMorning], confidence: 0.53d);
+
+        _context = new FacetSet([Monday, EarlyMorning]);
+    }
+
+    void Because() => _result = new PatternMatcher().MatchActions(
+        [_almostAlways, _sometimes, _onAnotherDay, _theMomentItself],
+        _context,
+        PatternConfidence.None,
+        10);
+
+    [Fact] void should_answer_with_the_actions_established_here() => _result.Count().ShouldEqual(2);
+    [Fact] void should_put_the_most_likely_action_first() => _result.First().ShouldEqual(_almostAlways);
+    [Fact] void should_keep_the_less_likely_action() => _result.Last().ShouldEqual(_sometimes);
+    [Fact] void should_not_answer_with_an_action_from_another_context() => _result.ShouldNotContain(_onAnotherDay);
+    [Fact] void should_not_hand_the_question_back_as_an_answer() => _result.ShouldNotContain(_theMomentItself);
+
+    static Facet Monday => new(FacetName.Day, "Monday");
+    static Facet EarlyMorning => new(FacetName.TimeBucket, "EarlyMorning");
+    static Facet Action(string command) => new(FacetName.CommandType, command);
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new("ingrid.holm", new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/one_action_established_at_several_context_sizes.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMatcher/when_matching_actions/one_action_established_at_several_context_sizes.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMatcher.when_matching_actions;
+
+/// <summary>
+/// A habit is mined at every context size at once - on a Monday, in the early morning, and on a Monday early
+/// morning are three itemsets describing one behavior. Returning all three says the same thing three times and
+/// pushes the second-most-likely action out of a limited result set, so one survives: the one conditioned on most
+/// of the question, which is the best-informed of the three even when a broader sibling reads as more confident.
+/// </summary>
+public class one_action_established_at_several_context_sizes : Specification
+{
+    BehaviorPattern _onTheWholeDay;
+    BehaviorPattern _atThatTimeOfDay;
+    BehaviorPattern _atThatMoment;
+    BehaviorPattern _aSecondAction;
+    FacetSet _context;
+    IEnumerable<BehaviorPattern> _result;
+
+    void Establish()
+    {
+        _onTheWholeDay = Pattern([Action("RegisterInvoice"), Monday], confidence: 0.99d);
+        _atThatTimeOfDay = Pattern([Action("RegisterInvoice"), EarlyMorning], confidence: 0.90d);
+        _atThatMoment = Pattern([Action("RegisterInvoice"), Monday, EarlyMorning], confidence: 0.80d);
+        _aSecondAction = Pattern([Action("MatchInvoice"), Monday, EarlyMorning], confidence: 0.20d);
+
+        _context = new FacetSet([Monday, EarlyMorning]);
+    }
+
+    void Because() => _result = new PatternMatcher().MatchActions(
+        [_onTheWholeDay, _atThatTimeOfDay, _atThatMoment, _aSecondAction],
+        _context,
+        PatternConfidence.None,
+        10);
+
+    [Fact] void should_answer_once_per_action() => _result.Count().ShouldEqual(2);
+    [Fact] void should_keep_the_answer_conditioned_on_most_of_the_question() => _result.ShouldContain(_atThatMoment);
+    [Fact] void should_drop_the_broader_sibling_even_though_it_reads_more_confident() => _result.ShouldNotContain(_onTheWholeDay);
+    [Fact] void should_drop_the_other_broader_sibling() => _result.ShouldNotContain(_atThatTimeOfDay);
+    [Fact] void should_still_rank_the_surviving_answers_by_confidence() => _result.First().ShouldEqual(_atThatMoment);
+    [Fact] void should_keep_the_second_action_that_would_otherwise_be_crowded_out() => _result.Last().ShouldEqual(_aSecondAction);
+
+    static Facet Monday => new(FacetName.Day, "Monday");
+    static Facet EarlyMorning => new(FacetName.TimeBucket, "EarlyMorning");
+    static Facet Action(string command) => new(FacetName.CommandType, command);
+
+    static BehaviorPattern Pattern(IEnumerable<Facet> facets, double confidence) =>
+        new("ingrid.holm", new FacetSet(facets), 10, confidence, 0.5d, 1d, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch);
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/given/a_patterns_service.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/given/a_patterns_service.cs
@@ -23,6 +23,8 @@ public class a_patterns_service : Specification
     protected KernelBehaviorPattern _mondayMorning;
     protected KernelBehaviorPattern _monday;
     protected KernelBehaviorPattern _lowConfidence;
+    protected KernelBehaviorPattern _registersInvoicesOnMondayMornings;
+    protected KernelBehaviorPattern _matchesInvoicesOnFridays;
 
     void Establish()
     {
@@ -30,7 +32,26 @@ public class a_patterns_service : Specification
         _monday = Pattern([new Facet(FacetName.Day, "Monday")], 0.8d);
         _lowConfidence = Pattern([new Facet(FacetName.TimeBucket, "Morning")], 0.2d);
 
-        KernelBehaviorPattern[] held = [_mondayMorning, _monday, _lowConfidence];
+        _registersInvoicesOnMondayMornings = Pattern(
+            [
+                new Facet(FacetName.CommandType, "RegisterInvoice"),
+                new Facet(FacetName.Day, "Monday"),
+                new Facet(FacetName.TimeBucket, "Morning")
+            ],
+            0.95d);
+
+        _matchesInvoicesOnFridays = Pattern(
+            [new Facet(FacetName.CommandType, "MatchInvoice"), new Facet(FacetName.Day, "Friday")],
+            1d);
+
+        KernelBehaviorPattern[] held =
+        [
+            _mondayMorning,
+            _monday,
+            _lowConfidence,
+            _registersInvoicesOnMondayMornings,
+            _matchesInvoicesOnFridays
+        ];
 
         _patterns = Substitute.For<IBehaviorPatternStorage>();
         _patterns

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns_for_scope/everything_a_scope_established.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_patterns_for_scope/everything_a_scope_established.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
 using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
 
 namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_patterns_for_scope;
@@ -21,6 +22,7 @@ public class everything_a_scope_established : given.a_patterns_service
         GroupingKey = Scope
     });
 
-    [Fact] void should_return_every_pattern_held() => _result.Count().ShouldEqual(3);
+    [Fact] void should_return_every_pattern_held() => _result.Count().ShouldEqual(5);
     [Fact] void should_include_the_ones_below_the_confidence_threshold() => _result.Any(_ => _.Confidence < 0.5d).ShouldBeTrue();
+    [Fact] void should_include_the_ones_naming_an_action() => _result.Any(_ => _.Facets.ContainsKey(FacetName.CommandType.Value)).ShouldBeTrue();
 }

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_usual_actions/for_a_moment_the_scope_has_a_habit_in.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_usual_actions/for_a_moment_the_scope_has_a_habit_in.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_usual_actions;
+
+/// <summary>
+/// The question the feature exists for, asked through the service: a day and a time of day in, a command out. The
+/// same request answered by <see cref="Chronicle.Services.Patterns.Patterns.GetPatterns"/> comes back naming the
+/// day and the time it was handed, because a pattern constraining a command is not a subset of a context that
+/// names none.
+/// </summary>
+public class for_a_moment_the_scope_has_a_habit_in : given.a_patterns_service
+{
+    IEnumerable<Pattern> _answers;
+    IEnumerable<Pattern> _descriptions;
+
+    async Task Because()
+    {
+        _answers = await _service.GetUsualActions(Request());
+        _descriptions = await _service.GetPatterns(Request());
+    }
+
+    [Fact] void should_answer_with_the_command() =>
+        _answers.First().Facets[FacetName.CommandType.Value].ShouldEqual("RegisterInvoice");
+
+    [Fact] void should_answer_with_how_likely_it_is() => _answers.First().Confidence.ShouldEqual(0.95d);
+    [Fact] void should_answer_only_with_actions() => _answers.Count().ShouldEqual(1);
+
+    [Fact] void should_not_answer_with_an_action_from_another_day() =>
+        _answers.Any(pattern => pattern.Facets[FacetName.CommandType.Value] == "MatchInvoice").ShouldBeFalse();
+
+    [Fact] void should_leave_the_describing_query_naming_no_command() =>
+        _descriptions.Any(pattern => pattern.Facets.ContainsKey(FacetName.CommandType.Value)).ShouldBeFalse();
+
+    static Contracts.Patterns.GetPatternsRequest Request() => new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = Scope,
+        Context = new Dictionary<string, string>
+        {
+            { FacetName.Day.Value, "Monday" },
+            { FacetName.TimeBucket.Value, "Morning" }
+        }
+    };
+}

--- a/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_usual_actions/without_a_scope.cs
+++ b/Source/Kernel/Core.Specs/Services/Patterns/for_Patterns/when_getting_usual_actions/without_a_scope.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+using Pattern = Cratis.Chronicle.Contracts.Patterns.Pattern;
+
+namespace Cratis.Chronicle.Services.Patterns.for_Patterns.when_getting_usual_actions;
+
+/// <summary>
+/// The scope selects whose behavior is being asked about. Without one there is no question to answer, and the read
+/// this query does is per scope - so it must be turned away before it reads rather than after.
+/// </summary>
+public class without_a_scope : given.a_patterns_service
+{
+    IEnumerable<Pattern> _result;
+
+    async Task Because() => _result = await _service.GetUsualActions(new()
+    {
+        EventStore = EventStore,
+        Namespace = EventStoreNamespaceName.Default,
+        GroupingKey = PatternGroupingKey.Unspecified,
+        Context = new Dictionary<string, string> { { FacetName.Day.Value, "Monday" } }
+    });
+
+    [Fact] void should_return_nothing() => _result.ShouldBeEmpty();
+
+    [Fact] async Task should_not_read_anything() =>
+        await _patterns.DidNotReceive().GetForScope(Arg.Any<PatternGroupingKey>());
+}

--- a/Source/Kernel/Core/Patterns/IPatternMatcher.cs
+++ b/Source/Kernel/Core/Patterns/IPatternMatcher.cs
@@ -23,4 +23,22 @@ public interface IPatternMatcher
         FacetSet context,
         PatternConfidence minimumConfidence,
         int maximumResults);
+
+    /// <summary>
+    /// Rank the actions usually taken in a context, at most one result per action.
+    /// </summary>
+    /// <param name="patterns">The <see cref="BehaviorPattern">patterns</see> to consider.</param>
+    /// <param name="context">The <see cref="FacetSet"/> describing the context, which may be partial.</param>
+    /// <param name="minimumConfidence">The lowest <see cref="PatternConfidence"/> an answer may hold.</param>
+    /// <param name="maximumResults">The largest number of answers to return.</param>
+    /// <returns>The patterns naming what usually happens, most likely first.</returns>
+    /// <remarks>
+    /// The counterpart to <see cref="Match"/>: that one asks which established patterns describe a situation, this
+    /// one asks what is usually done in it.
+    /// </remarks>
+    IEnumerable<BehaviorPattern> MatchActions(
+        IEnumerable<BehaviorPattern> patterns,
+        FacetSet context,
+        PatternConfidence minimumConfidence,
+        int maximumResults);
 }

--- a/Source/Kernel/Core/Patterns/PatternMatcher.cs
+++ b/Source/Kernel/Core/Patterns/PatternMatcher.cs
@@ -46,4 +46,52 @@ public class PatternMatcher : IPatternMatcher
                 .Take(maximumResults)
         ];
     }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// Confidence leads here, where specificity leads in <see cref="Match"/>, because the two rank different things.
+    /// Matching ranks descriptions of a situation, and the one covering most of what was asked describes it best.
+    /// This ranks answers, and confidence is already the chance of the action given the context it was established
+    /// in - a number directly comparable between one answer and the next, which a facet count is not.
+    /// </para>
+    /// <para>
+    /// One result per action. The same action is usually established at several context sizes at once - on a Monday,
+    /// in the early morning, and on a Monday early morning - and returning all three says the same thing three times
+    /// while pushing the second-most-likely action out of a limited result set. The survivor is the one conditioned
+    /// on most of the question, which is the best-informed estimate of the three.
+    /// </para>
+    /// </remarks>
+    public IEnumerable<BehaviorPattern> MatchActions(
+        IEnumerable<BehaviorPattern> patterns,
+        FacetSet context,
+        PatternConfidence minimumConfidence,
+        int maximumResults)
+    {
+        if (maximumResults <= 0)
+        {
+            return [];
+        }
+
+        return
+        [
+            .. patterns
+                .Where(pattern => pattern.AnswersFor(context) && pattern.Confidence.Value >= minimumConfidence.Value)
+                .GroupBy(pattern => pattern.Action)
+                .Select(BestInformed)
+                .OrderByDescending(pattern => pattern.Confidence.Value)
+                .ThenByDescending(pattern => pattern.ContextSpecificity)
+                .ThenByDescending(pattern => pattern.Support.Value)
+                .ThenBy(pattern => pattern.Facets.Key.Value, StringComparer.Ordinal)
+                .Take(maximumResults)
+        ];
+    }
+
+    static BehaviorPattern BestInformed(IEnumerable<BehaviorPattern> forOneAction) =>
+        forOneAction
+            .OrderByDescending(pattern => pattern.ContextSpecificity)
+            .ThenByDescending(pattern => pattern.Confidence.Value)
+            .ThenByDescending(pattern => pattern.Support.Value)
+            .ThenBy(pattern => pattern.Facets.Key.Value, StringComparer.Ordinal)
+            .First();
 }

--- a/Source/Kernel/Core/Patterns/PatternMiner.cs
+++ b/Source/Kernel/Core/Patterns/PatternMiner.cs
@@ -149,12 +149,12 @@ public class PatternMiner(
 
     double ConfidenceOf(LossyCountingEntry entry, LossyCountingSketch sketch, double support)
     {
-        if (!entry.Itemset.Constrains(FacetName.CommandType))
+        if (!entry.Itemset.ConstrainsAction)
         {
             return support;
         }
 
-        var context = new FacetSet(entry.Itemset.Facets.Where(facet => facet.Name != FacetName.CommandType));
+        var context = entry.Itemset.WithoutActions();
         if (context.IsEmpty)
         {
             return support;

--- a/Source/Kernel/Core/Services/Patterns/Patterns.cs
+++ b/Source/Kernel/Core/Services/Patterns/Patterns.cs
@@ -73,6 +73,41 @@ internal sealed class Patterns(
     }
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<Pattern>> GetUsualActions(Contracts.Patterns.GetPatternsRequest request, CallContext context = default)
+    {
+        var groupingKey = new PatternGroupingKey(request.GroupingKey);
+        if (!groupingKey.IsSpecified)
+        {
+            return [];
+        }
+
+        var configuration = options.Value.PatternDetection;
+        var requested = vocabulary.Select(request.Context.ToFacetSet());
+
+        // Read the scope rather than looking up candidate keys. An answer is the asked context plus an action, and
+        // the action's value is the thing being asked for - so its key cannot be formed in advance the way
+        // GetPatterns forms its candidates. What makes the read affordable is the mining bound rather than the
+        // query: an itemset only reaches storage by holding MinimumSupport of everything the scope did, so a scope
+        // holds patterns in the hundreds no matter how many events it produced.
+        var patterns = await storage
+            .GetEventStore(request.EventStore)
+            .GetNamespace(request.Namespace)
+            .Patterns
+            .GetForScope(groupingKey);
+
+        var minimumConfidence = request.MinimumConfidence > 0d
+            ? new PatternConfidence(request.MinimumConfidence)
+            : new PatternConfidence(configuration.MinimumConfidence);
+
+        var maximumResults = request.MaximumResults > 0 ? request.MaximumResults : DefaultMaximumResults;
+
+        return matcher
+            .MatchActions(patterns, requested, minimumConfidence, maximumResults)
+            .Select(pattern => pattern.ToContract())
+            .ToArray();
+    }
+
+    /// <inheritdoc/>
     public async Task<IEnumerable<Pattern>> GetPatternsForScope(Contracts.Patterns.GetPatternsForScopeRequest request, CallContext context = default)
     {
         var patterns = await storage


### PR DESCRIPTION
Asking what somebody usually does in a context now comes back with the command, not with a restatement of the question.

A pattern was matched when **its facets were a subset of the asked context**. Nobody asking what a person usually does on a Monday early morning can name the command in the question — naming it is what they are asking for — so the patterns that answer were exactly the ones the rule excluded. Against the `Backoffice` sample, Ingrid's `RegisterInvoice; Day=Monday; TimeBucket=EarlyMorning` sat at 100% over 730 occurrences while the query returned `TimeBucket=EarlyMorning` at 53%.

### Added

- `GetUsualActions` on the .NET client and the `Patterns` gRPC service — given a situation, what is usually *done* in it, ranked by confidence and at most one answer per action (#3872)
- `FacetName.IsAction`, `FacetSet.WithoutActions()` and `BehaviorPattern.AnswersFor` — the split between the action a pattern names and the context it was taken in, which mining already relied on privately

### Changed

- `GetPatternsAt` answers with commands rather than with the moment it was handed. It is built on `GetUsualActions` now, which is what its name and its documentation already promised.
- `GetPatterns` is unchanged and stays the call for the opposite question — given a situation you can describe completely, including the command, which established patterns cover it. That is the check to make before flagging an action as unusual, and it is the only one of the two answerable from a keyed candidate lookup.

### Notes

Confidence leads the ranking for answers where specificity leads for descriptions: confidence is already the chance of an action given the context it was established in, which compares directly between one answer and the next, where a facet count does not.

An answer must use some of the question. An action established in no context at all — "half of what this person ever does is post ledger entries" — has an empty context, and an empty set is a subset of every context there is, so it would answer every question identically including ones about moments the scope has never worked. Asking what somebody usually does on a Sunday night they never work returns nothing, which is the answer this surface exists to be able to give honestly. When the caller names nothing, the general behavior is what they asked for and is returned.

Verified against the `Backoffice` sample end to end: 11,337 events, the moment from the issue now answering `RegisterInvoice` at 100%, the person with no routine still answering nothing, and the Sunday-night case returning nothing rather than a base rate.
