### PR TITLE
Make the PII compliance docs language-neutral and accurate

### DIFF
--- a/Documentation/compliance/client.mdx
+++ b/Documentation/compliance/client.mdx
@@ -7,7 +7,9 @@ uid: Chronicle.Compliance.Client
 Chronicle's PII encryption is applied transparently by the kernel. From a client perspective, your responsibility is to annotate your domain model correctly so that the kernel knows which values to encrypt. There are two places to put this annotation, and you will typically use both in the same codebase.
 
 :::note[Client coverage]
-Property-level PII annotation (Option 1) is real in Kotlin and Elixir too — see below. `ConceptAs<T>`-level annotation (Option 2), combining both, and the DI-container registration step are all tied to C#-specific patterns (`ConceptAs<T>`, `IServiceCollection`) with no equivalent elsewhere in this corpus.
+Property-level annotation (Option 1) works in every client. Concept-level annotation (Option 2) works in C#, Kotlin/Java and TypeScript — all three have a `ConceptAs<T>`, and all three resolve a marker placed on it. Elixir has no concept construct, so Option 2 does not apply there; mark the field directly instead.
+
+The DI-container registration step is genuinely C#-specific — it is `IServiceCollection` wiring, and each other client discovers its artifacts its own way. See [Marking data as PII](./pii) for the full per-path support matrix.
 :::
 
 ## Option 1 — Annotate your event types

--- a/Documentation/compliance/client.mdx
+++ b/Documentation/compliance/client.mdx
@@ -7,7 +7,7 @@ uid: Chronicle.Compliance.Client
 Chronicle's PII encryption is applied transparently by the kernel. From a client perspective, your responsibility is to annotate your domain model correctly so that the kernel knows which values to encrypt. There are two places to put this annotation, and you will typically use both in the same codebase.
 
 :::note[Client coverage]
-Property-level annotation (Option 1) works in every client. Concept-level annotation (Option 2) works in C#, Kotlin/Java and TypeScript — all three have a `ConceptAs<T>`, and all three resolve a marker placed on it. Elixir has no concept construct, so Option 2 does not apply there; mark the field directly instead.
+Both options work in every client. C#, Kotlin/Java and TypeScript have a `ConceptAs<T>`; Elixir has `Chronicle.Concept`. All four serialize a concept as the value it wraps, so adopting one for a property already in production changes neither the wire format nor the registered schema.
 
 The DI-container registration step is genuinely C#-specific — it is `IServiceCollection` wiring, and each other client discovers its artifacts its own way. See [Marking data as PII](./pii) for the full per-path support matrix.
 :::

--- a/Documentation/compliance/client.mdx
+++ b/Documentation/compliance/client.mdx
@@ -41,7 +41,7 @@ Any event that uses `PersonName` is automatically encrypted — no further annot
 <ChronicleClientTabs snippet="compliance/client/concept-usage" />
 
 > [!TIP]
-> For the full `ConceptAs<T>` declaration pattern and placement rules, see [Applying PII to ConceptAs types](pii-with-concepts) and <xref:Fundamentals.Concepts>.
+> For the full `ConceptAs<T>` declaration pattern and placement rules, see [Declaring PII on a concept](pii-with-concepts) and <xref:Fundamentals.Concepts>.
 
 ### When to use this approach
 

--- a/Documentation/compliance/index.md
+++ b/Documentation/compliance/index.md
@@ -38,9 +38,9 @@ Chronicle supports two complementary approaches for marking data as personally i
 | `[PII]` on an event property | The property is a primitive type or an untyped value that holds personal data in a specific event. |
 | `[PII]` on a `ConceptAs<T>` type | The concept itself is inherently personal — any use of this type anywhere in any event is PII by definition. |
 
-The `ConceptAs<T>` approach is the preferred one. It is declared once and applies everywhere the type is used, so there is no risk of forgetting to mark a property in a future event. See [Applying PII to ConceptAs types](pii-with-concepts) for details.
+The `ConceptAs<T>` approach is the preferred one. It is declared once and applies everywhere the type is used, so there is no risk of forgetting to mark a property in a future event. See [Declaring PII on a concept](pii-with-concepts) for details.
 
-For a full description of the `[PII]` attribute and its rules, see [PII Attribute](pii).
+For a full description of the `[PII]` marker and its rules, see [Marking data as PII](pii).
 
 ## Event source identifiers cannot be encrypted
 
@@ -52,8 +52,8 @@ If the identifier itself is sensitive, use a non-sensitive surrogate key as the 
 
 | Topic | Description |
 |---|---|
