### PR TITLE
Let enums evolve in place, and map values across generations

### DIFF
--- a/.ai/skills/event-type-migrations/SKILL.md
+++ b/.ai/skills/event-type-migrations/SKILL.md
@@ -60,6 +60,21 @@ public class OrderPlacedV1ToV2 : EventTypeMigration<OrderPlaced, OrderPlacedV1>
 
 The property builder exposes `DefaultValue`, `RenamedFrom`, `Split`, and `Combine` — use them to express the change declaratively. Both `Upcast` and `Downcast` are abstract on the base, so both must be implemented (`Downcast` may be a no-op `builder.Properties(_ => { })` when no consumer needs the gen-1 shape).
 
+### 2b. When the *values* changed meaning, declare a value map
+
+The operations above move values between properties. When a value itself means something different in the new generation — an enum renumbered, a status code set replaced — override **`MapValues`** on the migration instead. It is declared once and applied forward when upcasting and inverted when downcasting:
+
+```csharp
+public override void MapValues(IEventValueMapBuilder<OrderStatusChanged, OrderStatusChangedV1> builder) =>
+    builder.For(current => current.Status, previous => previous.Status, map => map
+        .Map(OrderStatusV1.Pending, OrderStatus.Awaiting)
+        .Map(OrderStatusV1.Done, OrderStatus.Completed));
+```
+
+Values the map doesn't mention are carried across unchanged. Two values collapsing onto one take the first pair declared for that value on the way back. `MapValues` runs *before* `Upcast`/`Downcast`, so a direction that states its own transformation for the property keeps it — that's also how you express a deliberately one-way translation (`builder.Properties(pb => pb.MapValues(...))`).
+
+> **An enum gaining a member or having a member renamed needs no migration at all** — Chronicle accepts both in place and updates the registered schema, because neither changes what an already stored value means. Only a *removed* or *renumbered* member needs a new generation plus a value map.
+
 ### 3. Chain across generations
 
 For three generations, write two migrations (`1→2`, `2→3`) — each only knows its adjacent pair; Chronicle chains them.

--- a/Documentation/client-snippets/concepts/event-type-migrations/map-values.md
+++ b/Documentation/client-snippets/concepts/event-type-migrations/map-values.md
@@ -1,0 +1,43 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+public enum MigrationsSubscriptionStateV1
+{
+    Unknown = 0,
+    Active = 1,
+    Cancelled = 2
+}
+
+public enum MigrationsSubscriptionState
+{
+    Unspecified = 100,
+    Running = 101,
+    Stopped = 102
+}
+
+[EventType("subscription-state-changed", generation: 2)]
+public record MigrationsSubscriptionStateChanged(MigrationsSubscriptionState State);
+
+[EventTypeGenerationFor<MigrationsSubscriptionStateChanged>(1)]
+public record MigrationsSubscriptionStateChangedV1(MigrationsSubscriptionStateV1 State);
+
+public class MigrationsSubscriptionStateChangedMigration : EventTypeMigration<MigrationsSubscriptionStateChanged, MigrationsSubscriptionStateChangedV1>
+{
+    public override void Upcast(IEventMigrationBuilder<MigrationsSubscriptionStateChanged, MigrationsSubscriptionStateChangedV1> builder)
+    {
+        // The value map covers State in both directions
+    }
+
+    public override void Downcast(IEventMigrationBuilder<MigrationsSubscriptionStateChangedV1, MigrationsSubscriptionStateChanged> builder)
+    {
+        // The value map covers State in both directions
+    }
+
+    public override void MapValues(IEventValueMapBuilder<MigrationsSubscriptionStateChanged, MigrationsSubscriptionStateChangedV1> builder) =>
+        builder.For(current => current.State, previous => previous.State, map => map
+            .Map(MigrationsSubscriptionStateV1.Unknown, MigrationsSubscriptionState.Unspecified)
+            .Map(MigrationsSubscriptionStateV1.Active, MigrationsSubscriptionState.Running)
+            .Map(MigrationsSubscriptionStateV1.Cancelled, MigrationsSubscriptionState.Stopped));
+}
+```

--- a/Documentation/client-snippets/migrations/dotnet-client/map-values-one-direction.md
+++ b/Documentation/client-snippets/migrations/dotnet-client/map-values-one-direction.md
@@ -1,0 +1,7 @@
+```csharp
+public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentProcessed, MigrationsDotnetClientPaymentProcessedV1> builder) =>
+    builder.Properties(pb => pb
+        .MapValues(current => current.Status, previous => previous.Status, map => map
+            .Map(MigrationsDotnetClientPaymentStatusV1.Pending, MigrationsDotnetClientPaymentStatus.Awaiting)
+            .Map(MigrationsDotnetClientPaymentStatusV1.Settled, MigrationsDotnetClientPaymentStatus.Completed)));
+```

--- a/Documentation/client-snippets/migrations/dotnet-client/map-values-one-direction.md
+++ b/Documentation/client-snippets/migrations/dotnet-client/map-values-one-direction.md
@@ -1,7 +1,39 @@
 ```csharp
-public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentProcessed, MigrationsDotnetClientPaymentProcessedV1> builder) =>
-    builder.Properties(pb => pb
-        .MapValues(current => current.Status, previous => previous.Status, map => map
-            .Map(MigrationsDotnetClientPaymentStatusV1.Pending, MigrationsDotnetClientPaymentStatus.Awaiting)
-            .Map(MigrationsDotnetClientPaymentStatusV1.Settled, MigrationsDotnetClientPaymentStatus.Completed)));
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+public enum MigrationsDotnetClientDeclineReasonV1
+{
+    InsufficientFunds = 0,
+    CardExpired = 1,
+    CardReported = 2
+}
+
+public enum MigrationsDotnetClientDeclineReason
+{
+    Funds = 0,
+    Card = 1
+}
+
+[EventType("dotnet-client-payment-declined", generation: 2)]
+public record MigrationsDotnetClientPaymentDeclined(MigrationsDotnetClientDeclineReason Reason);
+
+[EventTypeGenerationFor<MigrationsDotnetClientPaymentDeclined>(1)]
+public record MigrationsDotnetClientPaymentDeclinedV1(MigrationsDotnetClientDeclineReasonV1 Reason);
+
+public class MigrationsDotnetClientPaymentDeclinedMigration : EventTypeMigration<MigrationsDotnetClientPaymentDeclined, MigrationsDotnetClientPaymentDeclinedV1>
+{
+    public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentDeclined, MigrationsDotnetClientPaymentDeclinedV1> builder) =>
+        builder.Properties(pb => pb
+            .MapValues(current => current.Reason, previous => previous.Reason, map => map
+                .Map(MigrationsDotnetClientDeclineReasonV1.InsufficientFunds, MigrationsDotnetClientDeclineReason.Funds)
+                .Map(MigrationsDotnetClientDeclineReasonV1.CardExpired, MigrationsDotnetClientDeclineReason.Card)
+                .Map(MigrationsDotnetClientDeclineReasonV1.CardReported, MigrationsDotnetClientDeclineReason.Card)));
+
+    public override void Downcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentDeclinedV1, MigrationsDotnetClientPaymentDeclined> builder) =>
+        builder.Properties(pb => pb
+            .MapValues(previous => previous.Reason, current => current.Reason, map => map
+                .Map(MigrationsDotnetClientDeclineReason.Funds, MigrationsDotnetClientDeclineReasonV1.InsufficientFunds)
+                .Map(MigrationsDotnetClientDeclineReason.Card, MigrationsDotnetClientDeclineReasonV1.CardExpired)));
+}
 ```

--- a/Documentation/client-snippets/migrations/dotnet-client/map-values.md
+++ b/Documentation/client-snippets/migrations/dotnet-client/map-values.md
@@ -1,0 +1,40 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+public enum MigrationsDotnetClientPaymentStatusV1
+{
+    Pending = 0,
+    Settled = 1
+}
+
+public enum MigrationsDotnetClientPaymentStatus
+{
+    Awaiting = 10,
+    Completed = 11
+}
+
+[EventType("dotnet-client-payment-processed", generation: 2)]
+public record MigrationsDotnetClientPaymentProcessed(MigrationsDotnetClientPaymentStatus Status);
+
+[EventTypeGenerationFor<MigrationsDotnetClientPaymentProcessed>(1)]
+public record MigrationsDotnetClientPaymentProcessedV1(MigrationsDotnetClientPaymentStatusV1 Status);
+
+public class MigrationsDotnetClientPaymentProcessedMigration : EventTypeMigration<MigrationsDotnetClientPaymentProcessed, MigrationsDotnetClientPaymentProcessedV1>
+{
+    public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentProcessed, MigrationsDotnetClientPaymentProcessedV1> builder)
+    {
+        // Status is covered by the value map
+    }
+
+    public override void Downcast(IEventMigrationBuilder<MigrationsDotnetClientPaymentProcessedV1, MigrationsDotnetClientPaymentProcessed> builder)
+    {
+        // Status is covered by the value map
+    }
+
+    public override void MapValues(IEventValueMapBuilder<MigrationsDotnetClientPaymentProcessed, MigrationsDotnetClientPaymentProcessedV1> builder) =>
+        builder.For(current => current.Status, previous => previous.Status, map => map
+            .Map(MigrationsDotnetClientPaymentStatusV1.Pending, MigrationsDotnetClientPaymentStatus.Awaiting)
+            .Map(MigrationsDotnetClientPaymentStatusV1.Settled, MigrationsDotnetClientPaymentStatus.Completed));
+}
+```

--- a/Documentation/concepts/event-type-migrations.mdx
+++ b/Documentation/concepts/event-type-migrations.mdx
@@ -56,6 +56,24 @@ Sets a default value for a new property:
 
 <ChronicleClientTabs snippet="concepts/event-type-migrations/default-value" />
 
+### Value map
+
+The operations above move values between properties. A **value map** changes the values themselves — it states which value in one generation is which value in the other. This is what you reach for when an enum is renumbered, or a status code takes on a new set of values, and the old numbers now mean something the new generation spells differently.
+
+Override `MapValues` on the migration rather than declaring it inside `Upcast` or `Downcast`:
+
+<ChronicleClientTabs snippet="concepts/event-type-migrations/map-values" />
+
+A map declared this way is applied **in both directions**: forward when upcasting, inverted when downcasting. The pair of values is one fact about the two generations, so you state it once and the two directions cannot drift apart.
+
+Three things are worth knowing:
+
+- **Values the map does not mention are carried across unchanged.** A map says what changed meaning; it is not an exhaustive listing of an enum that is free to grow.
+- **Two values collapsing onto one have no single inverse**, so the first pair declared for a target value is the one that represents it going back.
+- **The map does not have to stay on the same property.** The two property expressions may name different properties, in which case the map also carries the value across — covering a rename and a re-valuing in one statement.
+
+`MapValues` is applied *before* `Upcast` and `Downcast` run, so a direction that states its own transformation for the same property keeps it.
+
 ## How Migrations Work
 
 When an event is appended to the event store:

