### PR TITLE
Upgrade @cratis/components to 4.1.1 for causation property navigation

### DIFF
--- a/Source/Workbench/package.json
+++ b/Source/Workbench/package.json
@@ -22,7 +22,7 @@
         "@cratis/arc.react": "^22.6.0",
         "@cratis/arc.react.mvvm": "^22.6.0",
         "@cratis/arc.vite": "^22.6.0",
-        "@cratis/components": "^4.1.0",
+        "@cratis/components": "^4.1.1",
         "@cratis/fundamentals": "^7.18.1",
         "@cratis/screenplay-language": "^4.6.0",
         "@monaco-editor/react": "^4.7.0",

--- a/Source/Workbench/yarn.lock
+++ b/Source/Workbench/yarn.lock
@@ -261,9 +261,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cratis/components@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@cratis/components@npm:4.1.0"
+"@cratis/components@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@cratis/components@npm:4.1.1"
   dependencies:
     "@internationalized/date": "npm:3.12.3"
     allotment: "npm:1.20.5"
@@ -284,7 +284,7 @@ __metadata:
   peerDependenciesMeta:
     pixi.js:
       optional: true
-  checksum: 10/3dce57d8a24c63a3388bfe5374a543a72726d306ac5810d1475494679637e2b4a532c5c841cc65b0dacfc520814a085f783ff6bdfb55e84e38d8787c8edc7134
+  checksum: 10/a7f9ecf0e49a0bc838427532d3e4c0d118abe7105ed6f71ddf16a141b57e36edd720881bb2f414c8fceb43bc25df95b11536c807f9634c46ab1ec1fb31585301
   languageName: node
   linkType: hard
 
@@ -8682,7 +8682,7 @@ __metadata:
     "@cratis/arc.react": "npm:^22.6.0"
     "@cratis/arc.react.mvvm": "npm:^22.6.0"
     "@cratis/arc.vite": "npm:^22.6.0"
-    "@cratis/components": "npm:^4.1.0"
+    "@cratis/components": "npm:^4.1.1"
     "@cratis/fundamentals": "npm:^7.18.1"
     "@cratis/screenplay-language": "npm:^4.6.0"
     "@eslint/eslintrc": "npm:3.3.6"


### PR DESCRIPTION
# Summary

The event details panel in Sequences could not show a causation entry's properties. Opening Context → causation → properties moved the breadcrumb forward but rendered the root event context underneath it, so the breadcrumb and the values on screen disagreed with nothing to indicate the navigation had failed. The cause was in `@cratis/components`, which could not resolve a navigation path through an array; this picks up the fix.

## Fixed

- Event details in Sequences now shows the causation entry's own properties when navigating Context → causation → properties, instead of falling back to the root event context
- Navigating into the second or later causation entry now shows that entry's properties rather than the first entry's
- The property navigation breadcrumb shows which array element was navigated through, as `[0]`
