### PR TITLE
Complete the mutation registry across all providers, add AppliedThrough and read-model cut capture

### DIFF
--- a/Source/Clients/Connections/ChronicleConnection.cs
+++ b/Source/Clients/Connections/ChronicleConnection.cs
@@ -279,7 +279,8 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
             callInvoker.CreateGrpcService<IUsers>(clientFactory),
             callInvoker.CreateGrpcService<IApplications>(clientFactory),
             callInvoker.CreateGrpcService<IServer>(clientFactory),
-            callInvoker.CreateGrpcService<IConnectionService>(clientFactory));
+            callInvoker.CreateGrpcService<IConnectionService>(clientFactory),
+            callInvoker.CreateGrpcService<Contracts.Cuts.IReadModelCuts>(clientFactory));
 
         if (_skipKeepAlive)
         {

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_checking_applied_through/and_the_observer_is_ready.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_checking_applied_through/and_the_observer_is_ready.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using ClientAppliedThroughOutcome = Cratis.Chronicle.Observation.AppliedThroughOutcome;
+using ClientAppliedThroughResult = Cratis.Chronicle.Observation.AppliedThroughResult;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_checking_applied_through;
+
+public class and_the_observer_is_ready : given.an_event_sequence
+{
+    IObservers _observers;
+    ClientAppliedThroughResult _result;
+
+    void Establish()
+    {
+        _observers = Substitute.For<IObservers>();
+        services.Observers.Returns(_observers);
+        _observers.AppliedThrough(Arg.Any<AppliedThroughRequest>(), Arg.Any<ProtoBuf.Grpc.CallContext>()).Returns(new AppliedThroughResponse
+        {
+            IsSuccess = true,
+            Results = [new AppliedThroughObserverResult { ObserverId = "observer-1", Outcome = AppliedThroughOutcome.Ready }]
+        });
+    }
+
+    async Task Because() => _result = await _eventSequence.AppliedThrough(["observer-1"], 42UL);
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_report_the_observer_as_ready() => _result.Results.Single().Outcome.ShouldEqual(ClientAppliedThroughOutcome.Ready);
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_checking_applied_through/and_there_is_no_observer_surface.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_checking_applied_through/and_there_is_no_observer_surface.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Observation;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_checking_applied_through;
+
+public class and_there_is_no_observer_surface : given.an_event_sequence
+{
+    Exception _exception;
+
+    void Establish() => services.Observers.Returns(_ => throw new NotSupportedException());
+
+    async Task Because() => _exception = await Catch.Exception(() => _eventSequence.AppliedThrough(["observer-1"], 42UL));
+
+    [Fact] void should_fail_by_name() => _exception.ShouldBeOfExactType<CannotWaitForObserverCompletion>();
+}

--- a/Source/Clients/DotNET/EventSequences/EventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/EventSequence.cs
@@ -13,10 +13,13 @@ using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Events.Constraints;
 using Cratis.Chronicle.EventSequences.Concurrency;
 using Cratis.Chronicle.Identities;
+using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.Reactors;
 using Cratis.Chronicle.Transactions;
 using Cratis.Monads;
 using Cratis.Traces;
+using Grpc.Core;
+using ProtoBuf.Grpc;
 using ContractCompleteStreamError = Cratis.Chronicle.Contracts.EventSequences.CompleteStreamError;
 
 namespace Cratis.Chronicle.EventSequences;
@@ -440,6 +443,31 @@ public class EventSequence(
     {
         var observerEventTypes = ReactorInvoker.GetEventTypesFor(eventTypes, type);
         return await GetTailSequenceNumber(filterEventTypes: observerEventTypes);
+    }
+
+    /// <inheritdoc/>
+    public async Task<AppliedThroughResult> AppliedThrough(IEnumerable<ObserverId> observerIds, EventSequenceNumber targetPosition, TimeSpan? timeout = default)
+    {
+        var observers = GetObservers() ??
+            throw new CannotWaitForObserverCompletion(eventStoreName, eventSequenceId);
+
+        timeout ??= TimeSpanFactory.DefaultTimeout();
+        using var cts = new CancellationTokenSource(timeout.Value);
+
+        var response = await observers.AppliedThrough(
+            new Contracts.Observation.AppliedThroughRequest
+            {
+                EventStore = eventStoreName,
+                Namespace = @namespace,
+                EventSequenceId = eventSequenceId,
+                ObserverIds = observerIds.Select(_ => _.Value).ToArray(),
+                TargetEventSequenceNumber = targetPosition
+            },
+            new CallContext(new CallOptions(cancellationToken: cts.Token)));
+
+        return new AppliedThroughResult(
+            response.IsSuccess,
+            response.Results.Select(_ => new AppliedThroughObserverResult(_.ObserverId, _.Outcome.ToClient())).ToArray());
     }
 
     /// <inheritdoc/>

--- a/Source/Clients/DotNET/EventSequences/IEventSequence.cs
+++ b/Source/Clients/DotNET/EventSequences/IEventSequence.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Observation;
 using Cratis.Monads;
 
 namespace Cratis.Chronicle.EventSequences;
@@ -97,6 +98,20 @@ public interface IEventSequence
     /// This is based on the tail of the event types the observer is interested in.
     /// </remarks>
     Task<EventSequenceNumber> GetTailSequenceNumberForObserver(Type type);
+
+    /// <summary>
+    /// Checks whether a named set of observers have durably applied through a target position.
+    /// </summary>
+    /// <param name="observerIds">The explicit <see cref="ObserverId"/>s to check.</param>
+    /// <param name="targetPosition">The target <see cref="EventSequenceNumber"/> every named observer must have durably applied through.</param>
+    /// <param name="timeout">Optional timeout. If none is provided, it defaults to 5 seconds.</param>
+    /// <returns>An <see cref="AppliedThroughResult"/> carrying a typed outcome per requested observer.</returns>
+    /// <remarks>
+    /// Unlike <see cref="Observation.AppendResultWaitForCompletionExtensions.WaitForCompletion"/>, the observer set
+    /// is always explicit, and a caller's deadline is reported back as a typed <see cref="AppliedThroughOutcome.TimedOut"/>
+    /// per still-unresolved observer rather than an unstructured cancellation fault.
+    /// </remarks>
+    Task<AppliedThroughResult> AppliedThrough(IEnumerable<ObserverId> observerIds, EventSequenceNumber targetPosition, TimeSpan? timeout = default);
 
     /// <summary>
     /// Append a single event to the event store.

--- a/Source/Clients/DotNET/Observation/AppliedThroughObserverResult.cs
+++ b/Source/Clients/DotNET/Observation/AppliedThroughObserverResult.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents the typed outcome for one requested observer.
+/// </summary>
+/// <param name="ObserverId">The <see cref="Observation.ObserverId"/> this outcome is for.</param>
+/// <param name="Outcome">The <see cref="AppliedThroughOutcome"/> for this observer.</param>
+public record AppliedThroughObserverResult(ObserverId ObserverId, AppliedThroughOutcome Outcome);

--- a/Source/Clients/DotNET/Observation/AppliedThroughOutcome.cs
+++ b/Source/Clients/DotNET/Observation/AppliedThroughOutcome.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Defines the typed outcome for one observer in an <see cref="AppliedThroughResult"/>.
+/// </summary>
+public enum AppliedThroughOutcome
+{
+    /// <summary>
+    /// The outcome is unknown.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The observer durably applied through the target position.
+    /// </summary>
+    Ready = 1,
+
+    /// <summary>
+    /// The observer had not reached the target position before the caller's deadline.
+    /// </summary>
+    TimedOut = 2,
+
+    /// <summary>
+    /// The observer id was not found for the event sequence.
+    /// </summary>
+    Unavailable = 3,
+
+    /// <summary>
+    /// The observer has a failed partition and cannot make further progress without intervention.
+    /// </summary>
+    Failed = 4,
+
+    /// <summary>
+    /// The observer is replaying and its position cannot be trusted as forward progress.
+    /// </summary>
+    Replaying = 5,
+
+    /// <summary>
+    /// The observer is quarantined and will not resume on its own.
+    /// </summary>
+    Quarantined = 6,
+}

--- a/Source/Clients/DotNET/Observation/AppliedThroughOutcomeConverters.cs
+++ b/Source/Clients/DotNET/Observation/AppliedThroughOutcomeConverters.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Extension methods for converting <see cref="Contracts.Observation.AppliedThroughOutcome"/> to <see cref="AppliedThroughOutcome"/>.
+/// </summary>
+internal static class AppliedThroughOutcomeConverters
+{
+    /// <summary>
+    /// Convert to client.
+    /// </summary>
+    /// <param name="outcome"><see cref="Contracts.Observation.AppliedThroughOutcome"/> to convert from.</param>
+    /// <returns>Converted <see cref="AppliedThroughOutcome"/>.</returns>
+    public static AppliedThroughOutcome ToClient(this Contracts.Observation.AppliedThroughOutcome outcome) =>
+        outcome switch
+        {
+            Contracts.Observation.AppliedThroughOutcome.Ready => AppliedThroughOutcome.Ready,
+            Contracts.Observation.AppliedThroughOutcome.TimedOut => AppliedThroughOutcome.TimedOut,
+            Contracts.Observation.AppliedThroughOutcome.Unavailable => AppliedThroughOutcome.Unavailable,
+            Contracts.Observation.AppliedThroughOutcome.Failed => AppliedThroughOutcome.Failed,
+            Contracts.Observation.AppliedThroughOutcome.Replaying => AppliedThroughOutcome.Replaying,
+            Contracts.Observation.AppliedThroughOutcome.Quarantined => AppliedThroughOutcome.Quarantined,
+            _ => AppliedThroughOutcome.Unknown
+        };
+}

--- a/Source/Clients/DotNET/Observation/AppliedThroughResult.cs
+++ b/Source/Clients/DotNET/Observation/AppliedThroughResult.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Observation;
+
+/// <summary>
+/// Represents the result of checking whether a named set of observers have applied through a target position.
+/// </summary>
+/// <param name="IsSuccess">Whether every requested observer reached <see cref="AppliedThroughOutcome.Ready"/>.</param>
+/// <param name="Results">The typed outcome for every requested observer.</param>
+public record AppliedThroughResult(bool IsSuccess, IEnumerable<AppliedThroughObserverResult> Results);

--- a/Source/Clients/Testing/EventSequences/InProcessServices.cs
+++ b/Source/Clients/Testing/EventSequences/InProcessServices.cs
@@ -118,4 +118,7 @@ internal sealed class InProcessServices(
 
     /// <inheritdoc/>
     public Contracts.Clients.IConnectionService Connections => throw new NotSupportedException("Connections is not supported in test scenarios.");
+
+    /// <inheritdoc/>
+    public Contracts.Cuts.IReadModelCuts ReadModelCuts => throw new NotSupportedException("ReadModelCuts is not supported in test scenarios.");
 }

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -310,6 +310,9 @@ internal sealed class TestingServices(
     /// <inheritdoc/>
     public Contracts.Clients.IConnectionService Connections => throw new NotSupportedException("Connections is not supported in test scenarios.");
 
+    /// <inheritdoc/>
+    public Contracts.Cuts.IReadModelCuts ReadModelCuts => throw new NotSupportedException("ReadModelCuts is not supported in test scenarios.");
+
     sealed class EmptyInstancesOf<T> : IInstancesOf<T>
         where T : class
     {

--- a/Source/Kernel/Concepts/Cuts/EventSequenceCut.cs
+++ b/Source/Kernel/Concepts/Cuts/EventSequenceCut.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+
+namespace Cratis.Chronicle.Concepts.Cuts;
+
+/// <summary>
+/// Represents an exact position on one event sequence a read-model cut is bound to.
+/// </summary>
+/// <param name="EventSequenceId">The <see cref="Concepts.EventSequences.EventSequenceId"/> the position is on.</param>
+/// <param name="Position">The exact <see cref="EventSequenceNumber"/> - inclusive - every selected read model is bound to.</param>
+/// <remarks>
+/// A cut request carries a vector of these rather than a single global position, so dependencies spanning several
+/// event sequences can each be pinned to their own exact position without inventing one global revision number
+/// that does not exist across sequences.
+/// </remarks>
+public record EventSequenceCut(EventSequenceId EventSequenceId, EventSequenceNumber Position);

--- a/Source/Kernel/Concepts/Cuts/InvalidReadModelCutPayloadDigestLength.cs
+++ b/Source/Kernel/Concepts/Cuts/InvalidReadModelCutPayloadDigestLength.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Cuts;
+
+/// <summary>
+/// The exception that is thrown when a <see cref="ReadModelCutPayloadDigest"/> is constructed from a byte span that is not exactly 32 bytes long.
+/// </summary>
+/// <param name="actualLength">The actual number of bytes supplied.</param>
+public class InvalidReadModelCutPayloadDigestLength(int actualLength)
+    : Exception($"A read model cut payload digest must be exactly 32 bytes, but {actualLength} byte(s) were supplied");

--- a/Source/Kernel/Concepts/Cuts/ReadModelCutId.cs
+++ b/Source/Kernel/Concepts/Cuts/ReadModelCutId.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Cuts;
+
+/// <summary>
+/// Represents the deterministic identifier of a read-model cut, computed from the exact request it was captured
+/// for - the same request produces the same id, so a repeated request naturally resolves to the same manifest
+/// instead of capturing the same content twice.
+/// </summary>
+/// <param name="Value">The actual value.</param>
+public record ReadModelCutId(Guid Value) : ConceptAs<Guid>(Value)
+{
+    /// <summary>
+    /// Gets the representation of a not-set <see cref="ReadModelCutId"/>.
+    /// </summary>
+    public static readonly ReadModelCutId NotSet = new(Guid.Empty);
+
+    /// <summary>
+    /// Implicitly convert from <see cref="Guid"/> to <see cref="ReadModelCutId"/>.
+    /// </summary>
+    /// <param name="value"><see cref="Guid"/> to convert from.</param>
+    public static implicit operator ReadModelCutId(Guid value) => new(value);
+}

--- a/Source/Kernel/Concepts/Cuts/ReadModelCutOutcome.cs
+++ b/Source/Kernel/Concepts/Cuts/ReadModelCutOutcome.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Cuts;
+
+/// <summary>
+/// Defines the outcome of capturing one read model's payload at an exact cut.
+/// </summary>
+public enum ReadModelCutOutcome
+{
+    /// <summary>
+    /// The outcome is unknown. Never a produced value - a closed sentinel guarding against an unset field.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The payload was recomputed and its digest verified.
+    /// </summary>
+    Captured = 1,
+
+    /// <summary>
+    /// The read model is not backed by a projection - reducer-backed read models run in the connected client
+    /// process, not the kernel, so the kernel cannot recompute them without a live client round trip.
+    /// </summary>
+    Unsupported = 2,
+
+    /// <summary>
+    /// A mutation operation could still touch content at or below the requested cut, so the content is not
+    /// yet stable enough to capture exactly.
+    /// </summary>
+    MutationInProgress = 3,
+
+    /// <summary>
+    /// The read model identifier named in the selection does not exist.
+    /// </summary>
+    NotFound = 4,
+
+    /// <summary>
+    /// Recomputing the payload failed for a reason other than the above.
+    /// </summary>
+    Failed = 5,
+}

--- a/Source/Kernel/Concepts/Cuts/ReadModelCutPayloadDigest.cs
+++ b/Source/Kernel/Concepts/Cuts/ReadModelCutPayloadDigest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Concepts.Cuts;
+
+/// <summary>
+/// Represents the 32-byte SHA-256 digest of one read model's captured payload.
+/// </summary>
+public sealed class ReadModelCutPayloadDigest : IEquatable<ReadModelCutPayloadDigest>
+{
+    const int Length = 32;
+
+    readonly byte[] _bytes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReadModelCutPayloadDigest"/> class.
+    /// </summary>
+    /// <param name="bytes">The 32 digest bytes to copy.</param>
+    /// <exception cref="InvalidReadModelCutPayloadDigestLength">Thrown when <paramref name="bytes"/> does not contain exactly 32 bytes.</exception>
+    public ReadModelCutPayloadDigest(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != Length)
+        {
+            throw new InvalidReadModelCutPayloadDigestLength(bytes.Length);
+        }
+
+        _bytes = bytes.ToArray();
+    }
+
+    /// <summary>
+    /// Determines whether two digests contain the same bytes.
+    /// </summary>
+    /// <param name="left">The left digest.</param>
+    /// <param name="right">The right digest.</param>
+    /// <returns><see langword="true"/> when the digests are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(ReadModelCutPayloadDigest? left, ReadModelCutPayloadDigest? right) => Equals(left, right);
+
+    /// <summary>
+    /// Determines whether two digests contain different bytes.
+    /// </summary>
+    /// <param name="left">The left digest.</param>
+    /// <param name="right">The right digest.</param>
+    /// <returns><see langword="true"/> when the digests are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(ReadModelCutPayloadDigest? left, ReadModelCutPayloadDigest? right) => !Equals(left, right);
+
+    /// <summary>
+    /// Creates a defensive snapshot of the digest bytes.
+    /// </summary>
+    /// <returns>A new byte array containing the digest bytes.</returns>
+    public byte[] Snapshot() => _bytes.ToArray();
+
+    /// <summary>
+    /// Gets the digest as a lowercase hexadecimal string, for display and storage keys.
+    /// </summary>
+    /// <returns>The hexadecimal representation of the digest.</returns>
+    public override string ToString() => Convert.ToHexStringLower(_bytes);
+
+    /// <inheritdoc/>
+    public bool Equals(ReadModelCutPayloadDigest? other) => other is not null && _bytes.AsSpan().SequenceEqual(other._bytes);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is ReadModelCutPayloadDigest other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = default(HashCode);
+        hash.AddBytes(_bytes);
+        return hash.ToHashCode();
+    }
+}

--- a/Source/Kernel/Contracts/Cuts/EventSequenceCut.cs
+++ b/Source/Kernel/Contracts/Cuts/EventSequenceCut.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Represents an exact position on one event sequence a read-model cut is bound to.
+/// </summary>
+[ProtoContract]
+public class EventSequenceCut
+{
+    /// <summary>
+    /// Gets or sets the event sequence the position is on.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventSequenceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exact position - inclusive - every selected read model is bound to.
+    /// </summary>
+    [ProtoMember(2)]
+    public ulong Position { get; set; }
+}

--- a/Source/Kernel/Contracts/Cuts/IReadModelCuts.cs
+++ b/Source/Kernel/Contracts/Cuts/IReadModelCuts.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Defines the contract for capturing read-model payloads exactly at an event-sequence cut.
+/// </summary>
+[Service]
+public interface IReadModelCuts
+{
+    /// <summary>
+    /// Captures a selection of read models exactly at a vector of event-sequence cuts.
+    /// </summary>
+    /// <param name="request">The <see cref="ReadModelCutRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns>The published <see cref="ReadModelCutResponse"/>.</returns>
+    /// <remarks>
+    /// Recomputes each requested read model's payload from the event log up to and including its cut, rather
+    /// than reading the live sink - so a writer that advances a read model past the requested cut after the
+    /// request started never contaminates the payload. The same request, field for field, always resolves to
+    /// the same manifest.
+    /// </remarks>
+    [Operation]
+    Task<ReadModelCutResponse> Capture(ReadModelCutRequest request, CallContext context = default);
+}

--- a/Source/Kernel/Contracts/Cuts/ReadModelCutEntry.cs
+++ b/Source/Kernel/Contracts/Cuts/ReadModelCutEntry.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Represents the outcome and, on success, the payload digest for one read model in a <see cref="ReadModelCutResponse"/>.
+/// </summary>
+[ProtoContract]
+public class ReadModelCutEntry
+{
+    /// <summary>
+    /// Gets or sets the read model identifier this entry is for.
+    /// </summary>
+    [ProtoMember(1)]
+    public string ReadModel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the outcome for this read model.
+    /// </summary>
+    [ProtoMember(2)]
+    public ReadModelCutOutcome Outcome { get; set; }
+
+    /// <summary>
+    /// Gets or sets the read-model schema generation the payload was produced under, when <see cref="Outcome"/> is <see cref="ReadModelCutOutcome.Captured"/>.
+    /// </summary>
+    [ProtoMember(3)]
+    public uint? Generation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lowercase hexadecimal SHA-256 digest of the payload, when <see cref="Outcome"/> is <see cref="ReadModelCutOutcome.Captured"/>.
+    /// </summary>
+    [ProtoMember(4)]
+    public string? Digest { get; set; }
+
+    /// <summary>
+    /// Gets or sets a human-readable reason, when <see cref="Outcome"/> is not <see cref="ReadModelCutOutcome.Captured"/>.
+    /// </summary>
+    [ProtoMember(5)]
+    public string? FailureReason { get; set; }
+}

--- a/Source/Kernel/Contracts/Cuts/ReadModelCutOutcome.cs
+++ b/Source/Kernel/Contracts/Cuts/ReadModelCutOutcome.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Defines the outcome of capturing one read model's payload at an exact cut.
+/// </summary>
+public enum ReadModelCutOutcome
+{
+    /// <summary>
+    /// The outcome is unknown. Never a produced value - a closed sentinel guarding against an unset field.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The payload was recomputed and its digest verified.
+    /// </summary>
+    Captured = 1,
+
+    /// <summary>
+    /// The read model is not backed by a projection.
+    /// </summary>
+    Unsupported = 2,
+
+    /// <summary>
+    /// A mutation operation could still touch content at or below the requested cut.
+    /// </summary>
+    MutationInProgress = 3,
+
+    /// <summary>
+    /// The read model identifier named in the selection does not exist.
+    /// </summary>
+    NotFound = 4,
+
+    /// <summary>
+    /// Recomputing the payload failed for a reason other than the above.
+    /// </summary>
+    Failed = 5,
+}

--- a/Source/Kernel/Contracts/Cuts/ReadModelCutRequest.cs
+++ b/Source/Kernel/Contracts/Cuts/ReadModelCutRequest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Represents a request to capture a selection of read models exactly at a vector of event-sequence cuts.
+/// </summary>
+[ProtoContract]
+public class ReadModelCutRequest
+{
+    /// <summary>
+    /// Gets or sets the event store the selection belongs to.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace the selection belongs to.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exact position, per event sequence, every selected read model is bound to.
+    /// </summary>
+    [ProtoMember(3)]
+    public IEnumerable<EventSequenceCut> Cuts { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the read model identifiers to capture.
+    /// </summary>
+    [ProtoMember(4)]
+    public IEnumerable<string> Selection { get; set; } = [];
+}

--- a/Source/Kernel/Contracts/Cuts/ReadModelCutResponse.cs
+++ b/Source/Kernel/Contracts/Cuts/ReadModelCutResponse.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Cuts;
+
+/// <summary>
+/// Represents the published manifest resulting from a <see cref="ReadModelCutRequest"/>.
+/// </summary>
+[ProtoContract]
+public class ReadModelCutResponse
+{
+    /// <summary>
+    /// Gets or sets the deterministic identifier of the manifest.
+    /// </summary>
+    [ProtoMember(1)]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the exact position, per event sequence, every entry is bound to.
+    /// </summary>
+    [ProtoMember(2)]
+    public IEnumerable<EventSequenceCut> Cuts { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the outcome for every read model in the requested selection.
+    /// </summary>
+    [ProtoMember(3)]
+    public IEnumerable<ReadModelCutEntry> Entries { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets when the manifest was published.
+    /// </summary>
+    [ProtoMember(4)]
+    public DateTimeOffset PublishedAt { get; set; }
+}

--- a/Source/Kernel/Contracts/IServices.cs
+++ b/Source/Kernel/Contracts/IServices.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Contracts.Captures;
 using Cratis.Chronicle.Contracts.Clients;
 using Cratis.Chronicle.Contracts.Compliance;
+using Cratis.Chronicle.Contracts.Cuts;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.Contracts.Events.Constraints;
 using Cratis.Chronicle.Contracts.EventSequences;
@@ -161,4 +162,9 @@ public interface IServices
     /// Gets the <see cref="IConnectionService"/> service.
     /// </summary>
     IConnectionService Connections { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IReadModelCuts"/> service.
+    /// </summary>
+    IReadModelCuts ReadModelCuts { get; }
 }

--- a/Source/Kernel/Contracts/Observation/AppliedThroughObserverResult.cs
+++ b/Source/Kernel/Contracts/Observation/AppliedThroughObserverResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Observation;
+
+/// <summary>
+/// Represents the typed outcome for one requested observer in an <see cref="AppliedThroughResponse"/>.
+/// </summary>
+[ProtoContract]
+public class AppliedThroughObserverResult
+{
+    /// <summary>
+    /// Gets or sets the observer identifier this outcome is for.
+    /// </summary>
+    [ProtoMember(1)]
+    public string ObserverId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the typed outcome for this observer.
+    /// </summary>
+    [ProtoMember(2)]
+    public AppliedThroughOutcome Outcome { get; set; }
+}

--- a/Source/Kernel/Contracts/Observation/AppliedThroughOutcome.cs
+++ b/Source/Kernel/Contracts/Observation/AppliedThroughOutcome.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Observation;
+
+/// <summary>
+/// Defines the typed outcome for one observer in an <see cref="AppliedThroughResponse"/>.
+/// </summary>
+public enum AppliedThroughOutcome
+{
+    /// <summary>
+    /// The outcome is unknown. Never a produced value - a closed sentinel guarding against an unset field.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The observer durably applied through the target position.
+    /// </summary>
+    Ready = 1,
+
+    /// <summary>
+    /// The observer had not reached the target position before the caller's deadline.
+    /// </summary>
+    TimedOut = 2,
+
+    /// <summary>
+    /// The observer id named in the request does not exist for the event sequence.
+    /// </summary>
+    Unavailable = 3,
+
+    /// <summary>
+    /// The observer has a failed partition and cannot make further progress without intervention.
+    /// </summary>
+    Failed = 4,
+
+    /// <summary>
+    /// The observer is replaying and its position cannot be trusted as forward progress.
+    /// </summary>
+    Replaying = 5,
+
+    /// <summary>
+    /// The observer is quarantined and will not resume on its own.
+    /// </summary>
+    Quarantined = 6,
+}

--- a/Source/Kernel/Contracts/Observation/AppliedThroughRequest.cs
+++ b/Source/Kernel/Contracts/Observation/AppliedThroughRequest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Observation;
+
+/// <summary>
+/// Represents a request asking whether a named set of observers have durably applied through a target position.
+/// </summary>
+[ProtoContract]
+public class AppliedThroughRequest
+{
+    /// <summary>
+    /// Gets or sets the event store the observers belong to.
+    /// </summary>
+    [ProtoMember(1)]
+    public string EventStore { get; set; }
+
+    /// <summary>
+    /// Gets or sets the namespace the observers belong to.
+    /// </summary>
+    [ProtoMember(2)]
+    public string Namespace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the event sequence the observers observe.
+    /// </summary>
+    [ProtoMember(3)]
+    public string EventSequenceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the explicit set of observer identifiers to check. Unlike <see cref="WaitForObserverCompletionRequest"/>,
+    /// this is never "every observer on the sequence" implicitly.
+    /// </summary>
+    [ProtoMember(4)]
+    public IEnumerable<string> ObserverIds { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the target event sequence number every named observer must have durably applied through.
+    /// </summary>
+    [ProtoMember(5)]
+    public ulong TargetEventSequenceNumber { get; set; }
+}

--- a/Source/Kernel/Contracts/Observation/AppliedThroughResponse.cs
+++ b/Source/Kernel/Contracts/Observation/AppliedThroughResponse.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Contracts.Observation;
+
+/// <summary>
+/// Represents the result of checking whether a named set of observers have applied through a target position.
+/// </summary>
+[ProtoContract]
+public class AppliedThroughResponse
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether every requested observer reached <see cref="AppliedThroughOutcome.Ready"/>.
+    /// </summary>
+    [ProtoMember(1)]
+    public bool IsSuccess { get; set; }
+
+    /// <summary>
+    /// Gets or sets the typed outcome for every requested observer.
+    /// </summary>
+    [ProtoMember(2)]
+    public IEnumerable<AppliedThroughObserverResult> Results { get; set; } = [];
+}

--- a/Source/Kernel/Contracts/Observation/IObservers.cs
+++ b/Source/Kernel/Contracts/Observation/IObservers.cs
@@ -93,6 +93,21 @@ public interface IObservers
     Task<WaitForObserverCompletionResponse> WaitForCompletion(WaitForObserverCompletionRequest request, CallContext context = default);
 
     /// <summary>
+    /// Checks whether a named set of observers have durably applied through a target position.
+    /// </summary>
+    /// <param name="request">The <see cref="AppliedThroughRequest"/>.</param>
+    /// <param name="context">gRPC call context.</param>
+    /// <returns>An <see cref="AppliedThroughResponse"/> carrying a typed outcome per requested observer.</returns>
+    /// <remarks>
+    /// Unlike <see cref="WaitForCompletion"/>, the observer set is always explicit, never "every observer on the
+    /// sequence" implicitly, and a caller's deadline (via <paramref name="context"/>) is reported back as a typed
+    /// <see cref="AppliedThroughOutcome.TimedOut"/> per still-unresolved observer rather than an unstructured
+    /// cancellation fault - this never reports success from wall-clock timestamps or polling read-model contents,
+    /// only from durably observed observer state.
+    /// </remarks>
+    Task<AppliedThroughResponse> AppliedThrough(AppliedThroughRequest request, CallContext context = default);
+
+    /// <summary>
     /// Get all replayable observers for specific event types.
     /// </summary>
     /// <param name="request">The <see cref="GetReplayableObserversForEventTypesRequest"/>.</param>

--- a/Source/Kernel/Contracts/Services.cs
+++ b/Source/Kernel/Contracts/Services.cs
@@ -4,6 +4,7 @@
 using Cratis.Chronicle.Contracts.Captures;
 using Cratis.Chronicle.Contracts.Clients;
 using Cratis.Chronicle.Contracts.Compliance;
+using Cratis.Chronicle.Contracts.Cuts;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.Contracts.Events.Constraints;
 using Cratis.Chronicle.Contracts.EventSequences;
@@ -56,6 +57,7 @@ namespace Cratis.Chronicle.Contracts;
 /// <param name="Applications"><see cref="IApplications"/> instance.</param>
 /// <param name="Server"><see cref="IServer"/> instance.</param>
 /// <param name="Connections"><see cref="IConnectionService"/> instance.</param>
+/// <param name="ReadModelCuts"><see cref="IReadModelCuts"/> instance.</param>
 public sealed record Services(
     ICompliance Compliance,
     IEventStores EventStores,
@@ -82,4 +84,5 @@ public sealed record Services(
     IUsers Users,
     IApplications Applications,
     IServer Server,
-    IConnectionService Connections) : IServices;
+    IConnectionService Connections,
+    IReadModelCuts ReadModelCuts) : IServices;

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/given/all_dependencies.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/given/all_dependencies.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.Projections;
+using Cratis.Chronicle.Concepts.Projections.Definitions;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Concepts.Sinks;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Properties;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Storage.Cuts;
+using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.ReadModels;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.given;
+
+public class all_dependencies : Specification
+{
+    protected static readonly EventSequenceId EventSequence = "event-log";
+    protected static readonly ReadModelIdentifier ReadModel = "my-read-model";
+    protected static readonly ProjectionId Projection = new("my-projection");
+
+    protected IGrainFactory _grainFactory;
+    protected IStorage _storage;
+    protected IEventStoreStorage _eventStoreStorage;
+    protected IEventStoreNamespaceStorage _namespaceStorage;
+    protected IReadModelDefinitionsStorage _readModelDefinitionsStorage;
+    protected IReadModelCutStorage _cutStorage;
+    protected IEventSequenceStorage _eventSequenceStorage;
+    protected IProjectionsManager _projectionsManager;
+    protected IProjection _projection;
+    protected IExpandoObjectConverter _expandoObjectConverter;
+    protected ReadModelDefinition _readModelDefinition;
+    protected ProjectionDefinition _projectionDefinition;
+    protected IEventCursor _cursor;
+    protected ContractCuts.IReadModelCuts _service;
+
+    void Establish()
+    {
+        _grainFactory = Substitute.For<IGrainFactory>();
+        _storage = Substitute.For<IStorage>();
+        _eventStoreStorage = Substitute.For<IEventStoreStorage>();
+        _namespaceStorage = Substitute.For<IEventStoreNamespaceStorage>();
+        _readModelDefinitionsStorage = Substitute.For<IReadModelDefinitionsStorage>();
+        _cutStorage = Substitute.For<IReadModelCutStorage>();
+        _eventSequenceStorage = Substitute.For<IEventSequenceStorage>();
+        _projectionsManager = Substitute.For<IProjectionsManager>();
+        _projection = Substitute.For<IProjection>();
+        _expandoObjectConverter = Substitute.For<IExpandoObjectConverter>();
+
+        _storage.GetEventStore(Arg.Any<EventStoreName>()).Returns(_eventStoreStorage);
+        _eventStoreStorage.GetNamespace(Arg.Any<EventStoreNamespaceName>()).Returns(_namespaceStorage);
+        _eventStoreStorage.ReadModels.Returns(_readModelDefinitionsStorage);
+        _namespaceStorage.ReadModelCuts.Returns(_cutStorage);
+        _namespaceStorage.GetEventSequence(Arg.Any<EventSequenceId>()).Returns(_eventSequenceStorage);
+
+        _grainFactory.GetGrain<IProjectionsManager>(Arg.Any<string>()).Returns(_projectionsManager);
+        _grainFactory.GetGrain<IProjection>(Arg.Any<string>()).Returns(_projection);
+
+        _readModelDefinition = new ReadModelDefinition(
+            ReadModel,
+            "my-container",
+            "My Read Model",
+            ReadModelOwner.None,
+            ReadModelSource.Unknown,
+            ReadModelObserverType.Projection,
+            "my-projection",
+            new SinkDefinition(SinkConfigurationId.None, SinkTypeId.None),
+            new Dictionary<ReadModelGeneration, JsonSchema> { { (ReadModelGeneration)1, new JsonSchema() } },
+            []);
+        _readModelDefinitionsStorage.GetAll().Returns([_readModelDefinition]);
+
+        _projectionDefinition = new ProjectionDefinition(
+            ProjectionOwner.None,
+            EventSequence,
+            Projection,
+            ReadModel,
+            true,
+            true,
+            new JsonObject(),
+            new Dictionary<EventType, FromDefinition>(),
+            new Dictionary<EventType, JoinDefinition>(),
+            new Dictionary<PropertyPath, ChildrenDefinition>(),
+            [],
+            new FromEveryDefinition(new Dictionary<PropertyPath, string>(), false),
+            new Dictionary<EventType, RemovedWithDefinition>(),
+            new Dictionary<EventType, RemovedWithJoinDefinition>());
+        _projectionsManager.GetProjectionDefinitions().Returns([_projectionDefinition]);
+
+        _cursor = Substitute.For<IEventCursor>();
+        _cursor.MoveNext().Returns(true, false);
+        _cursor.Current.Returns([]);
+        _eventSequenceStorage.GetRange(Arg.Any<EventSequenceNumber>(), Arg.Any<EventSequenceNumber>()).Returns(_cursor);
+
+        _projection.Process(Arg.Any<EventStoreNamespaceName>(), Arg.Any<IEnumerable<AppendedEvent>>()).Returns([]);
+        _expandoObjectConverter.ToJsonObject(Arg.Any<ExpandoObject>(), Arg.Any<JsonSchema>()).Returns(new JsonObject());
+
+        _cutStorage.GetManifest(Arg.Any<ReadModelCutId>()).Returns((ReadModelCutManifest?)null);
+
+        _service = new ReadModelCuts(_grainFactory, _storage, _expandoObjectConverter);
+    }
+}

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_a_manifest_already_exists_for_the_request.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_a_manifest_already_exists_for_the_request.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Storage.Cuts;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.when_capturing;
+
+public class and_a_manifest_already_exists_for_the_request : given.all_dependencies
+{
+    ReadModelCutManifest _existingManifest;
+    ContractCuts.ReadModelCutResponse _result;
+
+    void Establish()
+    {
+        _existingManifest = new ReadModelCutManifest(
+            ReadModelCutId.NotSet,
+            "my-event-store",
+            "my-namespace",
+            [new Concepts.Cuts.EventSequenceCut(EventSequence, 5UL)],
+            [new ReadModelCutEntry(ReadModel, Concepts.Cuts.ReadModelCutOutcome.Captured, (ReadModelGeneration)1, null, null)],
+            DateTimeOffset.UnixEpoch);
+        _cutStorage.GetManifest(Arg.Any<ReadModelCutId>()).Returns(_existingManifest);
+    }
+
+    async Task Because() => _result = await _service.Capture(new ContractCuts.ReadModelCutRequest
+    {
+        EventStore = "my-event-store",
+        Namespace = "my-namespace",
+        Cuts = [new ContractCuts.EventSequenceCut { EventSequenceId = EventSequence, Position = 5UL }],
+        Selection = [ReadModel]
+    });
+
+    [Fact] void should_return_the_existing_manifests_entries() => _result.Entries.Single().ReadModel.ShouldEqual(ReadModel.Value);
+    [Fact] void should_not_look_up_projection_definitions() => _projectionsManager.DidNotReceive().GetProjectionDefinitions();
+    [Fact] void should_not_publish_a_new_manifest() => _cutStorage.DidNotReceive().PublishManifest(Arg.Any<ReadModelCutManifest>());
+}

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_no_cut_is_provided_for_the_projections_event_sequence.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_no_cut_is_provided_for_the_projections_event_sequence.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.when_capturing;
+
+public class and_no_cut_is_provided_for_the_projections_event_sequence : given.all_dependencies
+{
+    ContractCuts.ReadModelCutResponse _result;
+
+    async Task Because() => _result = await _service.Capture(new ContractCuts.ReadModelCutRequest
+    {
+        EventStore = "my-event-store",
+        Namespace = "my-namespace",
+        Cuts = [new ContractCuts.EventSequenceCut { EventSequenceId = "some-other-sequence", Position = 5UL }],
+        Selection = [ReadModel]
+    });
+
+    [Fact] void should_report_the_entry_as_failed() => _result.Entries.Single().Outcome.ShouldEqual(ContractCuts.ReadModelCutOutcome.Failed);
+    [Fact] void should_explain_the_failure() => _result.Entries.Single().FailureReason.ShouldNotBeNull();
+    [Fact] void should_not_save_any_payload() => _cutStorage.DidNotReceive().SavePayload(Arg.Any<Concepts.Cuts.ReadModelCutId>(), Arg.Any<ReadModelIdentifier>(), Arg.Any<string>());
+}

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_does_not_exist.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.when_capturing;
+
+public class and_the_read_model_does_not_exist : given.all_dependencies
+{
+    static readonly ReadModelIdentifier _unknownReadModel = "unknown-read-model";
+
+    ContractCuts.ReadModelCutResponse _result;
+
+    async Task Because() => _result = await _service.Capture(new ContractCuts.ReadModelCutRequest
+    {
+        EventStore = "my-event-store",
+        Namespace = "my-namespace",
+        Cuts = [new ContractCuts.EventSequenceCut { EventSequenceId = EventSequence, Position = 5UL }],
+        Selection = [_unknownReadModel]
+    });
+
+    [Fact] void should_report_the_entry_as_not_found() => _result.Entries.Single().Outcome.ShouldEqual(ContractCuts.ReadModelCutOutcome.NotFound);
+    [Fact] void should_not_save_any_payload() => _cutStorage.DidNotReceive().SavePayload(Arg.Any<Concepts.Cuts.ReadModelCutId>(), Arg.Any<ReadModelIdentifier>(), Arg.Any<string>());
+}

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_is_projection_backed.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_is_projection_backed.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using Cratis.Chronicle.Concepts.Events;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.when_capturing;
+
+public class and_the_read_model_is_projection_backed : given.all_dependencies
+{
+    ContractCuts.ReadModelCutResponse _result;
+
+    void Establish() => _projection.Process(Arg.Any<Concepts.EventStoreNamespaceName>(), Arg.Any<IEnumerable<AppendedEvent>>())
+        .Returns([new ExpandoObject()]);
+
+    async Task Because() => _result = await _service.Capture(new ContractCuts.ReadModelCutRequest
+    {
+        EventStore = "my-event-store",
+        Namespace = "my-namespace",
+        Cuts = [new ContractCuts.EventSequenceCut { EventSequenceId = EventSequence, Position = 5UL }],
+        Selection = [ReadModel]
+    });
+
+    [Fact] void should_return_exactly_one_entry() => _result.Entries.Count().ShouldEqual(1);
+    [Fact] void should_report_the_entry_as_captured() => _result.Entries.Single().Outcome.ShouldEqual(ContractCuts.ReadModelCutOutcome.Captured);
+    [Fact] void should_report_the_read_model_identifier() => _result.Entries.Single().ReadModel.ShouldEqual(ReadModel.Value);
+    [Fact] void should_include_a_digest() => _result.Entries.Single().Digest.ShouldNotBeNull();
+    [Fact] void should_save_the_payload() => _cutStorage.Received(1).SavePayload(Arg.Any<Concepts.Cuts.ReadModelCutId>(), ReadModel, Arg.Any<string>());
+    [Fact] void should_publish_the_manifest() => _cutStorage.Received(1).PublishManifest(Arg.Any<Storage.Cuts.ReadModelCutManifest>());
+    [Fact] void should_read_events_only_up_to_the_requested_cut() => _eventSequenceStorage.Received(1).GetRange(EventSequenceNumber.First, 5UL);
+}

--- a/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_is_reducer_backed.cs
+++ b/Source/Kernel/Core.Specs/Services/Cuts/for_ReadModelCuts/when_capturing/and_the_read_model_is_reducer_backed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts.for_ReadModelCuts.when_capturing;
+
+public class and_the_read_model_is_reducer_backed : given.all_dependencies
+{
+    ContractCuts.ReadModelCutResponse _result;
+
+    void Establish()
+    {
+        _readModelDefinition = _readModelDefinition with { ObserverType = ReadModelObserverType.Reducer };
+        _readModelDefinitionsStorage.GetAll().Returns([_readModelDefinition]);
+    }
+
+    async Task Because() => _result = await _service.Capture(new ContractCuts.ReadModelCutRequest
+    {
+        EventStore = "my-event-store",
+        Namespace = "my-namespace",
+        Cuts = [new ContractCuts.EventSequenceCut { EventSequenceId = EventSequence, Position = 5UL }],
+        Selection = [ReadModel]
+    });
+
+    [Fact] void should_report_the_entry_as_unsupported() => _result.Entries.Single().Outcome.ShouldEqual(ContractCuts.ReadModelCutOutcome.Unsupported);
+    [Fact] void should_not_save_any_payload() => _cutStorage.DidNotReceive().SavePayload(Arg.Any<Concepts.Cuts.ReadModelCutId>(), Arg.Any<ReadModelIdentifier>(), Arg.Any<string>());
+    [Fact] void should_still_publish_the_manifest() => _cutStorage.Received(1).PublishManifest(Arg.Any<Storage.Cuts.ReadModelCutManifest>());
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_callers_deadline_has_already_elapsed.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_callers_deadline_has_already_elapsed.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+using Grpc.Core;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_checking_applied_through;
+
+/// <summary>
+/// A caller's deadline elapsing must be reported as a typed outcome for whichever observer had not resolved yet,
+/// never as an unstructured cancellation fault out of the call.
+/// </summary>
+public class and_the_callers_deadline_has_already_elapsed : given.all_dependencies
+{
+    AppliedThroughResponse _result;
+
+    void Establish()
+    {
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = 12UL,
+            RunningState = Concepts.Observation.ObserverRunningState.Active,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(new Concepts.Observation.FailedPartitions());
+    }
+
+    async Task Because() => _result = await _observers.AppliedThrough(
+        new AppliedThroughRequest
+        {
+            EventStore = "event-store",
+            Namespace = "event-store-namespace",
+            EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+            ObserverIds = ["observer-1"],
+            TargetEventSequenceNumber = 42UL
+        },
+        new CallContext(new CallOptions(cancellationToken: new CancellationToken(true))));
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_observer_as_timed_out() => _result.Results.Single().Outcome.ShouldEqual(AppliedThroughOutcome.TimedOut);
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_has_a_failed_partition.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_has_a_failed_partition.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_checking_applied_through;
+
+public class and_the_observer_has_a_failed_partition : given.all_dependencies
+{
+    AppliedThroughResponse _result;
+
+    void Establish()
+    {
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = 12UL,
+            RunningState = Concepts.Observation.ObserverRunningState.Active,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+        var failedPartitions = new Concepts.Observation.FailedPartitions
+        {
+            Partitions =
+            [
+                new()
+                {
+                    ObserverId = "observer-1",
+                    Partition = Concepts.Keys.Key.Undefined
+                }
+            ]
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(failedPartitions);
+    }
+
+    async Task Because() => _result = await _observers.AppliedThrough(new AppliedThroughRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        ObserverIds = ["observer-1"],
+        TargetEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_observer_as_failed() => _result.Results.Single().Outcome.ShouldEqual(AppliedThroughOutcome.Failed);
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_has_reached_the_target.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_has_reached_the_target.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_checking_applied_through;
+
+public class and_the_observer_has_reached_the_target : given.all_dependencies
+{
+    AppliedThroughResponse _result;
+
+    void Establish()
+    {
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = 42UL,
+            RunningState = Concepts.Observation.ObserverRunningState.Active,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(new Concepts.Observation.FailedPartitions());
+    }
+
+    async Task Because() => _result = await _observers.AppliedThrough(new AppliedThroughRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        ObserverIds = ["observer-1"],
+        TargetEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_be_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_report_the_observer_as_ready() => _result.Results.Single().Outcome.ShouldEqual(AppliedThroughOutcome.Ready);
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_id_does_not_exist.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_id_does_not_exist.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_checking_applied_through;
+
+public class and_the_observer_id_does_not_exist : given.all_dependencies
+{
+    AppliedThroughResponse _result;
+
+    void Establish()
+    {
+        _observerDefinitionsStorage.GetAll().Returns([]);
+        _observerStateStorage.GetAll().Returns([]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(new Concepts.Observation.FailedPartitions());
+    }
+
+    async Task Because() => _result = await _observers.AppliedThrough(new AppliedThroughRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        ObserverIds = ["observer-that-does-not-exist"],
+        TargetEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_observer_as_unavailable() => _result.Results.Single().Outcome.ShouldEqual(AppliedThroughOutcome.Unavailable);
+}

--- a/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_is_quarantined.cs
+++ b/Source/Kernel/Core.Specs/Services/Observation/for_Observers/when_checking_applied_through/and_the_observer_is_quarantined.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Observation;
+using Cratis.Chronicle.Storage.Observation;
+
+namespace Cratis.Chronicle.Services.Observation.for_Observers.when_checking_applied_through;
+
+public class and_the_observer_is_quarantined : given.all_dependencies
+{
+    AppliedThroughResponse _result;
+
+    void Establish()
+    {
+        var observerDefinition = new ObserverDefinition(
+            "observer-1",
+            [],
+            Concepts.EventSequences.EventSequenceId.Log,
+            Concepts.Observation.ObserverType.Reactor,
+            Concepts.Observation.ObserverOwner.Client,
+            true);
+
+        // Quarantined despite having already handled past the target - the running state must decide the
+        // outcome, not the position, since a quarantined observer will not resume on its own.
+        var observerState = new ObserverState
+        {
+            Identifier = "observer-1",
+            LastHandledEventSequenceNumber = 100UL,
+            RunningState = Concepts.Observation.ObserverRunningState.Quarantined,
+            ReplayingPartitions = new HashSet<Concepts.Keys.Key>(),
+            CatchingUpPartitions = new HashSet<Concepts.Keys.Key>(),
+            FailedPartitions = [],
+            IsReplaying = false
+        };
+
+        _observerDefinitionsStorage.GetAll().Returns([observerDefinition]);
+        _observerStateStorage.GetAll().Returns([observerState]);
+        _failedPartitionsStorage.GetFor(Arg.Any<IEnumerable<Concepts.Observation.ObserverId>>()).Returns(new Concepts.Observation.FailedPartitions());
+    }
+
+    async Task Because() => _result = await _observers.AppliedThrough(new AppliedThroughRequest
+    {
+        EventStore = "event-store",
+        Namespace = "event-store-namespace",
+        EventSequenceId = Concepts.EventSequences.EventSequenceId.Log,
+        ObserverIds = ["observer-1"],
+        TargetEventSequenceNumber = 42UL
+    });
+
+    [Fact] void should_not_be_successful() => _result.IsSuccess.ShouldBeFalse();
+    [Fact] void should_report_the_observer_as_quarantined() => _result.Results.Single().Outcome.ShouldEqual(AppliedThroughOutcome.Quarantined);
+}

--- a/Source/Kernel/Core/Services/Cuts/ReadModelCuts.cs
+++ b/Source/Kernel/Core/Services/Cuts/ReadModelCuts.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Json;
+using Cratis.Chronicle.Projections;
+using Cratis.Chronicle.Schemas;
+using Cratis.Chronicle.Storage;
+using ProtoBuf.Grpc;
+using ConceptProjectionDefinition = Cratis.Chronicle.Concepts.Projections.Definitions.ProjectionDefinition;
+using ConceptReadModelDefinition = Cratis.Chronicle.Concepts.ReadModels.ReadModelDefinition;
+using ContractCuts = Cratis.Chronicle.Contracts.Cuts;
+using StorageCuts = Cratis.Chronicle.Storage.Cuts;
+
+namespace Cratis.Chronicle.Services.Cuts;
+
+/// <summary>
+/// Represents an implementation of <see cref="ContractCuts.IReadModelCuts"/>.
+/// </summary>
+/// <param name="grainFactory">The <see cref="IGrainFactory"/>.</param>
+/// <param name="storage">The <see cref="IStorage"/>.</param>
+/// <param name="expandoObjectConverter">The <see cref="IExpandoObjectConverter"/> for converting projected state to JSON.</param>
+public class ReadModelCuts(IGrainFactory grainFactory, IStorage storage, IExpandoObjectConverter expandoObjectConverter) : ContractCuts.IReadModelCuts
+{
+    /// <inheritdoc/>
+    public async Task<ContractCuts.ReadModelCutResponse> Capture(ContractCuts.ReadModelCutRequest request, CallContext context = default)
+    {
+        var eventStore = (EventStoreName)request.EventStore;
+        var namespaceName = (EventStoreNamespaceName)request.Namespace;
+        var cuts = request.Cuts.Select(_ => new EventSequenceCut((EventSequenceId)_.EventSequenceId, (EventSequenceNumber)_.Position)).ToArray();
+        var selection = request.Selection.Select(_ => (ReadModelIdentifier)_).ToArray();
+
+        var storageRequest = new StorageCuts.ReadModelCutRequest(eventStore, namespaceName, cuts, selection);
+        var id = StorageCuts.ReadModelCutIdCalculator.Calculate(storageRequest);
+
+        var namespaceStorage = storage.GetEventStore(eventStore).GetNamespace(namespaceName);
+        var cutStorage = namespaceStorage.ReadModelCuts;
+
+        var existing = await cutStorage.GetManifest(id);
+        if (existing is not null)
+        {
+            return ToResponse(existing);
+        }
+
+        var manifest = await CaptureManifest(id, eventStore, namespaceName, cuts, selection, namespaceStorage, cutStorage);
+        return ToResponse(manifest);
+    }
+
+    static async Task<IReadOnlyList<AppendedEvent>> ReadEventsUpTo(IEventStoreNamespaceStorage namespaceStorage, EventSequenceId eventSequenceId, EventSequenceNumber position)
+    {
+        var events = new List<AppendedEvent>();
+        var eventSequenceStorage = namespaceStorage.GetEventSequence(eventSequenceId);
+        using var cursor = await eventSequenceStorage.GetRange(EventSequenceNumber.First, position);
+        while (await cursor.MoveNext())
+        {
+            events.AddRange(cursor.Current);
+        }
+
+        return events;
+    }
+
+    static string ToCanonicalPayload(IEnumerable<ExpandoObject> instances, JsonSchema schema, IExpandoObjectConverter expandoObjectConverter)
+    {
+        var array = new JsonArray();
+        foreach (var instance in instances)
+        {
+            array.Add(expandoObjectConverter.ToJsonObject(instance, schema));
+        }
+
+        return array.ToJsonString();
+    }
+
+    static ReadModelCutPayloadDigest ComputeDigest(string payloadJson) => new(SHA256.HashData(Encoding.UTF8.GetBytes(payloadJson)));
+
+    static ContractCuts.ReadModelCutResponse ToResponse(StorageCuts.ReadModelCutManifest manifest) => new()
+    {
+        Id = manifest.Id,
+        Cuts = manifest.Cuts.Select(_ => new ContractCuts.EventSequenceCut
+        {
+            EventSequenceId = _.EventSequenceId,
+            Position = _.Position
+        }).ToArray(),
+        Entries = manifest.Entries.Select(ToContractEntry).ToArray(),
+        PublishedAt = manifest.PublishedAt
+    };
+
+    static ContractCuts.ReadModelCutEntry ToContractEntry(StorageCuts.ReadModelCutEntry entry) => new()
+    {
+        ReadModel = entry.ReadModel,
+        Outcome = (ContractCuts.ReadModelCutOutcome)(int)entry.Outcome,
+        Generation = entry.Generation?.Value,
+        Digest = entry.Digest?.ToString(),
+        FailureReason = entry.FailureReason
+    };
+
+    async Task<StorageCuts.ReadModelCutManifest> CaptureManifest(
+        ReadModelCutId id,
+        EventStoreName eventStore,
+        EventStoreNamespaceName namespaceName,
+        IReadOnlyCollection<EventSequenceCut> cuts,
+        IReadOnlyCollection<ReadModelIdentifier> selection,
+        IEventStoreNamespaceStorage namespaceStorage,
+        StorageCuts.IReadModelCutStorage cutStorage)
+    {
+        var cutsByEventSequence = cuts.ToDictionary(_ => _.EventSequenceId);
+        var readModelDefinitions = await storage.GetEventStore(eventStore).ReadModels.GetAll();
+        var projectionDefinitions = await grainFactory.GetGrain<IProjectionsManager>(eventStore).GetProjectionDefinitions();
+
+        var entries = new List<StorageCuts.ReadModelCutEntry>();
+        foreach (var readModelId in selection)
+        {
+            var entry = await CaptureEntry(
+                id,
+                readModelId,
+                cutsByEventSequence,
+                readModelDefinitions,
+                projectionDefinitions,
+                eventStore,
+                namespaceName,
+                namespaceStorage,
+                cutStorage);
+            entries.Add(entry);
+        }
+
+        var manifest = new StorageCuts.ReadModelCutManifest(id, eventStore, namespaceName, cuts, entries, DateTimeOffset.UtcNow);
+        await cutStorage.PublishManifest(manifest);
+        return manifest;
+    }
+
+    async Task<StorageCuts.ReadModelCutEntry> CaptureEntry(
+        ReadModelCutId id,
+        ReadModelIdentifier readModelId,
+        Dictionary<EventSequenceId, EventSequenceCut> cutsByEventSequence,
+        IEnumerable<ConceptReadModelDefinition> readModelDefinitions,
+        IEnumerable<ConceptProjectionDefinition> projectionDefinitions,
+        EventStoreName eventStore,
+        EventStoreNamespaceName namespaceName,
+        IEventStoreNamespaceStorage namespaceStorage,
+        StorageCuts.IReadModelCutStorage cutStorage)
+    {
+        var readModelDefinition = readModelDefinitions.FirstOrDefault(_ => _.Identifier == readModelId);
+        if (readModelDefinition is null)
+        {
+            return new(readModelId, ReadModelCutOutcome.NotFound, null, null, "No read model definition was found for this identifier.");
+        }
+
+        if (readModelDefinition.ObserverType != ReadModelObserverType.Projection)
+        {
+            return new(
+                readModelId,
+                ReadModelCutOutcome.Unsupported,
+                null,
+                null,
+                "The read model is not backed by a projection - reducer-backed read models run in the connected client process and cannot be recomputed by the kernel.");
+        }
+
+        var projectionDefinition = projectionDefinitions.FirstOrDefault(_ => _.ReadModel == readModelId);
+        if (projectionDefinition is null)
+        {
+            return new(readModelId, ReadModelCutOutcome.NotFound, null, null, "No projection definition was found for this read model.");
+        }
+
+        if (!cutsByEventSequence.TryGetValue(projectionDefinition.EventSequenceId, out var cut))
+        {
+            return new(
+                readModelId,
+                ReadModelCutOutcome.Failed,
+                null,
+                null,
+                $"The request did not include a cut for event sequence '{projectionDefinition.EventSequenceId}', which this read model's projection reads from.");
+        }
+
+        try
+        {
+            var events = await ReadEventsUpTo(namespaceStorage, projectionDefinition.EventSequenceId, cut.Position);
+            var projection = grainFactory.GetGrain<IProjection>(new Concepts.Projections.ProjectionKey(projectionDefinition.Identifier, eventStore));
+            var instances = await projection.Process(namespaceName, events);
+            var schema = readModelDefinition.GetSchemaForLatestGeneration();
+            var payloadJson = ToCanonicalPayload(instances, schema, expandoObjectConverter);
+            var digest = ComputeDigest(payloadJson);
+
+            await cutStorage.SavePayload(id, readModelId, payloadJson);
+            return new(readModelId, ReadModelCutOutcome.Captured, readModelDefinition.LatestGeneration, digest, null);
+        }
+        catch (Exception ex)
+        {
+            return new(readModelId, ReadModelCutOutcome.Failed, null, null, ex.Message);
+        }
+    }
+}

--- a/Source/Kernel/Core/Services/Observation/Observers.cs
+++ b/Source/Kernel/Core/Services/Observation/Observers.cs
@@ -85,6 +85,84 @@ internal sealed class Observers(IGrainFactory grainFactory, IStorage storage) : 
     }
 
     /// <inheritdoc/>
+    public async Task<AppliedThroughResponse> AppliedThrough(AppliedThroughRequest request, CallContext context = default)
+    {
+        var requestedIds = request.ObserverIds.ToHashSet(StringComparer.Ordinal);
+        var outcomes = new Dictionary<string, AppliedThroughOutcome>(StringComparer.Ordinal);
+
+        try
+        {
+            while (outcomes.Count < requestedIds.Count)
+            {
+                context.CancellationToken.ThrowIfCancellationRequested();
+
+                var observers = (await GetObservers(
+                    new AllObserversRequest
+                    {
+                        EventStore = request.EventStore,
+                        Namespace = request.Namespace
+                    },
+                    context))
+                    .Where(_ => _.EventSequenceId == request.EventSequenceId && requestedIds.Contains(_.Id))
+                    .ToArray();
+
+                var foundIds = observers.Select(_ => _.Id).ToHashSet(StringComparer.Ordinal);
+                foreach (var missingId in requestedIds.Except(foundIds))
+                {
+                    outcomes[missingId] = AppliedThroughOutcome.Unavailable;
+                }
+
+                if (observers.Length > 0)
+                {
+                    var observerIds = observers.Select(_ => (Concepts.Observation.ObserverId)_.Id).ToArray();
+                    var failedPartitions = await storage
+                        .GetEventStore(request.EventStore)
+                        .GetNamespace(request.Namespace)
+                        .FailedPartitions
+                        .GetFor(observerIds);
+                    var failedObserverIds = failedPartitions.Partitions.Select(_ => _.ObserverId.Value).ToHashSet(StringComparer.Ordinal);
+
+                    foreach (var observer in observers)
+                    {
+                        // A null classification means the observer is still active and simply has not reached
+                        // the target yet - it stays out of `outcomes` so the loop keeps polling it, rather than
+                        // being reported as a terminal outcome prematurely.
+                        var outcome = ClassifyObserver(observer, failedObserverIds, request.TargetEventSequenceNumber);
+                        if (outcome is not null)
+                        {
+                            outcomes[observer.Id] = outcome.Value;
+                        }
+                    }
+                }
+
+                if (outcomes.Count == requestedIds.Count)
+                {
+                    break;
+                }
+
+                await Task.Delay(ObserverCompletionPollingDelayMs, context.CancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            // The caller's deadline elapsed - report it as a typed outcome for whichever observers had not
+            // resolved yet, rather than letting the whole call fault. Success must never be inferred from the
+            // cancellation itself, only from outcomes already durably observed above.
+        }
+
+        foreach (var stillUnresolved in requestedIds.Except(outcomes.Keys))
+        {
+            outcomes[stillUnresolved] = AppliedThroughOutcome.TimedOut;
+        }
+
+        return new AppliedThroughResponse
+        {
+            IsSuccess = outcomes.Values.All(_ => _ == AppliedThroughOutcome.Ready),
+            Results = requestedIds.Select(id => new AppliedThroughObserverResult { ObserverId = id, Outcome = outcomes[id] }).ToArray()
+        };
+    }
+
+    /// <inheritdoc/>
     public Task ClearObserverQuarantine(ClearObserverQuarantine command, CallContext context = default) =>
         grainFactory.GetObserver(command).ClearObserverQuarantine();
 
@@ -198,5 +276,41 @@ internal sealed class Observers(IGrainFactory grainFactory, IStorage storage) : 
             select (definition, state);
 
         return observers.ToContract();
+    }
+
+    /// <summary>
+    /// Classifies a single observer's current state against the target position.
+    /// </summary>
+    /// <param name="observer">The observer's current <see cref="ObserverInformation"/>.</param>
+    /// <param name="failedObserverIds">The set of observer ids with a failed partition.</param>
+    /// <param name="targetEventSequenceNumber">The target position to compare against.</param>
+    /// <returns>The terminal outcome, or <see langword="null"/> when the observer is still active and simply has not reached the target yet.</returns>
+    static AppliedThroughOutcome? ClassifyObserver(ObserverInformation observer, HashSet<string> failedObserverIds, ulong targetEventSequenceNumber)
+    {
+        if (failedObserverIds.Contains(observer.Id))
+        {
+            return AppliedThroughOutcome.Failed;
+        }
+
+        // Checked before the position, deliberately: a replaying observer's checkpoint can be rewinding, so its
+        // current LastHandledEventSequenceNumber momentarily looking past the target must never be read as
+        // durable forward progress - the running state is what makes that distinction trustworthy.
+        switch (observer.RunningState)
+        {
+            case ObserverRunningState.Quarantined:
+                return AppliedThroughOutcome.Quarantined;
+            case ObserverRunningState.Replaying:
+                return AppliedThroughOutcome.Replaying;
+            case ObserverRunningState.Disconnected:
+                return AppliedThroughOutcome.Unavailable;
+        }
+
+        if (((EventSequenceNumber)observer.LastHandledEventSequenceNumber).IsActualValue &&
+            observer.LastHandledEventSequenceNumber >= targetEventSequenceNumber)
+        {
+            return AppliedThroughOutcome.Ready;
+        }
+
+        return null;
     }
 }

--- a/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
+++ b/Source/Kernel/Core/Setup/ChronicleServerSiloBuilderExtensions.cs
@@ -175,7 +175,8 @@ public static class ChronicleServerSiloBuilderExtensions
                     grainFactory,
                     sp.GetRequiredService<ILocalSiloDetails>(),
                     sp.GetRequiredService<ILogger<Cratis.Chronicle.Services.Clients.ConnectionService>>(),
-                    sp.GetRequiredService<IOptions<ChronicleOptions>>()));
+                    sp.GetRequiredService<IOptions<ChronicleOptions>>()),
+                new Cratis.Chronicle.Services.Cuts.ReadModelCuts(grainFactory, storage, expandoObjectConverter));
         });
 
         return builder;

--- a/Source/Kernel/Server/GrpcServiceRegistrations.cs
+++ b/Source/Kernel/Server/GrpcServiceRegistrations.cs
@@ -46,6 +46,7 @@ public static class GrpcServiceRegistrations
         services.AddSingleton<Contracts.Security.IUsers, Services.Security.Users>();
         services.AddSingleton<Contracts.Security.IApplications, Services.Security.Applications>();
         services.AddSingleton<Contracts.Host.IServer, Services.Host.Server>();
+        services.AddSingleton<Contracts.Cuts.IReadModelCuts, Services.Cuts.ReadModelCuts>();
 
         return services;
     }
@@ -86,6 +87,7 @@ public static class GrpcServiceRegistrations
             _.MapGrpcService<Services.Security.Users>();
             _.MapGrpcService<Services.Security.Applications>();
             _.MapGrpcService<Services.Host.Server>();
+            _.MapGrpcService<Services.Cuts.ReadModelCuts>();
         });
 
         return app;

--- a/Source/Kernel/Storage.InMemory/Cuts/ReadModelCutStorage.cs
+++ b/Source/Kernel/Storage.InMemory/Cuts/ReadModelCutStorage.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Storage.Cuts;
+
+namespace Cratis.Chronicle.Storage.InMemory.Cuts;
+
+/// <summary>
+/// Represents an in-memory implementation of <see cref="IReadModelCutStorage"/>.
+/// </summary>
+public class ReadModelCutStorage : IReadModelCutStorage
+{
+    readonly object _lock = new();
+    readonly Dictionary<(Guid Id, string ReadModel), string> _payloads = [];
+    readonly Dictionary<Guid, ReadModelCutManifest> _manifests = [];
+
+    /// <inheritdoc/>
+    public Task SavePayload(ReadModelCutId id, ReadModelIdentifier readModel, string payloadJson)
+    {
+        lock (_lock)
+        {
+            _payloads[(id.Value, readModel.Value)] = payloadJson;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<string?> GetPayload(ReadModelCutId id, ReadModelIdentifier readModel)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult(_payloads.TryGetValue((id.Value, readModel.Value), out var payload) ? payload : null);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> HasManifest(ReadModelCutId id)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult(_manifests.ContainsKey(id.Value));
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<ReadModelCutManifest?> GetManifest(ReadModelCutId id)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult(_manifests.TryGetValue(id.Value, out var manifest) ? manifest : null);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task PublishManifest(ReadModelCutManifest manifest)
+    {
+        lock (_lock)
+        {
+            _manifests.TryAdd(manifest.Id.Value, manifest);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Source/Kernel/Storage.InMemory/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.InMemory/EventStoreNamespaceStorage.cs
@@ -6,11 +6,13 @@ using Cratis.Chronicle.Concepts;
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Storage.Changes;
+using Cratis.Chronicle.Storage.Cuts;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using Cratis.Chronicle.Storage.EventSequences;
 using Cratis.Chronicle.Storage.EventSequences.Mutations;
 using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.InMemory.Changes;
+using Cratis.Chronicle.Storage.InMemory.Cuts;
 using Cratis.Chronicle.Storage.InMemory.Events.Constraints;
 using Cratis.Chronicle.Storage.InMemory.EventSequences;
 using Cratis.Chronicle.Storage.InMemory.EventSequences.Mutations;
@@ -60,6 +62,9 @@ public sealed class EventStoreNamespaceStorage(
 
     /// <inheritdoc/>
     public IIdentityStorage Identities { get; } = new IdentityStorage();
+
+    /// <inheritdoc/>
+    public IReadModelCutStorage ReadModelCuts { get; } = new ReadModelCutStorage();
 
     /// <inheritdoc/>
     public IJobStorage Jobs { get; } = new JobStorage(jobTypes);

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/given/a_mutation_registry.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/given/a_mutation_registry.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.given;
+
+/// <summary>
+/// Provides an <see cref="EventSequenceMutationRegistry"/> backed by a real, isolated MongoDB database for one
+/// spec run, together with the request-building helpers the in-memory reference specs use.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+public abstract class a_mutation_registry(MongoDBFixture fixture) : Specification
+{
+    IMongoClient _client = default!;
+    string _databaseName = default!;
+
+    /// <summary>
+    /// Gets the database the registry under test persists to.
+    /// </summary>
+    protected IEventStoreNamespaceDatabase Database { get; private set; } = default!;
+
+    /// <summary>
+    /// Gets the registry under test.
+    /// </summary>
+    protected IEventSequenceMutationRegistry Registry { get; private set; } = default!;
+
+    /// <summary>
+    /// Gets the identity of the target event sequence every spec begins a mutation against.
+    /// </summary>
+    protected EventSequenceMutationIdentity Target { get; private set; } = default!;
+
+    /// <summary>
+    /// Gets the target range proposed for a winning registration.
+    /// </summary>
+    protected EventSequenceMutationTarget ProposedTarget { get; private set; } = default!;
+
+    /// <summary>
+    /// Gets the default mutation request specs begin against <see cref="Target"/>.
+    /// </summary>
+    protected EventSequenceMutationRequest Request { get; private set; } = default!;
+
+    /// <summary>
+    /// Creates an <see cref="EventSequenceMutationRegistry"/> over the given real MongoDB database, matching the
+    /// constructor shape the registry is used with at runtime.
+    /// </summary>
+    /// <param name="database">The <see cref="IEventStoreNamespaceDatabase"/> to construct the registry over.</param>
+    /// <returns>The constructed registry.</returns>
+    protected static IEventSequenceMutationRegistry RegistryOver(IEventStoreNamespaceDatabase database) =>
+        new EventSequenceMutationRegistry("event-store", "namespace", database);
+
+    /// <summary>
+    /// Creates an event sequence mutation identity from a display string.
+    /// </summary>
+    /// <param name="display">The display form.</param>
+    /// <returns>The created identity.</returns>
+    protected static EventSequenceMutationIdentity Identity(string display) => EventSequenceMutationIdentity.TryCreate(display).Identity!;
+
+    /// <summary>
+    /// Builds a mutation request targeting the given identity, matching the shape and defaults the in-memory
+    /// reference specs use.
+    /// </summary>
+    /// <param name="target">The target event sequence identity.</param>
+    /// <param name="originSequenceNumber">The originating event's sequence number.</param>
+    /// <param name="payload">The command payload text.</param>
+    /// <param name="hash">The command hash text.</param>
+    /// <returns>The built request.</returns>
+    protected static EventSequenceMutationRequest BuildRequest(
+        EventSequenceMutationIdentity target,
+        ulong originSequenceNumber = 42,
+        string payload = "{\"name\":\"Ada\"}",
+        string hash = "command-hash")
+    {
+        var origin = Identity("origin-sequence");
+        const EventSequenceMutationKind kind = EventSequenceMutationKind.Revision;
+        var id = EventSequenceMutationDigestCalculator.CalculateId(target, origin, originSequenceNumber, kind);
+        return new(id, target, new(origin, originSequenceNumber), kind, new(payload, hash));
+    }
+
+    /// <summary>
+    /// Applies a transition to the successor of a begin result, mirroring the shape callers use once they hold a
+    /// token.
+    /// </summary>
+    /// <param name="registry">The registry to transition on.</param>
+    /// <param name="begin">The begin result carrying the predecessor token.</param>
+    /// <param name="transition">The transition to apply.</param>
+    /// <returns>The transition result.</returns>
+    protected static async Task<EventSequenceMutationRegistryTransitionResult> Apply(
+        IEventSequenceMutationRegistry registry,
+        EventSequenceMutationBeginResult begin,
+        EventSequenceMutationTransition transition) =>
+        await registry.Transition(begin.Active!.TargetSequence, begin.Token!, transition);
+
+    void Establish()
+    {
+        _databaseName = $"chr_mutation_registry_{Guid.NewGuid():N}";
+        _client = new MongoClient(fixture.ConnectionString);
+        var mongoDatabase = _client.GetDatabase(_databaseName);
+
+        Database = Substitute.For<IEventStoreNamespaceDatabase>();
+        Database.GetCollection<EventSequenceMutationHeadEntry>(WellKnownCollectionNames.EventSequenceMutationHeads)
+            .Returns(mongoDatabase.GetCollection<EventSequenceMutationHeadEntry>(WellKnownCollectionNames.EventSequenceMutationHeads));
+        Database.GetCollection<EventSequenceMutationHistoryEntry>(WellKnownCollectionNames.EventSequenceMutationHistory)
+            .Returns(mongoDatabase.GetCollection<EventSequenceMutationHistoryEntry>(WellKnownCollectionNames.EventSequenceMutationHistory));
+
+        Registry = RegistryOver(Database);
+        Target = Identity("target-sequence");
+        ProposedTarget = new(10UL, 13UL, 3UL);
+        Request = BuildRequest(Target);
+    }
+
+    async Task Destroy()
+    {
+        if (_databaseName is not null)
+        {
+            await _client.DropDatabaseAsync(_databaseName);
+        }
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_mutation/and_the_mutation_is_not_terminal.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_mutation/and_the_mutation_is_not_terminal.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_archiving_a_mutation;
+
+/// <summary>
+/// A mutation that has not yet reached <see cref="EventSequenceMutationPhase.SourceCommitted"/> is not eligible
+/// for archiving - the freshly reserved mutation from <see cref="IEventSequenceMutationRegistry.Begin"/> is still
+/// at the <see cref="EventSequenceMutationPhase.Reserved"/> phase.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_the_mutation_is_not_terminal(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationRegistryArchiveResult _result = default!;
+
+    async Task Because()
+    {
+        var begin = await Registry.Begin(Request, ProposedTarget);
+        _result = await Registry.Archive(Target, begin.Token!);
+    }
+
+    [Fact] void should_reject_the_archive() => _result.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.StateConflict);
+    [Fact] void should_carry_no_history() => _result.History.ShouldBeNull();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_mutation/and_the_mutation_is_terminal.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_mutation/and_the_mutation_is_terminal.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_archiving_a_mutation;
+
+/// <summary>
+/// A mutation that has reached <see cref="EventSequenceMutationPhase.SourceCommitted"/> is archived: the terminal
+/// receipt is inserted into the history collection and the head's active mutation is cleared. A retry that races
+/// the original archive - inserting the identical terminal receipt first - is recognized as the same outcome
+/// rather than surfaced as a duplicate-key storage error, because the racing caller still holds the full,
+/// payload-carrying definition it read before losing the race.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_the_mutation_is_terminal(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationRegistryArchiveResult _archived = default!;
+    EventSequenceMutationRegistryArchiveResult _raceRetry = default!;
+
+    async Task Because()
+    {
+        var begin = await Registry.Begin(Request, ProposedTarget);
+        var applying = await Apply(Registry, begin, EventSequenceMutationTransition.BeginApplying);
+        var verifying = await Registry.Transition(Target, applying.Token!, EventSequenceMutationTransition.BeginVerifying);
+        var committed = await Registry.Transition(Target, verifying.Token!, EventSequenceMutationTransition.CommitSourceWithoutRepair);
+
+        // Simulate a caller racing this exact archive: it also read 'committed.Active' and independently prepared
+        // and inserted the identical terminal receipt before this call's own insert lands.
+        var targetId = (EventSequenceId)Target.Display;
+        var prepared = EventSequenceMutationStateMachine.PrepareArchive(committed.Token!.Scope, committed.Active!, committed.Token!);
+        var racingHistory = prepared.History!;
+        var racingDocument = new EventSequenceMutationHistoryEntry(
+            racingHistory.Id,
+            targetId,
+            racingHistory.Ordinal,
+            racingHistory.Origin,
+            racingHistory.Kind,
+            racingHistory.CommandHash,
+            racingHistory.Target,
+            racingHistory.RepairState,
+            racingHistory.TerminalWitness);
+        await Database.GetCollection<EventSequenceMutationHistoryEntry>(WellKnownCollectionNames.EventSequenceMutationHistory)
+            .InsertOneAsync(racingDocument);
+
+        _archived = await Registry.Archive(Target, committed.Token!);
+
+        // A further retry with the same token must remain idempotent: the head was never cleared by the
+        // simulated racer above, so this exercises the very same duplicate-key detection path again.
+        _raceRetry = await Registry.Archive(Target, committed.Token!);
+    }
+
+    [Fact] void should_recognize_the_racing_insert_as_already_archived() => _archived.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.AlreadyArchived);
+    [Fact] void should_return_the_racing_receipt() => _archived.History!.Id.ShouldEqual(Request.Id);
+    [Fact] void should_return_a_payload_free_receipt() => _archived.History!.CommandHash.ShouldEqual(Request.Command.Hash);
+    [Fact] void should_be_the_same_outcome_on_every_read() => _raceRetry.Outcome.ShouldEqual(_archived.Outcome);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_another_mutation_is_active.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_another_mutation_is_active.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_a_mutation;
+
+/// <summary>
+/// A different mutation request targeting the same event sequence while one is already active must be rejected -
+/// only one mutation may be active per target sequence at a time.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_another_mutation_is_active(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationBeginResult _first = default!;
+    EventSequenceMutationBeginResult _second = default!;
+
+    async Task Because()
+    {
+        _first = await Registry.Begin(Request, ProposedTarget);
+        var otherRequest = BuildRequest(Target, originSequenceNumber: 99);
+        _second = await Registry.Begin(otherRequest, ProposedTarget);
+    }
+
+    [Fact] void should_report_a_mutation_already_in_progress() => _second.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.MutationAlreadyInProgress);
+    [Fact] void should_carry_the_active_mutation_identifier() => _second.ConflictingMutationId.ShouldEqual(_first.Active!.Id);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_it_is_the_first_time.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_it_is_the_first_time.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_a_mutation;
+
+/// <summary>
+/// The first ever <see cref="IEventSequenceMutationRegistry.Begin"/> call for a target sequence with no head
+/// document yet must upsert one and reserve the mutation, matching the in-memory registry's first-time outcome.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_it_is_the_first_time(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationBeginResult _result = default!;
+
+    async Task Because() => _result = await Registry.Begin(Request, ProposedTarget);
+
+    [Fact] void should_reserve_the_mutation() => _result.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Reserved);
+    [Fact] void should_carry_the_active_mutation() => _result.Active.ShouldNotBeNull();
+    [Fact] void should_start_at_the_reserved_phase() => _result.Active!.Phase.ShouldEqual(EventSequenceMutationPhase.Reserved);
+    [Fact] void should_start_at_the_first_state_version() => _result.Active!.StateVersion.ShouldEqual(EventSequenceMutationStateVersion.First);
+    [Fact] void should_assign_the_first_ordinal() => _result.Active!.Ordinal.ShouldEqual(EventSequenceMutationOrdinal.First);
+    [Fact] void should_carry_a_complete_token() => _result.Token.ShouldNotBeNull();
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_racing_concurrently.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_racing_concurrently.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_a_mutation;
+
+/// <summary>
+/// Sixteen callers racing <see cref="IEventSequenceMutationRegistry.Begin"/> with the exact same request against a
+/// real MongoDB must settle on exactly one winning reservation, with every other caller resuming it - proving the
+/// atomic upsert-if-absent-or-null compare-and-swap serializes concurrent reservations correctly, matching the
+/// in-memory registry's own concurrency proof.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_racing_concurrently(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    const int CallerCount = 16;
+
+    EventSequenceMutationBeginResult[] _results = default!;
+
+    async Task Because() =>
+        _results = await Race(Enumerable.Range(0, CallerCount)
+            .Select(_ => (Func<Task<EventSequenceMutationBeginResult>>)(() => Registry.Begin(Request, ProposedTarget))));
+
+    [Fact] void should_have_exactly_one_winner() => _results.Count(_ => _.Outcome == EventSequenceMutationBeginOutcome.Reserved).ShouldEqual(1);
+    [Fact] void should_resume_every_other_caller() => _results.Count(_ => _.Outcome == EventSequenceMutationBeginOutcome.Resumed).ShouldEqual(CallerCount - 1);
+    [Fact] void should_make_every_caller_observe_the_same_ordinal() => _results.Select(_ => _.Active!.Ordinal).Distinct().Count().ShouldEqual(1);
+    [Fact] void should_assign_the_first_ordinal() => _results.All(_ => _.Active!.Ordinal == EventSequenceMutationOrdinal.First).ShouldBeTrue();
+
+    static async Task<EventSequenceMutationBeginResult[]> Race(IEnumerable<Func<Task<EventSequenceMutationBeginResult>>> operations)
+    {
+        var operationArray = operations.ToArray();
+        var remaining = operationArray.Length;
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tasks = operationArray.Select(operation => Task.Run(async () =>
+        {
+            if (Interlocked.Decrement(ref remaining) == 0)
+            {
+                ready.SetResult();
+            }
+
+            await start.Task;
+            return await operation();
+        })).ToArray();
+        await ready.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        start.SetResult();
+        return await Task.WhenAll(tasks);
+    }
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_resuming_an_identical_request.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_resuming_an_identical_request.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_a_mutation;
+
+/// <summary>
+/// Calling <see cref="IEventSequenceMutationRegistry.Begin"/> a second time with the exact same request must
+/// resume the already-reserved mutation rather than reserving a new one - the head document already carries an
+/// active mutation whose id matches the incoming request.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_resuming_an_identical_request(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationBeginResult _first = default!;
+    EventSequenceMutationBeginResult _resumed = default!;
+
+    async Task Because()
+    {
+        _first = await Registry.Begin(Request, ProposedTarget);
+        _resumed = await Registry.Begin(Request, ProposedTarget);
+    }
+
+    [Fact] void should_resume_the_mutation() => _resumed.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Resumed);
+    [Fact] void should_return_the_same_mutation_identifier() => _resumed.Active!.Id.ShouldEqual(_first.Active!.Id);
+    [Fact] void should_return_the_same_ordinal() => _resumed.Active!.Ordinal.ShouldEqual(_first.Active!.Ordinal);
+    [Fact] void should_return_the_same_state_version() => _resumed.Active!.StateVersion.ShouldEqual(_first.Active!.StateVersion);
+    [Fact] void should_not_allocate_a_new_ordinal() => _resumed.Active!.Ordinal.ShouldEqual(EventSequenceMutationOrdinal.First);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_the_request_has_changed.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_a_mutation/and_the_request_has_changed.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_a_mutation;
+
+/// <summary>
+/// A second <see cref="IEventSequenceMutationRegistry.Begin"/> call reusing the same mutation id but carrying a
+/// different command payload cannot be a legitimate resume of the already-bound mutation.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_the_request_has_changed(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationBeginResult _first = default!;
+    EventSequenceMutationBeginResult _conflicting = default!;
+
+    async Task Because()
+    {
+        _first = await Registry.Begin(Request, ProposedTarget);
+        var changedRequest = Request with { Command = new("{\"name\":\"changed\"}", "changed-hash") };
+        _conflicting = await Registry.Begin(changedRequest, ProposedTarget);
+    }
+
+    [Fact] void should_report_a_definition_conflict() => _conflicting.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.DefinitionConflict);
+    [Fact] void should_carry_the_conflicting_mutation_identifier() => _conflicting.ConflictingMutationId.ShouldEqual(Request.Id);
+    [Fact] void should_leave_the_original_reservation_untouched() => _first.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Reserved);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking/and_the_sequence_is_already_unsealed.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking/and_the_sequence_is_already_unsealed.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_tracking;
+
+/// <summary>
+/// Beginning tracking a second time, once the sequence is already unsealed, must be idempotent rather than
+/// reporting a conflict - matching the in-memory registry's tolerance for a repeated begin-tracking call.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_the_sequence_is_already_unsealed(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationTrackingResult _result = default!;
+
+    async Task Because()
+    {
+        await Registry.BeginTracking(Target, EventSequenceMutationCoverage.Untracked);
+        _result = await Registry.BeginTracking(Target, EventSequenceMutationCoverage.Untracked);
+    }
+
+    [Fact] void should_report_tracking_as_already_active() => _result.Outcome.ShouldEqual(EventSequenceMutationTrackingOutcome.AlreadyTracking);
+    [Fact] void should_still_report_unsealed_coverage() => _result.Coverage.ShouldEqual((EventSequenceMutationCoverage?)EventSequenceMutationCoverage.Unsealed);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking/and_the_sequence_is_untracked.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking/and_the_sequence_is_untracked.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_beginning_tracking;
+
+/// <summary>
+/// Beginning tracking for an event sequence with no head document yet must upsert one and move its coverage to
+/// unsealed - a non-existent document is logically <see cref="EventSequenceMutationCoverage.Untracked"/>.
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_the_sequence_is_untracked(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationTrackingResult _result = default!;
+
+    async Task Because() => _result = await Registry.BeginTracking(Target, EventSequenceMutationCoverage.Untracked);
+
+    [Fact] void should_begin_tracking() => _result.Outcome.ShouldEqual(EventSequenceMutationTrackingOutcome.Began);
+    [Fact] void should_report_unsealed_coverage() => _result.Coverage.ShouldEqual((EventSequenceMutationCoverage?)EventSequenceMutationCoverage.Unsealed);
+}

--- a/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_transitioning_a_mutation/and_advancing_through_the_full_graph.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_transitioning_a_mutation/and_advancing_through_the_full_graph.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.MongoDB.Sinks;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations.for_EventSequenceMutationRegistry.when_transitioning_a_mutation;
+
+/// <summary>
+/// Drives a mutation through every legal edge of the state graph via the MongoDB-backed registry, proving the
+/// compare-and-swap write-back after each <see cref="EventSequenceMutationStateMachine.Apply"/> call persists the
+/// successor correctly, that an exact retry is idempotent, and that a token from before a Block/Resume cycle is
+/// rejected once replayed against the state the cycle left behind (the ABA case: the phase looks the same again,
+/// but the state version has moved on).
+/// </summary>
+/// <param name="fixture">The <see cref="MongoDBFixture"/> providing the MongoDB server.</param>
+[Collection(MongoDBCollection.Name)]
+public class and_advancing_through_the_full_graph(MongoDBFixture fixture) : given.a_mutation_registry(fixture)
+{
+    EventSequenceMutationRegistryTransitionResult[] _applied = default!;
+    EventSequenceMutationRegistryTransitionResult _retry = default!;
+    EventSequenceMutationRegistryTransitionResult _abaConflict = default!;
+
+    async Task Because()
+    {
+        var begin = await Registry.Begin(Request, ProposedTarget);
+        var applying = await Apply(Registry, begin, EventSequenceMutationTransition.BeginApplying);
+
+        // Exact retry: reapplying BeginApplying with the ORIGINAL pre-transition (Reserved) token, after the
+        // transition has already landed, must be recognized as the same transition rather than rejected.
+        _retry = await Registry.Transition(Target, begin.Token!, EventSequenceMutationTransition.BeginApplying);
+
+        var blocked = await Registry.Transition(Target, applying.Token!, EventSequenceMutationTransition.Block);
+        var resumed = await Registry.Transition(Target, blocked.Token!, EventSequenceMutationTransition.Resume);
+
+        // The ABA case: 'applying.Token' was a valid Applying-phase token before the Block/Resume round-trip.
+        // 'resumed' is Applying again too, but at a later state version - the stale token must not be accepted
+        // as if it still fenced the current state.
+        _abaConflict = await Registry.Transition(Target, applying.Token!, EventSequenceMutationTransition.BeginVerifying);
+
+        var verifying = await Registry.Transition(Target, resumed.Token!, EventSequenceMutationTransition.BeginVerifying);
+        var committed = await Registry.Transition(Target, verifying.Token!, EventSequenceMutationTransition.CommitSourceWithRepair);
+        var dispatching = await Registry.Transition(Target, committed.Token!, EventSequenceMutationTransition.BeginRepairDispatch);
+        var accepted = await Registry.Transition(Target, dispatching.Token!, EventSequenceMutationTransition.AcceptRepair);
+        _applied = [applying, blocked, resumed, verifying, committed, dispatching, accepted];
+    }
+
+    [Fact] void should_apply_every_legal_transition() => _applied.All(_ => _.Outcome == EventSequenceMutationRegistryTransitionOutcome.Applied).ShouldBeTrue();
+    [Fact] void should_report_an_exact_retry_as_already_applied() => _retry.Outcome.ShouldEqual(EventSequenceMutationRegistryTransitionOutcome.AlreadyApplied);
+    [Fact] void should_return_the_same_state_for_an_exact_retry() => _retry.Active!.StateVersion.ShouldEqual(_applied[0].Active!.StateVersion);
+    [Fact] void should_reject_the_stale_pre_cycle_token() => _abaConflict.Outcome.ShouldEqual(EventSequenceMutationRegistryTransitionOutcome.StateConflict);
+    [Fact] void should_preserve_the_ordinal_throughout() => _applied.All(_ => _.Active!.Ordinal == EventSequenceMutationOrdinal.First).ShouldBeTrue();
+    [Fact] void should_increment_the_state_version_on_every_applied_transition() =>
+        _applied.Select(_ => _.Active!.StateVersion.Value).ShouldContainOnly([2L, 3L, 4L, 5L, 6L, 7L, 8L]);
+    [Fact] void should_finish_with_accepted_repair() => _applied[^1].Active!.RepairState.ShouldEqual(EventSequenceMutationRepairState.Accepted);
+}

--- a/Source/Kernel/Storage.MongoDB/EventSequences/Mutations/EventSequenceMutationRegistry.cs
+++ b/Source/Kernel/Storage.MongoDB/EventSequences/Mutations/EventSequenceMutationRegistry.cs
@@ -1,0 +1,546 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using MongoDB.Driver;
+
+using ProviderNeutralHistoryEntry = Cratis.Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry;
+
+namespace Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations;
+
+/// <summary>
+/// Represents a namespace-scoped MongoDB event sequence mutation registry.
+/// </summary>
+/// <param name="eventStore">The event store that owns the registry.</param>
+/// <param name="namespace">The namespace that owns the registry.</param>
+/// <param name="database">The <see cref="IEventStoreNamespaceDatabase"/> to persist to.</param>
+/// <remarks>
+/// Every operation is backed by MongoDB compare-and-swap document operations rather than an in-process lock. The
+/// head document (keyed by <see cref="EventSequenceId"/>) carries at most one active mutation at a time; the
+/// history collection (keyed by <see cref="EventSequenceMutationId"/>) carries the payload-free terminal receipt
+/// for every mutation that has been archived. Because the terminal receipt never retains the original command
+/// payload, only <see cref="Begin"/> - which receives the caller's full request - can cryptographically verify a
+/// replay against an archived registration. <see cref="Transition"/> and <see cref="Archive"/> only receive a
+/// compact <see cref="EventSequenceMutationStateToken"/>, so once a mutation's head has been cleared they can no
+/// longer reconstruct a verifiable definition; a retry that arrives after the head was already cleared observes a
+/// <see cref="EventSequenceMutationRegistryTransitionOutcome.StateConflict"/> /
+/// <see cref="EventSequenceMutationRegistryArchiveOutcome.StateConflict"/> rather than a replayed success. A retry
+/// that races the original call before the head is cleared is still resolved correctly, because the caller that
+/// read the active mutation still holds its full, payload-carrying definition when the duplicate-key race is
+/// detected.
+/// </remarks>
+public class EventSequenceMutationRegistry(
+    EventStoreName eventStore,
+    EventStoreNamespaceName @namespace,
+    IEventStoreNamespaceDatabase database) : IEventSequenceMutationRegistry
+{
+    readonly IMongoCollection<EventSequenceMutationHeadEntry> _heads = database.GetCollection<EventSequenceMutationHeadEntry>(WellKnownCollectionNames.EventSequenceMutationHeads);
+    readonly IMongoCollection<EventSequenceMutationHistoryEntry> _history = database.GetCollection<EventSequenceMutationHistoryEntry>(WellKnownCollectionNames.EventSequenceMutationHistory);
+
+    /// <inheritdoc/>
+    public async Task<EventSequenceMutationBeginResult> Begin(
+        EventSequenceMutationRequest request,
+        EventSequenceMutationTarget proposedTarget,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return await Task.FromCanceled<EventSequenceMutationBeginResult>(cancellationToken).ConfigureAwait(false);
+        }
+
+        var validation = EventSequenceMutationValidator.ValidateRequest(request);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(validation);
+        }
+
+        var scope = Scope(request.TargetSequence);
+
+        var archivedReplay = await ResolveArchivedPermanentRecord(scope, request, cancellationToken).ConfigureAwait(false);
+        if (archivedReplay is not null)
+        {
+            return archivedReplay;
+        }
+
+        var targetId = TargetId(request.TargetSequence);
+        var head = await FindHead(targetId, cancellationToken).ConfigureAwait(false);
+        if (head?.Active is not null)
+        {
+            return head.Active.Id == request.Id
+                ? ResolveBoundResume(scope, request, head)
+                : EventSequenceMutationBeginResult.MutationAlreadyInProgress(head.Active.Id);
+        }
+
+        return await ReserveNewMutation(scope, request, proposedTarget, head, targetId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<EventSequenceMutationRegistryTransitionResult> Transition(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutationTransition transition,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return await Task.FromCanceled<EventSequenceMutationRegistryTransitionResult>(cancellationToken).ConfigureAwait(false);
+        }
+
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateToken(token);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(validation);
+        }
+
+        var scope = Scope(target);
+        var targetId = TargetId(target);
+        var head = await FindHead(targetId, cancellationToken).ConfigureAwait(false);
+
+        if (head?.Active is not { } active || active.Id != token.Id ||
+            !IsValidHead(scope, head.Coverage, head.LastAssignedOrdinal, active) ||
+            !MatchesBinding(scope, target, token, active))
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        var result = EventSequenceMutationStateMachine.Apply(scope, active, transition, token);
+        if (!result.Validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(result.Validation);
+        }
+
+        if (result.Outcome == EventSequenceMutationTransitionOutcome.Conflict)
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        if (result.Outcome == EventSequenceMutationTransitionOutcome.AlreadyApplied)
+        {
+            // The successor is byte-for-byte identical to the currently observed state, so there is nothing to
+            // persist - skip the write and hand back the unchanged value directly.
+            return EventSequenceMutationRegistryTransitionResult.AlreadyApplied(result.Mutation!, result.Token!);
+        }
+
+        if (result.Outcome != EventSequenceMutationTransitionOutcome.Applied)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Corrupt();
+        }
+
+        var filter = Builders<EventSequenceMutationHeadEntry>.Filter.And(
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.EventSequenceId, targetId),
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.Active!.StateVersion, active.StateVersion));
+        var update = Builders<EventSequenceMutationHeadEntry>.Update.Set(_ => _.Active, result.Mutation);
+
+        var updated = await _heads.FindOneAndUpdateAsync(
+            filter,
+            update,
+            new FindOneAndUpdateOptions<EventSequenceMutationHeadEntry> { ReturnDocument = ReturnDocument.After },
+            cancellationToken).ConfigureAwait(false);
+
+        return updated is not null
+            ? EventSequenceMutationRegistryTransitionResult.Applied(result.Mutation!, result.Token!)
+            : EventSequenceMutationRegistryTransitionResult.StateConflict();
+    }
+
+    /// <inheritdoc/>
+    public async Task<EventSequenceMutationRegistryArchiveResult> Archive(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return await Task.FromCanceled<EventSequenceMutationRegistryArchiveResult>(cancellationToken).ConfigureAwait(false);
+        }
+
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateToken(token);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(validation);
+        }
+
+        var scope = Scope(target);
+        var targetId = TargetId(target);
+        var head = await FindHead(targetId, cancellationToken).ConfigureAwait(false);
+
+        if (head?.Active is not { } active || active.Id != token.Id ||
+            !IsValidHead(scope, head.Coverage, head.LastAssignedOrdinal, active) ||
+            !MatchesBinding(scope, target, token, active))
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        var prepared = EventSequenceMutationStateMachine.PrepareArchive(scope, active, token);
+        if (!prepared.Validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(prepared.Validation);
+        }
+
+        if (prepared.Outcome == EventSequenceMutationArchiveOutcome.Conflict)
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        if (prepared.Outcome != EventSequenceMutationArchiveOutcome.Prepared || prepared.History is null)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Corrupt();
+        }
+
+        var history = prepared.History;
+        var document = ToDocument(history, targetId);
+
+        try
+        {
+            await _history.InsertOneAsync(document, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Someone else - a racing retry of this exact archive, or a prior attempt that crashed before it
+            // could clear the head - already inserted the terminal receipt. Because we read 'active' (with its
+            // full, payload-carrying definition) before losing this race, we can still verify and replay it.
+            return await ResolveArchiveRace(scope, token, active, cancellationToken).ConfigureAwait(false);
+        }
+
+        var clearFilter = Builders<EventSequenceMutationHeadEntry>.Filter.And(
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.EventSequenceId, targetId),
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.Active!.StateVersion, active.StateVersion));
+        var clearUpdate = Builders<EventSequenceMutationHeadEntry>.Update.Set(_ => _.Active, null);
+
+        var clearResult = await _heads.UpdateOneAsync(clearFilter, clearUpdate, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (clearResult.MatchedCount == 0)
+        {
+            // The state machine and the append-only history collection guarantee only one caller can ever reach
+            // this point for a given mutation, so a concurrently mutated head here means persisted state has
+            // diverged from the invariant the registry depends on.
+            return EventSequenceMutationRegistryArchiveResult.Corrupt();
+        }
+
+        var registration = new EventSequenceMutationRegistration(
+            active.Definition,
+            EventSequenceMutationRegistryLifecycle.Archived,
+            history.Ordinal,
+            history.TerminalWitness);
+        return EventSequenceMutationRegistryArchiveResult.Archived(scope, registration, history);
+    }
+
+    /// <inheritdoc/>
+    public async Task<EventSequenceMutationTrackingResult> BeginTracking(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationCoverage expected,
+        CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return await Task.FromCanceled<EventSequenceMutationTrackingResult>(cancellationToken).ConfigureAwait(false);
+        }
+
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateTrackingCoverage(expected);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        var scope = Scope(target);
+        validation = EventSequenceMutationValidator.ValidateScope(scope);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        var targetId = TargetId(target);
+        var filter = Builders<EventSequenceMutationHeadEntry>.Filter.And(
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.EventSequenceId, targetId),
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.Coverage, expected));
+        var update = Builders<EventSequenceMutationHeadEntry>.Update.Set(_ => _.Coverage, EventSequenceMutationCoverage.Unsealed);
+        var options = new FindOneAndUpdateOptions<EventSequenceMutationHeadEntry> { IsUpsert = true, ReturnDocument = ReturnDocument.After };
+
+        var updated = await TryFindOneAndUpdate(filter, update, options, cancellationToken).ConfigureAwait(false);
+        if (updated is not null)
+        {
+            return EventSequenceMutationTrackingResult.Began();
+        }
+
+        var current = await FindHead(targetId, cancellationToken).ConfigureAwait(false);
+        var currentCoverage = current?.Coverage ?? EventSequenceMutationCoverage.Untracked;
+        return currentCoverage == EventSequenceMutationCoverage.Unsealed
+            ? EventSequenceMutationTrackingResult.AlreadyTracking()
+            : EventSequenceMutationTrackingResult.Conflict(currentCoverage);
+    }
+
+    static EventSequenceMutationBeginResult ResolveBoundResume(
+        EventSequenceKey scope,
+        EventSequenceMutationRequest request,
+        EventSequenceMutationHeadEntry head)
+    {
+        var active = head.Active!;
+        if (!IsValidHead(scope, head.Coverage, head.LastAssignedOrdinal, active))
+        {
+            return EventSequenceMutationBeginResult.Corrupt();
+        }
+
+        var registration = new EventSequenceMutationRegistration(
+            active.Definition,
+            EventSequenceMutationRegistryLifecycle.Bound,
+            active.Ordinal,
+            null);
+
+        if (!registration.IsExactRequest(request))
+        {
+            return EventSequenceMutationBeginResult.DefinitionConflict(request.Id);
+        }
+
+        return EventSequenceMutationBeginResult.Resumed(active, EventSequenceMutationStateToken.Create(scope, active));
+    }
+
+    static EventSequenceId TargetId(EventSequenceMutationIdentity target) => target.Display;
+
+    static ProviderNeutralHistoryEntry ToStorageHistory(EventSequenceMutationHistoryEntry document) =>
+        new(document.MutationId, document.Ordinal, document.Origin, document.Kind, document.CommandHash, document.Target, document.RepairState, document.TerminalWitness);
+
+    static EventSequenceMutationHistoryEntry ToDocument(ProviderNeutralHistoryEntry history, EventSequenceId targetId) =>
+        new(history.Id, targetId, history.Ordinal, history.Origin, history.Kind, history.CommandHash, history.Target, history.RepairState, history.TerminalWitness);
+
+    static bool IsValidHead(
+        EventSequenceKey scope,
+        EventSequenceMutationCoverage coverage,
+        EventSequenceMutationOrdinal lastAssignedOrdinal,
+        EventSequenceMutation? active) =>
+        Enum.IsDefined(coverage) &&
+        lastAssignedOrdinal is { Value: >= 0 } &&
+        (active is null || (lastAssignedOrdinal == active.Ordinal && EventSequenceMutationValidator.ValidateActive(scope, active).IsValid));
+
+    static bool MatchesBinding(
+        EventSequenceKey scope,
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutation active) =>
+        token.Scope == scope &&
+        token.TargetKey == target.Key &&
+        active.TargetSequence == target &&
+        token.Id == active.Id &&
+        token.Ordinal == active.Ordinal &&
+        token.DefinitionDigestV1 == active.Definition.DefinitionDigestV1;
+
+    static bool IsExactArchiveRetry(EventSequenceMutationStateToken token, ProviderNeutralHistoryEntry history) =>
+        token.Phase == EventSequenceMutationPhase.SourceCommitted &&
+        token.BlockedFrom == EventSequenceMutationPhase.None &&
+        token.RepairState == history.RepairState &&
+        token.StateVersion.Value < long.MaxValue &&
+        token.StateVersion.Value + 1 == history.TerminalWitness.FinalStateVersion.Value;
+
+    async Task<EventSequenceMutationBeginResult?> ResolveArchivedPermanentRecord(
+        EventSequenceKey scope,
+        EventSequenceMutationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var document = await FindHistoryById(request.Id, cancellationToken).ConfigureAwait(false);
+        if (document is null)
+        {
+            return null;
+        }
+
+        var history = ToStorageHistory(document);
+
+        EventSequenceMutationDefinition candidateDefinition;
+        try
+        {
+            candidateDefinition = EventSequenceMutationDefinition.Create(scope, request, history.Target);
+        }
+        catch (InvalidEventSequenceMutation)
+        {
+            // The stored target could not reproduce a valid definition input alongside the caller's request and
+            // this scope - the persisted history is malformed.
+            return EventSequenceMutationBeginResult.Corrupt();
+        }
+
+        if (candidateDefinition.DefinitionDigestV1 != history.TerminalWitness.DefinitionDigestV1)
+        {
+            // The candidate, recomputed purely from the caller's own request plus the persisted target, does not
+            // reproduce the digest that was witnessed at archive time - this is not a replay of the same request.
+            return EventSequenceMutationBeginResult.DefinitionConflict(request.Id);
+        }
+
+        var registration = new EventSequenceMutationRegistration(
+            candidateDefinition,
+            EventSequenceMutationRegistryLifecycle.Archived,
+            history.Ordinal,
+            history.TerminalWitness);
+
+        return EventSequenceMutationBeginResult.Archived(scope, registration, history);
+    }
+
+    async Task<EventSequenceMutationBeginResult> ReserveNewMutation(
+        EventSequenceKey scope,
+        EventSequenceMutationRequest request,
+        EventSequenceMutationTarget proposedTarget,
+        EventSequenceMutationHeadEntry? head,
+        EventSequenceId targetId,
+        CancellationToken cancellationToken)
+    {
+        var deterministicValidation = EventSequenceMutationValidator.ValidateDeterministicId(request);
+        if (!deterministicValidation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(deterministicValidation);
+        }
+
+        var targetValidation = EventSequenceMutationValidator.ValidateTarget(proposedTarget);
+        if (!targetValidation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(targetValidation);
+        }
+
+        var definitionValidation = EventSequenceMutationValidator.ValidateDefinitionInputs(scope, request, proposedTarget);
+        if (!definitionValidation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(definitionValidation);
+        }
+
+        long nextOrdinalValue;
+        try
+        {
+            nextOrdinalValue = checked((head?.LastAssignedOrdinal ?? EventSequenceMutationOrdinal.NotSet).Value + 1);
+        }
+        catch (OverflowException)
+        {
+            return EventSequenceMutationBeginResult.Corrupt();
+        }
+
+        var ordinal = new EventSequenceMutationOrdinal(nextOrdinalValue);
+        var definition = EventSequenceMutationDefinition.Create(scope, request, proposedTarget);
+        var active = new EventSequenceMutation(
+            definition,
+            ordinal,
+            EventSequenceMutationStateVersion.First,
+            EventSequenceMutationPhase.Reserved,
+            EventSequenceMutationPhase.None,
+            EventSequenceMutationRepairState.Unspecified);
+
+        // Matches both "no document exists yet" (Mongo upserts a new one, folding this equality condition in as
+        // the base document) and "a document exists with no active mutation" - the two cases in which reserving
+        // is legal. A document with an active mutation fails to match and falls through to the conflict below.
+        var filter = Builders<EventSequenceMutationHeadEntry>.Filter.And(
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.EventSequenceId, targetId),
+            Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.Active, null));
+
+        var update = Builders<EventSequenceMutationHeadEntry>.Update
+            .Set(_ => _.Active, active)
+            .Set(_ => _.LastAssignedOrdinal, ordinal);
+
+        var options = new FindOneAndUpdateOptions<EventSequenceMutationHeadEntry>
+        {
+            IsUpsert = true,
+            ReturnDocument = ReturnDocument.After
+        };
+
+        var updated = await TryFindOneAndUpdate(filter, update, options, cancellationToken).ConfigureAwait(false);
+        if (updated is not null)
+        {
+            return EventSequenceMutationBeginResult.Reserved(active, EventSequenceMutationStateToken.Create(scope, active));
+        }
+
+        var current = await FindHead(targetId, cancellationToken).ConfigureAwait(false);
+        if (current?.Active is null)
+        {
+            return EventSequenceMutationBeginResult.Indeterminate();
+        }
+
+        return current.Active.Id == request.Id
+            ? ResolveBoundResume(scope, request, current)
+            : EventSequenceMutationBeginResult.MutationAlreadyInProgress(current.Active.Id);
+    }
+
+    async Task<EventSequenceMutationRegistryArchiveResult> ResolveArchiveRace(
+        EventSequenceKey scope,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutation active,
+        CancellationToken cancellationToken)
+    {
+        var existingDocument = await FindHistoryById(token.Id, cancellationToken).ConfigureAwait(false);
+        if (existingDocument is null)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Corrupt();
+        }
+
+        var existingHistory = ToStorageHistory(existingDocument);
+        if (!IsExactArchiveRetry(token, existingHistory))
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        var registration = new EventSequenceMutationRegistration(
+            active.Definition,
+            EventSequenceMutationRegistryLifecycle.Archived,
+            existingHistory.Ordinal,
+            existingHistory.TerminalWitness);
+        return EventSequenceMutationRegistryArchiveResult.AlreadyArchived(scope, registration, existingHistory);
+    }
+
+    /// <summary>
+    /// Runs an upsert-if-absent-or-matching <c>findAndModify</c>, treating a lost upsert race as a non-match
+    /// rather than an unhandled exception.
+    /// </summary>
+    /// <remarks>
+    /// When the filter fails to match (either because no document exists yet, or because an existing document's
+    /// other fields no longer match), Mongo attempts to insert a new document built from the filter's equality
+    /// terms. Two callers racing the exact same missing-document case can both reach that insert attempt before
+    /// either commits; only one insert can satisfy the unique <c>_id</c> index, and the loser observes this as a
+    /// duplicate-key error from the driver rather than a clean non-match. Swallowing it here and returning
+    /// <see langword="null"/> lets every caller re-read the now-settled document through the same fallback path
+    /// used for a genuine non-match.
+    /// </remarks>
+    /// <param name="filter">The <see cref="FilterDefinition{TDocument}"/> to match the head document with.</param>
+    /// <param name="update">The <see cref="UpdateDefinition{TDocument}"/> to apply on a match or upsert-insert.</param>
+    /// <param name="options">The <see cref="FindOneAndUpdateOptions{TDocument}"/> controlling the upsert.</param>
+    /// <param name="cancellationToken">The caller cancellation token.</param>
+    /// <returns>The updated document, or <see langword="null"/> when the filter did not match and the upsert lost a race.</returns>
+    async Task<EventSequenceMutationHeadEntry?> TryFindOneAndUpdate(
+        FilterDefinition<EventSequenceMutationHeadEntry> filter,
+        UpdateDefinition<EventSequenceMutationHeadEntry> update,
+        FindOneAndUpdateOptions<EventSequenceMutationHeadEntry> options,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _heads.FindOneAndUpdateAsync(filter, update, options, cancellationToken).ConfigureAwait(false);
+        }
+        catch (MongoCommandException ex) when (ex.Code == 11000 || ex.Message.Contains("E11000", StringComparison.Ordinal))
+        {
+            return null;
+        }
+    }
+
+    async Task<EventSequenceMutationHeadEntry?> FindHead(EventSequenceId targetId, CancellationToken cancellationToken) =>
+        await _heads.Find(Builders<EventSequenceMutationHeadEntry>.Filter.Eq(_ => _.EventSequenceId, targetId))
+            .Limit(1)
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    async Task<EventSequenceMutationHistoryEntry?> FindHistoryById(EventSequenceMutationId id, CancellationToken cancellationToken) =>
+        await _history.Find(Builders<EventSequenceMutationHistoryEntry>.Filter.Eq(_ => _.MutationId, id))
+            .Limit(1)
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    EventSequenceKey Scope(EventSequenceMutationIdentity target) => new(target.Display, eventStore, @namespace);
+}

