### PR TITLE
Make pattern capture keep up, stay per store, and survive restarts

### DIFF
--- a/Documentation/patterns/index.md
+++ b/Documentation/patterns/index.md
@@ -56,6 +56,12 @@ Chronicle does not store anything per event. It keeps a bounded **Lossy Counting
 
 Storage therefore scales with **distinct recurring behavior**, not with event volume. A store that appends millions of events but sees a few hundred recurring behaviors holds a few hundred rows.
 
+Mining happens in memory on every observed event; **persistence is deferred** — the scopes an interval touched are rewritten on the `PersistenceInterval` cadence, so a bulk ingest of thousands of events costs a handful of writes rather than one rewrite per event. Sketches are kept **per event store and per namespace**: the same scope name in two stores — or two tenants' namespaces — is two different people's behavior and never counts into one sketch.
+
+### Across restarts
+
+The sketch lives in memory, but what survived it is persisted — so when the server restarts, a scope's established patterns are **restored into the sketch before anything new is mined for it** and counting continues where it left off. Without that, the first events after a restart would be a fresh sketch's only observations, held with full support, and rewriting the scope from them would wipe established behavior. `Occurrences` stays a bounded approximation: a small tail of events can be re-mined after a crash, over-counting by at most the observer's checkpoint window.
+
 ### Confidence
 
 Confidence reads as the rule *"in this context, this action follows"*: the frequency of the whole combination over the frequency of the same combination without its `CommandType` facet. A combination that names no action is pure context, and its confidence is its support.
@@ -72,12 +78,13 @@ Under `Cratis:Chronicle:PatternDetection`:
 | `MinimumSupport` | `0.01` | The smallest share of events a combination must hold to survive |
 | `MinimumConfidence` | `0.5` | The smallest confidence a combination must hold to survive |
 | `DecayFactor` | `0.99` | Daily decay applied to a combination that has gone unseen |
+| `PersistenceInterval` | `5` | Seconds between persisting the scopes mining has touched |
 
 `Year` and `Month` are deliberately absent from `Facets`: they are kept on a surviving pattern for recency, but combining them multiplies the candidate space by every month the store has been running while splitting one behavior across all of them. Add them when a deployment wants to mine seasonality and can afford the cardinality.
 
 ## When capture starts
 
-Pattern capture observes the event types an event store has registered, and re-subscribes as more are registered — so a store that gains its first event types while the server is already running starts being captured then, not at the next restart.
+Pattern capture observes the event types an event store has registered, and re-subscribes as more are registered — so a store that gains its first event types while the server is already running starts being captured then, not at the next restart. A **namespace added while the server runs** is subscribed the moment it appears, so a tenant onboarded between restarts is mined from its first event.
 
 ## Naming the command
 

--- a/Samples/Backoffice/SampleHistory.cs
+++ b/Samples/Backoffice/SampleHistory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Events;
-
 namespace Samples.Backoffice;
 
 /// <summary>