-| [PII Attribute](pii) | The `[PII]` attribute — rules, usage, and constraints |
-| [Applying PII to ConceptAs types](pii-with-concepts) | How to mark domain value types as PII once and apply everywhere |
+| [Marking data as PII](pii) | The `[PII]` marker — rules, usage, and constraints |
+| [Declaring PII on a concept](pii-with-concepts) | How to mark domain value types as PII once and apply everywhere |
 | [Working with compliance from the client](client) | How to annotate events and ConceptAs types in your .NET client code |
 | [Read models and PII](read-models) | How PII encryption affects projections, reducers, and read model queries |
 | [Erasing a subject](erasing-a-subject.md) | What one erasure reaches, and how to erase across every event store |

--- a/Documentation/compliance/pii-with-concepts.mdx
+++ b/Documentation/compliance/pii-with-concepts.mdx
@@ -12,11 +12,11 @@ This page covers the **property type** path — Chronicle resolves `[PII]` throu
 | Path | C# | Kotlin/Java | TypeScript | Elixir |
 |---|---|---|---|---|
 | Property | yes | yes | yes | yes |
-| Declaring type | yes | no | no | no |
-| Property type (concept) | yes | yes | yes | no |
-| Constructor parameter | yes | partial | no | n/a |
+| Declaring type | yes | yes | yes | no |
+| Property type (concept) | yes | yes | yes | yes |
+| Constructor parameter | yes | yes | no | n/a |
 