--- a/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.MongoDB/EventStoreNamespaceStorage.cs
@@ -10,6 +10,7 @@ using Cratis.Chronicle.Configuration;
 using Cratis.Chronicle.Storage.Changes;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
 using Cratis.Chronicle.Storage.EventTypes;
 using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.Jobs;
@@ -17,6 +18,7 @@ using Cratis.Chronicle.Storage.Keys;
 using Cratis.Chronicle.Storage.MongoDB.Changes;
 using Cratis.Chronicle.Storage.MongoDB.Events.Constraints;
 using Cratis.Chronicle.Storage.MongoDB.EventSequences;
+using Cratis.Chronicle.Storage.MongoDB.EventSequences.Mutations;
 using Cratis.Chronicle.Storage.MongoDB.Identities;
 using Cratis.Chronicle.Storage.MongoDB.Jobs;
 using Cratis.Chronicle.Storage.MongoDB.Keys;
@@ -108,6 +110,7 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
         ReplayedReadModels = new ReplayedReadModelsStorage(eventStoreNamespaceDatabase);
         EventSeeding = new Seeding.EventSeedingStorage(eventStoreNamespaceDatabase);
         ProjectionFutures = new Projections.ProjectionFuturesStorage(eventStoreNamespaceDatabase, jsonSerializerOptions);