@@ -105,9 +103,11 @@ public static class SampleHistory
         Action<int> onProgress)
     {
         // The marker goes down first and is guarded by a uniqueness constraint, so a second run is turned away
-        // here rather than laying a duplicate history on top of the first.
+        // here rather than laying a duplicate history on top of the first. The constraint allows one such event
+        // per event source, so the marker must land on the same, well-known event source every run - a fresh id
+        // would open a fresh source and sail straight past the guard.
         var marker = await appender.Append(
-            EventSourceId.New(),
+            "sample-history",
             new SampleHistoryGenerated(new Quantity(seed)),
             Workforce.Overnight,
             DateTimeOffset.UtcNow,

--- a/Source/Kernel/Core.Specs/Namespaces/for_NamespacesReactor/when_namespace_is_added.cs
+++ b/Source/Kernel/Core.Specs/Namespaces/for_NamespacesReactor/when_namespace_is_added.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Patterns;
+using Cratis.Chronicle.Seeding;
+using Cratis.Chronicle.Storage.Seeding;
+
+namespace Cratis.Chronicle.Namespaces.for_NamespacesReactor;
+
+/// <summary>
+/// Startup subscribes pattern capture for every namespace that exists and event type registration re-subscribes
+/// when the type list grows - but a namespace added while the server runs, with no type change to piggyback on,
+/// would otherwise mine nothing until the next restart.
+/// </summary>
+public class when_namespace_is_added : Specification
+{
+    NamespacesReactor _reactor;
+    IPatternCapture _patternCapture;
+
+    void Establish()
+    {
+        _patternCapture = Substitute.For<IPatternCapture>();
+
+        var seeding = Substitute.For<IResultAwareEventSeeding>();
+        seeding.GetSeededEvents().Returns(new EventSeeds(
+            new Dictionary<EventTypeId, IEnumerable<SeededEventEntry>>(),
+            new Dictionary<EventSourceId, IEnumerable<SeededEventEntry>>()));
+
+        var grainFactory = Substitute.For<IGrainFactory>();
+        grainFactory.GetGrain<IResultAwareEventSeeding>(Arg.Any<string>(), Arg.Any<string>()).Returns(seeding);
+
+        _reactor = new(grainFactory, _patternCapture);
+    }
+
+    async Task Because() => await _reactor.Added(new NamespaceAdded("some-store", "some-namespace"), null!);
+
+    [Fact] async Task should_subscribe_pattern_capture_for_the_namespace() =>
+        await _patternCapture.Received(1).Subscribe("some-store", "some-namespace");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/given/a_pattern_capture_subscriber.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/given/a_pattern_capture_subscriber.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Patterns;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.given;
+
+public class a_pattern_capture_subscriber : Specification
+{
+    protected static readonly DateTimeOffset Occurred = new(2026, 8, 24, 9, 15, 0, TimeSpan.Zero);
+
+    protected TestKitSilo _silo;
+    protected PatternCaptureSubscriber _subscriber;
+    protected IPatternMiner _miner;
+    protected IEventFeatureExtractor _extractor;
+    protected IBehaviorPatternStorage _patterns;
+    protected EventStoreName _eventStore;
+    protected EventStoreNamespaceName _namespace;
+
+    async Task Establish()
+    {
+        _eventStore = "some-store";
+        _namespace = EventStoreNamespaceName.Default;
+
+        _miner = Substitute.For<IPatternMiner>();
+        _extractor = Substitute.For<IEventFeatureExtractor>();
+        _patterns = Substitute.For<IBehaviorPatternStorage>();
+        _patterns.GetForScope(Arg.Any<PatternGroupingKey>()).Returns([]);
+
+        var storage = Substitute.For<IStorage>();
+        var eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        var namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        storage.GetEventStore(_eventStore).Returns(eventStoreStorage);
+        eventStoreStorage.GetNamespace(_namespace).Returns(namespaceStorage);
+        namespaceStorage.Patterns.Returns(_patterns);
+
+        _silo = new TestKitSilo();
+        _silo.AddService(_miner);
+        _silo.AddService(_extractor);
+        _silo.AddService(storage);
+        _silo.AddService(Options.Create(new ChronicleOptions()));
+        _silo.AddService(Substitute.For<ILogger<PatternCaptureSubscriber>>());
+
+        var key = new ObserverSubscriberKey(
+            PatternCapture.ObserverIdentifier,
+            _eventStore,
+            _namespace,
+            EventSequenceId.Log,
+            ObserverSubscriberKey.AllPartitions,
+            "127.0.0.1:11111@1");
+        _subscriber = await _silo.CreateGrainAsync<PatternCaptureSubscriber>(key.ToString());
+    }
+
+    protected AppendedEvent EventAt(EventSequenceNumber sequenceNumber, PatternGroupingKey scope)
+    {
+        var context = EventContext.From(
+            _eventStore,
+            _namespace,
+            new EventType("some-event", EventTypeGeneration.First),
+            EventSourceType.Default,
+            new EventSourceId(Guid.NewGuid().ToString()),
+            EventStreamType.All,
+            EventStreamId.Default,
+            sequenceNumber,
+            CorrelationId.New());
+
+        var @event = new AppendedEvent(context, new ExpandoObject());
+        _extractor.Extract(@event).Returns(FeaturesFor(scope));
+        return @event;
+    }
+
+    protected static EventFeatures FeaturesFor(PatternGroupingKey scope) =>
+        new(
+            scope,
+            "some-command",
+            InitiatorType.User,
+            scope.Value,
+            FacetValue.Unspecified,
+            FacetValue.Unspecified,
+            FacetValue.Unspecified,
+            "some-aggregate",
+            2026,
+            8,
+            DayOfWeek.Monday,
+            TimeBucket.Morning,
+            Occurred);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_deactivating/with_touched_scopes.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_deactivating/with_touched_scopes.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_deactivating;
+
+public class with_touched_scopes : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    async Task Establish()
+    {
+        _miner.GetSurvivingPatterns(_eventStore, _namespace, _scope).Returns([]);
+        await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope)],
+            new ObserverSubscriberContext(null));
+    }
+
+    async Task Because() => await _silo.DeactivateAsync(_subscriber);
+
+    [Fact] void should_persist_what_the_interval_had_not_flushed_yet() => _patterns.Received(1).Save(Arg.Any<IEnumerable<BehaviorPattern>>());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_mining_fails.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_mining_fails.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+public class and_mining_fails : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    ObserverSubscriberResult _result;
+
+    void Establish() => _miner.When(miner => miner.Observe(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>(), Arg.Any<EventFeatures>())).Throw(new Exception("mining broke"));
+
+    async Task Because() =>
+        _result = await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope)],
+            new ObserverSubscriberContext(null));
+
+    [Fact] void should_answer_failed() => _result.State.ShouldEqual(ObserverSubscriberState.Failed);
+    [Fact] void should_carry_the_failure() => _result.ExceptionMessages.ShouldContain("mining broke");
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_no_event_names_a_scope.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_no_event_names_a_scope.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+public class and_no_event_names_a_scope : given.a_pattern_capture_subscriber
+{
+    ObserverSubscriberResult _result;
+
+    async Task Because()
+    {
+        _result = await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, new PatternGroupingKey(string.Empty))],
+            new ObserverSubscriberContext(null));
+        await _silo.FireAllTimersAsync();
+    }
+
+    [Fact] void should_answer_ok() => _result.State.ShouldEqual(ObserverSubscriberState.Ok);
+    [Fact] void should_answer_with_the_tail_of_the_batch() => _result.LastSuccessfulObservation.ShouldEqual((EventSequenceNumber)42UL);
+    [Fact] void should_not_mine() => _miner.DidNotReceiveWithAnyArgs().Observe(default!, default!, default!);
+    [Fact] void should_have_nothing_to_persist_once_the_interval_elapses() => _patterns.DidNotReceiveWithAnyArgs().Save(default!);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_restoring_established_patterns_fails.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_restoring_established_patterns_fails.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+/// <summary>
+/// Mining a scope whose established patterns could not be read would rewrite it from a fresh sketch and wipe what
+/// was established. Failing the batch instead redelivers it later - nothing was mined yet, so the retry counts
+/// nothing twice.
+/// </summary>
+public class and_restoring_established_patterns_fails : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    ObserverSubscriberResult _result;
+
+    void Establish() => _patterns.GetForScope(_scope).Returns<IEnumerable<BehaviorPattern>>(_ => throw new Exception("storage broke"));
+
+    async Task Because() =>
+        _result = await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope)],
+            new ObserverSubscriberContext(null));
+
+    [Fact] void should_answer_failed() => _result.State.ShouldEqual(ObserverSubscriberState.Failed);
+    [Fact] void should_carry_the_failure() => _result.ExceptionMessages.ShouldContain("storage broke");
+    [Fact] void should_not_mine_anything() => _miner.DidNotReceiveWithAnyArgs().Observe(default!, default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_persistence_interval_elapses.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_persistence_interval_elapses.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+public class and_the_persistence_interval_elapses : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+    static readonly FacetSet _facets = new([new Facet(FacetName.CommandType, "some-command")]);
+
+    BehaviorPattern _surviving;
+
+    async Task Establish()
+    {
+        _surviving = new BehaviorPattern(_scope, _facets, 10, 0.8, 0.2, 10, Occurred, Occurred);
+        _miner.GetSurvivingPatterns(_eventStore, _namespace, _scope).Returns([_surviving]);
+
+        await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope), EventAt(43UL, _scope)],
+            new ObserverSubscriberContext(null));
+    }
+
+    async Task Because() => await _silo.FireAllTimersAsync();
+
+    [Fact] void should_save_the_surviving_patterns_once_for_the_touched_scope() => _patterns.Received(1).Save(Arg.Is<IEnumerable<BehaviorPattern>>(patterns => patterns.Single() == _surviving));
+    [Fact] void should_remove_everything_no_longer_surviving_for_the_touched_scope() => _patterns.Received(1).RemoveAllExcept(_scope, Arg.Is<IEnumerable<FacetSetKey>>(keys => keys.Single() == _facets.Key));
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_persistence_interval_has_not_elapsed.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_persistence_interval_has_not_elapsed.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+public class and_the_persistence_interval_has_not_elapsed : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    ObserverSubscriberResult _result;
+
+    async Task Because() =>
+        _result = await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope), EventAt(43UL, _scope)],
+            new ObserverSubscriberContext(null));
+
+    [Fact] void should_answer_ok() => _result.State.ShouldEqual(ObserverSubscriberState.Ok);
+    [Fact] void should_answer_with_the_tail_of_the_batch() => _result.LastSuccessfulObservation.ShouldEqual((EventSequenceNumber)43UL);
+    [Fact] void should_mine_every_event() => _miner.Received(2).Observe(_eventStore, _namespace, Arg.Is<EventFeatures>(features => features.GroupingKey == _scope));
+    [Fact] void should_not_touch_storage() => _patterns.DidNotReceiveWithAnyArgs().Save(default!);
+    [Fact] void should_not_remove_anything() => _patterns.DidNotReceiveWithAnyArgs().RemoveAllExcept(default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_scope_has_established_patterns.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_observing_events/and_the_scope_has_established_patterns.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_observing_events;
+
+public class and_the_scope_has_established_patterns : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    BehaviorPattern _established;
+
+    void Establish()
+    {
+        _established = new BehaviorPattern(
+            _scope,
+            new FacetSet([new Facet(FacetName.CommandType, "some-command")]),
+            15,
+            1d,
+            0.75d,
+            15d,
+            Occurred,
+            Occurred);
+        _patterns.GetForScope(_scope).Returns([_established]);
+    }
+
+    async Task Because()
+    {
+        await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope)],
+            new ObserverSubscriberContext(null));
+        await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(43UL, _scope)],
+            new ObserverSubscriberContext(null));
+    }
+
+    [Fact] void should_restore_the_established_patterns_before_mining() =>
+        Received.InOrder(() =>
+        {
+            _miner.Restore(_eventStore, _namespace, _scope, Arg.Is<IEnumerable<BehaviorPattern>>(patterns => patterns.Single() == _established));
+            _miner.Observe(_eventStore, _namespace, Arg.Any<EventFeatures>());
+            _miner.Observe(_eventStore, _namespace, Arg.Any<EventFeatures>());
+        });
+
+    [Fact] async Task should_only_read_the_established_patterns_once_per_activation() => await _patterns.Received(1).GetForScope(_scope);
+    [Fact] void should_mine_every_event() => _miner.Received(2).Observe(_eventStore, _namespace, Arg.Any<EventFeatures>());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_persisting/and_nothing_was_touched.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_persisting/and_nothing_was_touched.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_persisting;
+
+public class and_nothing_was_touched : given.a_pattern_capture_subscriber
+{
+    async Task Because() => await _silo.FireAllTimersAsync();
+
+    [Fact] void should_not_touch_storage() => _patterns.DidNotReceiveWithAnyArgs().Save(default!);
+    [Fact] void should_not_remove_anything() => _patterns.DidNotReceiveWithAnyArgs().RemoveAllExcept(default!, default!);
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_persisting/and_storage_fails.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternCaptureSubscriber/when_persisting/and_storage_fails.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Keys;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Observation;
+using Cratis.Chronicle.Properties;
+using Orleans.TestKit;
+
+namespace Cratis.Chronicle.Patterns.for_PatternCaptureSubscriber.when_persisting;
+
+public class and_storage_fails : given.a_pattern_capture_subscriber
+{
+    static readonly PatternGroupingKey _scope = "some.user";
+
+    async Task Establish()
+    {
+        _miner.GetSurvivingPatterns(_eventStore, _namespace, _scope).Returns([]);
+        _patterns.Save(Arg.Any<IEnumerable<BehaviorPattern>>()).Returns(
+            _ => throw new Exception("storage broke"),
+            _ => Task.CompletedTask);
+
+        await _subscriber.OnNext(
+            new Key("partition", ArrayIndexers.NoIndexers),
+            [EventAt(42UL, _scope)],
+            new ObserverSubscriberContext(null));
+
+        // The first tick fails against storage; the scope must stay marked so the next tick tries again.
+        await _silo.FireAllTimersAsync();
+    }
+
+    async Task Because() => await _silo.FireAllTimersAsync();
+
+    [Fact] void should_retry_the_scope_on_the_next_tick() => _patterns.Received(2).Save(Arg.Any<IEnumerable<BehaviorPattern>>());
+    [Fact] void should_remove_what_no_longer_survives_once_saving_succeeds() => _patterns.Received(1).RemoveAllExcept(_scope, Arg.Any<IEnumerable<FacetSetKey>>());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/given/a_pattern_miner.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/given/a_pattern_miner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Patterns;
 using Cratis.Chronicle.Configuration;
 using Microsoft.Extensions.Options;
@@ -12,9 +13,14 @@ public class a_pattern_miner : Specification
     protected static readonly DateTimeOffset Occurred = new(2026, 8, 24, 9, 15, 0, TimeSpan.Zero);
 
     protected PatternMiner _miner;
+    protected EventStoreName _eventStore;
+    protected EventStoreNamespaceName _namespace;
 
     void Establish()
     {
+        _eventStore = "some-store";
+        _namespace = EventStoreNamespaceName.Default;
+
         var options = Options.Create(new ChronicleOptions
         {
             PatternDetection = new PatternDetection

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/a_recurring_behavior.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/a_recurring_behavior.cs
@@ -17,10 +17,10 @@ public class a_recurring_behavior : given.a_pattern_miner
     {
         for (var count = 0; count < 20; count++)
         {
-            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
         }
 
-        _result = _miner.GetSurvivingPatterns("user-42");
+        _result = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
     }
 
     [Fact] void should_mine_the_full_combination() =>

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/an_event_nobody_can_be_named_for.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/an_event_nobody_can_be_named_for.cs
@@ -17,10 +17,10 @@ public class an_event_nobody_can_be_named_for : given.a_pattern_miner
     {
         for (var count = 0; count < 20; count++)
         {
-            _miner.Observe(Features(PatternGroupingKey.Unspecified, "ApproveExpenseReport"));
+            _miner.Observe(_eventStore, _namespace, Features(PatternGroupingKey.Unspecified, "ApproveExpenseReport"));
         }
 
-        _result = _miner.GetSurvivingPatterns();
+        _result = _miner.GetSurvivingPatterns(_eventStore, _namespace, PatternGroupingKey.Unspecified);
     }
 
     [Fact] void should_not_mine_anything() => _result.ShouldBeEmpty();

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_for_two_users.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_for_two_users.cs
@@ -18,16 +18,16 @@ public class behavior_for_two_users : given.a_pattern_miner
     {
         for (var count = 0; count < 20; count++)
         {
-            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
         }
 
         for (var count = 0; count < 20; count++)
         {
-            _miner.Observe(Features("user-7", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+            _miner.Observe(_eventStore, _namespace, Features("user-7", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
         }
 
-        _forFirstUser = _miner.GetSurvivingPatterns("user-42");
-        _forSecondUser = _miner.GetSurvivingPatterns("user-7");
+        _forFirstUser = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
+        _forSecondUser = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-7");
     }
 
     [Fact] void should_mine_only_the_first_user_behavior_for_the_first_user() =>

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_that_only_sometimes_follows.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/behavior_that_only_sometimes_follows.cs
@@ -17,15 +17,15 @@ public class behavior_that_only_sometimes_follows : given.a_pattern_miner
     {
         for (var count = 0; count < 15; count++)
         {
-            _miner.Observe(Features("user-42", "ApproveExpenseReport"));
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
         }
 
         for (var count = 0; count < 5; count++)
         {
-            _miner.Observe(Features("user-42", "RejectExpenseReport"));
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "RejectExpenseReport"));
         }
 
-        _result = _miner.GetSurvivingPatterns("user-42");
+        _result = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
     }
 
     BehaviorPattern Approving => _result.Single(_ =>

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/the_same_scope_in_two_event_stores.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/the_same_scope_in_two_event_stores.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// The same scope name in two event stores is two different people's behavior. One miner serves every store the
+/// server holds, so counting them into one sketch would let each store's behavior contaminate what the other
+/// store reports - and what the other store persists.
+/// </summary>
+public class the_same_scope_in_two_event_stores : given.a_pattern_miner
+{
+    EventStoreName _otherEventStore;
+    IEnumerable<BehaviorPattern> _forFirstStore;
+    IEnumerable<BehaviorPattern> _forOtherStore;
+
+    void Establish() => _otherEventStore = "some-other-store";
+
+    void Because()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_otherEventStore, _namespace, Features("user-42", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+        }
+
+        _forFirstStore = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
+        _forOtherStore = _miner.GetSurvivingPatterns(_otherEventStore, _namespace, "user-42");
+    }
+
+    [Fact] void should_not_leak_the_other_store_behavior_into_the_first() =>
+        _forFirstStore.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("SubmitExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_not_leak_the_first_store_behavior_into_the_other() =>
+        _forOtherStore.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("ApproveExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_count_only_the_store_own_observations() =>
+        _forFirstStore.Concat(_forOtherStore).All(_ => _.Occurrences.Value == 20L).ShouldBeTrue();
+
+    [Fact] void should_hold_full_support_in_each_store_on_its_own() =>
+        _forFirstStore.Concat(_forOtherStore).All(_ => _.Support.Value == 1d).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/the_same_scope_in_two_namespaces.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_mining/the_same_scope_in_two_namespaces.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_mining;
+
+/// <summary>
+/// A namespace is a tenant. The same scope name in two namespaces is two different tenants' behavior, and
+/// counting them into one sketch would leak one tenant's routine into what the other tenant is told about
+/// its own users.
+/// </summary>
+public class the_same_scope_in_two_namespaces : given.a_pattern_miner
+{
+    EventStoreNamespaceName _otherNamespace;
+    IEnumerable<BehaviorPattern> _forFirstNamespace;
+    IEnumerable<BehaviorPattern> _forOtherNamespace;
+
+    void Establish() => _otherNamespace = "some-other-tenant";
+
+    void Because()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_eventStore, _otherNamespace, Features("user-42", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+        }
+
+        _forFirstNamespace = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
+        _forOtherNamespace = _miner.GetSurvivingPatterns(_eventStore, _otherNamespace, "user-42");
+    }
+
+    [Fact] void should_not_leak_the_other_tenant_behavior_into_the_first() =>
+        _forFirstNamespace.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("SubmitExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_not_leak_the_first_tenant_behavior_into_the_other() =>
+        _forOtherNamespace.All(_ => _.Facets.ValueOf(FacetName.CommandType) != new FacetValue("ApproveExpenseReport")).ShouldBeTrue();
+
+    [Fact] void should_count_only_the_tenant_own_observations() =>
+        _forFirstNamespace.Concat(_forOtherNamespace).All(_ => _.Occurrences.Value == 20L).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/a_scope_that_already_has_counts.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/a_scope_that_already_has_counts.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_restoring;
+
+/// <summary>
+/// Restoring is only meaningful into the absence a restart leaves behind. A scope that already holds live counts
+/// has counted things the persisted patterns have not, so a restore into it must be ignored rather than merged.
+/// </summary>
+public class a_scope_that_already_has_counts : given.a_pattern_miner
+{
+    IEnumerable<BehaviorPattern> _surviving;
+
+    void Establish()
+    {
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+    }
+
+    void Because()
+    {
+        var stale = new BehaviorPattern(
+            "user-42",
+            new FacetSet([new Facet(FacetName.CommandType, "SomethingElse")]),
+            99,
+            1d,
+            0.9d,
+            99d,
+            Occurred,
+            Occurred);
+
+        _miner.Restore(_eventStore, _namespace, "user-42", [stale]);
+        _surviving = _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42");
+    }
+
+    [Fact] void should_keep_the_live_counts() =>
+        _surviving.Where(_ => _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport").All(_ => _.Occurrences.Value == 20L).ShouldBeTrue();
+
+    [Fact] void should_ignore_what_the_restore_carried() =>
+        _surviving.Any(_ => _.Facets.ValueOf(FacetName.CommandType).Value == "SomethingElse").ShouldBeFalse();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/an_established_scope.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/an_established_scope.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_restoring;
+
+/// <summary>
+/// The sketch dies with its process while the patterns it survived into do not. Restoring what was persisted
+/// must give back exactly the behavior that was established - same combinations, same counts, same support and
+/// confidence - so mining continues where it left off instead of starting over.
+/// </summary>
+public class an_established_scope : given.a_pattern_miner
+{
+    EventStoreName _restoredInto;
+    BehaviorPattern[] _established;
+    BehaviorPattern[] _restored;
+
+    void Establish()
+    {
+        _restoredInto = "store-after-restart";
+
+        for (var count = 0; count < 15; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 5; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "RejectExpenseReport"));
+        }
+
+        _established = [.. _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42")];
+    }
+
+    void Because()
+    {
+        _miner.Restore(_restoredInto, _namespace, "user-42", _established);
+        _restored = [.. _miner.GetSurvivingPatterns(_restoredInto, _namespace, "user-42")];
+    }
+
+    BehaviorPattern MatchOf(BehaviorPattern pattern) => _restored.Single(_ => _.Facets.Key == pattern.Facets.Key);
+
+    [Fact] void should_hold_every_established_pattern() =>
+        _restored.Select(_ => _.Facets.Key).Order().ShouldContainOnly(_established.Select(_ => _.Facets.Key).Order());
+
+    [Fact] void should_hold_the_same_counts() =>
+        _established.All(_ => MatchOf(_).Occurrences == _.Occurrences).ShouldBeTrue();
+
+    [Fact] void should_hold_the_same_support() =>
+        _established.All(_ => MatchOf(_).Support == _.Support).ShouldBeTrue();
+
+    [Fact] void should_hold_the_same_confidence() =>
+        _established.All(_ => MatchOf(_).Confidence == _.Confidence).ShouldBeTrue();
+
+    [Fact] void should_preserve_when_the_behavior_was_seen() =>
+        _established.All(_ => MatchOf(_).FirstSeen == _.FirstSeen && MatchOf(_).LastSeen == _.LastSeen).ShouldBeTrue();
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/and_the_context_did_not_survive_on_its_own.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/and_the_context_did_not_survive_on_its_own.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_restoring;
+
+/// <summary>
+/// Only surviving patterns are persisted, and a pure context rarely survives on its own - its confidence is just
+/// its support. A pattern restored without its context would re-derive at zero confidence and be swept away on
+/// the first flush, so the restore must synthesize the context frequency back from the confidence that was
+/// written with the pattern.
+/// </summary>
+public class and_the_context_did_not_survive_on_its_own : given.a_pattern_miner
+{
+    EventStoreName _restoredInto;
+    BehaviorPattern[] _established;
+    BehaviorPattern[] _restored;
+
+    void Establish()
+    {
+        _restoredInto = "store-after-restart";
+
+        // Six approvals in one slot against fourteen submissions elsewhere: the approving pattern survives with
+        // full confidence, while its Monday-morning context alone holds three tenths support - below the halves
+        // confidence a pure context needs - and is not persisted.
+        for (var count = 0; count < 6; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+
+        for (var count = 0; count < 14; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+        }
+
+        _established = [.. _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42")];
+    }
+
+    void Because()
+    {
+        _miner.Restore(_restoredInto, _namespace, "user-42", _established);
+        _restored = [.. _miner.GetSurvivingPatterns(_restoredInto, _namespace, "user-42")];
+    }
+
+    static BehaviorPattern ApprovingAmong(IEnumerable<BehaviorPattern> patterns) => patterns.Single(_ =>
+        _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport" &&
+        _.Facets.ValueOf(FacetName.Day).Value == "Monday" &&
+        _.Facets.ValueOf(FacetName.TimeBucket).Value == "Morning" &&
+        _.Specificity == 3);
+
+    [Fact] void should_not_have_persisted_the_context_on_its_own() =>
+        _established.Any(_ => _.Facets.Key == ApprovingAmong(_established).Facets.WithoutActions().Key).ShouldBeFalse();
+
+    [Fact] void should_keep_the_established_pattern() => ApprovingAmong(_restored).ShouldNotBeNull();
+    [Fact] void should_re_derive_it_with_its_confidence() => ApprovingAmong(_restored).Confidence.ShouldEqual(ApprovingAmong(_established).Confidence);
+    [Fact] void should_re_derive_it_with_its_counts() => ApprovingAmong(_restored).Occurrences.Value.ShouldEqual(6L);
+    [Fact] void should_hold_every_established_pattern() =>
+        _restored.Select(_ => _.Facets.Key).Order().ShouldContainOnly(_established.Select(_ => _.Facets.Key).Order());
+}

--- a/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/and_then_observing_more_behavior.cs
+++ b/Source/Kernel/Core.Specs/Patterns/for_PatternMiner/when_restoring/and_then_observing_more_behavior.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Patterns;
+
+namespace Cratis.Chronicle.Patterns.for_PatternMiner.when_restoring;
+
+/// <summary>
+/// Without restoring, the first event after a restart would be a fresh sketch's only observation - held with full
+/// support, and rewriting the scope from it would wipe the established behavior in favor of whatever happened to
+/// occur first. Restored counts must keep their standing against a stray newcomer.
+/// </summary>
+public class and_then_observing_more_behavior : given.a_pattern_miner
+{
+    EventStoreName _restoredInto;
+    IEnumerable<BehaviorPattern> _surviving;
+
+    void Establish()
+    {
+        _restoredInto = "store-after-restart";
+
+        for (var count = 0; count < 20; count++)
+        {
+            _miner.Observe(_eventStore, _namespace, Features("user-42", "ApproveExpenseReport"));
+        }
+
+        _miner.Restore(_restoredInto, _namespace, "user-42", _miner.GetSurvivingPatterns(_eventStore, _namespace, "user-42"));
+    }
+
+    void Because()
+    {
+        _miner.Observe(_restoredInto, _namespace, Features("user-42", "SubmitExpenseReport", DayOfWeek.Friday, TimeBucket.Evening));
+        _surviving = _miner.GetSurvivingPatterns(_restoredInto, _namespace, "user-42");
+    }
+
+    [Fact] void should_keep_the_established_behavior() =>
+        _surviving.Any(_ =>
+            _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport" &&
+            _.Facets.ValueOf(FacetName.Day).Value == "Monday" &&
+            _.Facets.ValueOf(FacetName.TimeBucket).Value == "Morning").ShouldBeTrue();
+
+    [Fact] void should_keep_the_established_counts() =>
+        _surviving.Where(_ => _.Facets.ValueOf(FacetName.CommandType).Value == "ApproveExpenseReport").All(_ => _.Occurrences.Value == 20L).ShouldBeTrue();
+
+    [Fact] void should_not_let_a_single_new_event_survive() =>
+        _surviving.Any(_ => _.Facets.ValueOf(FacetName.CommandType).Value == "SubmitExpenseReport").ShouldBeFalse();
+}

--- a/Source/Kernel/Core/Configuration/PatternDetection.cs
+++ b/Source/Kernel/Core/Configuration/PatternDetection.cs
@@ -66,4 +66,17 @@ public class PatternDetection
     /// value of 1 disables decay entirely and a smaller value forgets faster.
     /// </remarks>
     public double DecayFactor { get; init; } = 0.99;
+
+    /// <summary>
+    /// Gets how many seconds pass between persisting the scopes mining has touched.
+    /// </summary>
+    /// <remarks>
+    /// Mining is in-memory and cheap; persisting a scope rewrites everything that currently survives for it.
+    /// Persisting per observed batch couples the write cost to the event rate times the size of each scope's
+    /// behavior - a bulk ingest of a few thousand events becomes hundreds of thousands of storage writes, all
+    /// serialized through the one activation the subscriber has. Persisting on this cadence instead bounds the
+    /// cost by how many scopes were touched in the interval, no matter how many events touched them. Values at
+    /// or below zero are treated as one second.
+    /// </remarks>
+    public int PersistenceInterval { get; init; } = 5;
 }

--- a/Source/Kernel/Core/Namespaces/NamespacesReactor.cs
+++ b/Source/Kernel/Core/Namespaces/NamespacesReactor.cs
@@ -5,6 +5,7 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Seeding;
 using Cratis.Chronicle.Observation.Reactors.Kernel;
+using Cratis.Chronicle.Patterns;
 using Cratis.Chronicle.Seeding;
 
 #pragma warning disable IDE0060 // Remove unused parameter
@@ -15,18 +16,27 @@ namespace Cratis.Chronicle.Namespaces;
 /// Represents a reactor that handles namespace events.
 /// </summary>
 /// <param name="grainFactory">The <see cref="IGrainFactory"/> for creating grains.</param>
+/// <param name="patternCapture">The <see cref="IPatternCapture"/> for observing the new namespace's events.</param>
 [Reactor(eventSequence: WellKnownEventSequences.System, systemEventStoreOnly: true)]
-public class NamespacesReactor(IGrainFactory grainFactory) : Reactor
+public class NamespacesReactor(IGrainFactory grainFactory, IPatternCapture patternCapture) : Reactor
 {
     /// <summary>
-    /// Handles the addition of a namespace by applying any existing global seed data to it.
+    /// Handles the addition of a namespace by subscribing pattern capture for it and applying any existing global
+    /// seed data to it.
     /// </summary>
     /// <param name="event">The event containing the namespace information.</param>
     /// <param name="eventContext">The context of the event.</param>
     /// <returns>Await Task.</returns>
     /// <exception cref="EventSeedingIncomplete">Thrown when at least one global seed entry was not appended to the namespace.</exception>
+    /// <remarks>
+    /// Startup subscribes pattern capture for every namespace that exists, and event type registration
+    /// re-subscribes when the type list grows - but a namespace added while the server runs, with no type change
+    /// to piggyback on, would otherwise mine nothing until the next restart.
+    /// </remarks>
     public async Task Added(NamespaceAdded @event, EventContext eventContext)
     {
+        await patternCapture.Subscribe(@event.EventStore, @event.Namespace);
+
         var globalKey = EventSeedingKey.ForGlobal(@event.EventStore);
         var globalGrain = grainFactory.GetGrain<IResultAwareEventSeeding>(globalKey.ToString());
         var seeds = await globalGrain.GetSeededEvents();

--- a/Source/Kernel/Core/Patterns/IPatternMiner.cs
+++ b/Source/Kernel/Core/Patterns/IPatternMiner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Patterns;
 
 namespace Cratis.Chronicle.Patterns;
@@ -8,13 +9,30 @@ namespace Cratis.Chronicle.Patterns;
 /// <summary>
 /// Defines a system that mines recurring behavior from a stream of events.
 /// </summary>
+/// <remarks>
+/// Every operation names the event store and namespace it works within. Behavior belongs to a scope <b>inside</b>
+/// a store's namespace - the same scope name in two stores is two different people's behavior, and counting them
+/// into one sketch would contaminate both.
+/// </remarks>
 public interface IPatternMiner
 {
     /// <summary>
     /// Mine the facts extracted from one event.
     /// </summary>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the event belongs to.</param>
+    /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the event belongs to.</param>
     /// <param name="features">The <see cref="EventFeatures"/> to mine.</param>
-    void Observe(EventFeatures features);
+    void Observe(EventStoreName eventStore, EventStoreNamespaceName @namespace, EventFeatures features);
+
+    /// <summary>
+    /// Seed a scope with the patterns an earlier life of the miner had established, unless the scope already
+    /// holds live counts.
+    /// </summary>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the scope belongs to.</param>
+    /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the scope belongs to.</param>
+    /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to restore.</param>
+    /// <param name="patterns">The <see cref="BehaviorPattern">patterns</see> that survived the earlier life.</param>
+    void Restore(EventStoreName eventStore, EventStoreNamespaceName @namespace, PatternGroupingKey groupingKey, IEnumerable<BehaviorPattern> patterns);
 
     /// <summary>
     /// Decay every mined itemset as of a point in time.
@@ -23,15 +41,11 @@ public interface IPatternMiner
     void Decay(DateTimeOffset asOf);
 
     /// <summary>
-    /// Gets every itemset that currently clears the support and confidence thresholds, across all scopes.
-    /// </summary>
-    /// <returns>The surviving <see cref="BehaviorPattern">patterns</see>.</returns>
-    IEnumerable<BehaviorPattern> GetSurvivingPatterns();
-
-    /// <summary>
     /// Gets every itemset that currently clears the support and confidence thresholds for one scope.
     /// </summary>
+    /// <param name="eventStore">The <see cref="EventStoreName"/> the scope belongs to.</param>
+    /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the scope belongs to.</param>
     /// <param name="groupingKey">The <see cref="PatternGroupingKey"/> to get for.</param>
     /// <returns>The surviving <see cref="BehaviorPattern">patterns</see>.</returns>
-    IEnumerable<BehaviorPattern> GetSurvivingPatterns(PatternGroupingKey groupingKey);
+    IEnumerable<BehaviorPattern> GetSurvivingPatterns(EventStoreName eventStore, EventStoreNamespaceName @namespace, PatternGroupingKey groupingKey);
 }

--- a/Source/Kernel/Core/Patterns/LossyCountingSketch.cs
+++ b/Source/Kernel/Core/Patterns/LossyCountingSketch.cs
@@ -102,6 +102,29 @@ public sealed class LossyCountingSketch
     }
 
     /// <summary>
+    /// Seed the sketch with entries counted by an earlier life of it, continuing from where that one left off.
+    /// </summary>
+    /// <param name="entries">The <see cref="LossyCountingEntry">entries</see> to seed with.</param>
+    /// <param name="observed">How many observations the earlier life had seen.</param>
+    /// <remarks>
+    /// The in-memory sketch dies with its process while what survived it is persisted, so a fresh sketch that
+    /// starts from zero would report its first few observations with full support - and rewriting a scope from
+    /// that would wipe established behavior in favor of whatever happened right after a restart. Restoring puts
+    /// the persisted survivors back with the counts they had, so mining continues instead of starting over.
+    /// Restored entries carry no error term: they were surviving patterns, counted precisely for as long as they
+    /// have been retained.
+    /// </remarks>
+    public void Restore(IEnumerable<LossyCountingEntry> entries, long observed)
+    {
+        Observed = observed;
+
+        foreach (var entry in entries)
+        {
+            _entries[entry.Itemset.Key] = MutableEntry.From(entry);
+        }
+    }
+
+    /// <summary>
     /// Drop every itemset that has not kept up with the stream.
     /// </summary>
     /// <remarks>
@@ -190,6 +213,15 @@ public sealed class LossyCountingSketch
         public DateTimeOffset FirstSeen { get; private set; } = occurred;
 
         public DateTimeOffset LastSeen { get; private set; } = occurred;
+
+        public static MutableEntry From(LossyCountingEntry entry) =>
+            new(entry.Itemset, entry.Error, entry.FirstSeen)
+            {
+                Frequency = entry.Frequency,
+                Weight = entry.Weight,
+                LastSeen = entry.LastSeen,
+                _weightAsOf = entry.LastSeen
+            };
 
         public void Count(DateTimeOffset occurred, double decayFactor)
         {

--- a/Source/Kernel/Core/Patterns/PatternCaptureLogging.cs
+++ b/Source/Kernel/Core/Patterns/PatternCaptureLogging.cs
@@ -11,6 +11,9 @@ internal static partial class PatternCaptureLogging
     [LoggerMessage(LogLevel.Warning, "Failed capturing behavior patterns for event store {EventStore} in namespace {Namespace}")]
     internal static partial void FailedCapturingPatterns(this ILogger<PatternCaptureSubscriber> logger, EventStoreName eventStore, EventStoreNamespaceName @namespace, Exception exception);
 
+    [LoggerMessage(LogLevel.Warning, "Failed persisting behavior patterns for {ScopeCount} scopes in event store {EventStore} in namespace {Namespace} - they stay marked for the next flush")]
+    internal static partial void FailedPersistingPatterns(this ILogger<PatternCaptureSubscriber> logger, EventStoreName eventStore, EventStoreNamespaceName @namespace, int scopeCount, Exception exception);
+
     [LoggerMessage(LogLevel.Debug, "Subscribing pattern capture for event store {EventStore} in namespace {Namespace} to {EventTypeCount} event types")]
     internal static partial void SubscribingPatternCapture(this ILogger<PatternCapture> logger, EventStoreName eventStore, EventStoreNamespaceName @namespace, int eventTypeCount);
 

--- a/Source/Kernel/Core/Patterns/PatternCaptureSubscriber.cs
+++ b/Source/Kernel/Core/Patterns/PatternCaptureSubscriber.cs
@@ -1,13 +1,16 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Concepts.Keys;
 using Cratis.Chronicle.Concepts.Observation;
+using Cratis.Chronicle.Concepts.Patterns;
+using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Patterns;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Cratis.Chronicle.Patterns;
 
@@ -18,24 +21,67 @@ namespace Cratis.Chronicle.Patterns;
 /// <param name="miner">The <see cref="IPatternMiner"/> to mine with.</param>
 /// <param name="extractor">The <see cref="IEventFeatureExtractor"/> for reading an event's contextual facts.</param>
 /// <param name="storage">The <see cref="IStorage"/> to persist surviving patterns to.</param>
+/// <param name="options">The <see cref="IOptions{TOptions}"/> holding the <see cref="ChronicleOptions"/>.</param>
 /// <param name="logger">The <see cref="ILogger"/> for logging.</param>
 /// <remarks>
 /// <para>
-/// Nothing per event is written. A batch is mined in memory and then the scopes it touched are rewritten from what
-/// currently survives, so storage holds the scope's behavior as it now stands rather than a log of how it got
-/// there.
+/// Observing only mines - in memory, cheap - and marks the scope dirty. A timer persists what the interval
+/// touched. Persisting a scope means rewriting everything that currently survives for it, so doing it per
+/// observed batch couples the write cost to the event rate times the size of each scope's behavior: a bulk
+/// ingest of a few thousand events becomes hundreds of thousands of storage writes, all serialized through the
+/// one activation an unpartitioned subscriber has, and every delivery queued behind them times out. Deferring to
+/// the timer bounds the write cost by how many scopes acted in the interval, no matter how many events they
+/// produced.
 /// </para>
 /// <para>
-/// Only the scopes a batch touched are rewritten. Rewriting every scope on every batch would make the write cost
-/// grow with how many people have ever used the store rather than with how many acted just now.
+/// The first time a scope acts in this activation's life, its established patterns are restored into the miner
+/// before anything is mined. The sketch dies with its process while the patterns it survived into do not, so a
+/// scope mined from zero would rewrite its established behavior with whatever happened right after a restart.
+/// When the restore cannot be read, the batch is failed and redelivered rather than mined - nothing has been
+/// counted yet, so the retry counts nothing twice. A small tail of events can still be re-mined after a crash,
+/// because observer progress is checkpointed in batches; that over-counts by at most the checkpoint window, and
+/// occurrences are a bounded approximation - a bounded overlap is the cost of continuing instead of starting
+/// over.
+/// </para>
+/// <para>
+/// A failed persist keeps the scopes dirty and answers nothing but the log - the next tick simply tries again.
+/// Failing the observation instead would fail partitions and redeliver events that were already mined, doubling
+/// their counts, over state that is derived and rewritten in full on the next flush anyway.
+/// </para>
+/// <para>
+/// Only the scopes an interval touched are rewritten. Rewriting every scope on every flush would make the write
+/// cost grow with how many people have ever used the store rather than with how many acted just now.
 /// </para>
 /// </remarks>
 public class PatternCaptureSubscriber(
     IPatternMiner miner,
     IEventFeatureExtractor extractor,
     IStorage storage,
+    IOptions<ChronicleOptions> options,
     ILogger<PatternCaptureSubscriber> logger) : Grain, IPatternCaptureSubscriber
 {
+    readonly HashSet<PatternGroupingKey> _touchedScopes = [];
+    readonly HashSet<PatternGroupingKey> _restoredScopes = [];
+    ObserverSubscriberKey _key = ObserverSubscriberKey.Unspecified;
+
+    IBehaviorPatternStorage Patterns => storage.GetEventStore(_key.EventStore).GetNamespace(_key.Namespace).Patterns;
+
+    /// <inheritdoc/>
+    public override Task OnActivateAsync(CancellationToken cancellationToken)
+    {
+        _key = ObserverSubscriberKey.Parse(this.GetPrimaryKeyString());
+        var interval = TimeSpan.FromSeconds(Math.Max(1, options.Value.PatternDetection.PersistenceInterval));
+        this.RegisterGrainTimer(Persist, new GrainTimerCreationOptions { DueTime = interval, Period = interval });
+        return base.OnActivateAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        await Persist();
+        await base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
     /// <inheritdoc/>
     public async Task<ObserverSubscriberResult> OnNext(Key partition, IEnumerable<AppendedEvent> events, ObserverSubscriberContext context)
     {
@@ -45,25 +91,19 @@ public class PatternCaptureSubscriber(
             return ObserverSubscriberResult.Ok(EventSequenceNumber.Unavailable);
         }
 
-        var key = ObserverSubscriberKey.Parse(this.GetPrimaryKeyString());
-
         try
         {
-            var touched = new HashSet<Concepts.Patterns.PatternGroupingKey>();
-            foreach (var features in batch.Select(extractor.Extract))
-            {
-                if (!features.GroupingKey.IsSpecified)
-                {
-                    continue;
-                }
+            var mined = batch
+                .Select(extractor.Extract)
+                .Where(features => features.GroupingKey.IsSpecified)
+                .ToArray();
 
-                miner.Observe(features);
-                touched.Add(features.GroupingKey);
-            }
+            await RestoreScopesActingForTheFirstTime(mined.Select(features => features.GroupingKey));
 
-            if (touched.Count > 0)
+            foreach (var features in mined)
             {
-                await Persist(key.EventStore, key.Namespace, touched);
+                miner.Observe(_key.EventStore, _key.Namespace, features);
+                _touchedScopes.Add(features.GroupingKey);
             }
 
             return ObserverSubscriberResult.Ok(batch[^1].Context.SequenceNumber);
@@ -72,7 +112,7 @@ public class PatternCaptureSubscriber(
         {
             // Mining is derived, secondary information. A failure here must not stop the event sequence being
             // observed for everything else, so it is reported as this observer's failure and nothing more.
-            logger.FailedCapturingPatterns(key.EventStore, key.Namespace, ex);
+            logger.FailedCapturingPatterns(_key.EventStore, _key.Namespace, ex);
             return new ObserverSubscriberResult(
                 ObserverSubscriberState.Failed,
                 EventSequenceNumber.Unavailable,
@@ -81,15 +121,43 @@ public class PatternCaptureSubscriber(
         }
     }
 
-    async Task Persist(EventStoreName eventStore, EventStoreNamespaceName @namespace, IEnumerable<Concepts.Patterns.PatternGroupingKey> scopes)
+    async Task RestoreScopesActingForTheFirstTime(IEnumerable<PatternGroupingKey> scopes)
     {
-        var patterns = storage.GetEventStore(eventStore).GetNamespace(@namespace).Patterns;
-
-        foreach (var scope in scopes)
+        foreach (var scope in scopes.Distinct().Where(scope => !_restoredScopes.Contains(scope)))
         {
-            var surviving = miner.GetSurvivingPatterns(scope).ToArray();
-            await patterns.Save(surviving);
-            await patterns.RemoveAllExcept(scope, surviving.Select(pattern => pattern.Facets.Key));
+            var established = await Patterns.GetForScope(scope);
+            miner.Restore(_key.EventStore, _key.Namespace, scope, established);
+            _restoredScopes.Add(scope);
+        }
+    }
+
+    async Task Persist()
+    {
+        if (_touchedScopes.Count == 0)
+        {
+            return;
+        }
+
+        var scopes = _touchedScopes.ToArray();
+        _touchedScopes.Clear();
+
+        try
+        {
+            var patterns = Patterns;
+
+            foreach (var scope in scopes)
+            {
+                var surviving = miner.GetSurvivingPatterns(_key.EventStore, _key.Namespace, scope).ToArray();
+                await patterns.Save(surviving);
+                await patterns.RemoveAllExcept(scope, surviving.Select(pattern => pattern.Facets.Key));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Rewriting a scope is idempotent, so scopes that did get written before the failure are simply
+            // rewritten again on the next tick along with the ones that did not.
+            _touchedScopes.UnionWith(scopes);
+            logger.FailedPersistingPatterns(_key.EventStore, _key.Namespace, scopes.Length, ex);
         }
     }
 }

--- a/Source/Kernel/Core/Patterns/PatternMiner.cs
+++ b/Source/Kernel/Core/Patterns/PatternMiner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.Patterns;
 using Cratis.Chronicle.Configuration;
 using Cratis.DependencyInjection;
@@ -10,13 +11,19 @@ namespace Cratis.Chronicle.Patterns;
 
 /// <summary>
 /// Represents an implementation of <see cref="IPatternMiner"/> backed by a <see cref="LossyCountingSketch"/> per
-/// scope.
+/// scope within an event store's namespace.
 /// </summary>
 /// <remarks>
 /// <para>
 /// One sketch per grouping key rather than one for everybody: a habit is a person's, and a shared sketch would let
 /// a busy user's routine outvote everyone else's while making "what does this user usually do" unanswerable.
 /// Whether a global sketch should exist alongside these, for org-wide behavior, is deliberately left open.
+/// </para>
+/// <para>
+/// Sketches are keyed by event store and namespace as well as by scope, because the miner is one instance serving
+/// every store the server holds. The same scope name in two stores - or two tenants' namespaces - is two different
+/// people's behavior; a sketch keyed by scope alone would count them together and contaminate both stores'
+/// persisted patterns.
 /// </para>
 /// <para>
 /// An event nobody can be named for is not mined at all. Its behavior belongs to no scope, so it could only be
@@ -33,12 +40,12 @@ public class PatternMiner(
     IFacetSetGenerator generator,
     IOptions<ChronicleOptions> options) : IPatternMiner
 {
-    readonly Dictionary<PatternGroupingKey, LossyCountingSketch> _sketches = [];
+    readonly Dictionary<(EventStoreName EventStore, EventStoreNamespaceName Namespace, PatternGroupingKey GroupingKey), LossyCountingSketch> _sketches = [];
     readonly Lock _lock = new();
     readonly PatternDetection _configuration = options.Value.PatternDetection;
 
     /// <inheritdoc/>
-    public void Observe(EventFeatures features)
+    public void Observe(EventStoreName eventStore, EventStoreNamespaceName @namespace, EventFeatures features)
     {
         if (!features.GroupingKey.IsSpecified)
         {
@@ -55,7 +62,63 @@ public class PatternMiner(
 
         lock (_lock)
         {
-            GetSketch(features.GroupingKey).Observe(itemsets, features.Occurred);
+            GetSketch(eventStore, @namespace, features.GroupingKey).Observe(itemsets, features.Occurred);
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <para>
+    /// Live counts win: restoring is only meaningful into the absence a restart leaves behind. Once a scope holds a
+    /// sketch, whatever it has counted is more current than what was persisted from it, so a restore into it is
+    /// ignored rather than merged.
+    /// </para>
+    /// <para>
+    /// Only surviving patterns were persisted, but re-deriving a pattern's confidence needs the frequency of its
+    /// context - the itemset without its action - and a pure context rarely survives on its own, because its
+    /// confidence is just its support. Every number needed is still recoverable from what was written: support was
+    /// frequency over observations and confidence was frequency over context frequency, so the observation count
+    /// and every missing context entry are synthesized back from the patterns that reference them. Without that,
+    /// every restored pattern whose context was absent would re-derive at zero confidence and be swept away on the
+    /// first flush after a restart - precisely the wipe restoring exists to prevent.
+    /// </para>
+    /// </remarks>
+    public void Restore(EventStoreName eventStore, EventStoreNamespaceName @namespace, PatternGroupingKey groupingKey, IEnumerable<BehaviorPattern> patterns)
+    {
+        lock (_lock)
+        {
+            var key = (eventStore, @namespace, groupingKey);
+            if (_sketches.ContainsKey(key))
+            {
+                return;
+            }
+
+            var sketch = new LossyCountingSketch(_configuration.Error, _configuration.DecayFactor);
+            var established = patterns.ToArray();
+
+            if (established.Length > 0)
+            {
+                // Support was written as frequency over observations, so the observation count the sketch had is
+                // recoverable from any pattern - the largest answer is the most precise against rounding.
+                var observed = established.Max(pattern => pattern.Support.Value > 0d
+                    ? (long)Math.Round(pattern.Occurrences.Value / pattern.Support.Value)
+                    : 0L);
+
+                var entries = established.ToDictionary(
+                    pattern => pattern.Facets.Key,
+                    pattern => new LossyCountingEntry(
+                        pattern.Facets,
+                        pattern.Occurrences,
+                        0L,
+                        pattern.Weight,
+                        pattern.FirstSeen,
+                        pattern.LastSeen));
+
+                SynthesizeMissingContexts(established, entries);
+                sketch.Restore(entries.Values, observed);
+            }
+
+            _sketches[key] = sketch;
         }
     }
 
@@ -73,31 +136,64 @@ public class PatternMiner(
     }
 
     /// <inheritdoc/>
-    public IEnumerable<BehaviorPattern> GetSurvivingPatterns()
+    public IEnumerable<BehaviorPattern> GetSurvivingPatterns(EventStoreName eventStore, EventStoreNamespaceName @namespace, PatternGroupingKey groupingKey)
     {
         lock (_lock)
         {
-            return [.. _sketches.SelectMany(pair => Surviving(pair.Key, pair.Value))];
-        }
-    }
-
-    /// <inheritdoc/>
-    public IEnumerable<BehaviorPattern> GetSurvivingPatterns(PatternGroupingKey groupingKey)
-    {
-        lock (_lock)
-        {
-            return _sketches.TryGetValue(groupingKey, out var sketch)
+            return _sketches.TryGetValue((eventStore, @namespace, groupingKey), out var sketch)
                 ? [.. Surviving(groupingKey, sketch)]
                 : [];
         }
     }
 
-    LossyCountingSketch GetSketch(PatternGroupingKey groupingKey)
+    /// <summary>
+    /// Add the context entries a restore has to synthesize, each with the frequency its patterns say it must
+    /// have had.
+    /// </summary>
+    /// <param name="established">The persisted <see cref="BehaviorPattern">patterns</see> being restored.</param>
+    /// <param name="entries">The entries being restored, keyed by itemset - contexts already among them are left alone.</param>
+    /// <remarks>
+    /// Several patterns can share one context, and each names the same context frequency through its own confidence;
+    /// the largest recovered answer is kept as the most precise against rounding.
+    /// </remarks>
+    static void SynthesizeMissingContexts(BehaviorPattern[] established, Dictionary<FacetSetKey, LossyCountingEntry> entries)
     {
-        if (!_sketches.TryGetValue(groupingKey, out var sketch))
+        var contexts = new Dictionary<FacetSetKey, (FacetSet Context, long Frequency, BehaviorPattern Pattern)>();
+
+        foreach (var pattern in established.Where(pattern => pattern.Facets.ConstrainsAction && pattern.Confidence.Value > 0d))
+        {
+            var context = pattern.Facets.WithoutActions();
+            if (context.IsEmpty || entries.ContainsKey(context.Key))
+            {
+                continue;
+            }
+
+            var frequency = (long)Math.Round(pattern.Occurrences.Value / pattern.Confidence.Value);
+            if (!contexts.TryGetValue(context.Key, out var existing) || existing.Frequency < frequency)
+            {
+                contexts[context.Key] = (context, frequency, pattern);
+            }
+        }
+
+        foreach (var (context, frequency, pattern) in contexts.Values)
+        {
+            entries[context.Key] = new LossyCountingEntry(
+                context,
+                frequency,
+                0L,
+                pattern.Weight,
+                pattern.FirstSeen,
+                pattern.LastSeen);
+        }
+    }
+
+    LossyCountingSketch GetSketch(EventStoreName eventStore, EventStoreNamespaceName @namespace, PatternGroupingKey groupingKey)
+    {
+        var key = (eventStore, @namespace, groupingKey);
+        if (!_sketches.TryGetValue(key, out var sketch))
         {
             sketch = new LossyCountingSketch(_configuration.Error, _configuration.DecayFactor);
-            _sketches[groupingKey] = sketch;
+            _sketches[key] = sketch;
         }
 
         return sketch;


### PR DESCRIPTION
# Summary

Ingesting a few thousand events could melt the kernel down: pattern capture rewrote every touched scope's full surviving pattern set on every observed batch, serialized through its single activation. Deliveries queued behind those writes blew the subscriber timeout, failed partitions by the hundreds, and spawned a storm of retry jobs against the same congested grain. Investigating that also surfaced that behavior patterns leaked between event stores and namespaces, and that a server restart wiped a scope's established behavior on its next event. All three are fixed and covered by specs.

## Added

- `PatternDetection.PersistenceInterval` setting controlling how often mined behavior patterns are persisted (default 5 seconds).

## Fixed

- Bulk event ingestion no longer overwhelms pattern capture: observing only mines in memory, and the scopes an interval touched are persisted on a cadence — eliminating the subscriber timeouts, failed partitions, and retry-job storms high-rate appends previously caused.
- Behavior patterns are isolated per event store and per namespace — the same scope name in two stores, or in two tenants' namespaces, no longer counts into one sketch and contaminates both sides' persisted patterns.
- Established behavior patterns survive a server restart: a scope's persisted patterns are restored into the miner before its first event after a restart is mined, instead of being wiped in favor of whatever happened to occur first.
- A namespace added while the server is running is subscribed for pattern capture immediately, instead of only after the next restart or event type registration.
- The Backoffice sample's `generate` is genuinely re-runnable: its history marker now lands on a well-known event source so the guarding uniqueness constraint actually turns a second run away.