-Kotlin/Java and TypeScript both have a `ConceptAs<T>` equivalent and already resolve a `@Pii`/`@pii()` marker on that type, so the pattern on this page ports directly — see [Marking data as PII](./pii) for the full path table. Elixir has no concept construct, so there is no idiomatic way to port a concept-level declaration there; mark the field directly with `pii/1,2` instead (see [Applying to an event property](./pii#applying-to-an-event-property)). The declaring-type and constructor-parameter paths remain C#-only — open defects in the non-C# clients, not deliberate design choices.
+**Every client supports the pattern on this page.** C#, Kotlin/Java and TypeScript each have a `ConceptAs<T>`; Elixir has `Chronicle.Concept`, which serializes as the value it wraps in the same way. Declare the marker once on the concept and every event and read model property using that type is encrypted — see [Marking data as PII](./pii) for the full path table and the two remaining gaps.
 :::
 
 > [!TIP]

--- a/Documentation/compliance/pii-with-concepts.mdx
+++ b/Documentation/compliance/pii-with-concepts.mdx
@@ -2,12 +2,21 @@
 uid: Chronicle.Compliance.PIIWithConcepts
 ---
 
-# Applying PII to ConceptAs types
+# Declaring PII on a concept
 
 The most robust way to declare that a value is personally identifiable is to mark the `ConceptAs<T>` type itself with `[PII]`. Doing so means the declaration lives exactly once — on the type — and every event property that uses that type is automatically encrypted, regardless of where or how many times it appears across your event model.
 
 :::note[Client coverage]
-This page is specifically about `ConceptAs<T>`, a C# strongly-typed value-wrapper pattern. Kotlin and Elixir have no equivalent typed-wrapper convention in this corpus, so there's no idiomatic way to port a "concept-level" PII declaration to them — mark the property directly instead (see [PII Attribute](./pii)). TypeScript already has partial coverage here since a plain wrapper class works without needing to inherit from anything.
+This page covers the **property type** path — Chronicle resolves `[PII]` through four paths in total (property, declaring type, property type, constructor parameter), and marking a concept's type once is not C#-only:
+
+| Path | C# | Kotlin/Java | TypeScript | Elixir |
+|---|---|---|---|---|
+| Property | yes | yes | yes | yes |
+| Declaring type | yes | no | no | no |
+| Property type (concept) | yes | yes | yes | no |
+| Constructor parameter | yes | partial | no | n/a |
+
+Kotlin/Java and TypeScript both have a `ConceptAs<T>` equivalent and already resolve a `@Pii`/`@pii()` marker on that type, so the pattern on this page ports directly — see [Marking data as PII](./pii) for the full path table. Elixir has no concept construct, so there is no idiomatic way to port a concept-level declaration there; mark the field directly with `pii/1,2` instead (see [Applying to an event property](./pii#applying-to-an-event-property)). The declaring-type and constructor-parameter paths remain C#-only — open defects in the non-C# clients, not deliberate design choices.
 :::
 
 > [!TIP]

--- a/Documentation/compliance/pii.mdx
+++ b/Documentation/compliance/pii.mdx
@@ -16,11 +16,15 @@ Chronicle resolves `[PII]` on a property through four paths, checked in this ord
 | Path | C# | Kotlin/Java | TypeScript | Elixir |
 |---|---|---|---|---|
 | Property | yes | yes | yes | yes |
-| Declaring type | yes | no | no | no |
-| Property type (concept) | yes | yes | yes | no |
-| Constructor parameter | yes | partial | no | n/a |
+| Declaring type | yes | yes | yes | no |
+| Property type (concept) | yes | yes | yes | yes |
+| Constructor parameter | yes | yes | no | n/a |
 
-Every client covers the **property** path — that's what the tabs on this page show. Kotlin/Java and TypeScript also resolve a marker on the property's **concept type** (`ConceptAs<T>` or its client equivalent), matching C#'s preferred approach — see [Declaring PII on a concept](pii-with-concepts). Elixir has no concept construct, so that path does not apply there. The **declaring type** and **constructor parameter** paths remain C#-only: Kotlin/Java reaches a constructor parameter only when it is also declared as a property (`val`/`var`), and no other client cascades a class-level marker onto its sibling properties. These are open defects in the non-C# clients, not deliberate design choices.
+Every client covers the **property** path, and every client resolves a marker on the property's **concept type** — declare it once on the concept and every event and read model using that type is covered. That is the preferred approach; see [Declaring PII on a concept](pii-with-concepts).
+
+Two gaps remain. Elixir has no way to mark a whole multi-field struct as PII in one declaration — a concept wraps a single value, so mark the fields you need. And the TypeScript decorator does not read a constructor parameter, which matters only for classes that take their values positionally rather than as declared properties.
+
+Whichever path applies, the marker lands on the individual **leaf** values in the schema, not on the object that contains them — so a concept nested inside a value object is still encrypted, and the document keeps its shape on release.
 :::
 
 ## Marker signatures

--- a/Documentation/compliance/pii.mdx
+++ b/Documentation/compliance/pii.mdx
@@ -2,36 +2,53 @@
 uid: Chronicle.Compliance.PII
 ---
 
-# PII Attribute
+# Marking data as PII
 
-The `[PII]` attribute marks data as personally identifiable information (PII) under GDPR. When Chronicle sees this attribute on an event property or a type, it encrypts the value automatically when the event is written to the event log and decrypts it transparently on read.
+Marking a value `[PII]` tells Chronicle it holds personally identifiable information under GDPR — a C# attribute, a Kotlin/Java `@Pii` annotation, a TypeScript `@pii()` decorator, or an Elixir `pii` macro, depending on the client. When Chronicle sees the marker on an event property or a type, it encrypts the value automatically when the event is written to the event log and decrypts it transparently on read.
 
 Personal data rarely sits in a flat list of properties. A date of birth arrives wrapped in a `VerifiedDateOfBirth` value object alongside who verified it; a diagnosis carries the condition and the clinician together. Chronicle follows the marker down through that structure: whether you mark a concept nested inside a value object, or the value object type itself, encryption lands on the individual values at the bottom. The document keeps its shape, each value stays independently encrypted, and the release on read mirrors the encryption on write.
 
 <ChronicleClientTabs snippet="compliance/pii/import" />
 
 :::note[Client coverage]
-Kotlin (`@Pii`), Elixir (`pii/1,2`), and TypeScript (`@pii()`) all have a real, working equivalent for marking an **event property** as PII — see [Applying to an event property](#applying-to-an-event-property) below. The **class-level** form (marking a `ConceptAs<T>` type itself as PII, so every property using that type is covered) is tied to C#'s `ConceptAs<T>` pattern specifically; Kotlin/Java/Elixir have no equivalent typed-wrapper convention established in this corpus, so those tabs — and the `EventSourceId` restriction that only makes sense in that context — stay C#-only for now.
+Chronicle resolves `[PII]` on a property through four paths, checked in this order: a marker on the property itself, a marker on the type that declares the property, a marker on the property's own type (the concept case), and a marker on a matching constructor parameter. C#'s `PIIMetadataProvider` implements all four.
+
+| Path | C# | Kotlin/Java | TypeScript | Elixir |
+|---|---|---|---|---|
+| Property | yes | yes | yes | yes |
+| Declaring type | yes | no | no | no |
+| Property type (concept) | yes | yes | yes | no |
+| Constructor parameter | yes | partial | no | n/a |
+
+Every client covers the **property** path — that's what the tabs on this page show. Kotlin/Java and TypeScript also resolve a marker on the property's **concept type** (`ConceptAs<T>` or its client equivalent), matching C#'s preferred approach — see [Declaring PII on a concept](pii-with-concepts). Elixir has no concept construct, so that path does not apply there. The **declaring type** and **constructor parameter** paths remain C#-only: Kotlin/Java reaches a constructor parameter only when it is also declared as a property (`val`/`var`), and no other client cascades a class-level marker onto its sibling properties. These are open defects in the non-C# clients, not deliberate design choices.
 :::
 
-## Attribute definition
+## Marker signatures
 
-The signature, for reference:
+The marker, in each client:
 
 ```text
 // C#
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property | AttributeTargets.Parameter)]
 public sealed class PIIAttribute(string details = "") : Attribute
 
+// Kotlin / Java
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Pii(val description: String = "")
+
 // TypeScript
 export function pii(details?: string): PropertyDecorator & ClassDecorator
+
+// Elixir
+defmacro pii(field, details \\ "")
 ```
 
 The optional `details` parameter lets you record *why* the value is classified as PII — for example, the legal basis under which it is collected or the retention period. This information is stored in the event schema and can be used by compliance reporting tools.
 
 <ChronicleClientTabs snippet="compliance/pii/with-details" />
 
-## Where the attribute is valid
+## Where you can mark PII
 
 | Target | Supported | Notes |
 |---|---|---|
@@ -43,6 +60,8 @@ The optional `details` parameter lets you record *why* the value is classified a
 | Geospatial (`Point`, `LineString`, `Polygon`) | **No** | Never classified inside, and marking one encrypts a value that cannot be materialized back after erasure — see [Geospatial values are not looked inside](#geospatial-values-are-not-looked-inside) |
 | Polymorphic base type or dictionary | **No** | Chronicle cannot classify values inside either and fails rather than store them unprotected |
 | `EventSourceId` or `EventSourceId<T>` | **No** | Throws `PIINotSupportedOnEventSourceId` at runtime |
+
+This table describes what the C# client validates. No other client performs the same checks yet: Kotlin/Java, TypeScript, and Elixir don't verify that a `[PII]`-marked type actually extends the client's `ConceptAs<T>` equivalent, and none of them throws an equivalent of `PIINotSupportedOnEventSourceId` when you mark an event-source identifier type — the marker is silently accepted rather than rejected. Treat both restrictions as rules to follow across every client, not ones every client enforces for you today.
 
 ## Applying to an event property
 
@@ -59,7 +78,7 @@ The preferred approach is to mark the `ConceptAs<T>` type itself as PII. Every p
 <ChronicleClientTabs snippet="compliance/pii/concept-level" />
 
 > [!TIP]
-> Use <xref:Fundamentals.Concepts> as a reference for the full `ConceptAs<T>` pattern. For guidance on declaring compliance on concept types, see [Applying PII to ConceptAs types](pii-with-concepts).
+> Use <xref:Fundamentals.Concepts> as a reference for the full `ConceptAs<T>` pattern. For guidance on declaring compliance on concept types, see [Declaring PII on a concept](pii-with-concepts).
 
 ## Applying to a value object
 

--- a/Documentation/compliance/toc.yml
+++ b/Documentation/compliance/toc.yml
@@ -1,8 +1,8 @@
 - name: Overview
   href: index.md
-- name: PII Attribute
+- name: Marking data as PII
   href: pii.mdx
-- name: Applying PII to ConceptAs types
+- name: Declaring PII on a concept
   href: pii-with-concepts.mdx
 - name: Working with compliance from the client
   href: client.mdx


### PR DESCRIPTION
## Changed

- The compliance topic **PII Attribute** is now **Marking data as PII**, and **Applying PII to ConceptAs types** is now **Declaring PII on a concept**. Only the C# client calls this an attribute — Kotlin/Java use the `@Pii` annotation, TypeScript the `@pii()` decorator, and Elixir the `pii` macro. Page URLs, `uid` values and snippet IDs are unchanged (#3907)
- The PII pages now show the marker signature for every client rather than only C# and TypeScript (#3907)

## Fixed

- The "Client coverage" notes on the PII pages claimed concept-level PII was C#-only and that Kotlin/Java and Elixir had "no equivalent typed-wrapper convention". Kotlin/Java have had `ConceptAs<T>` for some time and already resolved a marker on it, and Elixir now has `Chronicle.Concept` — so declaring PII once on a concept works in every client. The notes are replaced with a verified per-path support matrix (#3907)
- The compliance client page made the same claim about concept-level annotation being tied to C#-specific patterns (#3907)
- The `[PII]` validity table read as if every client enforced the `ConceptAs<T>` and `EventSourceId` restrictions. It now says which client enforces what (#3907)