+        EventSequenceMutations = new EventSequenceMutationRegistry(eventStore, @namespace, eventStoreNamespaceDatabase);
 
         _converter = new EventConverter(
             eventStore,
@@ -164,6 +167,9 @@ public class EventStoreNamespaceStorage : IEventStoreNamespaceStorage
 
     /// <inheritdoc/>
     public IProjectionFuturesStorage ProjectionFutures { get; }
+
+    /// <inheritdoc/>
+    public IEventSequenceMutationRegistry EventSequenceMutations { get; }
 
     /// <inheritdoc/>
     /// <remarks>

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/given/a_mutation_registry.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/given/a_mutation_registry.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.EntityFrameworkCore.Concepts;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry.given;
+
+/// <summary>
+/// Sets up an <see cref="EventSequenceMutationRegistry"/> backed by a shared in-memory SQLite database.
+/// A single open connection is shared across every <see cref="IDatabase.Namespace"/> scope so rows
+/// written by one call survive into the next - the registry opens a fresh <see cref="NamespaceDbContext"/>
+/// per method call, exactly as it does in production.
+/// </summary>
+public class a_mutation_registry : Specification, IDisposable
+{
+    protected static readonly EventStoreName _eventStore = "test-store";
+    protected static readonly EventStoreNamespaceName _namespace = "test-namespace";
+
+    protected SqliteConnection _connection;
+    protected IDatabase _database;
+    protected IEventSequenceMutationRegistry _registry;
+    protected EventSequenceMutationIdentity _target;
+    protected EventSequenceMutationTarget _proposedTarget;
+    protected EventSequenceMutationRequest _request;
+
+    void Establish()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        using (var schemaContext = CreateContext())
+        {
+            schemaContext.Database.EnsureCreated();
+        }
+
+        _database = Substitute.For<IDatabase>();
+        _database.Namespace(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>())
+            .Returns(_ => Task.FromResult(new DbContextScope<NamespaceDbContext>(CreateContext(), () => { })));
+
+        _registry = new EventSequenceMutationRegistry(_eventStore, _namespace, _database);
+        _target = Identity("target-sequence");
+        _proposedTarget = new(10UL, 13UL, 3UL);
+        _request = Request(_target);
+    }
+
+    protected static NamespaceDbContext CreateContextFor(SqliteConnection connection)
+    {
+        var options = new DbContextOptionsBuilder<NamespaceDbContext>()
+            .UseSqlite(connection)
+            .AddConceptAsSupport()
+            .Options;
+        return new NamespaceDbContext(options);
+    }
+
+    protected NamespaceDbContext CreateContext() => CreateContextFor(_connection);
+
+    protected static EventSequenceMutationIdentity Identity(string display) => EventSequenceMutationIdentity.TryCreate(display).Identity!;
+
+    protected static EventSequenceMutationRequest Request(
+        EventSequenceMutationIdentity target,
+        ulong originSequenceNumber = 42,
+        string payload = "{\"name\":\"Ada\"}",
+        string hash = "command-hash")
+    {
+        var origin = Identity("origin-sequence");
+        const EventSequenceMutationKind kind = EventSequenceMutationKind.Revision;
+        var id = EventSequenceMutationDigestCalculator.CalculateId(target, origin, originSequenceNumber, kind);
+        return new(id, target, new(origin, originSequenceNumber), kind, new(payload, hash));
+    }
+
+    protected static async Task<EventSequenceMutationRegistryTransitionResult> Apply(
+        IEventSequenceMutationRegistry registry,
+        EventSequenceMutationBeginResult begin,
+        EventSequenceMutationTransition transition) =>
+        await registry.Transition(begin.Active!.TargetSequence, begin.Token!, transition);
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_terminal_mutation.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_archiving_a_terminal_mutation.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry;
+
+public class when_archiving_a_terminal_mutation : given.a_mutation_registry
+{
+    EventSequenceMutationRegistryArchiveResult _ineligible;
+    EventSequenceMutationRegistryArchiveResult _archived;
+    EventSequenceMutationRegistryArchiveResult _retry;
+    EventSequenceMutationBeginResult _permanentReplay;
+    EventSequenceMutationBeginResult _permanentConflict;
+    EventSequenceMutationRegistryArchiveResult _staleArchive;
+    EventSequenceMutationRegistryArchiveResult _wrongVersionArchive;
+    EventSequenceMutationRegistryTransitionResult _transitionReplay;
+    EventSequenceMutationBeginResult _next;
+
+    async Task Because()
+    {
+        var begin = await _registry.Begin(_request, _proposedTarget);
+        _ineligible = await _registry.Archive(_target, begin.Token!);
+
+        var applying = await Apply(_registry, begin, EventSequenceMutationTransition.BeginApplying);
+        var verifying = await _registry.Transition(_target, applying.Token!, EventSequenceMutationTransition.BeginVerifying);
+        var committed = await _registry.Transition(_target, verifying.Token!, EventSequenceMutationTransition.CommitSourceWithoutRepair);
+
+        _archived = await _registry.Archive(_target, committed.Token!);
+        _retry = await _registry.Archive(_target, committed.Token!);
+        _staleArchive = await _registry.Archive(_target, begin.Token!);
+
+        var wrongVersionToken = EventSequenceMutationStateToken.Create(
+            committed.Token!.Scope,
+            committed.Active! with { StateVersion = committed.Active.StateVersion.Next() });
+        _wrongVersionArchive = await _registry.Archive(_target, wrongVersionToken);
+
+        _permanentReplay = await _registry.Begin(_request, new(100UL, 101UL, 1UL));
+        _permanentConflict = await _registry.Begin(_request with { Command = new("changed", "changed-hash") }, _proposedTarget);
+        _transitionReplay = await _registry.Transition(_target, committed.Token!, EventSequenceMutationTransition.Block);
+        _next = await _registry.Begin(Request(_target, originSequenceNumber: 43), _proposedTarget);
+    }
+
+    [Fact] void should_reject_a_nonterminal_archive() => _ineligible.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.StateConflict);
+    [Fact] void should_archive_the_terminal_mutation() => _archived.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.Archived);
+    [Fact] void should_return_a_payload_free_receipt() => _archived.History!.CommandHash.ShouldEqual(_request.Command.Hash);
+    [Fact] void should_make_an_exact_archive_idempotent() => _retry.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.AlreadyArchived);
+    [Fact] void should_return_the_exact_original_receipt_on_retry() => _retry.History.ShouldEqual(_archived.History);
+    [Fact] void should_reject_a_stale_preterminal_archive_token() => _staleArchive.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.StateConflict);
+    [Fact] void should_reject_a_wrong_version_archive_token() => _wrongVersionArchive.Outcome.ShouldEqual(EventSequenceMutationRegistryArchiveOutcome.StateConflict);
+    [Fact] void should_replay_the_permanent_archived_registration() => _permanentReplay.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Archived);
+    [Fact] void should_permanently_reject_a_changed_request_after_archive() => _permanentConflict.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.DefinitionConflict);
+    [Fact] void should_return_history_to_a_transition_after_archive() => _transitionReplay.Outcome.ShouldEqual(EventSequenceMutationRegistryTransitionOutcome.AlreadyArchived);
+    [Fact] void should_allocate_the_next_ordinal() => _next.Active!.Ordinal.Value.ShouldEqual(2L);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_for_the_first_time.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_for_the_first_time.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry;
+
+public class when_beginning_for_the_first_time : given.a_mutation_registry
+{
+    EventSequenceMutationBeginResult _result;
+
+    async Task Because() => _result = await _registry.Begin(_request, _proposedTarget);
+
+    [Fact] void should_reserve_the_mutation() => _result.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Reserved);
+    [Fact] void should_return_the_exact_request() => _result.Active!.Definition.Request.ShouldEqual(_request);
+    [Fact] void should_freeze_the_proposed_target() => _result.Active!.Target.ShouldEqual(_proposedTarget);
+    [Fact] void should_assign_the_first_ordinal() => _result.Active!.Ordinal.Value.ShouldEqual(1L);
+    [Fact] void should_start_at_state_version_one() => _result.Active!.StateVersion.Value.ShouldEqual(1L);
+    [Fact] void should_start_reserved() => _result.Active!.Phase.ShouldEqual(EventSequenceMutationPhase.Reserved);
+    [Fact] void should_return_the_exact_scope() => _result.Token!.Scope.ShouldEqual(new EventSequenceKey(_target.Display, "test-store", "test-namespace"));
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_beginning_tracking.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry;
+
+public class when_beginning_tracking : given.a_mutation_registry
+{
+    EventSequenceMutationTrackingResult _began;
+    EventSequenceMutationTrackingResult _alreadyTracking;
+    EventSequenceMutationTrackingResult _sealedConflict;
+    EventSequenceMutationBeginResult _resumed;
+    EventSequenceMutation _activeBeforeTracking;
+    EventSequenceMutationStateToken _tokenBeforeTracking;
+
+    async Task Because()
+    {
+        var begin = await _registry.Begin(_request, _proposedTarget);
+        _activeBeforeTracking = begin.Active!;
+        _tokenBeforeTracking = begin.Token!;
+
+        _began = await _registry.BeginTracking(_target, EventSequenceMutationCoverage.Untracked);
+        _alreadyTracking = await _registry.BeginTracking(_target, EventSequenceMutationCoverage.Untracked);
+
+        // Resuming the exact same request must round-trip the active mutation unchanged -
+        // beginning tracking is not itself a mutation state transition.
+        _resumed = await _registry.Begin(_request, _proposedTarget);
+
+        var sealedTarget = Identity("sealed-target");
+        await using (var context = CreateContext())
+        {
+            context.EventSequenceMutationHeads.Add(new EventSequenceMutationHeadEntry
+            {
+                EventSequenceId = (EventSequenceId)sealedTarget.Display,
+                Coverage = EventSequenceMutationCoverage.Sealed,
+                LastAssignedOrdinal = EventSequenceMutationOrdinal.NotSet
+            });
+            await context.SaveChangesAsync();
+        }
+
+        _sealedConflict = await _registry.BeginTracking(sealedTarget, EventSequenceMutationCoverage.Untracked);
+    }
+
+    [Fact] void should_begin_tracking() => _began.Outcome.ShouldEqual(EventSequenceMutationTrackingOutcome.Began);
+    [Fact] void should_report_tracking_as_idempotent() => _alreadyTracking.Outcome.ShouldEqual(EventSequenceMutationTrackingOutcome.AlreadyTracking);
+    [Fact] void should_preserve_the_complete_active_mutation() => _resumed.Active.ShouldEqual(_activeBeforeTracking);
+    [Fact] void should_preserve_the_complete_fencing_token() => _resumed.Token.ShouldEqual(_tokenBeforeTracking);
+    [Fact] void should_report_sealed_coverage_as_a_conflict() => _sealedConflict.Coverage.ShouldEqual((EventSequenceMutationCoverage?)EventSequenceMutationCoverage.Sealed);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_resolving_begin_registration_conflicts.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_resolving_begin_registration_conflicts.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry;
+
+/// <summary>
+/// Covers Begin registration-conflict outcomes: resuming an exact request, a definition
+/// conflict on a mismatched resume, a busy target, and reserving an independent target.
+/// </summary>
+/// <remarks>
+/// This does not cover the in-memory reference's "same id, different target" scenario
+/// (a manually mismatched request whose <c>Id</c> was computed for a different target sequence
+/// than the one it now carries). The in-memory registry catches that case only because it keeps a
+/// second, global-by-id index that survives independently of any one target's head row. The SQL
+/// schema intentionally has no such table (two tables only: heads keyed by event sequence, history
+/// keyed by event sequence + ordinal with a unique index on MutationId) - a request's id is
+/// re-verified as deterministic for its *own* target sequence on every fresh reservation instead
+/// (<see cref="EventSequenceMutationValidator.ValidateDeterministicId"/>), which is a strictly
+/// stronger check for that case: a request presenting an id that does not match its own target
+/// is rejected as Invalid rather than silently reinterpreted against a stale registration.
+/// </remarks>
+public class when_resolving_begin_registration_conflicts : given.a_mutation_registry
+{
+    EventSequenceMutationBeginResult _resumed;
+    EventSequenceMutationBeginResult _definitionConflict;
+    EventSequenceMutationBeginResult _busy;
+    EventSequenceMutationBeginResult _independent;
+
+    async Task Because()
+    {
+        await _registry.Begin(_request, _proposedTarget);
+        _resumed = await _registry.Begin(_request, new(100UL, 101UL, 1UL));
+        _definitionConflict = await _registry.Begin(_request with { Command = new("different", "different-hash") }, _proposedTarget);
+        _busy = await _registry.Begin(Request(_target, originSequenceNumber: 43), _proposedTarget);
+        _independent = await _registry.Begin(Request(Identity("independent-target")), _proposedTarget);
+    }
+
+    [Fact] void should_resume_the_exact_request() => _resumed.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Resumed);
+    [Fact] void should_ignore_a_new_target_for_the_exact_request() => _resumed.Active!.Target.ShouldEqual(_proposedTarget);
+    [Fact] void should_reject_a_nonexact_request() => _definitionConflict.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.DefinitionConflict);
+    [Fact] void should_report_the_exact_busy_outcome() => (_busy.Outcome == EventSequenceMutationBeginOutcome.MutationAlreadyInProgress && _busy.Error == EventSequenceMutationRegistryError.MutationAlreadyInProgress).ShouldBeTrue();
+    [Fact] void should_report_only_the_active_id_when_the_target_is_busy() => _busy.ConflictingMutationId.ShouldEqual(_request.Id);
+    [Fact] void should_reserve_an_independent_target() => _independent.Outcome.ShouldEqual(EventSequenceMutationBeginOutcome.Reserved);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_transitioning_through_the_state_graph.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_EventSequenceMutationRegistry/when_transitioning_through_the_state_graph.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations.for_EventSequenceMutationRegistry;
+
+public class when_transitioning_through_the_state_graph : given.a_mutation_registry
+{
+    EventSequenceMutationRegistryTransitionResult[] _applied;
+    EventSequenceMutationRegistryTransitionResult _retry;
+    EventSequenceMutationRegistryTransitionResult _staleConflict;
+
+    async Task Because()
+    {
+        var begin = await _registry.Begin(_request, _proposedTarget);
+        var applying = await Apply(_registry, begin, EventSequenceMutationTransition.BeginApplying);
+
+        // Exact retry of an already-applied transition, fenced by the very same predecessor token.
+        _retry = await _registry.Transition(_target, begin.Token!, EventSequenceMutationTransition.BeginApplying);
+
+        // A different transition fenced by the SAME now-stale token - a token reuse after the
+        // state has already advanced once. This is the ABA-fencing check the new
+        // ActiveStateVersion column exists for: without it, a SQL implementation keyed only on
+        // the phase composite could not tell this apart from a legitimate retry.
+        _staleConflict = await _registry.Transition(_target, begin.Token!, EventSequenceMutationTransition.BeginVerifying);
+
+        var blocked = await _registry.Transition(_target, applying.Token!, EventSequenceMutationTransition.Block);
+        var resumed = await _registry.Transition(_target, blocked.Token!, EventSequenceMutationTransition.Resume);
+        var verifying = await _registry.Transition(_target, resumed.Token!, EventSequenceMutationTransition.BeginVerifying);
+        var committed = await _registry.Transition(_target, verifying.Token!, EventSequenceMutationTransition.CommitSourceWithRepair);
+        var dispatching = await _registry.Transition(_target, committed.Token!, EventSequenceMutationTransition.BeginRepairDispatch);
+        var accepted = await _registry.Transition(_target, dispatching.Token!, EventSequenceMutationTransition.AcceptRepair);
+        _applied = [applying, blocked, resumed, verifying, committed, dispatching, accepted];
+    }
+
+    [Fact] void should_apply_every_legal_transition() => _applied.All(_ => _.Outcome == EventSequenceMutationRegistryTransitionOutcome.Applied).ShouldBeTrue();
+    [Fact] void should_report_an_exact_retry() => _retry.Outcome.ShouldEqual(EventSequenceMutationRegistryTransitionOutcome.AlreadyApplied);
+    [Fact] void should_reject_a_stale_token_reused_for_another_edge() => _staleConflict.Outcome.ShouldEqual(EventSequenceMutationRegistryTransitionOutcome.StateConflict);
+    [Fact] void should_preserve_the_ordinal() => _applied.All(_ => _.Active!.Ordinal.Value == 1).ShouldBeTrue();
+    [Fact] void should_increment_every_applied_state_version() => _applied.Select(_ => _.Active!.StateVersion.Value).ShouldContainOnly([2L, 3L, 4L, 5L, 6L, 7L, 8L]);
+    [Fact] void should_finish_with_accepted_repair() => _applied[^1].Active!.RepairState.ShouldEqual(EventSequenceMutationRepairState.Accepted);
+}

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_v16_45_0/when_building_provider_operations.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_v16_45_0/when_building_provider_operations.cs
@@ -14,6 +14,8 @@ public class when_building_provider_operations : Specification
     const string Sqlite = "Microsoft.EntityFrameworkCore.Sqlite";
 
     IReadOnlyDictionary<string, (string Ordinal, string Text, string Id)> _types;