--- a/Documentation/migrations/dotnet-client.mdx
+++ b/Documentation/migrations/dotnet-client.mdx
@@ -69,7 +69,7 @@ Unlike the property-builder operations, a value map is declared by overriding `M
 
 The map is applied forward when upcasting and inverted when downcasting, so you state it once. Values it does not mention are carried across unchanged, and two values collapsing onto one take the first pair declared for that value on the way back.
 
-`MapValues` runs before `Upcast` and `Downcast`, so a direction that declares its own transformation for the same property keeps it. That is also how you express a translation that is deliberately not reversible — declare it on the property builder for the one direction it applies to:
+`MapValues` runs before `Upcast` and `Downcast`, so a direction that declares its own transformation for the same property keeps it. That is also the way to express a translation that is not symmetric — several values collapsing onto one, where the way back has to make a choice the forward map cannot state. Declare that as a `MapValues` on the property builder, per direction:
 
 <ChronicleClientTabs snippet="migrations/dotnet-client/map-values-one-direction" />
 

--- a/Documentation/migrations/dotnet-client.mdx
+++ b/Documentation/migrations/dotnet-client.mdx
@@ -59,6 +59,24 @@ Provides a literal default for a property that did not exist in the source gener
 
 <ChronicleClientTabs snippet="migrations/dotnet-client/default-value" />
 
+## MapValues
+
+The four operations above move values between properties. `MapValues` changes the values themselves — it says which value in one generation is which value in the other, which is what you need when an enum is renumbered or a code set is replaced wholesale.
+
+Unlike the property-builder operations, a value map is declared by overriding `MapValues` on the migration:
+
+<ChronicleClientTabs snippet="migrations/dotnet-client/map-values" />
+
+The map is applied forward when upcasting and inverted when downcasting, so you state it once. Values it does not mention are carried across unchanged, and two values collapsing onto one take the first pair declared for that value on the way back.
+
+`MapValues` runs before `Upcast` and `Downcast`, so a direction that declares its own transformation for the same property keeps it. That is also how you express a translation that is deliberately not reversible — declare it on the property builder for the one direction it applies to:
+
+<ChronicleClientTabs snippet="migrations/dotnet-client/map-values-one-direction" />
+
+:::note[Client coverage]
+`MapValues` is currently C#-only.
+:::
+
 ## Multi-generation migrations
 
 If your event type spans more than two generations, define one migrator per generation pair. Chronicle chains them automatically.

--- a/Documentation/migrations/validation.mdx
+++ b/Documentation/migrations/validation.mdx
@@ -66,6 +66,22 @@ Cratis.Chronicle.Services.Events.EventTypeSchemaChanged:
 
 The fix is always to introduce a new generation and a corresponding migrator rather than silently mutating an existing one.
 
+### What an enum may still do
+
+Immutability is about what an already stored event *means*, so two kinds of change to an enum are accepted in place and update the registered schema rather than being rejected:
+
+- **Gaining a member.** Nothing already stored carries the new value, so nothing already stored changes meaning.
+- **Renaming a member.** An event's payload carries the underlying number, not the name; the name is resolved through the schema when the value is read. An enum mirroring an external system is renamed on that system's schedule, and Chronicle does not make you cut a generation for a spelling you do not control.
+
+Two changes remain breaking, because both leave already stored values denoting something other than what they denoted when they were written:
+
+- **Removing a member** — stored events carrying that value now denote nothing.
+- **Renumbering a member** — the names survive but move onto different numbers, so every stored event silently reads as a different member.
+
+For those two, cut a new generation and declare a [value map](../concepts/event-type-migrations#value-map) in the migration saying what the old values became. Chronicle applies it forward when upcasting and inverted when downcasting.
+
+Everything outside enums — a property added, removed, retyped, or renamed — is unchanged: still a schema change, still needing a new generation.
+
 ## Relaxing validation for development
 
 Strict validation is **always enforced in the production image** of the Kernel. The development image relaxes this by honouring the `EnableEventTypeGenerationValidation` flag sent from the client.

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionState.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionState.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+/// <summary>
+/// The subscription states the same upstream system uses now, on different underlying numbers.
+/// </summary>
+public enum SubscriptionState
+{
+    Unspecified = 100,
+    Running = 101,
+    Stopped = 102
+}

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChanged.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChanged.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+[EventType(generation: 2)]
+public record SubscriptionStateChanged(SubscriptionState State);

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChangedMigrator.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChangedMigrator.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Migrations;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+/// <summary>
+/// States what the upstream system's old state numbers became, once. Neither direction declares a transformation of
+/// its own - the map is read forward when upcasting and inverted when downcasting.
+/// </summary>
+public class SubscriptionStateChangedMigrator : EventTypeMigration<SubscriptionStateChanged, SubscriptionStateChangedV1>
+{
+    public override void Upcast(IEventMigrationBuilder<SubscriptionStateChanged, SubscriptionStateChangedV1> builder)
+    {
+    }
+
+    public override void Downcast(IEventMigrationBuilder<SubscriptionStateChangedV1, SubscriptionStateChanged> builder)
+    {
+    }
+
+    public override void MapValues(IEventValueMapBuilder<SubscriptionStateChanged, SubscriptionStateChangedV1> builder) =>
+        builder.For(current => current.State, previous => previous.State, map => map
+            .Map(SubscriptionStateV1.Unknown, SubscriptionState.Unspecified)
+            .Map(SubscriptionStateV1.Active, SubscriptionState.Running)
+            .Map(SubscriptionStateV1.Cancelled, SubscriptionState.Stopped));
+}

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChangedV1.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateChangedV1.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+[EventTypeGenerationFor<SubscriptionStateChanged>(1)]
+public record SubscriptionStateChangedV1(SubscriptionStateV1 State);

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateV1.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/SubscriptionStateV1.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+/// <summary>
+/// The subscription states an upstream system used before it renumbered them.
+/// </summary>
+public enum SubscriptionStateV1
+{
+    Unknown = 0,
+    Active = 1,
+    Cancelled = 2
+}

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_1.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_1.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map.and_event_is_generation_1.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+[Collection(ChronicleCollection.Name)]
+public class and_event_is_generation_1(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
+    {
+        public override IEnumerable<Type> EventTypes => [typeof(SubscriptionStateChangedV1), typeof(SubscriptionStateChanged)];
+        public override IEnumerable<Type> EventTypeMigrators => [typeof(SubscriptionStateChangedMigrator)];
+
+        public EventSourceId EventSourceId { get; } = "some-subscription";
+        public SubscriptionStateChangedV1 Event { get; private set; }
+        public IAppendResult AppendResult { get; private set; }
+
+        void Establish()
+        {
+            Event = new SubscriptionStateChangedV1(SubscriptionStateV1.Active);
+        }
+
+        async Task Because()
+        {
+            AppendResult = await EventStore.EventLog.Append(EventSourceId, Event);
+        }
+    }
+
+    [Fact] void should_succeed() => Context.AppendResult.IsSuccess.ShouldBeTrue();
+    [Fact] Task should_have_correct_tail_sequence_number() => Context.ShouldHaveTailSequenceNumber(EventSequenceNumber.First);
+
+    [Fact] Task should_have_mapped_the_state_into_generation_2_content() =>
+        Context.ShouldHaveAppendedEvent<SubscriptionStateChanged>(0, Context.EventSourceId.Value, e => e.State.ShouldEqual(SubscriptionState.Running));
+}

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_2.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_2.cs
@@ -12,6 +12,7 @@ namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_wi
 /// on its way to being stored at the older generation. What it must not do is come back out of the log translated -
 /// an append at the current generation has nothing to translate.
 /// </summary>
+/// <param name="context">The <see cref="context"/> the specification runs against.</param>
 [Collection(ChronicleCollection.Name)]
 public class and_event_is_generation_2(context context) : Given<context>(context)
 {

--- a/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_2.cs
+++ b/Integration/Client/for_EventSequence/when_appending_event_with_a_value_map/and_event_is_generation_2.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using context = Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map.and_event_is_generation_2.context;
+
+namespace Cratis.Chronicle.Integration.for_EventSequence.when_appending_event_with_a_value_map;
+
+/// <summary>
+/// The map is present in both directions, so an event written at the newer generation goes through the inverted one
+/// on its way to being stored at the older generation. What it must not do is come back out of the log translated -
+/// an append at the current generation has nothing to translate.
+/// </summary>
+[Collection(ChronicleCollection.Name)]
+public class and_event_is_generation_2(context context) : Given<context>(context)
+{
+    public class context(ChronicleFixture chronicleInProcessFixture) : Specification(chronicleInProcessFixture)
+    {
+        public override IEnumerable<Type> EventTypes => [typeof(SubscriptionStateChangedV1), typeof(SubscriptionStateChanged)];
+        public override IEnumerable<Type> EventTypeMigrators => [typeof(SubscriptionStateChangedMigrator)];
+
+        public EventSourceId EventSourceId { get; } = "another-subscription";
+        public SubscriptionStateChanged Event { get; private set; }
+        public IAppendResult AppendResult { get; private set; }
+
+        void Establish()
+        {
+            Event = new SubscriptionStateChanged(SubscriptionState.Stopped);
+        }
+
+        async Task Because()
+        {
+            AppendResult = await EventStore.EventLog.Append(EventSourceId, Event);
+        }
+    }
+
+    [Fact] void should_succeed() => Context.AppendResult.IsSuccess.ShouldBeTrue();
+    [Fact] Task should_have_correct_tail_sequence_number() => Context.ShouldHaveTailSequenceNumber(EventSequenceNumber.First);
+
+    [Fact] Task should_have_left_the_state_alone_at_the_generation_it_was_written_at() =>
+        Context.ShouldHaveAppendedEvent<SubscriptionStateChanged>(0, Context.EventSourceId.Value, e => e.State.ShouldEqual(SubscriptionState.Stopped));
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilder/when_mapping_enum_values.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilder/when_mapping_enum_values.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventMigrationPropertyBuilder;
+
+/// <summary>
+/// An event's payload carries an enum as its underlying number, so a map written in terms of enum members has to be
+/// rendered the same way - a map of names would never match anything.
+/// </summary>
+public class when_mapping_enum_values : Specification
+{
+    EventMigrationPropertyBuilder _builder;
+
+    void Establish() => _builder = new EventMigrationPropertyBuilder();
+
+    void Because() => _builder.MapValues("Status", "Status", [new ValueMapping(PreviousStatus.Verified, CurrentStatus.Confirmed)]);
+
+    [Fact] void should_render_the_source_member_as_its_underlying_value() =>
+        _builder.Properties["Status"]["$mapValues"]["mappings"][0]["from"].GetValue<int>().ShouldEqual(1);
+
+    [Fact] void should_render_the_target_member_as_its_underlying_value() =>
+        _builder.Properties["Status"]["$mapValues"]["mappings"][0]["to"].GetValue<int>().ShouldEqual(11);
+
+    enum PreviousStatus
+    {
+        Unknown = 0,
+        Verified = 1
+    }
+
+    enum CurrentStatus
+    {
+        Unspecified = 10,
+        Confirmed = 11
+    }
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilder/when_mapping_values.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilder/when_mapping_values.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventMigrationPropertyBuilder;
+
+public class when_mapping_values : Specification
+{
+    EventMigrationPropertyBuilder _builder;
+
+    void Establish() => _builder = new EventMigrationPropertyBuilder();
+
+    void Because() => _builder.MapValues("Status", "State", [new ValueMapping(0, 10), new ValueMapping(1, 11)]);
+
+    [Fact] void should_have_property_keyed_by_target_name() => _builder.Properties.ContainsKey("Status").ShouldBeTrue();
+
+    [Fact] void should_have_map_values_expression() =>
+        _builder.Properties["Status"]["$mapValues"].ShouldNotBeNull();
+
+    [Fact] void should_read_from_the_source_property() =>
+        _builder.Properties["Status"]["$mapValues"]["source"].GetValue<string>().ShouldEqual("State");
+
+    [Fact] void should_carry_every_mapping() =>
+        _builder.Properties["Status"]["$mapValues"]["mappings"].AsArray().Count.ShouldEqual(2);
+
+    [Fact] void should_carry_the_value_being_mapped_from() =>
+        _builder.Properties["Status"]["$mapValues"]["mappings"][0]["from"].GetValue<int>().ShouldEqual(0);
+
+    [Fact] void should_carry_the_value_being_mapped_to() =>
+        _builder.Properties["Status"]["$mapValues"]["mappings"][0]["to"].GetValue<int>().ShouldEqual(10);
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilderFor/when_mapping_values.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventMigrationPropertyBuilderFor/when_mapping_values.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventMigrationPropertyBuilderFor;
+
+public class when_mapping_values : Specification
+{
+    EventMigrationPropertyBuilder _inner;
+    EventMigrationPropertyBuilderFor<TargetEvent, SourceEvent> _builder;
+
+    void Establish()
+    {
+        _inner = new EventMigrationPropertyBuilder();
+        _builder = new EventMigrationPropertyBuilderFor<TargetEvent, SourceEvent>(_inner);
+    }
+
+    void Because() => _builder.MapValues(t => t.Age, s => s.FullName, map => map.Map("unknown", 0));
+
+    [Fact] void should_have_property_keyed_by_target_name() => _inner.Properties.ContainsKey("Age").ShouldBeTrue();
+
+    [Fact] void should_have_map_values_expression() => _inner.Properties["Age"].ToString().ShouldContain("$mapValues");
+
+    [Fact] void should_read_from_the_source_property() =>
+        _inner.Properties["Age"]["$mapValues"]["source"].GetValue<string>().ShouldEqual("FullName");
+
+    [Fact] void should_carry_the_declared_mapping() =>
+        _inner.Properties["Age"]["$mapValues"]["mappings"][0]["from"].GetValue<string>().ShouldEqual("unknown");
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestEventV1.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestEventV1.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration;
+
+[EventType("ValueMapTestEvent", 1)]
+public record ValueMapTestEventV1(ValueMapTestStatusV1 Status);

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestEventV2.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestEventV2.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration;
+
+[EventType("ValueMapTestEvent", 2)]
+public record ValueMapTestEventV2(ValueMapTestStatus Status);

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestStatus.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestStatus.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration;
+
+/// <summary>
+/// The statuses the same external system uses now, on different underlying numbers.
+/// </summary>
+public enum ValueMapTestStatus
+{
+    Unspecified = 100,
+    Confirmed = 101,
+    Withdrawn = 102
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestStatusV1.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/ValueMapTestStatusV1.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration;
+
+/// <summary>
+/// The statuses an external system used before it renumbered them.
+/// </summary>
+public enum ValueMapTestStatusV1
+{
+    Unknown = 0,
+    Verified = 1,
+    Revoked = 2
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_it_is_read_backwards.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_it_is_read_backwards.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration.when_declaring_a_value_map;
+
+/// <summary>
+/// The point of stating the change as a map is that the downcast falls out of it - the migration never wrote a
+/// reverse map, and stating it twice is how the two directions drift apart.
+/// </summary>
+public class and_it_is_read_backwards : given.a_declared_value_map
+{
+    [Fact] void should_produce_a_map_values_expression() => _downcast["Status"]["$mapValues"].ShouldNotBeNull();
+
+    [Fact] void should_read_from_the_upgraded_generations_property() =>
+        _downcast["Status"]["$mapValues"]["source"].GetValue<string>().ShouldEqual("Status");
+
+    [Fact] void should_carry_every_declared_mapping() =>
+        _downcast["Status"]["$mapValues"]["mappings"].AsArray().Count.ShouldEqual(3);
+
+    [Fact] void should_map_from_the_upgraded_member() =>
+        Mapping(_downcast, 1)["from"].GetValue<int>().ShouldEqual((int)ValueMapTestStatus.Confirmed);
+
+    [Fact] void should_map_to_the_previous_member() =>
+        Mapping(_downcast, 1)["to"].GetValue<int>().ShouldEqual((int)ValueMapTestStatusV1.Verified);
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_it_is_read_forward.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_it_is_read_forward.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration.when_declaring_a_value_map;
+
+/// <summary>
+/// Upcasting reads the map exactly as it was written - from the previous generation's member to the upgraded one's.
+/// </summary>
+public class and_it_is_read_forward : given.a_declared_value_map
+{
+    [Fact] void should_produce_a_map_values_expression() => _upcast["Status"]["$mapValues"].ShouldNotBeNull();
+
+    [Fact] void should_read_from_the_previous_generations_property() =>
+        _upcast["Status"]["$mapValues"]["source"].GetValue<string>().ShouldEqual("Status");
+
+    [Fact] void should_carry_every_declared_mapping() =>
+        _upcast["Status"]["$mapValues"]["mappings"].AsArray().Count.ShouldEqual(3);
+
+    [Fact] void should_map_from_the_previous_member() =>
+        Mapping(_upcast, 1)["from"].GetValue<int>().ShouldEqual((int)ValueMapTestStatusV1.Verified);
+
+    [Fact] void should_map_to_the_upgraded_member() =>
+        Mapping(_upcast, 1)["to"].GetValue<int>().ShouldEqual((int)ValueMapTestStatus.Confirmed);
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_several_values_collapse_onto_one.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_several_values_collapse_onto_one.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration.when_declaring_a_value_map;
+
+/// <summary>
+/// Two members collapsing onto one have no single inverse, so the derived downcast picks the first pair declared for
+/// that member rather than emitting two mappings that would fight over the same value. A migration that needs the
+/// other answer states the reverse map itself.
+/// </summary>
+public class and_several_values_collapse_onto_one : Specification
+{
+    JsonObject _downcast;
+
+    void Establish()
+    {
+        var builder = new EventMigrationBuilder();
+        ((IEventTypeMigration)new CollapsingMigration()).Downcast(builder);
+        _downcast = builder.ToJson();
+    }
+
+    [Fact] void should_produce_one_mapping_for_the_shared_member() =>
+        _downcast["Status"]["$mapValues"]["mappings"].AsArray().Count.ShouldEqual(1);
+
+    [Fact] void should_map_back_to_the_first_member_declared_for_it() =>
+        _downcast["Status"]["$mapValues"]["mappings"][0]["to"].GetValue<int>().ShouldEqual((int)ValueMapTestStatusV1.Verified);
+
+    class CollapsingMigration : EventTypeMigration<ValueMapTestEventV2, ValueMapTestEventV1>
+    {
+        public override void Upcast(IEventMigrationBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder)
+        {
+        }
+
+        public override void Downcast(IEventMigrationBuilder<ValueMapTestEventV1, ValueMapTestEventV2> builder)
+        {
+        }
+
+        public override void MapValues(IEventValueMapBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder) =>
+            builder.For(current => current.Status, previous => previous.Status, map => map
+                .Map(ValueMapTestStatusV1.Verified, ValueMapTestStatus.Confirmed)
+                .Map(ValueMapTestStatusV1.Revoked, ValueMapTestStatus.Confirmed));
+    }
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_the_direction_states_its_own_map.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/and_the_direction_states_its_own_map.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration.when_declaring_a_value_map;
+
+/// <summary>
+/// The derived map is a default, not a law - a direction that states its own answer keeps it, which is the way out
+/// when the inverse the map derives is not the one the domain wants.
+/// </summary>
+public class and_the_direction_states_its_own_map : Specification
+{
+    JsonObject _downcast;
+
+    void Establish()
+    {
+        var builder = new EventMigrationBuilder();
+        ((IEventTypeMigration)new OverridingMigration()).Downcast(builder);
+        _downcast = builder.ToJson();
+    }
+
+    [Fact] void should_keep_the_map_the_direction_stated() =>
+        _downcast["Status"]["$mapValues"]["mappings"][0]["to"].GetValue<int>().ShouldEqual((int)ValueMapTestStatusV1.Revoked);
+
+    class OverridingMigration : EventTypeMigration<ValueMapTestEventV2, ValueMapTestEventV1>
+    {
+        public override void Upcast(IEventMigrationBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder)
+        {
+        }
+
+        public override void Downcast(IEventMigrationBuilder<ValueMapTestEventV1, ValueMapTestEventV2> builder) =>
+            builder.Properties(properties => properties
+                .MapValues(previous => previous.Status, current => current.Status, map => map
+                    .Map(ValueMapTestStatus.Confirmed, ValueMapTestStatusV1.Revoked)));
+
+        public override void MapValues(IEventValueMapBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder) =>
+            builder.For(current => current.Status, previous => previous.Status, map => map
+                .Map(ValueMapTestStatusV1.Verified, ValueMapTestStatus.Confirmed));
+    }
+}

--- a/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/given/a_declared_value_map.cs
+++ b/Source/Clients/DotNET.Specs/Events/Migrations/for_EventTypeMigration/when_declaring_a_value_map/given/a_declared_value_map.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Events.Migrations.for_EventTypeMigration.when_declaring_a_value_map.given;
+
+/// <summary>
+/// A migration whose only statement about the two generations is a value map, so what ends up in the upcast and the
+/// downcast is entirely what the map produced.
+/// </summary>
+public class a_declared_value_map : Specification
+{
+    protected JsonObject _upcast;
+    protected JsonObject _downcast;
+
+    void Establish()
+    {
+        var migration = new ValueMapMigration();
+        var upcastBuilder = new EventMigrationBuilder();
+        var downcastBuilder = new EventMigrationBuilder();
+
+        ((IEventTypeMigration)migration).Upcast(upcastBuilder);
+        ((IEventTypeMigration)migration).Downcast(downcastBuilder);
+
+        _upcast = upcastBuilder.ToJson();
+        _downcast = downcastBuilder.ToJson();
+    }
+
+    protected static JsonNode Mapping(JsonObject direction, int index) =>
+        direction["Status"]["$mapValues"]["mappings"][index]!;
+
+    class ValueMapMigration : EventTypeMigration<ValueMapTestEventV2, ValueMapTestEventV1>
+    {
+        public override void Upcast(IEventMigrationBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder)
+        {
+        }
+
+        public override void Downcast(IEventMigrationBuilder<ValueMapTestEventV1, ValueMapTestEventV2> builder)
+        {
+        }
+
+        public override void MapValues(IEventValueMapBuilder<ValueMapTestEventV2, ValueMapTestEventV1> builder) =>
+            builder.For(current => current.Status, previous => previous.Status, map => map
+                .Map(ValueMapTestStatusV1.Unknown, ValueMapTestStatus.Unspecified)
+                .Map(ValueMapTestStatusV1.Verified, ValueMapTestStatus.Confirmed)
+                .Map(ValueMapTestStatusV1.Revoked, ValueMapTestStatus.Withdrawn));
+    }
+}

--- a/Source/Clients/DotNET/Events/Migrations/EventMigrationPropertyBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/EventMigrationPropertyBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Cratis.Chronicle.Events.Migrations;
@@ -14,6 +16,7 @@ public class EventMigrationPropertyBuilder : IEventMigrationPropertyBuilder
     const string CombineExpression = "$combine";
     const string RenameExpression = "$rename";
     const string DefaultValueExpression = "$defaultValue";
+    const string MapValuesExpression = "$mapValues";
 
     readonly Dictionary<PropertyExpression, JsonNode> _properties = [];
 
@@ -66,4 +69,40 @@ public class EventMigrationPropertyBuilder : IEventMigrationPropertyBuilder
             [DefaultValueExpression] = JsonValue.Create(value)
         };
     }
+
+    /// <inheritdoc/>
+    public void MapValues(PropertyName targetProperty, PropertyName sourceProperty, IEnumerable<ValueMapping> mappings)
+    {
+        _properties[(PropertyExpression)(string)targetProperty] = new JsonObject
+        {
+            [MapValuesExpression] = new JsonObject
+            {
+                ["source"] = (string)sourceProperty,
+                ["mappings"] = new JsonArray([.. mappings.Select(ToMappingNode)])
+            }
+        };
+    }
+
+    static JsonNode ToMappingNode(ValueMapping mapping) => new JsonObject
+    {
+        ["from"] = ToJsonNode(mapping.From),
+        ["to"] = ToJsonNode(mapping.To)
+    };
+
+    /// <summary>
+    /// Renders a mapped value the way the value will appear in an event's payload.
+    /// </summary>
+    /// <param name="value">The value to render.</param>
+    /// <returns>The value as a <see cref="JsonNode"/>.</returns>
+    /// <remarks>
+    /// An enum is rendered as its underlying numeric value, which is what a payload carries - rendering it by name
+    /// would produce a map that never matches anything.
+    /// </remarks>
+    static JsonNode? ToJsonNode(object? value) => value switch
+    {
+        null => null,
+        Enum enumValue => JsonSerializer.SerializeToNode(
+            Convert.ChangeType(enumValue, Enum.GetUnderlyingType(enumValue.GetType()), CultureInfo.InvariantCulture)),
+        _ => JsonSerializer.SerializeToNode(value, value.GetType())
+    };
 }

--- a/Source/Clients/DotNET/Events/Migrations/EventMigrationPropertyBuilderFor.cs
+++ b/Source/Clients/DotNET/Events/Migrations/EventMigrationPropertyBuilderFor.cs
@@ -70,6 +70,23 @@ public class EventMigrationPropertyBuilderFor<TTarget, TSource>(IEventMigrationP
         return this;
     }
 
+    /// <inheritdoc/>
+    public IEventMigrationPropertyBuilder<TTarget, TSource> MapValues<TProperty, TSourceProperty>(
+        Expression<Func<TTarget, TProperty>> targetProperty,
+        Expression<Func<TSource, TSourceProperty>> sourceProperty,
+        Action<IValueMapBuilder<TSourceProperty, TProperty>> map)
+    {
+        var mapBuilder = new ValueMapBuilder<TSourceProperty, TProperty>();
+        map(mapBuilder);
+
+        inner.MapValues(
+            GetPropertyName(targetProperty),
+            GetPropertyName(sourceProperty),
+            mapBuilder.Mappings);
+
+        return this;
+    }
+
     static PropertyName GetPropertyName<T, TProp>(Expression<Func<T, TProp>> expression) =>
         new(expression.GetPropertyPath());
 }

--- a/Source/Clients/DotNET/Events/Migrations/EventTypeMigration.cs
+++ b/Source/Clients/DotNET/Events/Migrations/EventTypeMigration.cs
@@ -63,17 +63,44 @@ public abstract class EventTypeMigration<TUpgrade, TPrevious> : IEventTypeMigrat
     /// <param name="builder">The <see cref="IEventMigrationBuilder{TPrevious, TUpgrade}"/> to use.</param>
     public abstract void Downcast(IEventMigrationBuilder<TPrevious, TUpgrade> builder);
 
+    /// <summary>
+    /// Declare the values that keep their property but change what they mean between the two generations.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEventValueMapBuilder{TUpgrade, TPrevious}"/> to use.</param>
+    /// <remarks>
+    /// A map declared here is applied in both directions - forward when upcasting, inverted when downcasting - so an
+    /// enum member that was renumbered, or a code that took on a new spelling, is stated once instead of twice. It is
+    /// applied before <see cref="Upcast"/> and <see cref="Downcast"/> run, so a migration that needs a different
+    /// answer for one direction states that direction's transformation itself and it wins.
+    /// </remarks>
+    public virtual void MapValues(IEventValueMapBuilder<TUpgrade, TPrevious> builder)
+    {
+    }
+
     /// <inheritdoc/>
     void IEventTypeMigration.Upcast(IEventMigrationBuilder builder)
     {
-        var typedBuilder = new EventMigrationBuilderFor<TUpgrade, TPrevious>(builder);
-        Upcast(typedBuilder);
+        ApplyValueMaps(builder, (maps, properties) => maps.ApplyUpcast(properties));
+        Upcast(new EventMigrationBuilderFor<TUpgrade, TPrevious>(builder));
     }
 
     /// <inheritdoc/>
     void IEventTypeMigration.Downcast(IEventMigrationBuilder builder)
     {
-        var typedBuilder = new EventMigrationBuilderFor<TPrevious, TUpgrade>(builder);
-        Downcast(typedBuilder);
+        ApplyValueMaps(builder, (maps, properties) => maps.ApplyDowncast(properties));
+        Downcast(new EventMigrationBuilderFor<TPrevious, TUpgrade>(builder));
+    }
+
+    void ApplyValueMaps(IEventMigrationBuilder builder, Action<EventValueMapBuilder<TUpgrade, TPrevious>, IEventMigrationPropertyBuilder> apply)
+    {
+        var maps = new EventValueMapBuilder<TUpgrade, TPrevious>();
+        MapValues(maps);
+
+        if (!maps.HasMaps)
+        {
+            return;
+        }
+
+        builder.Properties(properties => apply(maps, properties));
     }
 }

--- a/Source/Clients/DotNET/Events/Migrations/EventValueMapBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/EventValueMapBuilder.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using Cratis.Chronicle.Properties;
+
+namespace Cratis.Chronicle.Events.Migrations;
+
+/// <summary>
+/// Represents an implementation of <see cref="IEventValueMapBuilder{TUpgrade, TPrevious}"/>.
+/// </summary>
+/// <typeparam name="TUpgrade">The upgraded (newer generation) event type.</typeparam>
+/// <typeparam name="TPrevious">The previous (older generation) event type.</typeparam>
+public class EventValueMapBuilder<TUpgrade, TPrevious> : IEventValueMapBuilder<TUpgrade, TPrevious>
+{
+    readonly List<PropertyValueMap> _maps = [];
+
+    /// <summary>
+    /// Gets whether any value map has been declared.
+    /// </summary>
+    public bool HasMaps => _maps.Count > 0;
+
+    /// <inheritdoc/>
+    public IEventValueMapBuilder<TUpgrade, TPrevious> For<TUpgradeProperty, TPreviousProperty>(
+        Expression<Func<TUpgrade, TUpgradeProperty>> upgradeProperty,
+        Expression<Func<TPrevious, TPreviousProperty>> previousProperty,
+        Action<IValueMapBuilder<TPreviousProperty, TUpgradeProperty>> map)
+    {
+        var mapBuilder = new ValueMapBuilder<TPreviousProperty, TUpgradeProperty>();
+        map(mapBuilder);
+
+        _maps.Add(new PropertyValueMap(
+            new PropertyName(upgradeProperty.GetPropertyPath()),
+            new PropertyName(previousProperty.GetPropertyPath()),
+            [.. mapBuilder.Mappings]));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Apply every declared map to the upcast of the migration, translating previous values into upgraded ones.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEventMigrationPropertyBuilder"/> to apply to.</param>
+    public void ApplyUpcast(IEventMigrationPropertyBuilder builder) =>
+        _maps.ForEach(map => builder.MapValues(map.UpgradeProperty, map.PreviousProperty, map.Mappings));
+
+    /// <summary>
+    /// Apply every declared map to the downcast of the migration, translating upgraded values back into previous ones.
+    /// </summary>
+    /// <param name="builder">The <see cref="IEventMigrationPropertyBuilder"/> to apply to.</param>
+    public void ApplyDowncast(IEventMigrationPropertyBuilder builder) =>
+        _maps.ForEach(map => builder.MapValues(map.PreviousProperty, map.UpgradeProperty, Invert(map.Mappings)));
+
+    /// <summary>
+    /// Inverts a map so it translates the other way.
+    /// </summary>
+    /// <param name="mappings">The mappings to invert.</param>
+    /// <returns>The inverted mappings.</returns>
+    /// <remarks>
+    /// Several source values collapsing onto one target value have no single inverse, so the first pair declared for
+    /// a target value is the one that gets to represent it going back. A migration that needs a different answer
+    /// states the reverse map itself in its <c>Downcast</c>, which overrides what is derived here.
+    /// </remarks>
+    static ValueMapping[] Invert(IEnumerable<ValueMapping> mappings) =>
+        [.. mappings
+            .GroupBy(mapping => mapping.To)
+            .Select(group => new ValueMapping(group.Key, group.First().From))];
+
+    /// <summary>
+    /// Represents one declared value map, tying the two generations' properties to the values that change meaning.
+    /// </summary>
+    /// <param name="UpgradeProperty">The property on the upgraded generation.</param>
+    /// <param name="PreviousProperty">The property on the previous generation.</param>
+    /// <param name="Mappings">The values that change meaning, expressed from previous to upgraded.</param>
+    sealed record PropertyValueMap(PropertyName UpgradeProperty, PropertyName PreviousProperty, ValueMapping[] Mappings);
+}

--- a/Source/Clients/DotNET/Events/Migrations/IEventMigrationPropertyBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/IEventMigrationPropertyBuilder.cs
@@ -38,4 +38,16 @@ public interface IEventMigrationPropertyBuilder
     /// <param name="targetProperty">The name of the property to set the default value on.</param>
     /// <param name="value">The default value.</param>
     void DefaultValue(PropertyName targetProperty, object value);
+
+    /// <summary>
+    /// Translate the individual values of a property that mean something different in the target generation.
+    /// </summary>
+    /// <param name="targetProperty">The name of the property to write the translated value into.</param>
+    /// <param name="sourceProperty">The source property to read the value from.</param>
+    /// <param name="mappings">The values that change meaning, and what they become.</param>
+    /// <remarks>
+    /// A value no mapping mentions is carried across unchanged, and so is the value of a payload that does not carry
+    /// the source property at all.
+    /// </remarks>
+    void MapValues(PropertyName targetProperty, PropertyName sourceProperty, IEnumerable<ValueMapping> mappings);
 }

--- a/Source/Clients/DotNET/Events/Migrations/IEventMigrationPropertyBuilder{TTarget,TSource}.cs
+++ b/Source/Clients/DotNET/Events/Migrations/IEventMigrationPropertyBuilder{TTarget,TSource}.cs
@@ -61,4 +61,22 @@ public interface IEventMigrationPropertyBuilder<TTarget, TSource>
     IEventMigrationPropertyBuilder<TTarget, TSource> DefaultValue<TProperty>(
         Expression<Func<TTarget, TProperty>> targetProperty,
         TProperty value);
+
+    /// <summary>
+    /// Translate the individual values of a property that mean something different in the target generation.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of the target property.</typeparam>
+    /// <typeparam name="TSourceProperty">The type of the source property.</typeparam>
+    /// <param name="targetProperty">Expression selecting the target property to write the translated value into.</param>
+    /// <param name="sourceProperty">Expression selecting the source property to read the value from.</param>
+    /// <param name="map">Action declaring which value becomes which.</param>
+    /// <returns>The builder for continued configuration.</returns>
+    /// <remarks>
+    /// This states the translation for one direction only. To state it once and have both directions follow, override
+    /// <c>MapValues</c> on <see cref="EventTypeMigration{TUpgrade, TPrevious}"/> instead.
+    /// </remarks>
+    IEventMigrationPropertyBuilder<TTarget, TSource> MapValues<TProperty, TSourceProperty>(
+        Expression<Func<TTarget, TProperty>> targetProperty,
+        Expression<Func<TSource, TSourceProperty>> sourceProperty,
+        Action<IValueMapBuilder<TSourceProperty, TProperty>> map);
 }

--- a/Source/Clients/DotNET/Events/Migrations/IEventValueMapBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/IEventValueMapBuilder.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+
+namespace Cratis.Chronicle.Events.Migrations;
+
+/// <summary>
+/// Defines a builder for the value maps of an event type migration - the values that keep their property but change
+/// what they mean between two generations.
+/// </summary>
+/// <typeparam name="TUpgrade">The upgraded (newer generation) event type.</typeparam>
+/// <typeparam name="TPrevious">The previous (older generation) event type.</typeparam>
+/// <remarks>
+/// A map declared here is stated once and applied in both directions: forward when upcasting, inverted when
+/// downcasting. That is the whole point of declaring it as a map rather than as two transformations - the pair of
+/// values is one fact about the two generations, and stating it twice is how the two directions drift apart. A
+/// direction that states its own transformation for the same property keeps it.
+/// </remarks>
+public interface IEventValueMapBuilder<TUpgrade, TPrevious>
+{
+    /// <summary>
+    /// Declare the value map for a property, from how the previous generation expressed it to how the upgraded
+    /// generation does.
+    /// </summary>
+    /// <typeparam name="TUpgradeProperty">The type of the property on the upgraded generation.</typeparam>
+    /// <typeparam name="TPreviousProperty">The type of the property on the previous generation.</typeparam>
+    /// <param name="upgradeProperty">Expression selecting the property on the upgraded generation.</param>
+    /// <param name="previousProperty">Expression selecting the property on the previous generation.</param>
+    /// <param name="map">Action declaring which value becomes which.</param>
+    /// <returns>The builder for continued configuration.</returns>
+    /// <remarks>
+    /// The two properties do not have to share a name - the map carries the value across from one to the other, so it
+    /// also covers a rename of the property it maps.
+    /// </remarks>
+    IEventValueMapBuilder<TUpgrade, TPrevious> For<TUpgradeProperty, TPreviousProperty>(
+        Expression<Func<TUpgrade, TUpgradeProperty>> upgradeProperty,
+        Expression<Func<TPrevious, TPreviousProperty>> previousProperty,
+        Action<IValueMapBuilder<TPreviousProperty, TUpgradeProperty>> map);
+}

--- a/Source/Clients/DotNET/Events/Migrations/IValueMapBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/IValueMapBuilder.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations;
+
+/// <summary>
+/// Defines a builder for the individual values of a property that change meaning between two event type generations.
+/// </summary>
+/// <typeparam name="TFrom">The type of the value in the source generation.</typeparam>
+/// <typeparam name="TTo">The type of the value in the target generation.</typeparam>
+public interface IValueMapBuilder<TFrom, TTo>
+{
+    /// <summary>
+    /// State that a value in the source generation becomes a specific value in the target generation.
+    /// </summary>
+    /// <param name="from">The value as it appears in the source generation.</param>
+    /// <param name="to">The value it becomes in the target generation.</param>
+    /// <returns>The builder for continued configuration.</returns>
+    /// <remarks>
+    /// Only values the map mentions are translated - anything else is carried across as it is, because a value the
+    /// map stays silent about means the same thing in both generations.
+    /// </remarks>
+    IValueMapBuilder<TFrom, TTo> Map(TFrom from, TTo to);
+}

--- a/Source/Clients/DotNET/Events/Migrations/ValueMapBuilder.cs
+++ b/Source/Clients/DotNET/Events/Migrations/ValueMapBuilder.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations;
+
+/// <summary>
+/// Represents an implementation of <see cref="IValueMapBuilder{TFrom, TTo}"/>.
+/// </summary>
+/// <typeparam name="TFrom">The type of the value in the source generation.</typeparam>
+/// <typeparam name="TTo">The type of the value in the target generation.</typeparam>
+public class ValueMapBuilder<TFrom, TTo> : IValueMapBuilder<TFrom, TTo>
+{
+    readonly List<ValueMapping> _mappings = [];
+
+    /// <summary>
+    /// Gets the mappings that have been declared.
+    /// </summary>
+    public IEnumerable<ValueMapping> Mappings => _mappings;
+
+    /// <inheritdoc/>
+    public IValueMapBuilder<TFrom, TTo> Map(TFrom from, TTo to)
+    {
+        _mappings.Add(new ValueMapping(from!, to!));
+        return this;
+    }
+}

--- a/Source/Clients/DotNET/Events/Migrations/ValueMapping.cs
+++ b/Source/Clients/DotNET/Events/Migrations/ValueMapping.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Events.Migrations;
+
+/// <summary>
+/// Represents a single value in a migration's value map and what that value becomes on the other side.
+/// </summary>
+/// <param name="From">The value as it appears in the source generation.</param>
+/// <param name="To">The value it becomes in the target generation.</param>
+public record ValueMapping(object From, object To);

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_nested_enumeration_gained_a_member.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_nested_enumeration_gained_a_member.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// An enumeration is as likely to sit behind a <c>$defs</c> entry or inside a nested object as it is to sit directly
+/// on a root property, and it grows there for exactly the same reasons.
+/// </summary>
+public class and_a_nested_enumeration_gained_a_member : Specification
+{
+    const string Stored =
+        """
+        {"type":"object","$defs":{"Status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}},"properties":{"details":{"type":"object","properties":{"status":{"$ref":"#/$defs/Status"}}}}}
+        """;
+
+    const string Generated =
+        """
+        {"type":"object","$defs":{"Status":{"type":"integer","enum":[0,1,2],"x-enumNames":["Unknown","Verified","Revoked"]}},"properties":{"details":{"type":"object","properties":{"status":{"$ref":"#/$defs/Status"}}}}}
+        """;
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_stopped_being_an_enumeration.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_stopped_being_an_enumeration.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// The tolerance is for an enumeration that evolved, not for a property that stopped being one - dropping the member
+/// list changes how every stored value materializes.
+/// </summary>
+public class and_a_property_stopped_being_an_enumeration : Specification
+{
+    const string Stored = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+    const string Generated = """{"type":"object","properties":{"status":{"type":"integer"}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_not_consider_them_compatible() => _result.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_was_added.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_was_added.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// Everything outside the enumeration and nullability tolerances stays a breaking change - a property added to a
+/// generation that is already storing events still needs a new generation and a migration.
+/// </summary>
+public class and_a_property_was_added : Specification
+{
+    const string Stored = """{"type":"object","properties":{"name":{"type":"string"}}}""";
+    const string Generated = """{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_not_consider_them_compatible() => _result.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_gained_a_member.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_gained_a_member.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// A member added to an enumeration leaves every stored value denoting exactly what it denoted before, so the
+/// enumeration is free to grow without a new generation.
+/// </summary>
+public class and_an_enumeration_gained_a_member : Specification
+{
+    const string Stored = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+    const string Generated = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1,2],"x-enumNames":["Unknown","Verified","Revoked"]}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_removed.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_removed.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// A member that disappears leaves every event already stored with that value denoting nothing, which is a change to
+/// the meaning of history and therefore needs a new generation with a value map saying what those values became.
+/// </summary>
+public class and_an_enumeration_member_was_removed : Specification
+{
+    const string Stored = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1,2],"x-enumNames":["Unknown","Verified","Revoked"]}}}""";
+    const string Generated = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_not_consider_them_compatible() => _result.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_renamed.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_renamed.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// The underlying value is what a stored payload carries, so renaming a member changes nothing about what history
+/// says - and an enumeration mirroring an external system gets renamed on that system's schedule, not the owning
+/// application's.
+/// </summary>
+public class and_an_enumeration_member_was_renamed : Specification
+{
+    const string Stored = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+    const string Generated = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unspecified","Confirmed"]}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_renumbered.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_an_enumeration_member_was_renumbered.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// Renumbering keeps the names but moves them onto different underlying values, so every event already stored now
+/// reads as a different member. That is the one enumeration change a value map exists for, and it needs a new
+/// generation to carry it.
+/// </summary>
+public class and_an_enumeration_member_was_renumbered : Specification
+{
+    const string Stored = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+    const string Generated = """{"type":"object","properties":{"status":{"type":"integer","enum":[10,11],"x-enumNames":["Unknown","Verified"]}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_not_consider_them_compatible() => _result.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_they_differ_only_by_a_nullable_marker.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_they_differ_only_by_a_nullable_marker.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// The nullability tolerance that predates the enumeration one still holds - a Chronicle upgrade can introduce the
+/// marker on a schema stored before the marker existed.
+/// </summary>
+public class and_they_differ_only_by_a_nullable_marker : Specification
+{
+    const string Stored = """{"type":"object","properties":{"occurredAt":{"type":"string","format":"date-time-offset"}}}""";
+    const string Generated = """{"type":"object","properties":{"occurredAt":{"type":"string","format":"date-time-offset?"}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure/Json/JsonValues.cs
+++ b/Source/Infrastructure/Json/JsonValues.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json;
+
+/// <summary>
+/// Helpers for comparing individual JSON values.
+/// </summary>
+public static class JsonValues
+{
+    /// <summary>
+    /// Renders a JSON value as a string that compares equal for any two representations of the same value.
+    /// </summary>
+    /// <param name="value">The value to render, which may be <see langword="null"/>.</param>
+    /// <returns>The canonical representation of the value.</returns>
+    /// <remarks>
+    /// A number is rendered without the trailing zeros its writer happened to use, so the same value survives a round
+    /// trip through a store that renders it at a different scale or width. Everything else is rendered as JSON, which
+    /// keeps a string distinct from a number sharing its digits.
+    /// </remarks>
+    public static string Canonical(JsonNode? value)
+    {
+        if (value is not JsonValue jsonValue || !jsonValue.TryGetValue<decimal>(out var number))
+        {
+            return value?.ToJsonString() ?? "null";
+        }
+
+        var text = number.ToString(CultureInfo.InvariantCulture);
+        return text.Contains('.') ? text.TrimEnd('0').TrimEnd('.') : text;
+    }
+}

--- a/Source/Infrastructure/Schemas/JsonSchemaCompatibilityExtensions.cs
+++ b/Source/Infrastructure/Schemas/JsonSchemaCompatibilityExtensions.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Json;
+
+namespace Cratis.Chronicle.Schemas;
+
+/// <summary>
+/// Extension methods for deciding whether a newly generated <see cref="JsonSchema"/> still describes the data an
+/// already stored one describes.
+/// </summary>
+public static class JsonSchemaCompatibilityExtensions
+{
+    const string EnumerationKey = "enum";
+    const string EnumerationNamesKey = "x-enumNames";
+    const string FormatKey = "format";
+
+    /// <summary>
+    /// Determines whether a newly generated schema is a compatible evolution of an already stored one.
+    /// </summary>
+    /// <param name="stored">The stored <see cref="JsonSchema"/>.</param>
+    /// <param name="generated">The newly generated <see cref="JsonSchema"/> to check against it.</param>
+    /// <returns><see langword="true"/> when the generated schema still describes the stored data; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Everything outside the two tolerances below has to match exactly - a stored event's payload is interpreted
+    /// through the schema registered for its generation, so a change to the shape silently changes the meaning of
+    /// history and must go through a new generation instead.
+    /// <para>
+    /// The first tolerance is a nullability marker (a trailing <c>?</c> on a <c>format</c> value). It only refines
+    /// how an unset value materializes, and a Chronicle upgrade can introduce it on a schema that was stored before
+    /// the marker existed.
+    /// </para>
+    /// <para>
+    /// The second is an enumeration that only gained members or had members renamed. Neither changes what an already
+    /// stored value means: the member a stored value denotes keeps its underlying value, and its name is frequently
+    /// not the owning application's to control in the first place - an enumeration mirroring an external system
+    /// grows and gets renamed on that system's schedule. Members that <em>disappear</em> or are renumbered are a
+    /// different matter, because a stored value then denotes nothing or something else, so those stay a breaking
+    /// change that needs a new generation and a value map to state what the old values now mean.
+    /// </para>
+    /// </remarks>
+    public static bool IsCompatibleWith(this JsonSchema stored, JsonSchema generated)
+    {
+        var storedNode = JsonNode.Parse(stored.ToJson());
+        var generatedNode = JsonNode.Parse(generated.ToJson());
+
+        StripNullableFormatMarkers(storedNode);
+        StripNullableFormatMarkers(generatedNode);
+
+        return TryEraseCompatibleEnumerations(storedNode, generatedNode) &&
+            storedNode?.ToJsonString() == generatedNode?.ToJsonString();
+    }
+
+    /// <summary>
+    /// Strips every nullability marker - a trailing <c>?</c> appended to a <c>format</c> value - from a schema node.
+    /// </summary>
+    /// <param name="node">The <see cref="JsonNode"/> to strip, which may be <see langword="null"/>.</param>
+    internal static void StripNullableFormatMarkers(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject jsonObject:
+                if (jsonObject[FormatKey] is JsonValue formatValue &&
+                    formatValue.TryGetValue<string>(out var format) &&
+                    format.EndsWith('?'))
+                {
+                    jsonObject[FormatKey] = format[..^1];
+                }
+
+                foreach (var property in jsonObject.ToArray().Where(_ => _.Key != FormatKey))
+                {
+                    StripNullableFormatMarkers(property.Value);
+                }
+
+                break;
+
+            case JsonArray jsonArray:
+                foreach (var item in jsonArray.ToArray())
+                {
+                    StripNullableFormatMarkers(item);
+                }
+
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Walks two schema nodes in lockstep and removes every enumeration declaration the two agree on, so that what
+    /// is left can be compared verbatim.
+    /// </summary>
+    /// <param name="stored">The node from the stored schema.</param>
+    /// <param name="generated">The node from the generated schema.</param>
+    /// <returns><see langword="false"/> as soon as an enumeration is found that lost or renumbered a member; otherwise <see langword="true"/>.</returns>
+    /// <remarks>
+    /// Only nodes present on both sides are visited. A node present on one side alone is a difference the caller's
+    /// verbatim comparison catches on its own, and erasing an enumeration on one side without the other would hide it.
+    /// </remarks>
+    static bool TryEraseCompatibleEnumerations(JsonNode? stored, JsonNode? generated)
+    {
+        switch (stored)
+        {
+            case JsonObject storedObject when generated is JsonObject generatedObject:
+                if (storedObject.ContainsKey(EnumerationKey) || generatedObject.ContainsKey(EnumerationKey))
+                {
+                    if (!EnumerationOnlyGrewOrWasRenamed(storedObject, generatedObject))
+                    {
+                        return false;
+                    }
+
+                    EraseEnumeration(storedObject);
+                    EraseEnumeration(generatedObject);
+                }
+
+                return storedObject
+                    .ToArray()
+                    .Where(entry => generatedObject.ContainsKey(entry.Key))
+                    .All(entry => TryEraseCompatibleEnumerations(entry.Value, generatedObject[entry.Key]));
+
+            case JsonArray storedArray when generated is JsonArray generatedArray:
+                return Enumerable
+                    .Range(0, Math.Min(storedArray.Count, generatedArray.Count))
+                    .All(index => TryEraseCompatibleEnumerations(storedArray[index], generatedArray[index]));
+
+            default:
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether two enumeration declarations differ only by members the generated one added, or by member names.
+    /// </summary>
+    /// <param name="stored">The node from the stored schema.</param>
+    /// <param name="generated">The node from the generated schema.</param>
+    /// <returns><see langword="true"/> when every stored member is still declared; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Member names are deliberately not compared at all - the underlying value is what a stored payload carries, so
+    /// a rename leaves every stored value denoting exactly what it denoted before.
+    /// </remarks>
+    static bool EnumerationOnlyGrewOrWasRenamed(JsonObject stored, JsonObject generated)
+    {
+        if (stored[EnumerationKey] is not JsonArray storedMembers ||
+            generated[EnumerationKey] is not JsonArray generatedMembers)
+        {
+            return false;
+        }
+
+        var declared = generatedMembers.Select(JsonValues.Canonical).ToHashSet(StringComparer.Ordinal);
+        return storedMembers.Select(JsonValues.Canonical).All(declared.Contains);
+    }
+
+    static void EraseEnumeration(JsonObject node)
+    {
+        node.Remove(EnumerationKey);
+        node.Remove(EnumerationNamesKey);
+    }
+}

--- a/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
+++ b/Source/Infrastructure/Schemas/JsonSchemaExtensions.cs
@@ -272,37 +272,8 @@ public static class JsonSchemaExtensions
     static string WithoutNullableFormatMarkers(string schemaJson)
     {
         var node = JsonNode.Parse(schemaJson);
-        StripNullableFormatMarkers(node);
+        JsonSchemaCompatibilityExtensions.StripNullableFormatMarkers(node);
         return node?.ToJsonString() ?? schemaJson;
-    }
-
-    static void StripNullableFormatMarkers(JsonNode? node)
-    {
-        switch (node)
-        {
-            case JsonObject jsonObject:
-                if (jsonObject["format"] is JsonValue formatValue &&
-                    formatValue.TryGetValue<string>(out var format) &&
-                    format.EndsWith('?'))
-                {
-                    jsonObject["format"] = format[..^1];
-                }
-
-                foreach (var property in jsonObject.ToArray().Where(_ => _.Key != "format"))
-                {
-                    StripNullableFormatMarkers(property.Value);
-                }
-
-                break;
-
-            case JsonArray jsonArray:
-                foreach (var item in jsonArray.ToArray())
-                {
-                    StripNullableFormatMarkers(item);
-                }
-
-                break;
-        }
     }
 
     static bool IsDeclaredMember(JsonSchemaProperty schemaProperty, object? value)

--- a/Source/Kernel/Concepts/WellKnownExpressions.cs
+++ b/Source/Kernel/Concepts/WellKnownExpressions.cs
@@ -94,6 +94,12 @@ public static class WellKnownExpressions
     public const string Combine = "$combine";
 
     /// <summary>
+    /// The value map expression for event migrations - translates individual values of a property from what they
+    /// meant in one generation to what they mean in another.
+    /// </summary>
+    public const string MapValues = "$mapValues";
+
+    /// <summary>
     /// The all expression for subscribing to all event types.
     /// </summary>
     public const string All = "$all";

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_event_is_stored_at_the_newer_generation.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_event_is_stored_at_the_newer_generation.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_value_map;
+
+/// <summary>
+/// The generations a store keeps are computed in both directions, so an event written at the newer generation has to
+/// come back out at the older one carrying the number that generation gives the meaning - the map read backwards.
+/// </summary>
+public class and_the_event_is_stored_at_the_newer_generation : given.a_definition_with_a_value_map
+{
+    protected override EventTypeGeneration StoredAtGeneration => 2;
+
+    void Establish() => _content = new JsonObject { ["status"] = 10 };
+
+    async Task Because() => _result = await _eventTypeMigrations.MigrateToAllGenerations(_eventStoreName, _eventType, _content, _contentAsExpandoObject);
+
+    [Fact] void should_return_both_generations() => _result.Count.ShouldEqual(2);
+
+    [Fact] void should_translate_the_value_for_the_downcasted_generation() =>
+        _expandoObjectConverter.Received().ToExpandoObject(Arg.Is<JsonObject>(_ => StatusIs(_, 0)), Arg.Any<JsonSchema>());
+
+    [Fact] void should_leave_the_value_alone_for_the_source_generation() =>
+        _expandoObjectConverter.Received().ToExpandoObject(Arg.Is<JsonObject>(_ => StatusIs(_, 10)), Arg.Any<JsonSchema>());
+}

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_value_is_mapped.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_value_is_mapped.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_value_map;
+
+/// <summary>
+/// The map states that generation 1's <c>0</c> is generation 2's <c>10</c>, so upcasting an event stored at
+/// generation 1 has to produce the number the newer generation gives that meaning.
+/// </summary>
+public class and_the_value_is_mapped : given.a_definition_with_a_value_map
+{
+    void Establish() => _content = new JsonObject { ["status"] = 0 };
+
+    async Task Because() => _result = await _eventTypeMigrations.MigrateToAllGenerations(_eventStoreName, _eventType, _content, _contentAsExpandoObject);
+
+    [Fact] void should_return_both_generations() => _result.Count.ShouldEqual(2);
+
+    [Fact] void should_translate_the_value_for_the_upcasted_generation() =>
+        _expandoObjectConverter.Received().ToExpandoObject(Arg.Is<JsonObject>(_ => StatusIs(_, 10)), Arg.Any<JsonSchema>());
+
+    [Fact] void should_leave_the_value_alone_for_the_source_generation() =>
+        _expandoObjectConverter.Received().ToExpandoObject(Arg.Is<JsonObject>(_ => StatusIs(_, 0)), Arg.Any<JsonSchema>());
+}

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_value_is_not_in_the_map.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/and_the_value_is_not_in_the_map.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_value_map;
+
+/// <summary>
+/// A map says which values changed meaning, so a value it stays silent about has to survive untouched - anything
+/// else would make every map an exhaustive listing of an enumeration that is free to grow.
+/// </summary>
+public class and_the_value_is_not_in_the_map : given.a_definition_with_a_value_map
+{
+    void Establish() => _content = new JsonObject { ["status"] = 7 };
+
+    async Task Because() => _result = await _eventTypeMigrations.MigrateToAllGenerations(_eventStoreName, _eventType, _content, _contentAsExpandoObject);
+
+    [Fact] void should_carry_the_value_across_unchanged() =>
+        _expandoObjectConverter.Received(2).ToExpandoObject(Arg.Is<JsonObject>(_ => StatusIs(_, 7)), Arg.Any<JsonSchema>());
+}

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/given/a_definition_with_a_value_map.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_value_map/given/a_definition_with_a_value_map.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_value_map.given;
+
+/// <summary>
+/// A two-generation event type whose <c>status</c> enumeration was renumbered between the generations, with the
+/// value map a migration declares to say what the old numbers became - and its inverse for the way back.
+/// </summary>
+public class a_definition_with_a_value_map : Migrations.for_EventTypeMigrations.given.all_dependencies
+{
+    protected ExpandoObject _gen1ExpandoObject;
+    protected ExpandoObject _gen2ExpandoObject;
+    protected IDictionary<EventTypeGeneration, ExpandoObject> _result;
+
+    /// <summary>
+    /// Gets the generation the event being migrated was stored at, which decides whether the map is exercised
+    /// forward or inverted.
+    /// </summary>
+    protected virtual EventTypeGeneration StoredAtGeneration => 1;
+
+    async Task Establish()
+    {
+        _eventType = new EventType(_eventType.Id, StoredAtGeneration);
+
+        var gen1Schema = await JsonSchema.FromJsonAsync("{}");
+        var gen2Schema = await JsonSchema.FromJsonAsync("{}");
+
+        var definition = new EventTypeDefinition(
+            _eventType.Id,
+            EventTypeOwner.None,
+            false,
+            [
+                new EventTypeGenerationDefinition(1, gen1Schema),
+                new EventTypeGenerationDefinition(2, gen2Schema)
+            ],
+            [
+                new EventTypeMigrationDefinition(
+                    1,
+                    2,
+                    [],
+                    ValueMap(0, 10),
+                    ValueMap(10, 0))
+            ]);
+
+        _eventTypesStorage.GetDefinition(_eventType.Id).Returns(definition);
+
+        _gen1ExpandoObject = new ExpandoObject();
+        _gen2ExpandoObject = new ExpandoObject();
+
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), gen1Schema).Returns(_gen1ExpandoObject);
+        _expandoObjectConverter.ToExpandoObject(Arg.Any<JsonObject>(), gen2Schema).Returns(_gen2ExpandoObject);
+    }
+
+    protected static JsonObject ValueMap(int from, int to) => new()
+    {
+        ["status"] = new JsonObject
+        {
+            ["$mapValues"] = new JsonObject
+            {
+                ["source"] = "status",
+                ["mappings"] = new JsonArray(new JsonObject { ["from"] = from, ["to"] = to })
+            }
+        }
+    };
+
+    protected static bool StatusIs(JsonObject content, int expected) =>
+        content["status"] is JsonValue value && value.GetValue<int>() == expected;
+}

--- a/Source/Kernel/Core/EventSequences/Migrations/EventMigrationExpressions.cs
+++ b/Source/Kernel/Core/EventSequences/Migrations/EventMigrationExpressions.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Json;
+
+namespace Cratis.Chronicle.EventSequences.Migrations;
+
+/// <summary>
+/// Evaluates the built-in expressions an event type migration carries for transformations JMESPath cannot express
+/// on its own.
+/// </summary>
+internal static class EventMigrationExpressions
+{
+    /// <summary>
+    /// Extracts one part of a source property's value, split on a separator.
+    /// </summary>
+    /// <param name="content">The event content being migrated.</param>
+    /// <param name="config">The configuration of the expression.</param>
+    /// <returns>The extracted part, or an empty value when there is nothing to extract.</returns>
+    public static JsonValue? EvaluateSplit(JsonObject content, JsonObject config)
+    {
+        var source = config["source"]?.GetValue<string>();
+        var separator = config["separator"]?.GetValue<string>() ?? string.Empty;
+        var part = config["part"]?.GetValue<int>() ?? 0;
+
+        if (source is null || !content.TryGetPropertyValue(source, out var sourceNode) || sourceNode is null)
+            return JsonValue.Create(string.Empty);
+
+        var sourceValue = sourceNode.GetValue<string>();
+        var parts = sourceValue.Split(separator);
+        return JsonValue.Create(parts.Length > part ? parts[part] : string.Empty);
+    }
+
+    /// <summary>
+    /// Concatenates several source properties into one value.
+    /// </summary>
+    /// <param name="content">The event content being migrated.</param>
+    /// <param name="config">The configuration of the expression.</param>
+    /// <returns>The concatenated value.</returns>
+    public static JsonValue? EvaluateCombine(JsonObject content, JsonObject config)
+    {
+        if (config["sources"] is not JsonArray sources)
+            return JsonValue.Create(string.Empty);
+
+        var separator = config["separator"]?.GetValue<string>() ?? string.Empty;
+
+        var builder = new StringBuilder();
+        var first = true;
+        foreach (var source in sources)
+        {
+            var propertyName = source?.GetValue<string>();
+            if (propertyName != null && content.TryGetPropertyValue(propertyName, out var node) && node != null)
+            {
+                if (!first)
+                    builder.Append(separator);
+                builder.Append(node.GetValue<string>());
+                first = false;
+            }
+        }
+        return JsonValue.Create(builder.ToString());
+    }
+
+    /// <summary>
+    /// Reads the value a property carried under its previous name.
+    /// </summary>
+    /// <param name="content">The event content being migrated.</param>
+    /// <param name="oldName">The name the property had in the source generation.</param>
+    /// <returns>The value, or <see langword="null"/> when the source generation did not carry it.</returns>
+    public static JsonNode? EvaluateRename(JsonObject content, string? oldName)
+    {
+        if (oldName is null || !content.TryGetPropertyValue(oldName, out var value))
+            return null;
+        return value?.DeepClone();
+    }
+
+    /// <summary>
+    /// Translates a source property's value through a value map.
+    /// </summary>
+    /// <param name="content">The event content being migrated.</param>
+    /// <param name="config">The configuration of the expression.</param>
+    /// <param name="value">When this returns <see langword="true"/>, the translated value.</param>
+    /// <returns><see langword="true"/> when the expression produced a value; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// A value the map does not mention is carried across unchanged - the map states what changed meaning between
+    /// two generations, so every value it stays silent about means in the target generation exactly what it meant in
+    /// the source one. When the source property is absent from the payload altogether there is nothing to translate,
+    /// and this reports no result rather than writing a null over whatever the surrounding transformation produced.
+    /// </remarks>
+    public static bool TryEvaluateMapValues(JsonObject content, JsonObject config, out JsonNode? value)
+    {
+        value = null;
+
+        var source = config["source"]?.GetValue<string>();
+        if (source is null || !content.TryGetPropertyValue(source, out var sourceNode))
+        {
+            return false;
+        }
+
+        value = sourceNode?.DeepClone();
+
+        if (config["mappings"] is not JsonArray mappings)
+        {
+            return true;
+        }
+
+        var sourceValue = JsonValues.Canonical(sourceNode);
+        var mapped = mappings
+            .OfType<JsonObject>()
+            .FirstOrDefault(mapping => JsonValues.Canonical(mapping["from"]) == sourceValue);
+
+        if (mapped is not null)
+        {
+            value = mapped["to"]?.DeepClone();
+        }
+
+        return true;
+    }
+}

--- a/Source/Kernel/Core/EventSequences/Migrations/EventTypeMigrations.cs
+++ b/Source/Kernel/Core/EventSequences/Migrations/EventTypeMigrations.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Dynamic;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Cratis.Chronicle.Concepts;
@@ -49,50 +48,6 @@ public class EventTypeMigrations(
         await DowncastToLowerGenerations(eventType.Generation, content, definition, result);
 
         return result;
-    }
-
-    static JsonValue? EvaluateSplit(JsonObject content, JsonObject config)
-    {
-        var source = config["source"]?.GetValue<string>();
-        var separator = config["separator"]?.GetValue<string>() ?? string.Empty;
-        var part = config["part"]?.GetValue<int>() ?? 0;
-
-        if (source is null || !content.TryGetPropertyValue(source, out var sourceNode) || sourceNode is null)
-            return JsonValue.Create(string.Empty);
-
-        var sourceValue = sourceNode.GetValue<string>();
-        var parts = sourceValue.Split(separator);
-        return JsonValue.Create(parts.Length > part ? parts[part] : string.Empty);
-    }
-
-    static JsonValue? EvaluateCombine(JsonObject content, JsonObject config)
-    {
-        if (config["sources"] is not JsonArray sources)
-            return JsonValue.Create(string.Empty);
-
-        var separator = config["separator"]?.GetValue<string>() ?? string.Empty;
-
-        var builder = new StringBuilder();
-        var first = true;
-        foreach (var source in sources)
-        {
-            var propertyName = source?.GetValue<string>();
-            if (propertyName != null && content.TryGetPropertyValue(propertyName, out var node) && node != null)
-            {
-                if (!first)
-                    builder.Append(separator);
-                builder.Append(node.GetValue<string>());
-                first = false;
-            }
-        }
-        return JsonValue.Create(builder.ToString());
-    }
-
-    static JsonNode? EvaluateRename(JsonObject content, string? oldName)
-    {
-        if (oldName is null || !content.TryGetPropertyValue(oldName, out var value))
-            return null;
-        return value?.DeepClone();
     }
 
     async Task UpcastToHigherGenerations(
@@ -185,15 +140,23 @@ public class EventTypeMigrations(
                         break;
 
                     case WellKnownExpressions.Split when expr[WellKnownExpressions.Split] is JsonObject splitConfig:
-                        customResults[property.Key] = EvaluateSplit(content, splitConfig);
+                        customResults[property.Key] = EventMigrationExpressions.EvaluateSplit(content, splitConfig);
                         break;
 
                     case WellKnownExpressions.Combine when expr[WellKnownExpressions.Combine] is JsonObject combineConfig:
-                        customResults[property.Key] = EvaluateCombine(content, combineConfig);
+                        customResults[property.Key] = EventMigrationExpressions.EvaluateCombine(content, combineConfig);
                         break;
 
                     case WellKnownExpressions.Rename:
-                        customResults[property.Key] = EvaluateRename(content, expr[WellKnownExpressions.Rename]?.GetValue<string>());
+                        customResults[property.Key] = EventMigrationExpressions.EvaluateRename(content, expr[WellKnownExpressions.Rename]?.GetValue<string>());
+                        break;
+
+                    case WellKnownExpressions.MapValues when expr[WellKnownExpressions.MapValues] is JsonObject mapConfig:
+                        if (EventMigrationExpressions.TryEvaluateMapValues(content, mapConfig, out var mappedValue))
+                        {
+                            customResults[property.Key] = mappedValue;
+                        }
+
                         break;
 
                     default:

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -387,11 +387,13 @@ internal sealed class EventTypes(
             // schema so both sides go through identical normalization before comparison.
             newSchema.EnsureComplianceMetadata();
 
-            // Ignore nullability markers ('?' on a format value): a Chronicle upgrade can add them to an
-            // existing event schema (a nullable known value type that stored 'date-time-offset' now generates
-            // 'date-time-offset?'). That marker only refines how an unset value materializes, not the data
-            // shape, so a marker-only difference is not a breaking schema change.
-            if (!existingGeneration.Schema.EqualsIgnoringNullableFormatMarkers(newSchema))
+            // Compare for compatibility rather than equality. Two differences cannot change what an already
+            // stored payload means and must not be rejected: a nullability marker ('?' on a format value), which
+            // a Chronicle upgrade can introduce on a schema stored before the marker existed, and an enumeration
+            // that only gained members or had members renamed - neither moves an existing member off the
+            // underlying value a stored payload carries. Everything else, including a member that disappeared or
+            // was renumbered, still needs a new generation.
+            if (!existingGeneration.Schema.IsCompatibleWith(newSchema))
             {
                 throw new EventTypeSchemaChanged(eventType.Type.Id, genDef.Generation);
             }

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -360,6 +360,15 @@ internal sealed class EventTypes(
                     }
 
                     break;
+
+                case WellKnownExpressions.MapValues when entry.Value is JsonObject mapConfig:
+                    var mapSource = mapConfig["source"]?.GetValue<string>();
+                    if (mapSource is not null)
+                    {
+                        yield return mapSource;
+                    }
+
+                    break;
             }
         }
     }

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_an_enumeration_gained_a_member.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_an_enumeration_gained_a_member.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+/// <summary>
+/// An enumeration frequently mirrors something the application does not own, and gaining a member does not change
+/// what any already stored value means. Registration must let the generation take the wider member list rather than
+/// rejecting it as <see cref="EventTypeSchemaChanged"/> and forcing a generation for something history never noticed.
+/// </summary>
+public class and_an_enumeration_gained_a_member : given.all_dependencies
+{
+    const string StoredSchema = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+    const string WiderSchema = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1,2],"x-enumNames":["Unknown","Verified","Revoked"]}}}""";
+
+    Exception _exception;
+
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, StoredSchema)));
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 1 },
+                    Schema = WiderSchema,
+                    Generations =
+                    {
+                        new Contracts.Events.EventTypeGenerationDefinition { Generation = 1, Schema = WiderSchema }
+                    }
+                }
+            ]
+        }));
+
+    [Fact] void should_not_throw() => _exception.ShouldBeNull();
+
+    [Fact] void should_store_the_wider_member_list() =>
+        _eventTypesStorage.Received(1).Register(Arg.Is<IEnumerable<Concepts.Events.EventTypeToRegister>>(
+            _ => _.Single().Definition.Generations.Single().Schema.ToJson().Contains("Revoked")));
+}

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_an_enumeration_member_was_removed.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_an_enumeration_member_was_removed.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+/// <summary>
+/// Growing an enumeration is safe; losing a member is not. Events already stored with the removed value would be
+/// left denoting nothing, so this stays a schema change that needs a new generation - and a value map to say what
+/// the departed value became.
+/// </summary>
+public class and_an_enumeration_member_was_removed : given.all_dependencies
+{
+    const string StoredSchema = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1,2],"x-enumNames":["Unknown","Verified","Revoked"]}}}""";
+    const string NarrowerSchema = """{"type":"object","properties":{"status":{"type":"integer","enum":[0,1],"x-enumNames":["Unknown","Verified"]}}}""";
+
+    Exception _exception;
+
+    void Establish() => StoredEventTypes(StoredEventType("some-event", (1, StoredSchema)));
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 1 },
+                    Schema = NarrowerSchema,
+                    Generations =
+                    {
+                        new Contracts.Events.EventTypeGenerationDefinition { Generation = 1, Schema = NarrowerSchema }
+                    }
+                }
+            ]
+        }));
+
+    [Fact] void should_throw_event_type_schema_changed() => _exception.ShouldBeOfExactType<EventTypeSchemaChanged>();
+}


### PR DESCRIPTION
# Summary

Event type schema gating treated any change to an enum's member list as a breaking schema change, so gaining or renaming a member forced a new generation and a migrator for something no stored event can notice. Enums frequently mirror an external system that grows and renames on its own schedule.

Enums that grow or get renamed are now accepted in place. For the two changes that genuinely alter what history says — a member removed or renumbered — migrations gain a **value map**, declared once and applied forward when upcasting and inverted when downcasting.

## Added

- `MapValues` on `EventTypeMigration<TUpgrade, TPrevious>` — declare which value in one generation is which value in the other, once, and Chronicle applies the map forward when upcasting and inverted when downcasting. Values the map does not mention are carried across unchanged.
- `MapValues` on the migration property builder, for a translation that applies to one direction only. A direction that declares its own transformation for a property keeps it, overriding what the value map derives.

## Changed

- An event type generation whose enum only gained members, or had members renamed, no longer registers as `EventTypeSchemaChanged`. The wider member list replaces the registered schema instead. Removing or renumbering a member is still a schema change that needs a new generation.