+    IReadOnlyDictionary<string, string> _postgreSqlDigestTypes;
+    IReadOnlyDictionary<string, string> _sqlServerDigestTypes;
 
     void Because()
     {
@@ -23,11 +25,25 @@ public class when_building_provider_operations : Specification
             [SqlServer] = ColumnTypesFor(SqlServer),
             [Sqlite] = ColumnTypesFor(Sqlite)
         };
+
+        // maxLength is not carried on AddColumnOperation.MaxLength by the shared StringColumn
+        // helper - it is baked directly into the provider-native column type string instead
+        // (VARCHAR(n) / NVARCHAR(n)), and SQLite has no length-bounded text type at all
+        // (StringColumn always emits "TEXT" there, regardless of maxLength), so the 32-byte
+        // hex sizing is only observable on the length-aware providers.
+        _postgreSqlDigestTypes = DigestColumnTypesFor(PostgreSql);
+        _sqlServerDigestTypes = DigestColumnTypesFor(SqlServer);
     }
 
     [Fact] void should_use_postgresql_native_types() => _types[PostgreSql].ShouldEqual(("BIGINT", "TEXT", "UUID"));
     [Fact] void should_use_sql_server_native_types() => _types[SqlServer].ShouldEqual(("BIGINT", "NVARCHAR(MAX)", "UNIQUEIDENTIFIER"));
     [Fact] void should_use_sqlite_canonical_text_mutation_ids() => _types[Sqlite].ShouldEqual(("INTEGER", "TEXT", "TEXT"));
+    [Fact] void should_size_the_active_definition_digest_column_to_a_32_byte_hex_string_on_postgresql() => _postgreSqlDigestTypes["ActiveDefinitionDigestV1"].ShouldEqual("VARCHAR(64)");
+    [Fact] void should_size_the_history_definition_digest_column_to_a_32_byte_hex_string_on_postgresql() => _postgreSqlDigestTypes["DefinitionDigestV1"].ShouldEqual("VARCHAR(64)");
+    [Fact] void should_size_the_history_receipt_digest_column_to_a_32_byte_hex_string_on_postgresql() => _postgreSqlDigestTypes["ReceiptDigestV1"].ShouldEqual("VARCHAR(64)");
+    [Fact] void should_size_the_active_definition_digest_column_to_a_32_byte_hex_string_on_sql_server() => _sqlServerDigestTypes["ActiveDefinitionDigestV1"].ShouldEqual("NVARCHAR(64)");
+    [Fact] void should_size_the_history_definition_digest_column_to_a_32_byte_hex_string_on_sql_server() => _sqlServerDigestTypes["DefinitionDigestV1"].ShouldEqual("NVARCHAR(64)");
+    [Fact] void should_size_the_history_receipt_digest_column_to_a_32_byte_hex_string_on_sql_server() => _sqlServerDigestTypes["ReceiptDigestV1"].ShouldEqual("NVARCHAR(64)");
 
     static (string Ordinal, string Text, string Id) ColumnTypesFor(string provider)
     {
@@ -41,6 +57,22 @@ public class when_building_provider_operations : Specification
             heads.Columns.Single(_ => _.Name == "LastAssignedOrdinal").ColumnType!,
             heads.Columns.Single(_ => _.Name == "ActiveCommandPayload").ColumnType!,
             heads.Columns.Single(_ => _.Name == "ActiveMutationId").ColumnType!);
+    }
+
+    static IReadOnlyDictionary<string, string> DigestColumnTypesFor(string provider)
+    {
+        var migrationBuilder = new MigrationBuilder(provider);
+        new ExposedMigration().Apply(migrationBuilder);
+        var operations = migrationBuilder.Operations.OfType<CreateTableOperation>();
+        var heads = operations.Single(_ => _.Name == WellKnownTableNames.EventSequenceMutationHeads);
+        var history = operations.Single(_ => _.Name == WellKnownTableNames.EventSequenceMutationHistory);
+
+        return new Dictionary<string, string>
+        {
+            ["ActiveDefinitionDigestV1"] = heads.Columns.Single(_ => _.Name == "ActiveDefinitionDigestV1").ColumnType!,
+            ["DefinitionDigestV1"] = history.Columns.Single(_ => _.Name == "DefinitionDigestV1").ColumnType!,
+            ["ReceiptDigestV1"] = history.Columns.Single(_ => _.Name == "ReceiptDigestV1").ColumnType!
+        };
     }
 
     sealed class ExposedMigration : MutationMigration

--- a/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_v16_45_0/when_migrating_a_previous_namespace.cs
+++ b/Source/Kernel/Storage.Sql.Specs/EventStores/Namespaces/EventSequences/Mutations/for_v16_45_0/when_migrating_a_previous_namespace.cs
@@ -17,6 +17,8 @@ namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mut
 
 public class when_migrating_a_previous_namespace : Specification
 {
+    static readonly string _zeroDigestHex = new('0', 64);
+
     SqliteConnection _connection;
     NamespaceDbContext _context;
     bool _hasHeads;
@@ -30,6 +32,9 @@ public class when_migrating_a_previous_namespace : Specification
     int _coverageDefault;
     long _lastAssignedOrdinalDefault;
     bool _allActiveColumnsNullable;
+    bool _hasActiveStateVersion;
+    bool _hasActiveDefinitionDigest;
+    bool _hasHistoryTerminalWitnessColumns;
     string _storedMutationId;
     string _mutationIdStorageClass;
     bool _alternateMutationIdEncodingRejected;
@@ -74,6 +79,12 @@ public class when_migrating_a_previous_namespace : Specification
         _headForeignKeyCount = await RowCount($"PRAGMA foreign_key_list(\"{WellKnownTableNames.EventSequenceMutationHeads}\")");
         _historyForeignKeyCount = await RowCount($"PRAGMA foreign_key_list(\"{WellKnownTableNames.EventSequenceMutationHistory}\")");
         _allActiveColumnsNullable = await ActiveColumnsAreNullable();
+        _hasActiveStateVersion = await ColumnExists(WellKnownTableNames.EventSequenceMutationHeads, "ActiveStateVersion");
+        _hasActiveDefinitionDigest = await ColumnExists(WellKnownTableNames.EventSequenceMutationHeads, "ActiveDefinitionDigestV1");
+        _hasHistoryTerminalWitnessColumns =
+            await ColumnExists(WellKnownTableNames.EventSequenceMutationHistory, "FinalStateVersion") &&
+            await ColumnExists(WellKnownTableNames.EventSequenceMutationHistory, "DefinitionDigestV1") &&
+            await ColumnExists(WellKnownTableNames.EventSequenceMutationHistory, "ReceiptDigestV1");
 
         await Execute($"INSERT INTO \"{WellKnownTableNames.EventSequenceMutationHeads}\" (\"EventSequenceId\") VALUES ('event-log')");
         await using var defaults = _connection.CreateCommand();
@@ -110,8 +121,10 @@ public class when_migrating_a_previous_namespace : Specification
             await Execute($$"""
                 INSERT INTO "{{WellKnownTableNames.EventSequenceMutationHistory}}" (
                     "EventSequenceId", "Ordinal", "MutationId", "OriginSequence", "OriginSequenceNumber",
-                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState")
-                VALUES ('event-log', 2, X'{{alternateEncoding}}', 'system', 1, 1, 'command-hash', 0, 1, 1, 4);
+                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState",
+                    "FinalStateVersion", "DefinitionDigestV1", "ReceiptDigestV1")
+                VALUES ('event-log', 2, X'{{alternateEncoding}}', 'system', 1, 1, 'command-hash', 0, 1, 1, 4,
+                    1, '{{_zeroDigestHex}}', '{{_zeroDigestHex}}');
                 """);
         }
         catch (SqliteException)
@@ -126,8 +139,10 @@ public class when_migrating_a_previous_namespace : Specification
             await Execute($$"""
                 INSERT INTO "{{WellKnownTableNames.EventSequenceMutationHistory}}" (
                     "EventSequenceId", "Ordinal", "MutationId", "OriginSequence", "OriginSequenceNumber",
-                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState")
-                VALUES ('event-log', 3, '{{alternateSpelling}}', 'system', 1, 1, 'command-hash', 0, 1, 1, 4);
+                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState",
+                    "FinalStateVersion", "DefinitionDigestV1", "ReceiptDigestV1")
+                VALUES ('event-log', 3, '{{alternateSpelling}}', 'system', 1, 1, 'command-hash', 0, 1, 1, 4,
+                    1, '{{_zeroDigestHex}}', '{{_zeroDigestHex}}');
                 """);
         }
         catch (SqliteException)
@@ -140,8 +155,10 @@ public class when_migrating_a_previous_namespace : Specification
             await Execute($$"""
                 INSERT INTO "{{WellKnownTableNames.EventSequenceMutationHistory}}" (
                     "EventSequenceId", "Ordinal", "MutationId", "OriginSequence", "OriginSequenceNumber",
-                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState")
-                VALUES ('event-log', 4, '{{canonicalMutationId}}' || char(0) || '!', 'system', 1, 1, 'command-hash', 0, 1, 1, 4);
+                    "Kind", "CommandHash", "TargetStart", "TargetEndExclusive", "TargetExpectedCount", "RepairState",
+                    "FinalStateVersion", "DefinitionDigestV1", "ReceiptDigestV1")
+                VALUES ('event-log', 4, '{{canonicalMutationId}}' || char(0) || '!', 'system', 1, 1, 'command-hash', 0, 1, 1, 4,
+                    1, '{{_zeroDigestHex}}', '{{_zeroDigestHex}}');
                 """);
         }
         catch (SqliteException)
@@ -167,6 +184,9 @@ public class when_migrating_a_previous_namespace : Specification
     [Fact] void should_default_coverage_to_untracked() => _coverageDefault.ShouldEqual(0);
     [Fact] void should_default_last_assigned_ordinal_to_zero() => _lastAssignedOrdinalDefault.ShouldEqual(0L);
     [Fact] void should_make_the_entire_active_group_nullable() => _allActiveColumnsNullable.ShouldBeTrue();
+    [Fact] void should_add_the_active_state_version_fencing_column() => _hasActiveStateVersion.ShouldBeTrue();
+    [Fact] void should_add_the_active_definition_digest_column() => _hasActiveDefinitionDigest.ShouldBeTrue();
+    [Fact] void should_add_the_history_terminal_witness_columns() => _hasHistoryTerminalWitnessColumns.ShouldBeTrue();
     [Fact] void should_store_mutation_ids_in_canonical_uppercase_format() => _storedMutationId.ShouldEqual("8AE3BA16-1B36-4D8A-8F19-A341225B368A");
     [Fact] void should_store_mutation_ids_in_one_canonical_sqlite_encoding() => _mutationIdStorageClass.ShouldEqual("text");
     [Fact] void should_reject_alternate_mutation_id_encodings() => _alternateMutationIdEncodingRejected.ShouldBeTrue();
@@ -267,7 +287,22 @@ public class when_migrating_a_previous_namespace : Specification
                 }
             }
         }
-        return activeColumns == 13;
+        return activeColumns == 15;
+    }
+
+    async Task<bool> ColumnExists(string tableName, string columnName)
+    {
+        await using var command = _connection.CreateCommand();
+        command.CommandText = $"PRAGMA table_info(\"{tableName}\")";
+        await using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            if (string.Equals(reader.GetString(1), columnName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     sealed class ExposedMigration : MutationMigration

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationDigestColumns.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationDigestColumns.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations;
+
+/// <summary>
+/// Converts event sequence mutation digests to and from their canonical hex-string column representation.
+/// </summary>
+/// <remarks>
+/// <see cref="EventSequenceMutationDefinitionDigestV1"/> and <see cref="EventSequenceMutationReceiptDigestV1"/>
+/// are not <c>ConceptAs&lt;T&gt;</c> types, so the automatic concept value-conversion Cratis.Arc.EntityFrameworkCore
+/// wires up does not apply to them - they need an explicit <c>HasConversion</c> in <see cref="NamespaceDbContext"/>.
+/// Their constructors accept a <see cref="ReadOnlySpan{T}"/>, which cannot appear inside an EF Core conversion
+/// expression tree (ref struct parameters are not supported there), so the conversion goes through these plain
+/// methods instead - each is a normal method call from the expression tree's perspective, with the span usage
+/// hidden inside an ordinary method body. Both digests are 32 bytes, so the hex form is always 64 characters,
+/// matching the column width already used for <c>ActiveCommandHash</c>/<c>CommandHash</c>.
+/// </remarks>
+static class EventSequenceMutationDigestColumns
+{
+    /// <summary>
+    /// Converts a version 1 definition digest to its canonical hex-string column representation.
+    /// </summary>
+    /// <param name="digest">The definition digest to convert.</param>
+    /// <returns>The hex-string representation.</returns>
+    internal static string DefinitionDigestToHex(EventSequenceMutationDefinitionDigestV1 digest) => Convert.ToHexString(digest.Snapshot());
+
+    /// <summary>
+    /// Converts a hex-string column value back to a version 1 definition digest.
+    /// </summary>
+    /// <param name="hex">The hex-string representation to convert.</param>
+    /// <returns>The definition digest.</returns>
+    internal static EventSequenceMutationDefinitionDigestV1 DefinitionDigestFromHex(string hex) => new(Convert.FromHexString(hex));
+
+    /// <summary>
+    /// Converts a version 1 receipt digest to its canonical hex-string column representation.
+    /// </summary>
+    /// <param name="digest">The receipt digest to convert.</param>
+    /// <returns>The hex-string representation.</returns>
+    internal static string ReceiptDigestToHex(EventSequenceMutationReceiptDigestV1 digest) => Convert.ToHexString(digest.Snapshot());
+
+    /// <summary>
+    /// Converts a hex-string column value back to a version 1 receipt digest.
+    /// </summary>
+    /// <param name="hex">The hex-string representation to convert.</param>
+    /// <returns>The receipt digest.</returns>
+    internal static EventSequenceMutationReceiptDigestV1 ReceiptDigestFromHex(string hex) => new(Convert.FromHexString(hex));
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationHeadEntry.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationHeadEntry.cs
@@ -39,6 +39,17 @@ public class EventSequenceMutationHeadEntry
     public EventSequenceMutationOrdinal? ActiveOrdinal { get; set; }
 
     /// <summary>
+    /// Gets or sets the active mutation state version.
+    /// </summary>
+    /// <remarks>
+    /// This is the ABA-fencing field. It is strictly monotonic and unique across the mutation's
+    /// lifetime, so a compare-and-swap <c>UPDATE ... WHERE ActiveStateVersion = @expected</c> can
+    /// distinguish two visits to the same phase composite after a Block→Resume cycle, where the
+    /// phase/blocked-from/repair-state alone would be ambiguous.
+    /// </remarks>
+    public EventSequenceMutationStateVersion? ActiveStateVersion { get; set; }
+
+    /// <summary>
     /// Gets or sets the event sequence containing the event that originated the active mutation.
     /// </summary>
     public EventSequenceId? ActiveOriginSequence { get; set; }
@@ -77,6 +88,11 @@ public class EventSequenceMutationHeadEntry
     /// Gets or sets the expected event count in the active mutation target.
     /// </summary>
     public EventCount? ActiveTargetExpectedCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version 1 digest of the active mutation definition.
+    /// </summary>
+    public EventSequenceMutationDefinitionDigestV1? ActiveDefinitionDigestV1 { get; set; }
 
     /// <summary>
     /// Gets or sets the active mutation phase.

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationHistoryEntry.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationHistoryEntry.cs
@@ -67,4 +67,29 @@ public class EventSequenceMutationHistoryEntry
     /// Gets or sets the terminal repair state.
     /// </summary>
     public EventSequenceMutationRepairState RepairState { get; set; }
+
+    /// <summary>
+    /// Gets or sets the final persisted mutation state version recorded in the terminal witness.
+    /// </summary>
+    public EventSequenceMutationStateVersion FinalStateVersion { get; set; } = EventSequenceMutationStateVersion.NotSet;
+
+    /// <summary>
+    /// Gets or sets the version 1 digest of the mutation definition recorded in the terminal witness.
+    /// </summary>
+    /// <remarks>
+    /// A history row is only ever written once terminal, so this is always known at insert time and
+    /// the column is non-nullable. The zero-filled default below is never a valid persisted value -
+    /// it only satisfies the non-nullable reference type before the real computed digest is assigned.
+    /// </remarks>
+    public EventSequenceMutationDefinitionDigestV1 DefinitionDigestV1 { get; set; } = new(new byte[32]);
+
+    /// <summary>
+    /// Gets or sets the version 1 digest of the terminal receipt recorded in the terminal witness.
+    /// </summary>
+    /// <remarks>
+    /// A history row is only ever written once terminal, so this is always known at insert time and
+    /// the column is non-nullable. The zero-filled default below is never a valid persisted value -
+    /// it only satisfies the non-nullable reference type before the real computed digest is assigned.
+    /// </remarks>
+    public EventSequenceMutationReceiptDigestV1 ReceiptDigestV1 { get; set; } = new(new byte[32]);
 }

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationRegistry.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationRegistry.cs
@@ -1,0 +1,601 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.EventSequences;
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations;
+
+/// <summary>
+/// Represents a namespace-scoped SQL event sequence mutation registry.
+/// </summary>
+/// <param name="eventStore">The event store that owns the registry.</param>
+/// <param name="namespace">The namespace that owns the registry.</param>
+/// <param name="database">The <see cref="IDatabase"/> used for storage operations.</param>
+/// <remarks>
+/// Every operation opens its own <see cref="NamespaceDbContext"/> scope and expresses fencing
+/// through compare-and-swap <c>UPDATE ... WHERE</c> statements (<see cref="EntityFrameworkQueryableExtensions"/>
+/// style <c>ExecuteUpdateAsync</c>) or unique-constraint-guarded inserts, rather than an in-process
+/// lock - concurrent callers race the database itself, exactly as production traffic would.
+/// <para>
+/// A mutation's command payload is only persisted on the head row's <c>Active*</c> columns while the
+/// mutation is bound (not yet archived); the history table is deliberately payload-free (see
+/// <see cref="Cratis.Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry"/>).
+/// <see cref="Archive"/> therefore clears only <see cref="EventSequenceMutationHeadEntry.ActiveMutationId"/>
+/// when it releases a head row - not the remaining <c>Active*</c> columns - so that an immediate retry of
+/// <see cref="Transition"/> or <see cref="Archive"/> against the same, still-archived mutation can still
+/// reconstruct a digest-validating registration from the residual columns. A later <see cref="Begin"/>
+/// against the same target overwrites every <c>Active*</c> column unconditionally, so the residue never
+/// leaks into a new mutation. If a newer mutation has since reused the target sequence and overwritten the
+/// residue before a stale retry arrives, that retry cannot be verified against the original payload (the
+/// history table alone is not enough) and reports <see cref="EventSequenceMutationRegistryTransitionOutcome.StateConflict"/> /
+/// <see cref="EventSequenceMutationRegistryArchiveOutcome.StateConflict"/> rather than fabricating success.
+/// </para>
+/// </remarks>
+public sealed class EventSequenceMutationRegistry(
+    EventStoreName eventStore,
+    EventStoreNamespaceName @namespace,
+    IDatabase database) : IEventSequenceMutationRegistry
+{
+    /// <inheritdoc/>
+    public Task<EventSequenceMutationBeginResult> Begin(
+        EventSequenceMutationRequest request,
+        EventSequenceMutationTarget proposedTarget,
+        CancellationToken cancellationToken = default) =>
+        cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<EventSequenceMutationBeginResult>(cancellationToken)
+            : BeginCore(request, proposedTarget, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<EventSequenceMutationRegistryTransitionResult> Transition(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutationTransition transition,
+        CancellationToken cancellationToken = default) =>
+        cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<EventSequenceMutationRegistryTransitionResult>(cancellationToken)
+            : TransitionCore(target, token, transition, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<EventSequenceMutationRegistryArchiveResult> Archive(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        CancellationToken cancellationToken = default) =>
+        cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<EventSequenceMutationRegistryArchiveResult>(cancellationToken)
+            : ArchiveCore(target, token, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<EventSequenceMutationTrackingResult> BeginTracking(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationCoverage expected,
+        CancellationToken cancellationToken = default) =>
+        cancellationToken.IsCancellationRequested
+            ? Task.FromCanceled<EventSequenceMutationTrackingResult>(cancellationToken)
+            : BeginTrackingCore(target, expected, cancellationToken);
+
+    static async Task<bool> TryInsertFreshHead(NamespaceDbContext db, EventSequenceId key, EventSequenceMutation active, CancellationToken cancellationToken)
+    {
+        var row = new EventSequenceMutationHeadEntry
+        {
+            EventSequenceId = key,
+            Coverage = EventSequenceMutationCoverage.Untracked,
+            LastAssignedOrdinal = active.Ordinal
+        };
+        EventSequenceMutationRowConversion.SetActiveColumns(row, active);
+        db.EventSequenceMutationHeads.Add(row);
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (DbUpdateException)
+        {
+            db.Entry(row).State = EntityState.Detached;
+            return false;
+        }
+    }
+
+    static async Task<bool> TryClaimFreedHead(NamespaceDbContext db, EventSequenceId key, EventSequenceMutation active, CancellationToken cancellationToken)
+    {
+        var affected = await db.EventSequenceMutationHeads
+            .Where(h => h.EventSequenceId == key && h.ActiveMutationId == null)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(h => h.LastAssignedOrdinal, active.Ordinal)
+                    .SetProperty(h => h.ActiveMutationId, active.Id)
+                    .SetProperty(h => h.ActiveOrdinal, active.Ordinal)
+                    .SetProperty(h => h.ActiveStateVersion, active.StateVersion)
+                    .SetProperty(h => h.ActiveOriginSequence, (EventSequenceId)active.Origin.Sequence.Display)
+                    .SetProperty(h => h.ActiveOriginSequenceNumber, active.Origin.SequenceNumber)
+                    .SetProperty(h => h.ActiveKind, active.Kind)
+                    .SetProperty(h => h.ActiveCommandPayload, active.Command.Payload)
+                    .SetProperty(h => h.ActiveCommandHash, active.Command.Hash)
+                    .SetProperty(h => h.ActiveTargetStart, active.Target.Start)
+                    .SetProperty(h => h.ActiveTargetEndExclusive, active.Target.EndExclusive)
+                    .SetProperty(h => h.ActiveTargetExpectedCount, active.Target.ExpectedCount)
+                    .SetProperty(h => h.ActiveDefinitionDigestV1, active.Definition.DefinitionDigestV1)
+                    .SetProperty(h => h.ActivePhase, active.Phase)
+                    .SetProperty(h => h.ActiveBlockedFrom, active.BlockedFrom)
+                    .SetProperty(h => h.ActiveRepairState, active.RepairState),
+                cancellationToken);
+        return affected == 1;
+    }
+
+    static EventSequenceMutationBeginResult ResumeBound(EventSequenceKey scope, EventSequenceMutationRequest request, EventSequenceMutationHeadEntry row)
+    {
+        if (!EventSequenceMutationRowConversion.MatchesBoundRequest(row, request))
+        {
+            return EventSequenceMutationBeginResult.DefinitionConflict(request.Id);
+        }
+
+        var active = EventSequenceMutationRowConversion.ReconstructActive(row, request.TargetSequence);
+        return EventSequenceMutationBeginResult.Resumed(active, EventSequenceMutationStateToken.Create(scope, active));
+    }
+
+    static EventSequenceMutationBeginResult ResumeArchived(
+        EventSequenceKey scope,
+        EventSequenceMutationRequest request,
+        EventSequenceMutationHistoryEntry historyRow)
+    {
+        var frozenTarget = new EventSequenceMutationTarget(historyRow.TargetStart, historyRow.TargetEndExclusive, historyRow.TargetExpectedCount);
+        var recomputedDigest = EventSequenceMutationDigestCalculator.CalculateDefinitionDigest(scope, request, frozenTarget);
+        if (recomputedDigest != historyRow.DefinitionDigestV1)
+        {
+            return EventSequenceMutationBeginResult.DefinitionConflict(request.Id);
+        }
+
+        var definition = EventSequenceMutationDefinition.Create(scope, request, frozenTarget);
+        var witness = EventSequenceMutationRowConversion.ToTerminalWitness(historyRow);
+        var registration = new EventSequenceMutationRegistration(definition, EventSequenceMutationRegistryLifecycle.Archived, historyRow.Ordinal, witness);
+        var history = EventSequenceMutationRowConversion.ToStorageHistory(historyRow);
+        return EventSequenceMutationBeginResult.Archived(scope, registration, history);
+    }
+
+    static bool IsExactArchiveRetryToken(EventSequenceMutationStateToken token, EventSequenceMutationHistoryEntry historyRow) =>
+        token.Phase == EventSequenceMutationPhase.SourceCommitted &&
+        token.BlockedFrom == EventSequenceMutationPhase.None &&
+        token.RepairState == historyRow.RepairState &&
+        token.StateVersion.Value < long.MaxValue &&
+        token.StateVersion.Value + 1 == historyRow.FinalStateVersion.Value;
+
+    async Task<EventSequenceMutationBeginResult> BeginCore(
+        EventSequenceMutationRequest request,
+        EventSequenceMutationTarget proposedTarget,
+        CancellationToken cancellationToken)
+    {
+        if (request is null || request.Id is null || request.Id == EventSequenceMutationId.NotSet ||
+            request.TargetSequence?.Key.IsInitialized != true)
+        {
+            return EventSequenceMutationBeginResult.Invalid(EventSequenceMutationValidator.ValidateRequest(request));
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var db = scope.DbContext;
+        var key = (EventSequenceId)request.TargetSequence.Display;
+        var mutationScope = Scope(request.TargetSequence);
+
+        // A mutation identifier is permanently and globally bound once archived - check this first,
+        // regardless of which target sequence's head row a fresh call would otherwise consult.
+        var archivedRow = await db.EventSequenceMutationHistory.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.MutationId == request.Id, cancellationToken);
+        if (archivedRow is not null)
+        {
+            return ResumeArchived(mutationScope, request, archivedRow);
+        }
+
+        var headRow = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+
+        if (headRow is not null && headRow.ActiveMutationId == request.Id)
+        {
+            return ResumeBound(mutationScope, request, headRow);
+        }
+
+        if (headRow?.ActiveMutationId is not null)
+        {
+            return EventSequenceMutationBeginResult.MutationAlreadyInProgress(headRow.ActiveMutationId);
+        }
+
+        var validation = EventSequenceMutationValidator.ValidateRequest(request);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateDeterministicId(request);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateTarget(proposedTarget);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateDefinitionInputs(mutationScope, request, proposedTarget);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationBeginResult.Invalid(validation);
+        }
+
+        long ordinalValue;
+        try
+        {
+            ordinalValue = checked((headRow?.LastAssignedOrdinal.Value ?? 0L) + 1);
+        }
+        catch (OverflowException)
+        {
+            return EventSequenceMutationBeginResult.Corrupt();
+        }
+
+        var definition = EventSequenceMutationDefinition.Create(mutationScope, request, proposedTarget);
+        var ordinal = new EventSequenceMutationOrdinal(ordinalValue);
+        var active = new EventSequenceMutation(
+            definition,
+            ordinal,
+            EventSequenceMutationStateVersion.First,
+            EventSequenceMutationPhase.Reserved,
+            EventSequenceMutationPhase.None,
+            EventSequenceMutationRepairState.Unspecified);
+
+        var claimed = headRow is null
+            ? await TryInsertFreshHead(db, key, active, cancellationToken)
+            : await TryClaimFreedHead(db, key, active, cancellationToken);
+
+        if (claimed)
+        {
+            return EventSequenceMutationBeginResult.Reserved(active, EventSequenceMutationStateToken.Create(mutationScope, active));
+        }
+
+        // Lost a race for this row - re-read and resolve exactly as the initial read would have.
+        var raced = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+        if (raced?.ActiveMutationId == request.Id)
+        {
+            return ResumeBound(mutationScope, request, raced);
+        }
+
+        return raced?.ActiveMutationId is { } racedId
+            ? EventSequenceMutationBeginResult.MutationAlreadyInProgress(racedId)
+            : EventSequenceMutationBeginResult.Contended();
+    }
+
+    async Task<EventSequenceMutationRegistryTransitionResult> TransitionCore(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutationTransition transition,
+        CancellationToken cancellationToken)
+    {
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateToken(token);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(validation);
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var db = scope.DbContext;
+        var key = (EventSequenceId)target.Display;
+        var mutationScope = Scope(target);
+
+        var row = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+
+        if (row is null || row.ActiveMutationId != token.Id)
+        {
+            return await ResolveArchivedTransition(db, mutationScope, target, token, row, cancellationToken);
+        }
+
+        if (mutationScope != token.Scope || target.Key != token.TargetKey)
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        var current = EventSequenceMutationRowConversion.ReconstructActive(row, target);
+        if (current.Ordinal != token.Ordinal || current.Definition.DefinitionDigestV1 != token.DefinitionDigestV1)
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        var result = EventSequenceMutationStateMachine.Apply(mutationScope, current, transition, token);
+        if (!result.Validation.IsValid)
+        {
+            return EventSequenceMutationRegistryTransitionResult.Invalid(result.Validation);
+        }
+
+        return result.Outcome switch
+        {
+            EventSequenceMutationTransitionOutcome.Conflict => EventSequenceMutationRegistryTransitionResult.StateConflict(),
+            EventSequenceMutationTransitionOutcome.AlreadyApplied => EventSequenceMutationRegistryTransitionResult.AlreadyApplied(result.Mutation!, result.Token!),
+            EventSequenceMutationTransitionOutcome.Applied => await WriteTransition(db, key, current, result, cancellationToken),
+            _ => EventSequenceMutationRegistryTransitionResult.Corrupt()
+        };
+    }
+
+    async Task<EventSequenceMutationRegistryTransitionResult> WriteTransition(
+        NamespaceDbContext db,
+        EventSequenceId key,
+        EventSequenceMutation current,
+        EventSequenceMutationTransitionResult result,
+        CancellationToken cancellationToken)
+    {
+        var successor = result.Mutation!;
+        var affected = await db.EventSequenceMutationHeads
+            .Where(h => h.EventSequenceId == key && h.ActiveStateVersion == current.StateVersion)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(h => h.ActiveStateVersion, successor.StateVersion)
+                    .SetProperty(h => h.ActivePhase, successor.Phase)
+                    .SetProperty(h => h.ActiveBlockedFrom, successor.BlockedFrom)
+                    .SetProperty(h => h.ActiveRepairState, successor.RepairState),
+                cancellationToken);
+
+        return affected == 1
+            ? EventSequenceMutationRegistryTransitionResult.Applied(successor, result.Token!)
+            : EventSequenceMutationRegistryTransitionResult.StateConflict();
+    }
+
+    async Task<EventSequenceMutationRegistryTransitionResult> ResolveArchivedTransition(
+        NamespaceDbContext db,
+        EventSequenceKey scope,
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutationHeadEntry? row,
+        CancellationToken cancellationToken)
+    {
+        var historyRow = await db.EventSequenceMutationHistory.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.MutationId == token.Id, cancellationToken);
+        if (historyRow is null)
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        if (scope != token.Scope || target.Key != token.TargetKey ||
+            historyRow.Ordinal != token.Ordinal || historyRow.DefinitionDigestV1 != token.DefinitionDigestV1)
+        {
+            return EventSequenceMutationRegistryTransitionResult.StateConflict();
+        }
+
+        var reconstructed = EventSequenceMutationRowConversion.TryReconstructArchivedFromResidue(target, row, historyRow);
+        return reconstructed is { } archived
+            ? EventSequenceMutationRegistryTransitionResult.AlreadyArchived(scope, archived.Registration, archived.History)
+            : EventSequenceMutationRegistryTransitionResult.StateConflict();
+    }
+
+    async Task<EventSequenceMutationRegistryArchiveResult> ArchiveCore(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        CancellationToken cancellationToken)
+    {
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateToken(token);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(validation);
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var db = scope.DbContext;
+        var key = (EventSequenceId)target.Display;
+        var mutationScope = Scope(target);
+
+        var row = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+
+        if (row is null || row.ActiveMutationId != token.Id)
+        {
+            return await ResolveArchivedArchive(db, mutationScope, target, token, row, cancellationToken);
+        }
+
+        if (mutationScope != token.Scope || target.Key != token.TargetKey)
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        var current = EventSequenceMutationRowConversion.ReconstructActive(row, target);
+        if (current.Ordinal != token.Ordinal || current.Definition.DefinitionDigestV1 != token.DefinitionDigestV1)
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        var prepared = EventSequenceMutationStateMachine.PrepareArchive(mutationScope, current, token);
+        if (!prepared.Validation.IsValid)
+        {
+            return EventSequenceMutationRegistryArchiveResult.Invalid(prepared.Validation);
+        }
+
+        return prepared.Outcome switch
+        {
+            EventSequenceMutationArchiveOutcome.Conflict => EventSequenceMutationRegistryArchiveResult.StateConflict(),
+            EventSequenceMutationArchiveOutcome.Prepared when prepared.History is not null =>
+                await CommitArchive(db, mutationScope, key, current, prepared.History, cancellationToken),
+            _ => EventSequenceMutationRegistryArchiveResult.Corrupt()
+        };
+    }
+
+    async Task<EventSequenceMutationRegistryArchiveResult> CommitArchive(
+        NamespaceDbContext db,
+        EventSequenceKey scope,
+        EventSequenceId key,
+        EventSequenceMutation preArchive,
+        Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry history,
+        CancellationToken cancellationToken)
+    {
+        var registration = new EventSequenceMutationRegistration(
+            preArchive.Definition,
+            EventSequenceMutationRegistryLifecycle.Archived,
+            history.Ordinal,
+            history.TerminalWitness);
+
+        var historyRow = EventSequenceMutationRowConversion.ToRow(key, history);
+        db.EventSequenceMutationHistory.Add(historyRow);
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            db.Entry(historyRow).State = EntityState.Detached;
+
+            // Someone else already archived this mutation id (the unique index on MutationId).
+            // Verify it is the exact lineage we just prepared before reporting success.
+            var existing = await db.EventSequenceMutationHistory.AsNoTracking()
+                .FirstOrDefaultAsync(h => h.MutationId == history.Id, cancellationToken);
+            if (existing is null)
+            {
+                return EventSequenceMutationRegistryArchiveResult.Corrupt();
+            }
+
+            var existingHistory = EventSequenceMutationRowConversion.ToStorageHistory(existing);
+            return existingHistory == history
+                ? EventSequenceMutationRegistryArchiveResult.AlreadyArchived(scope, registration, existingHistory)
+                : EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        // Only the fencing column is cleared here - see the type-level remarks for why the
+        // remaining Active* columns are intentionally left in place until the next Begin.
+        var clearedRows = await db.EventSequenceMutationHeads
+            .Where(h => h.EventSequenceId == key && h.ActiveStateVersion == preArchive.StateVersion)
+            .ExecuteUpdateAsync(s => s.SetProperty(h => h.ActiveMutationId, (EventSequenceMutationId?)null), cancellationToken);
+
+        return clearedRows == 1
+            ? EventSequenceMutationRegistryArchiveResult.Archived(scope, registration, history)
+            : EventSequenceMutationRegistryArchiveResult.Corrupt();
+    }
+
+    async Task<EventSequenceMutationRegistryArchiveResult> ResolveArchivedArchive(
+        NamespaceDbContext db,
+        EventSequenceKey scope,
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationStateToken token,
+        EventSequenceMutationHeadEntry? row,
+        CancellationToken cancellationToken)
+    {
+        var historyRow = await db.EventSequenceMutationHistory.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.MutationId == token.Id, cancellationToken);
+        if (historyRow is null)
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        if (scope != token.Scope || target.Key != token.TargetKey ||
+            historyRow.Ordinal != token.Ordinal || historyRow.DefinitionDigestV1 != token.DefinitionDigestV1)
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        if (!IsExactArchiveRetryToken(token, historyRow))
+        {
+            return EventSequenceMutationRegistryArchiveResult.StateConflict();
+        }
+
+        var reconstructed = EventSequenceMutationRowConversion.TryReconstructArchivedFromResidue(target, row, historyRow);
+        return reconstructed is { } archived
+            ? EventSequenceMutationRegistryArchiveResult.AlreadyArchived(scope, archived.Registration, archived.History)
+            : EventSequenceMutationRegistryArchiveResult.StateConflict();
+    }
+
+    async Task<EventSequenceMutationTrackingResult> BeginTrackingCore(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationCoverage expected,
+        CancellationToken cancellationToken)
+    {
+        var validation = EventSequenceMutationValidator.ValidateIdentity(target);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        validation = EventSequenceMutationValidator.ValidateTrackingCoverage(expected);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        var mutationScope = Scope(target);
+        validation = EventSequenceMutationValidator.ValidateScope(mutationScope);
+        if (!validation.IsValid)
+        {
+            return EventSequenceMutationTrackingResult.Invalid(validation);
+        }
+
+        await using var scope = await database.Namespace(eventStore, @namespace);
+        var db = scope.DbContext;
+        var key = (EventSequenceId)target.Display;
+
+        var row = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+
+        if (row is null)
+        {
+            var fresh = new EventSequenceMutationHeadEntry
+            {
+                EventSequenceId = key,
+                Coverage = EventSequenceMutationCoverage.Unsealed,
+                LastAssignedOrdinal = EventSequenceMutationOrdinal.NotSet
+            };
+            db.EventSequenceMutationHeads.Add(fresh);
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken);
+                return EventSequenceMutationTrackingResult.Began();
+            }
+            catch (DbUpdateException)
+            {
+                db.Entry(fresh).State = EntityState.Detached;
+                row = await db.EventSequenceMutationHeads.AsNoTracking()
+                    .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+                if (row is null)
+                {
+                    return EventSequenceMutationTrackingResult.Indeterminate();
+                }
+            }
+        }
+
+        return row.Coverage switch
+        {
+            EventSequenceMutationCoverage.Unsealed => EventSequenceMutationTrackingResult.AlreadyTracking(),
+            EventSequenceMutationCoverage.Sealed => EventSequenceMutationTrackingResult.Conflict(EventSequenceMutationCoverage.Sealed),
+            EventSequenceMutationCoverage.Untracked => await ClaimUntracked(db, key, cancellationToken),
+            _ => EventSequenceMutationTrackingResult.Corrupt()
+        };
+    }
+
+    async Task<EventSequenceMutationTrackingResult> ClaimUntracked(NamespaceDbContext db, EventSequenceId key, CancellationToken cancellationToken)
+    {
+        var affected = await db.EventSequenceMutationHeads
+            .Where(h => h.EventSequenceId == key && h.Coverage == EventSequenceMutationCoverage.Untracked)
+            .ExecuteUpdateAsync(s => s.SetProperty(h => h.Coverage, EventSequenceMutationCoverage.Unsealed), cancellationToken);
+        if (affected == 1)
+        {
+            return EventSequenceMutationTrackingResult.Began();
+        }
+
+        var reread = await db.EventSequenceMutationHeads.AsNoTracking()
+            .FirstOrDefaultAsync(h => h.EventSequenceId == key, cancellationToken);
+        return reread?.Coverage switch
+        {
+            EventSequenceMutationCoverage.Unsealed => EventSequenceMutationTrackingResult.AlreadyTracking(),
+            EventSequenceMutationCoverage.Sealed => EventSequenceMutationTrackingResult.Conflict(EventSequenceMutationCoverage.Sealed),
+            _ => EventSequenceMutationTrackingResult.Indeterminate()
+        };
+    }
+
+    EventSequenceKey Scope(EventSequenceMutationIdentity target) => new(target.Display, eventStore, @namespace);
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationRowConversion.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/EventSequenceMutationRowConversion.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Concepts.EventSequences.Mutations;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
+
+namespace Cratis.Chronicle.Storage.Sql.EventStores.Namespaces.EventSequences.Mutations;
+
+/// <summary>
+/// Converts between the flat SQL persistence entities and the provider-neutral mutation domain types.
+/// </summary>
+static class EventSequenceMutationRowConversion
+{
+    /// <summary>
+    /// Reconstructs the active mutation from a head row whose <see cref="EventSequenceMutationHeadEntry.ActiveMutationId"/> is set.
+    /// </summary>
+    /// <param name="row">The head row to reconstruct from.</param>
+    /// <param name="target">The target identity the row belongs to.</param>
+    /// <returns>The reconstructed active mutation.</returns>
+    internal static EventSequenceMutation ReconstructActive(EventSequenceMutationHeadEntry row, EventSequenceMutationIdentity target)
+    {
+        var definition = ReconstructDefinitionFromResidue(row, target, row.ActiveMutationId!);
+        return new EventSequenceMutation(
+            definition,
+            row.ActiveOrdinal!,
+            row.ActiveStateVersion!,
+            row.ActivePhase!.Value,
+            row.ActiveBlockedFrom!.Value,
+            row.ActiveRepairState!.Value);
+    }
+
+    /// <summary>
+    /// Reconstructs a mutation definition from a head row's <c>Active*</c> columns, using an explicit
+    /// mutation identifier rather than the row's own <see cref="EventSequenceMutationHeadEntry.ActiveMutationId"/>.
+    /// </summary>
+    /// <param name="row">The head row to reconstruct from - only its non-identifier <c>Active*</c> columns are read.</param>
+    /// <param name="target">The target identity the row belongs to.</param>
+    /// <param name="mutationId">The mutation identifier to reconstruct the definition for.</param>
+    /// <returns>The reconstructed definition.</returns>
+    /// <remarks>
+    /// Used to reconstruct a definition from the residual <c>Active*</c> columns a head row keeps after
+    /// <see cref="EventSequenceMutationRegistry.Archive"/> clears only <see cref="EventSequenceMutationHeadEntry.ActiveMutationId"/> -
+    /// see the registry's type-level remarks for why the identifier itself cannot be read from the row in that case.
+    /// </remarks>
+    internal static EventSequenceMutationDefinition ReconstructDefinitionFromResidue(
+        EventSequenceMutationHeadEntry row,
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationId mutationId)
+    {
+        var origin = new EventSequenceMutationOrigin(
+            RecreateIdentity(row.ActiveOriginSequence!.Value),
+            new EventSequenceNumber(row.ActiveOriginSequenceNumber!.Value));
+        var request = new EventSequenceMutationRequest(
+            mutationId,
+            target,
+            origin,
+            row.ActiveKind!.Value,
+            new EventSequenceMutationCommandEnvelope(row.ActiveCommandPayload!, row.ActiveCommandHash!));
+        var frozenTarget = new EventSequenceMutationTarget(row.ActiveTargetStart!, row.ActiveTargetEndExclusive!, row.ActiveTargetExpectedCount!);
+        return new EventSequenceMutationDefinition(request, frozenTarget, row.ActiveDefinitionDigestV1!);
+    }
+
+    /// <summary>
+    /// Sets every <c>Active*</c> column on a head row from an active mutation.
+    /// </summary>
+    /// <param name="row">The head row to update.</param>
+    /// <param name="active">The active mutation to write.</param>
+    internal static void SetActiveColumns(EventSequenceMutationHeadEntry row, EventSequenceMutation active)
+    {
+        row.ActiveMutationId = active.Id;
+        row.ActiveOrdinal = active.Ordinal;
+        row.ActiveStateVersion = active.StateVersion;
+        row.ActiveOriginSequence = (Concepts.EventSequences.EventSequenceId)active.Origin.Sequence.Display;
+        row.ActiveOriginSequenceNumber = active.Origin.SequenceNumber;
+        row.ActiveKind = active.Kind;
+        row.ActiveCommandPayload = active.Command.Payload;
+        row.ActiveCommandHash = active.Command.Hash;
+        row.ActiveTargetStart = active.Target.Start;
+        row.ActiveTargetEndExclusive = active.Target.EndExclusive;
+        row.ActiveTargetExpectedCount = active.Target.ExpectedCount;
+        row.ActiveDefinitionDigestV1 = active.Definition.DefinitionDigestV1;
+        row.ActivePhase = active.Phase;
+        row.ActiveBlockedFrom = active.BlockedFrom;
+        row.ActiveRepairState = active.RepairState;
+    }
+
+    /// <summary>
+    /// Determines whether a bound (still payload-bearing) head row was registered from the exact request supplied.
+    /// </summary>
+    /// <param name="row">The head row currently bound to the request's mutation identifier.</param>
+    /// <param name="request">The request to compare. A newly proposed target is intentionally not part of this comparison.</param>
+    /// <returns><see langword="true"/> when every comparable field is exactly equal.</returns>
+    internal static bool MatchesBoundRequest(EventSequenceMutationHeadEntry row, EventSequenceMutationRequest? request) =>
+        request is { Origin.Sequence: not null, Origin.SequenceNumber: not null, Command.Payload: not null, Command.Hash: not null } &&
+        string.Equals(row.ActiveOriginSequence!.Value, request.Origin.Sequence.Display, StringComparison.Ordinal) &&
+        row.ActiveOriginSequenceNumber!.Value == request.Origin.SequenceNumber.Value &&
+        row.ActiveKind!.Value == request.Kind &&
+        string.Equals(row.ActiveCommandPayload, request.Command.Payload, StringComparison.Ordinal) &&
+        string.Equals(row.ActiveCommandHash!.Value, request.Command.Hash.Value, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Tries to reconstruct a validating archived registration from a history row plus the residual
+    /// <c>Active*</c> columns a head row keeps after an archive that has not yet been reclaimed by a
+    /// newer <see cref="EventSequenceMutationRegistry.Begin"/> call.
+    /// </summary>
+    /// <param name="target">The target identity the rows belong to.</param>
+    /// <param name="row">The head row, or <see langword="null"/> when no row exists for the target.</param>
+    /// <param name="historyRow">The permanent history row for the archived mutation.</param>
+    /// <returns>The reconstructed registration and storage history entry, or <see langword="null"/> when reconstruction is not possible.</returns>
+    internal static (EventSequenceMutationRegistration Registration, Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry History)? TryReconstructArchivedFromResidue(
+        EventSequenceMutationIdentity target,
+        EventSequenceMutationHeadEntry? row,
+        EventSequenceMutationHistoryEntry historyRow)
+    {
+        if (row is null || row.ActiveMutationId is not null ||
+            row.ActiveCommandHash is null || !string.Equals(row.ActiveCommandHash.Value, historyRow.CommandHash.Value, StringComparison.Ordinal) ||
+            row.ActiveDefinitionDigestV1 is null || row.ActiveDefinitionDigestV1 != historyRow.DefinitionDigestV1)
+        {
+            return null;
+        }
+
+        var definition = ReconstructDefinitionFromResidue(row, target, historyRow.MutationId);
+        var witness = ToTerminalWitness(historyRow);
+        var registration = new EventSequenceMutationRegistration(definition, EventSequenceMutationRegistryLifecycle.Archived, historyRow.Ordinal, witness);
+        var history = ToStorageHistory(historyRow);
+        return (registration, history);
+    }
+
+    /// <summary>
+    /// Builds the storage-layer terminal history entry from its persisted SQL row.
+    /// </summary>
+    /// <param name="row">The history row to convert.</param>
+    /// <returns>The reconstructed terminal history entry.</returns>
+    internal static Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry ToStorageHistory(EventSequenceMutationHistoryEntry row)
+    {
+        var witness = ToTerminalWitness(row);
+        return new(
+            row.MutationId,
+            row.Ordinal,
+            new EventSequenceMutationOrigin(RecreateIdentity(row.OriginSequence.Value), row.OriginSequenceNumber),
+            row.Kind,
+            row.CommandHash,
+            new EventSequenceMutationTarget(row.TargetStart, row.TargetEndExclusive, row.TargetExpectedCount),
+            row.RepairState,
+            witness);
+    }
+
+    /// <summary>
+    /// Builds the terminal witness carried by a persisted history row.
+    /// </summary>
+    /// <param name="row">The history row to convert.</param>
+    /// <returns>The reconstructed terminal witness.</returns>
+    internal static EventSequenceMutationTerminalWitness ToTerminalWitness(EventSequenceMutationHistoryEntry row) =>
+        new(row.FinalStateVersion, row.DefinitionDigestV1, row.ReceiptDigestV1);
+
+    /// <summary>
+    /// Builds the SQL history row to insert for a prepared archive.
+    /// </summary>
+    /// <param name="eventSequenceId">The row key of the owning event sequence.</param>
+    /// <param name="history">The prepared, provider-neutral history entry.</param>
+    /// <returns>The SQL persistence entity to insert.</returns>
+    internal static EventSequenceMutationHistoryEntry ToRow(Concepts.EventSequences.EventSequenceId eventSequenceId, Chronicle.Storage.EventSequences.Mutations.EventSequenceMutationHistoryEntry history) =>
+        new()
+        {
+            EventSequenceId = eventSequenceId,
+            Ordinal = history.Ordinal,
+            MutationId = history.Id,
+            OriginSequence = (Concepts.EventSequences.EventSequenceId)history.Origin.Sequence.Display,
+            OriginSequenceNumber = history.Origin.SequenceNumber,
+            Kind = history.Kind,
+            CommandHash = history.CommandHash,
+            TargetStart = history.Target.Start,
+            TargetEndExclusive = history.Target.EndExclusive,
+            TargetExpectedCount = history.Target.ExpectedCount,
+            RepairState = history.RepairState,
+            FinalStateVersion = history.TerminalWitness.FinalStateVersion,
+            DefinitionDigestV1 = history.TerminalWitness.DefinitionDigestV1,
+            ReceiptDigestV1 = history.TerminalWitness.ReceiptDigestV1
+        };
+
+    static EventSequenceMutationIdentity RecreateIdentity(string display) => EventSequenceMutationIdentity.TryCreate(display).Identity!;
+}

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/Migrations/v16_45_0.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventSequences/Mutations/Migrations/v16_45_0.cs
@@ -29,6 +29,7 @@ public class v16_45_0 : Migration
                     ? table.StringColumn(migrationBuilder, maxLength: 36, nullable: true)
                     : table.GuidColumn(migrationBuilder, nullable: true),
                 ActiveOrdinal = table.NumberColumn<long>(migrationBuilder, nullable: true),
+                ActiveStateVersion = table.NumberColumn<long>(migrationBuilder, nullable: true),
                 ActiveOriginSequence = table.StringColumn(migrationBuilder, maxLength: 200, nullable: true),
                 ActiveOriginSequenceNumber = table.NumberColumn<ulong>(migrationBuilder, nullable: true),
                 ActiveKind = table.NumberColumn<int>(migrationBuilder, nullable: true),
@@ -37,6 +38,7 @@ public class v16_45_0 : Migration
                 ActiveTargetStart = table.NumberColumn<ulong>(migrationBuilder, nullable: true),
                 ActiveTargetEndExclusive = table.NumberColumn<ulong>(migrationBuilder, nullable: true),
                 ActiveTargetExpectedCount = table.NumberColumn<ulong>(migrationBuilder, nullable: true),
+                ActiveDefinitionDigestV1 = table.StringColumn(migrationBuilder, maxLength: 64, nullable: true),
                 ActivePhase = table.NumberColumn<int>(migrationBuilder, nullable: true),
                 ActiveBlockedFrom = table.NumberColumn<int>(migrationBuilder, nullable: true),
                 ActiveRepairState = table.NumberColumn<int>(migrationBuilder, nullable: true)
@@ -70,7 +72,10 @@ public class v16_45_0 : Migration
                 TargetStart = table.NumberColumn<ulong>(migrationBuilder, nullable: false),
                 TargetEndExclusive = table.NumberColumn<ulong>(migrationBuilder, nullable: false),
                 TargetExpectedCount = table.NumberColumn<ulong>(migrationBuilder, nullable: false),
-                RepairState = table.NumberColumn<int>(migrationBuilder, nullable: false)
+                RepairState = table.NumberColumn<int>(migrationBuilder, nullable: false),
+                FinalStateVersion = table.NumberColumn<long>(migrationBuilder, nullable: false),
+                DefinitionDigestV1 = table.StringColumn(migrationBuilder, maxLength: 64, nullable: false),
+                ReceiptDigestV1 = table.StringColumn(migrationBuilder, maxLength: 64, nullable: false)
             },
             constraints: table =>
             {

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/EventStoreNamespaceStorage.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.Jobs;
 using Cratis.Chronicle.Storage.Changes;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using Cratis.Chronicle.Storage.EventSequences;
+using Cratis.Chronicle.Storage.EventSequences.Mutations;
 using Cratis.Chronicle.Storage.Identities;
 using Cratis.Chronicle.Storage.Jobs;
 using Cratis.Chronicle.Storage.Keys;
@@ -43,6 +44,9 @@ public class EventStoreNamespaceStorage(EventStoreName eventStore, EventStoreNam
 
     /// <inheritdoc/>
     public IIdentityStorage Identities { get; } = new Identities.IdentityStorage(eventStore, @namespace, database);
+
+    /// <inheritdoc/>
+    public IEventSequenceMutationRegistry EventSequenceMutations { get; } = new EventSequences.Mutations.EventSequenceMutationRegistry(eventStore, @namespace, database);
 
     /// <inheritdoc/>
     public IJobStorage Jobs { get; } = new Jobs.JobStorage(eventStore, @namespace, database, jobTypes, jsonSerializerOptions);

--- a/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceDbContext.cs
+++ b/Source/Kernel/Storage.Sql/EventStores/Namespaces/NamespaceDbContext.cs
@@ -131,6 +131,7 @@ public class NamespaceDbContext(DbContextOptions<NamespaceDbContext> options) : 
                 entity.Property(e => e.LastAssignedOrdinal).HasDefaultValue(EventSequenceMutationOrdinal.NotSet).IsRequired();
                 entity.Property(e => e.ActiveMutationId).IsRequired(false);
                 entity.Property(e => e.ActiveOrdinal).IsRequired(false);
+                entity.Property(e => e.ActiveStateVersion).IsRequired(false);
                 entity.Property(e => e.ActiveOriginSequence).HasMaxLength(200).IsRequired(false);
                 entity.Property(e => e.ActiveOriginSequenceNumber).IsRequired(false);
                 entity.Property(e => e.ActiveKind).IsRequired(false);
@@ -139,6 +140,10 @@ public class NamespaceDbContext(DbContextOptions<NamespaceDbContext> options) : 
                 entity.Property(e => e.ActiveTargetStart).IsRequired(false);
                 entity.Property(e => e.ActiveTargetEndExclusive).IsRequired(false);
                 entity.Property(e => e.ActiveTargetExpectedCount).IsRequired(false);
+                entity.Property(e => e.ActiveDefinitionDigestV1)
+                    .HasConversion(d => EventSequenceMutationDigestColumns.DefinitionDigestToHex(d!), s => EventSequenceMutationDigestColumns.DefinitionDigestFromHex(s))
+                    .HasMaxLength(64)
+                    .IsRequired(false);
                 entity.Property(e => e.ActivePhase).IsRequired(false);
                 entity.Property(e => e.ActiveBlockedFrom).IsRequired(false);
                 entity.Property(e => e.ActiveRepairState).IsRequired(false);
@@ -159,6 +164,15 @@ public class NamespaceDbContext(DbContextOptions<NamespaceDbContext> options) : 
                 entity.Property(e => e.TargetEndExclusive).IsRequired();
                 entity.Property(e => e.TargetExpectedCount).IsRequired();
                 entity.Property(e => e.RepairState).IsRequired();
+                entity.Property(e => e.FinalStateVersion).IsRequired();
+                entity.Property(e => e.DefinitionDigestV1)
+                    .HasConversion(d => EventSequenceMutationDigestColumns.DefinitionDigestToHex(d), s => EventSequenceMutationDigestColumns.DefinitionDigestFromHex(s))
+                    .HasMaxLength(64)
+                    .IsRequired();
+                entity.Property(e => e.ReceiptDigestV1)
+                    .HasConversion(d => EventSequenceMutationDigestColumns.ReceiptDigestToHex(d), s => EventSequenceMutationDigestColumns.ReceiptDigestFromHex(s))
+                    .HasMaxLength(64)
+                    .IsRequired();
             });
 
         // Match the column mappings to the provider-native JSON type the migrations create

--- a/Source/Kernel/Storage/Cuts/IReadModelCutStorage.cs
+++ b/Source/Kernel/Storage/Cuts/IReadModelCutStorage.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Defines a namespace-scoped store for read-model cut payloads and their published manifests.
+/// </summary>
+/// <remarks>
+/// Payloads and the manifest are written in two phases: every payload first, the manifest only once every
+/// payload for the request has been written and verified present. A manifest is never partially published -
+/// <see cref="PublishManifest"/> is the single atomic step that makes a capture visible at all.
+/// </remarks>
+public interface IReadModelCutStorage
+{
+    /// <summary>
+    /// Saves one read model's captured payload, content-addressed by the cut id and read model.
+    /// </summary>
+    /// <param name="id">The <see cref="ReadModelCutId"/> the payload belongs to.</param>
+    /// <param name="readModel">The <see cref="ReadModelIdentifier"/> the payload is for.</param>
+    /// <param name="payloadJson">The canonical JSON payload.</param>
+    /// <returns>Awaitable task.</returns>
+    Task SavePayload(ReadModelCutId id, ReadModelIdentifier readModel, string payloadJson);
+
+    /// <summary>
+    /// Gets one read model's captured payload.
+    /// </summary>
+    /// <param name="id">The <see cref="ReadModelCutId"/> the payload belongs to.</param>
+    /// <param name="readModel">The <see cref="ReadModelIdentifier"/> the payload is for.</param>
+    /// <returns>The payload JSON, or <see langword="null"/> when not found.</returns>
+    Task<string?> GetPayload(ReadModelCutId id, ReadModelIdentifier readModel);
+
+    /// <summary>
+    /// Checks whether a manifest has already been published for a cut id.
+    /// </summary>
+    /// <param name="id">The <see cref="ReadModelCutId"/> to check.</param>
+    /// <returns>True if a manifest exists; otherwise false.</returns>
+    Task<bool> HasManifest(ReadModelCutId id);
+
+    /// <summary>
+    /// Gets the published manifest for a cut id.
+    /// </summary>
+    /// <param name="id">The <see cref="ReadModelCutId"/> to get the manifest for.</param>
+    /// <returns>The <see cref="ReadModelCutManifest"/>, or <see langword="null"/> when not found.</returns>
+    Task<ReadModelCutManifest?> GetManifest(ReadModelCutId id);
+
+    /// <summary>
+    /// Publishes a manifest, making the capture it describes visible.
+    /// </summary>
+    /// <param name="manifest">The <see cref="ReadModelCutManifest"/> to publish.</param>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// Idempotent - publishing the same id twice with identical content is a no-op; the deterministic id means a
+    /// repeated identical request can safely publish again without creating a second record.
+    /// </remarks>
+    Task PublishManifest(ReadModelCutManifest manifest);
+}

--- a/Source/Kernel/Storage/Cuts/ReadModelCutEntry.cs
+++ b/Source/Kernel/Storage/Cuts/ReadModelCutEntry.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Represents the outcome and, on success, the payload location for one read model in a <see cref="ReadModelCutManifest"/>.
+/// </summary>
+/// <param name="ReadModel">The read model identifier this entry is for.</param>
+/// <param name="Outcome">The <see cref="ReadModelCutOutcome"/> for this read model.</param>
+/// <param name="Generation">
+/// The read-model schema generation the payload was produced under, when <paramref name="Outcome"/> is
+/// <see cref="ReadModelCutOutcome.Captured"/>. This is the current generation, not a reconstructed historical
+/// one - there is no projection-definition-history store this can be pinned against, so it is recorded for
+/// honest provenance rather than as proof of a point-in-time schema.
+/// </param>
+/// <param name="Digest">The <see cref="ReadModelCutPayloadDigest"/> of the payload, when <paramref name="Outcome"/> is <see cref="ReadModelCutOutcome.Captured"/>.</param>
+/// <param name="FailureReason">A human-readable reason, when <paramref name="Outcome"/> is not <see cref="ReadModelCutOutcome.Captured"/>.</param>
+public sealed record ReadModelCutEntry(
+    ReadModelIdentifier ReadModel,
+    ReadModelCutOutcome Outcome,
+    ReadModelGeneration? Generation,
+    ReadModelCutPayloadDigest? Digest,
+    string? FailureReason);

--- a/Source/Kernel/Storage/Cuts/ReadModelCutIdCalculator.cs
+++ b/Source/Kernel/Storage/Cuts/ReadModelCutIdCalculator.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using Cratis.Chronicle.Concepts.Cuts;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Computes the deterministic <see cref="ReadModelCutId"/> for a <see cref="ReadModelCutRequest"/>.
+/// </summary>
+public static class ReadModelCutIdCalculator
+{
+    static readonly byte[] _domain = Encoding.ASCII.GetBytes("cratis.chronicle/read-model-cut-id");
+
+    /// <summary>
+    /// Calculates the deterministic id for a request - the same request, field for field, always produces the
+    /// same id, so a repeated request resolves to the same manifest instead of capturing the same content twice.
+    /// </summary>
+    /// <param name="request">The <see cref="ReadModelCutRequest"/> to calculate the id for.</param>
+    /// <returns>The deterministic <see cref="ReadModelCutId"/>.</returns>
+    public static ReadModelCutId Calculate(ReadModelCutRequest request)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(_domain);
+
+        WriteText(stream, request.EventStore.Value);
+        WriteText(stream, request.Namespace.Value);
+
+        foreach (var cut in request.Cuts.OrderBy(_ => _.EventSequenceId.Value, StringComparer.Ordinal))
+        {
+            WriteText(stream, cut.EventSequenceId.Value);
+            WriteUInt64(stream, cut.Position.Value);
+        }
+
+        foreach (var readModel in request.Selection.OrderBy(_ => _.Value, StringComparer.Ordinal))
+        {
+            WriteText(stream, readModel.Value);
+        }
+
+        var hash = SHA256.HashData(stream.ToArray());
+        return new ReadModelCutId(new Guid(hash.AsSpan(0, 16)));
+    }
+
+    static void WriteText(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteUInt64(stream, (ulong)bytes.Length);
+        stream.Write(bytes);
+    }
+
+    static void WriteUInt64(Stream stream, ulong value)
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
+        stream.Write(buffer);
+    }
+}

--- a/Source/Kernel/Storage/Cuts/ReadModelCutManifest.cs
+++ b/Source/Kernel/Storage/Cuts/ReadModelCutManifest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Cuts;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Represents the immutable, published record of a read-model cut - what was requested, and the outcome for
+/// every selected read model.
+/// </summary>
+/// <param name="Id">The deterministic <see cref="ReadModelCutId"/> for this exact request.</param>
+/// <param name="EventStore">The event store the capture belongs to.</param>
+/// <param name="Namespace">The namespace the capture belongs to.</param>
+/// <param name="Cuts">The exact position, per event sequence, every entry is bound to.</param>
+/// <param name="Entries">The outcome for every read model in the requested selection.</param>
+/// <param name="PublishedAt">When the manifest was published. Provenance only - never used to decide correctness.</param>
+/// <remarks>
+/// A manifest is only ever written once every entry's payload (for the entries that succeeded) has been written
+/// and verified - there is no partially-published manifest, and nothing reads a capture as valid before this
+/// record exists.
+/// </remarks>
+public sealed record ReadModelCutManifest(
+    ReadModelCutId Id,
+    EventStoreName EventStore,
+    EventStoreNamespaceName Namespace,
+    IReadOnlyCollection<EventSequenceCut> Cuts,
+    IReadOnlyCollection<ReadModelCutEntry> Entries,
+    DateTimeOffset PublishedAt);

--- a/Source/Kernel/Storage/Cuts/ReadModelCutRequest.cs
+++ b/Source/Kernel/Storage/Cuts/ReadModelCutRequest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Represents a request to capture a selection of read models exactly at a vector of event-sequence cuts.
+/// </summary>
+/// <param name="EventStore">The event store the selection belongs to.</param>
+/// <param name="Namespace">The namespace the selection belongs to.</param>
+/// <param name="Cuts">The exact position, per event sequence, every selected read model is bound to.</param>
+/// <param name="Selection">The read model identifiers to capture.</param>
+public sealed record ReadModelCutRequest(
+    EventStoreName EventStore,
+    EventStoreNamespaceName Namespace,
+    IReadOnlyCollection<EventSequenceCut> Cuts,
+    IReadOnlyCollection<ReadModelIdentifier> Selection);

--- a/Source/Kernel/Storage/Cuts/ReadModelCutStorageNotSupported.cs
+++ b/Source/Kernel/Storage/Cuts/ReadModelCutStorageNotSupported.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// The exception that is thrown when a storage provider does not support read-model cut storage.
+/// </summary>
+/// <param name="operation">The unsupported operation.</param>
+public class ReadModelCutStorageNotSupported(string operation) : Exception($"The read model cut storage operation '{operation}' is not supported by this storage provider.")
+{
+    /// <summary>
+    /// Gets the unsupported operation.
+    /// </summary>
+    public string Operation { get; } = operation;
+}

--- a/Source/Kernel/Storage/Cuts/UnsupportedReadModelCutStorage.cs
+++ b/Source/Kernel/Storage/Cuts/UnsupportedReadModelCutStorage.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Cuts;
+using Cratis.Chronicle.Concepts.ReadModels;
+
+namespace Cratis.Chronicle.Storage.Cuts;
+
+/// <summary>
+/// Represents a fail-loud read-model cut storage for providers without cut storage support.
+/// </summary>
+public sealed class UnsupportedReadModelCutStorage : IReadModelCutStorage
+{
+    /// <summary>
+    /// Gets the shared unsupported storage instance.
+    /// </summary>
+    public static readonly UnsupportedReadModelCutStorage Instance = new();
+
+    /// <inheritdoc/>
+    public Task SavePayload(ReadModelCutId id, ReadModelIdentifier readModel, string payloadJson) =>
+        throw new ReadModelCutStorageNotSupported(nameof(SavePayload));
+
+    /// <inheritdoc/>
+    public Task<string?> GetPayload(ReadModelCutId id, ReadModelIdentifier readModel) =>
+        throw new ReadModelCutStorageNotSupported(nameof(GetPayload));
+
+    /// <inheritdoc/>
+    public Task<bool> HasManifest(ReadModelCutId id) =>
+        throw new ReadModelCutStorageNotSupported(nameof(HasManifest));
+
+    /// <inheritdoc/>
+    public Task<ReadModelCutManifest?> GetManifest(ReadModelCutId id) =>
+        throw new ReadModelCutStorageNotSupported(nameof(GetManifest));
+
+    /// <inheritdoc/>
+    public Task PublishManifest(ReadModelCutManifest manifest) =>
+        throw new ReadModelCutStorageNotSupported(nameof(PublishManifest));
+}

--- a/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
+++ b/Source/Kernel/Storage/IEventStoreNamespaceStorage.cs
@@ -3,6 +3,7 @@
 
 using Cratis.Chronicle.Concepts.EventSequences;
 using Cratis.Chronicle.Storage.Changes;
+using Cratis.Chronicle.Storage.Cuts;
 using Cratis.Chronicle.Storage.Events.Constraints;
 using Cratis.Chronicle.Storage.EventSequences;
 using Cratis.Chronicle.Storage.EventSequences.Mutations;
@@ -108,6 +109,11 @@ public interface IEventStoreNamespaceStorage
     /// Gets the namespace-scoped permanent event sequence mutation registry.
     /// </summary>
     IEventSequenceMutationRegistry EventSequenceMutations => UnsupportedEventSequenceMutationRegistry.Instance;
+
+    /// <summary>
+    /// Gets the namespace-scoped read-model cut payload and manifest storage.
+    /// </summary>
+    IReadModelCutStorage ReadModelCuts => UnsupportedReadModelCutStorage.Instance;
 
     /// <summary>
     /// Get the event sequences that exist for the event store namespace.


### PR DESCRIPTION
## Summary

Builds on #3929's event-sequence mutation fencing foundations with three additions: a coordinated read barrier over an explicit observer set (#3910), exact-cut read-model capture (#3921), and MongoDB/SQL implementations of the mutation registry so it has parity across all three storage providers.

## Added

- `IObservers.AppliedThrough` — a read barrier that waits for an explicit set of observers to reach a target event sequence position, classifying each observer's outcome individually (ready, timed out, replaying, quarantined, unavailable, failed) instead of collapsing them into one aggregate result (#3910)
- `IReadModelCuts.Capture` — recomputes a selection of projection-backed read models from the event log up to an explicit per-event-sequence cut rather than reading the live sink, so a writer that advances a read model past the requested cut after the request started cannot contaminate the captured payload. Payloads and their digests are written first; the manifest is published only once every entry is written (#3921)
- MongoDB and SQL (SQLite/PostgreSQL/SQL Server) implementations of `IEventSequenceMutationRegistry`, matching the in-memory registry #3929 introduced

## Known limitations

- `IReadModelCuts.Capture` does not yet fence against an in-flight event-sequence mutation — the registry has no read-only query surface yet to check against. A capture requested while a mutation is `Applying`/`Verifying` below the requested cut can currently observe pre-mutation content rather than being rejected.
- A reducer-backed read model in a capture selection is reported as `Unsupported` rather than attempted — reducer logic runs in the connected client process, not the kernel, so it cannot be recomputed server-side.
- **The mutation registry is not yet wired into `EventSequence.Revise`/`Redact`.** Nothing calls `Begin`/`Transition`/`Archive` today, so #3920's actual fencing behavior is not active yet — this PR completes the registry's storage layer (now on all three providers) but not its integration into the append/revise/redact call paths. Driving a mutation through the registry's phase graph (`Reserved → Applying → Verifying → SourceCommitted`, optionally through a repair-dispatch cycle) honestly requires a real verify step against the actual storage write, and repair-dispatch requires deciding what "repair" means operationally when only a single storage provider is involved. Reaching for a shallow wrap that drives the phases without a real verification would report `SourceCommitted`/`NotRequired` in the permanent history table without anything having actually been verified - it was deliberately left undone rather than faked.

## Verification

- `dotnet build` (Debug and Release) — zero warnings, zero errors, including the full `Server` project (Kernel + Contracts + all storage providers + Api + Workbench)
- `dotnet test` — zero failures across `Core.Specs` (3114 specs), `Storage.Specs`, `Storage.InMemory.Specs` (238), `Storage.MongoDB.Specs` (828, against a real MongoDB container), `Storage.Sql.Specs` (172, in-memory SQLite)
- Found and fixed a real bug surfaced by the MongoDB registry specs against a live container: an upsert-style `findAndModify` whose filter includes a non-key condition can lose a genuine race to a concurrent caller and previously surfaced that as an unhandled duplicate-key exception instead of resolving through the existing read-and-resolve fallback
