### PR TITLE
Fix silent projection, reducer, job and client-connection failures

### DIFF
--- a/Documentation/clients/dotnet/health-checks.md
+++ b/Documentation/clients/dotnet/health-checks.md
@@ -1,0 +1,68 @@
+---
+title: Health checks
+description: Report whether the client holds a live connection to the Chronicle kernel through the ASP.NET Core health check pipeline.
+---
+
+An ASP.NET Core host that cannot reach the Chronicle kernel starts, stays alive, and answers
+requests — while being unable to serve any of them. The Chronicle health check makes that state
+visible to whatever is watching your host: a Kubernetes readiness probe, a load balancer, or a
+dashboard.
+
+## What you get
+
+`AddCratisChronicle` registers the health check for you. There is nothing to add.
+
+The check is registered under the name **`chronicle`**, with the tags **`chronicle`** and
+**`ready`**. It reports:
+
+- **Healthy** — the client holds a live connection to the kernel.
+- **Unhealthy** — the client is not connected, or the kernel could not be reached at all. The
+  exception, when there was one, is carried on the result.
+
+The check reads the connection's state; it does not itself dial the kernel on every probe. The
+client's own watchdog is what keeps reconnecting in the background.
+
+## Exposing it
+
+Registering a check does not expose an endpoint — you still map one. The tags let you separate
+readiness from liveness, which is the distinction that matters here:
+
+```csharp
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("ready")
+});
+
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = _ => false
+});
+```
+
+Chronicle tags itself `ready` and deliberately **not** for liveness. A host that cannot reach the
+kernel should be taken out of rotation, but restarting it does not bring the kernel back — so a
+liveness probe that failed on this would restart a healthy host in a loop while the kernel is down.
+
+## Choosing the failure status
+
+Report a failure as `Degraded` instead when your host can still do useful work without Chronicle:
+
+```csharp
+builder.Services.AddChronicleHealthCheck(HealthStatus.Degraded);
+```
+
+Call this before `AddCratisChronicle`, or on its own in a host that wires the client up itself.
+Registration is idempotent, so the automatic registration will not add a second check.
+
+## Startup behavior
+
+The host starts even when the kernel is unreachable. `UseCratisChronicle` attempts a connection when
+the application has started, logs a warning if it cannot get one, and leaves the client's watchdog to
+keep retrying. The health check is what reports that state in the meantime — so a readiness probe
+holds traffic back until the connection comes up, rather than the host failing to start at all.
+
+## Related
+
+- [Get started](./getting-started.md) — wiring the client into a host.
+- [Observing artifact registration](./registration-outcome.md) — whether the artifacts a connected
+  client declared actually registered, which is a separate question from whether it is connected.

--- a/Documentation/clients/dotnet/index.md
+++ b/Documentation/clients/dotnet/index.md
@@ -38,6 +38,7 @@ dotnet add package Cratis.Chronicle.AspNetCore
 
 ## .NET-specific pages
 
+- [Health checks](./health-checks.md)
 - [Console quickstart](/chronicle/get-started/console/)
 - [ASP.NET Core hosting](/chronicle/get-started/aspnetcore/)
 - [Worker Service hosting](/chronicle/get-started/worker/)

--- a/Documentation/clients/dotnet/toc.yml
+++ b/Documentation/clients/dotnet/toc.yml
@@ -4,6 +4,8 @@
   href: getting-started.md
 - name: Observing artifact registration
   href: registration-outcome.md
+- name: Health checks
+  href: health-checks.md
 - name: Captures
   href: captures/toc.yml
 - name: External Services

--- a/Documentation/read-models/index.md
+++ b/Documentation/read-models/index.md
@@ -34,6 +34,7 @@ the events:
 | [Getting snapshots](./getting-snapshots) | Retrieve historical snapshots of a read model's state. |
 | [Watching read models](./watching-read-models) | Observe a read model and react to changes in real time. |
 | [Releasing PII](./releasing-pii) | Decrypt PII in a read model instance you already have, and how the subject is resolved. |
+| [Indexing read models](./indexing.md) | Declare indexes with `[Index]` so they are recreated whenever the container is — including after a replay. |
 
 To expose a read model to a React frontend, pair it with an [Arc query](/arc/backend/queries/) — or see
 the whole loop in [Build a full-stack feature](/build-a-full-app/).

--- a/Documentation/read-models/indexing.md
+++ b/Documentation/read-models/indexing.md
@@ -1,0 +1,80 @@
+---
+uid: Chronicle.ReadModels.Indexing
+---
+
+# Indexing Read Models
+
+A read model is stored in a collection or table, and the store needs indexes to read it efficiently.
+You could create those indexes yourself, but you would have to create them again every time the
+container is recreated — and Chronicle recreates it on its own, during a replay.
+
+The `[Index]` attribute moves the decision to where it belongs: onto the read model. You declare
+which properties are indexed, and Chronicle creates them in whichever store the read model is
+persisted to, every time the container is built.
+
+## Declaring an index
+
+Put `[Index]` on the property — or, for a record, on the constructor parameter:
+
+```csharp
+[ReadModel]
+public record Order(
+    OrderId Id,
+    [Index] CustomerId CustomerId,
+    [Index] OrderNumber Number,
+    decimal Total);
+```
+
+The key of a read model does not need `[Index]` — the store already indexes it.
+
+## Nested and child properties
+
+Indexes are collected by walking the read model, so a property on a nested object or on a child
+collection's element type is indexed at its full path:
+
+```csharp
+[ReadModel]
+public record Order(
+    OrderId Id,
+    IEnumerable<OrderLine> Lines);
+
+public record OrderLine(
+    [Index] ProductId ProductId,
+    int Quantity);
+```
+
+This declares an index on `lines.productId`. The path uses the naming policy the client is
+configured with, the same one that decides how the properties are stored.
+
+## Why it lives on the read model
+
+Chronicle replays a read model by building it into a **shadow container** — a separate collection or
+table — and swapping that in when the replay completes. The container the application reads from
+afterwards is therefore not the one it read from before: it is a new one, and it only has the
+indexes that were created on it.
+
+That is the reason `[Index]` exists. Because the declaration travels with the read model's
+definition rather than being applied to a container by hand, Chronicle can recreate the indexes for
+whichever container it is currently building — the original one, or the shadow one a replay is
+filling. An index created manually against the live collection does not survive the swap; a declared
+one does.
+
+It is also why this is declarative rather than store-specific. `[Index]` says *what* should be
+indexed; each sink decides *how*. On MongoDB that means an ascending index built in the background
+and named `chronicle_idx_<path>`; another store expresses the same declaration its own way.
+
+## When it takes effect
+
+Indexes are ensured when Chronicle sets up storage for the read model — when the sink is first built
+for it, and when a replay begins filling its shadow container. Creating an index that already exists
+is skipped, so this is safe to run repeatedly.
+
+Adding `[Index]` to a read model that is already in production applies on the next start of the
+kernel. It does not require a replay — the index is created against the existing container.
+
+## What it does not do
+
+`[Index]` does not give you a query surface. Chronicle's read model API is keyed, and indexing does
+not change that — see [Querying Read Models](./querying.md) for what to do when you need to search a
+read model by something other than its key. What indexing does is make *that* work efficient, whether
+the query comes from Chronicle's own key lookups or from your code going to the store directly.

--- a/Documentation/read-models/toc.yml
+++ b/Documentation/read-models/toc.yml
@@ -10,6 +10,8 @@
   href: getting-collection-instances.mdx
 - name: Querying Read Models
   href: querying.md
+- name: Indexing Read Models
+  href: indexing.md
 - name: Materialized Read Models
   href: materialized-pagination.mdx
 - name: Getting Snapshots

--- a/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/given/a_health_check.cs
+++ b/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/given/a_health_check.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.AspNetCore.Diagnostics.for_ChronicleHealthCheck.given;
+
+public class a_health_check : Specification
+{
+    protected ChronicleHealthCheck _healthCheck;
+    protected IChronicleClient _client;
+    protected IEventStore _eventStore;
+    protected IChronicleConnection _connection;
+    protected IConnectionLifecycle _lifecycle;
+    protected HealthCheckContext _context;
+
+    void Establish()
+    {
+        _lifecycle = Substitute.For<IConnectionLifecycle>();
+        _connection = Substitute.For<IChronicleConnection>();
+        _connection.Lifecycle.Returns(_lifecycle);
+        _eventStore = Substitute.For<IEventStore>();
+        _eventStore.Connection.Returns(_connection);
+        _client = Substitute.For<IChronicleClient>();
+        _client.GetEventStore(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>()).Returns(_eventStore);
+
+        _context = new HealthCheckContext
+        {
+            Registration = new HealthCheckRegistration(ChronicleHealthCheck.Name, Substitute.For<IHealthCheck>(), null, null)
+        };
+
+        _healthCheck = new ChronicleHealthCheck(
+            _client,
+            Options.Create(new ChronicleAspNetCoreOptions { EventStore = "the-store" }));
+    }
+}

--- a/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_client_is_connected.cs
+++ b/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_client_is_connected.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cratis.Chronicle.AspNetCore.Diagnostics.for_ChronicleHealthCheck.when_checking_health;
+
+public class and_the_client_is_connected : given.a_health_check
+{
+    HealthCheckResult _result;
+
+    void Establish() => _lifecycle.IsConnected.Returns(true);
+
+    async Task Because() => _result = await _healthCheck.CheckHealthAsync(_context);
+
+    [Fact] void should_report_healthy() => _result.Status.ShouldEqual(HealthStatus.Healthy);
+}

--- a/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_client_is_not_connected.cs
+++ b/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_client_is_not_connected.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cratis.Chronicle.AspNetCore.Diagnostics.for_ChronicleHealthCheck.when_checking_health;
+
+public class and_the_client_is_not_connected : given.a_health_check
+{
+    HealthCheckResult _result;
+
+    void Establish() => _lifecycle.IsConnected.Returns(false);
+
+    async Task Because() => _result = await _healthCheck.CheckHealthAsync(_context);
+
+    [Fact] void should_report_unhealthy() => _result.Status.ShouldEqual(HealthStatus.Unhealthy);
+    [Fact] void should_name_the_event_store() => _result.Description.ShouldContain("the-store");
+}

--- a/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_kernel_cannot_be_reached.cs
+++ b/Source/Clients/AspNetCore.Specs/Diagnostics/for_ChronicleHealthCheck/when_checking_health/and_the_kernel_cannot_be_reached.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Connections;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cratis.Chronicle.AspNetCore.Diagnostics.for_ChronicleHealthCheck.when_checking_health;
+
+/// <summary>
+/// Getting at the event store is itself a call that fails while the kernel is unreachable (#3948). A health check
+/// that let that through would report nothing at all - and an unreachable kernel is exactly what it exists to say.
+/// </summary>
+public class and_the_kernel_cannot_be_reached : given.a_health_check
+{
+    HealthCheckResult _result;
+
+    void Establish() =>
+        _client.GetEventStore(Arg.Any<EventStoreName>(), Arg.Any<EventStoreNamespaceName>())
+            .Returns<IEventStore>(_ => throw new ConnectionUnavailable("chronicle://the-kernel"));
+
+    async Task Because() => _result = await _healthCheck.CheckHealthAsync(_context);
+
+    [Fact] void should_report_unhealthy() => _result.Status.ShouldEqual(HealthStatus.Unhealthy);
+    [Fact] void should_carry_the_failure() => _result.Exception.ShouldBeOfExactType<ConnectionUnavailable>();
+}

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderExtensions.cs
@@ -3,9 +3,11 @@
 
 using Cratis.Chronicle;
 using Cratis.Chronicle.AspNetCore;
+using Cratis.Chronicle.Connections;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -58,6 +60,7 @@ public static class ChronicleClientWebApplicationBuilderExtensions
         configure?.Invoke(chronicleBuilder);
 
         builder.Services.AddCratisChronicleClient(chronicleBuilder);
+        builder.Services.AddChronicleHealthCheck();
 
         return builder;
     }
@@ -75,8 +78,25 @@ public static class ChronicleClientWebApplicationBuilderExtensions
         {
             var client = app.ApplicationServices.GetRequiredService<IChronicleClient>();
             var options = app.ApplicationServices.GetRequiredService<IOptions<ChronicleAspNetCoreOptions>>();
-            var eventStore = client.GetEventStore(options.Value.EventStore).GetAwaiter().GetResult();
-            eventStore.Connection.Connect().GetAwaiter().GetResult();
+            var logger = app.ApplicationServices.GetRequiredService<ILogger<IApplicationBuilder>>();
+
+            try
+            {
+                var eventStore = client.GetEventStore(options.Value.EventStore).GetAwaiter().GetResult();
+                eventStore.Connection.Connect().GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (ex is ConnectionTimedOut or ConnectionUnavailable)
+            {
+                // A kernel that is briefly unreachable while a host starts is ordinary, and the connection's
+                // watchdog keeps reconnecting in the background - so this must not take the host down with it.
+                // Connecting now reports failure rather than swallowing it (#3948), which is why this is caught
+                // here rather than never raised. The Chronicle health check reports the state until it recovers.
+                //
+                // Only the connection failures are caught. Anything else here means the client is misconfigured
+                // rather than unable to reach a kernel - it will never come good on its own, so it keeps taking
+                // startup down where it is seen instead of leaving a host running with no event store.
+                logger.CouldNotConnectOnStartup(ex);
+            }
         });
 
         return app;

--- a/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderLogMessages.cs
+++ b/Source/Clients/AspNetCore/ChronicleClientWebApplicationBuilderLogMessages.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.AspNetCore;
+
+internal static partial class ChronicleClientWebApplicationBuilderLogMessages
+{
+    [LoggerMessage(LogLevel.Warning, "Could not connect to the Chronicle kernel on startup. Reconnection continues in the background.")]
+    internal static partial void CouldNotConnectOnStartup(this ILogger<IApplicationBuilder> logger, Exception exception);
+}

--- a/Source/Clients/AspNetCore/Diagnostics/ChronicleHealthCheck.cs
+++ b/Source/Clients/AspNetCore/Diagnostics/ChronicleHealthCheck.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Cratis.Chronicle.AspNetCore.Diagnostics;
+
+/// <summary>
+/// Represents a <see cref="IHealthCheck"/> reporting whether the client holds a live connection to the Chronicle kernel.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ChronicleHealthCheck"/> class.
+/// </remarks>
+/// <param name="client"><see cref="IChronicleClient"/> to report on.</param>
+/// <param name="options">The <see cref="ChronicleAspNetCoreOptions"/> naming the event store to report on.</param>
+public class ChronicleHealthCheck(IChronicleClient client, IOptions<ChronicleAspNetCoreOptions> options) : IHealthCheck
+{
+    /// <summary>
+    /// The name the health check is registered under.
+    /// </summary>
+    public const string Name = "chronicle";
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var eventStore = options.Value.EventStore;
+
+        try
+        {
+            var store = await client.GetEventStore(eventStore);
+            return store.Connection.Lifecycle.IsConnected
+                ? HealthCheckResult.Healthy($"Connected to the Chronicle kernel for event store '{eventStore}'.")
+                : HealthCheckResult.Unhealthy($"Not connected to the Chronicle kernel for event store '{eventStore}'.");
+        }
+        catch (Exception ex)
+        {
+            // Reaching the client at all can fail while the kernel is unreachable, and a health check that
+            // propagates that is a health check that reports nothing. An unreachable kernel is precisely the
+            // state this exists to report.
+            return HealthCheckResult.Unhealthy($"Could not reach the Chronicle kernel for event store '{eventStore}'.", ex);
+        }
+    }
+}

--- a/Source/Clients/AspNetCore/Diagnostics/ChronicleHealthCheckServiceCollectionExtensions.cs
+++ b/Source/Clients/AspNetCore/Diagnostics/ChronicleHealthCheckServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.AspNetCore.Diagnostics;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extensions for adding the Chronicle <see cref="IHealthCheck"/> to the ASP.NET Core health check pipeline.
+/// </summary>
+public static class ChronicleHealthCheckServiceCollectionExtensions
+{
+    /// <summary>
+    /// The tags the Chronicle health check is registered with.
+    /// </summary>
+    /// <remarks>
+    /// <c>ready</c> is the conventional tag for a readiness probe - a host that cannot reach the kernel can start
+    /// and stay alive, but it cannot serve. It is deliberately not tagged for liveness, since restarting the host
+    /// does not bring the kernel back.
+    /// </remarks>
+    public static readonly string[] Tags = ["chronicle", "ready"];
+
+    /// <summary>
+    /// Add the Chronicle health check, reporting whether the client holds a live connection to the kernel.
+    /// </summary>
+    /// <param name="services"><see cref="IServiceCollection"/> to add to.</param>
+    /// <param name="failureStatus">Optional <see cref="HealthStatus"/> to report when not connected. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <returns><see cref="IServiceCollection"/> for continuation.</returns>
+    /// <remarks>
+    /// Registering a check does not expose an endpoint - the app still maps one, for instance with
+    /// <c>app.MapHealthChecks("/health/ready", new() { Predicate = _ => _.Tags.Contains("ready") })</c>.
+    /// Registration is idempotent, so calling this after it has been added automatically does nothing.
+    /// </remarks>
+    public static IServiceCollection AddChronicleHealthCheck(this IServiceCollection services, HealthStatus failureStatus = HealthStatus.Unhealthy)
+    {
+        if (services.Any(_ => _.ServiceType == typeof(HealthCheckRegistrationMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton<HealthCheckRegistrationMarker>();
+        services.AddHealthChecks()
+            .AddCheck<ChronicleHealthCheck>(ChronicleHealthCheck.Name, failureStatus, Tags);
+
+        return services;
+    }
+
+    sealed class HealthCheckRegistrationMarker;
+}

--- a/Source/Clients/Connections.Specs/Support/ControllableTimeProvider.cs
+++ b/Source/Clients/Connections.Specs/Support/ControllableTimeProvider.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Cratis.Chronicle.Connections.for_ConnectionWatchdog;
+namespace Cratis.Chronicle.Connections;
 
 public class ControllableTimeProvider : TimeProvider
 {

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/given/a_connection_that_cannot_reach_the_kernel.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/given/a_connection_that_cannot_reach_the_kernel.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.given;
+
+public class a_connection_that_cannot_reach_the_kernel : Specification
+{
+    protected const int ConnectTimeoutSeconds = 2;
+
+    protected ChronicleConnection _connection;
+    protected IConnectionLifecycle _lifecycle;
+    protected IChronicleServerAddressResolver _serverAddressResolver;
+    protected ControllableTimeProvider _time;
+    protected int _resolveAttempts;
+
+    void Establish()
+    {
+        _time = new ControllableTimeProvider();
+        _lifecycle = Substitute.For<IConnectionLifecycle>();
+        _lifecycle.IsConnected.Returns(false);
+        _lifecycle.ConnectionId.Returns(ConnectionId.New());
+
+        // Failing to resolve an address is how an unreachable kernel presents before a channel is even dialed,
+        // and it makes the attempt fail without dialing one from a spec.
+        _serverAddressResolver = Substitute.For<IChronicleServerAddressResolver>();
+        _serverAddressResolver
+            .Resolve(Arg.Any<ChronicleConnectionString>())
+            .Returns(_ =>
+            {
+                _resolveAttempts++;
+                return Task.FromException<IReadOnlyList<ChronicleServerAddress>>(new UnableToResolveClientUri());
+            });
+
+        _connection = new ChronicleConnection(
+            ChronicleConnectionString.Default,
+            ConnectTimeoutSeconds,
+            null,
+            null,
+            _lifecycle,
+            new Cratis.Tasks.TaskFactory(),
+            Substitute.For<ICorrelationIdAccessor>(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None,
+            NullLogger<ChronicleConnection>.Instance,
+            skipTlsValidation: true,
+            skipCompatibilityCheck: true,
+            skipKeepAlive: true,
+            serverAddressResolver: _serverAddressResolver,
+            timeProvider: _time);
+    }
+
+    void Destroy() => _connection.Dispose();
+}

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/given/a_connection_that_lost_a_working_kernel.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/given/a_connection_that_lost_a_working_kernel.cs
@@ -5,7 +5,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Cratis.Chronicle.Connections.for_ChronicleConnection.given;
 
-public class a_connection_that_cannot_reach_the_kernel : Specification
+/// <summary>
+/// A connection that established itself once and then lost the kernel - the case #3948 reports. The failure state
+/// deliberately does not arm before the first successful connect, so a spec about it has to connect first.
+/// </summary>
+public class a_connection_that_lost_a_working_kernel : Specification
 {
     protected const int ConnectTimeoutSeconds = 2;
 
@@ -13,24 +17,36 @@ public class a_connection_that_cannot_reach_the_kernel : Specification
     protected IConnectionLifecycle _lifecycle;
     protected IChronicleServerAddressResolver _serverAddressResolver;
     protected ControllableTimeProvider _time;
+    protected bool _isConnected;
+    protected bool _kernelIsReachable;
     protected int _resolveAttempts;
 
     void Establish()
     {
         _time = new ControllableTimeProvider();
+        _kernelIsReachable = true;
+        _isConnected = false;
+
         _lifecycle = Substitute.For<IConnectionLifecycle>();
-        _lifecycle.IsConnected.Returns(false);
+        _lifecycle.IsConnected.Returns(_ => _isConnected);
         _lifecycle.ConnectionId.Returns(ConnectionId.New());
+        _lifecycle.Connected().Returns(_ =>
+        {
+            _isConnected = true;
+            return Task.CompletedTask;
+        });
 
         // Failing to resolve an address is how an unreachable kernel presents before a channel is even dialed,
-        // and it makes the attempt fail without dialing one from a spec.
+        // and it makes an attempt fail without dialing one from a spec.
         _serverAddressResolver = Substitute.For<IChronicleServerAddressResolver>();
         _serverAddressResolver
             .Resolve(Arg.Any<ChronicleConnectionString>())
             .Returns(_ =>
             {
                 _resolveAttempts++;
-                return Task.FromException<IReadOnlyList<ChronicleServerAddress>>(new UnableToResolveClientUri());
+                return _kernelIsReachable
+                    ? Task.FromResult<IReadOnlyList<ChronicleServerAddress>>([ChronicleConnectionString.Default.ServerAddress])
+                    : Task.FromException<IReadOnlyList<ChronicleServerAddress>>(new UnableToResolveClientUri());
             });
 
         _connection = new ChronicleConnection(
@@ -49,6 +65,18 @@ public class a_connection_that_cannot_reach_the_kernel : Specification
             skipKeepAlive: true,
             serverAddressResolver: _serverAddressResolver,
             timeProvider: _time);
+    }
+
+    /// <summary>
+    /// Connect once against a reachable kernel, then lose it - leaving the connection in the state the issue is about.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    protected async Task ConnectThenLoseTheKernel()
+    {
+        await _connection.Connect();
+        _isConnected = false;
+        _kernelIsReachable = false;
+        _resolveAttempts = 0;
     }
 
     void Destroy() => _connection.Dispose();

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_a_recent_attempt_already_failed.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_a_recent_attempt_already_failed.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3948 — while the kernel stays unreachable, every
+/// caller used to pay a full connect attempt of its own, on its own thread, with no bound on how many could be
+/// waiting at once. Only one attempt per back-off window should reach the kernel; the rest fail at once.
+/// </summary>
+public class and_a_recent_attempt_already_failed : given.a_connection_that_cannot_reach_the_kernel
+{
+    Exception _result;
+
+    async Task Because()
+    {
+        await Catch.Exception(_connection.Connect);
+        _result = await Catch.Exception(_connection.Connect);
+    }
+
+    [Fact] void should_fail_the_call() => _result.ShouldNotBeNull();
+    [Fact] void should_report_the_connection_as_unavailable() => _result.ShouldBeOfExactType<ConnectionUnavailable>();
+    [Fact] void should_not_attempt_to_connect_again() => _resolveAttempts.ShouldEqual(1);
+}

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_a_recent_attempt_already_failed.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_a_recent_attempt_already_failed.cs
@@ -8,12 +8,13 @@ namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
 /// caller used to pay a full connect attempt of its own, on its own thread, with no bound on how many could be
 /// waiting at once. Only one attempt per back-off window should reach the kernel; the rest fail at once.
 /// </summary>
-public class and_a_recent_attempt_already_failed : given.a_connection_that_cannot_reach_the_kernel
+public class and_a_recent_attempt_already_failed : given.a_connection_that_lost_a_working_kernel
 {
     Exception _result;
 
     async Task Because()
     {
+        await ConnectThenLoseTheKernel();
         await Catch.Exception(_connection.Connect);
         _result = await Catch.Exception(_connection.Connect);
     }

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_back_off_after_a_failed_attempt_has_elapsed.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_back_off_after_a_failed_attempt_has_elapsed.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
+
+/// <summary>
+/// The back-off after a failed connect keeps callers off the kernel, but it must not be a terminal state - a
+/// kernel that comes back has to be reachable again without restarting the client (#3948).
+/// </summary>
+public class and_the_back_off_after_a_failed_attempt_has_elapsed : given.a_connection_that_cannot_reach_the_kernel
+{
+    Exception _result;
+
+    async Task Because()
+    {
+        await Catch.Exception(_connection.Connect);
+        _time.Advance(TimeSpan.FromSeconds(ConnectTimeoutSeconds + 1));
+        _result = await Catch.Exception(_connection.Connect);
+    }
+
+    [Fact] void should_attempt_to_connect_again() => _resolveAttempts.ShouldEqual(2);
+    [Fact] void should_still_fail_while_the_kernel_is_unreachable() => _result.ShouldNotBeNull();
+    [Fact] void should_surface_the_actual_failure_rather_than_short_circuiting() => _result.ShouldBeOfExactType<UnableToResolveClientUri>();
+}

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_back_off_after_a_failed_attempt_has_elapsed.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_back_off_after_a_failed_attempt_has_elapsed.cs
@@ -7,12 +7,13 @@ namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
 /// The back-off after a failed connect keeps callers off the kernel, but it must not be a terminal state - a
 /// kernel that comes back has to be reachable again without restarting the client (#3948).
 /// </summary>
-public class and_the_back_off_after_a_failed_attempt_has_elapsed : given.a_connection_that_cannot_reach_the_kernel
+public class and_the_back_off_after_a_failed_attempt_has_elapsed : given.a_connection_that_lost_a_working_kernel
 {
     Exception _result;
 
     async Task Because()
     {
+        await ConnectThenLoseTheKernel();
         await Catch.Exception(_connection.Connect);
         _time.Advance(TimeSpan.FromSeconds(ConnectTimeoutSeconds + 1));
         _result = await Catch.Exception(_connection.Connect);

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_cannot_be_reached.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_cannot_be_reached.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3948 — a failed connect must reach its caller as a
+/// failure. Reporting success while the lifecycle stayed disconnected left no failure state to observe, so every
+/// later call re-entered and paid the connect attempt again, one blocked thread at a time.
+/// </summary>
+public class and_the_kernel_cannot_be_reached : given.a_connection_that_cannot_reach_the_kernel
+{
+    Exception _result;
+
+    async Task Because() => _result = await Catch.Exception(_connection.Connect);
+
+    [Fact] void should_fail_the_call() => _result.ShouldNotBeNull();
+    [Fact] void should_have_attempted_to_connect() => _resolveAttempts.ShouldEqual(1);
+    [Fact] void should_not_report_the_connection_as_established() => _lifecycle.DidNotReceive().Connected();
+}

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_cannot_be_reached.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_cannot_be_reached.cs
@@ -4,17 +4,22 @@
 namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
 
 /// <summary>
-/// Regression for https://github.com/Cratis/Chronicle/issues/3948 — a failed connect must reach its caller as a
-/// failure. Reporting success while the lifecycle stayed disconnected left no failure state to observe, so every
-/// later call re-entered and paid the connect attempt again, one blocked thread at a time.
+/// Regression for https://github.com/Cratis/Chronicle/issues/3948 — once a connection has worked, a failed
+/// attempt must reach its caller as a failure. Reporting success while the lifecycle stayed disconnected left no
+/// failure state to observe, so every later call re-entered and paid the attempt again, one blocked thread at a
+/// time.
 /// </summary>
-public class and_the_kernel_cannot_be_reached : given.a_connection_that_cannot_reach_the_kernel
+public class and_the_kernel_cannot_be_reached : given.a_connection_that_lost_a_working_kernel
 {
     Exception _result;
 
-    async Task Because() => _result = await Catch.Exception(_connection.Connect);
+    async Task Because()
+    {
+        await ConnectThenLoseTheKernel();
+        _result = await Catch.Exception(_connection.Connect);
+    }
 
     [Fact] void should_fail_the_call() => _result.ShouldNotBeNull();
     [Fact] void should_have_attempted_to_connect() => _resolveAttempts.ShouldEqual(1);
-    [Fact] void should_not_report_the_connection_as_established() => _lifecycle.DidNotReceive().Connected();
+    [Fact] void should_not_report_the_connection_as_established() => _isConnected.ShouldBeFalse();
 }

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_is_not_up_yet_for_the_first_connect.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_kernel_is_not_up_yet_for_the_first_connect.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
+
+/// <summary>
+/// A kernel that has not come up yet while its client starts is ordinary, and the client is expected to keep
+/// trying rather than fail whoever asked first. The failure state #3948 introduces is for a connection that
+/// worked and then stopped recovering, so it must not arm before the first successful connect - a host that
+/// cannot boot through a slow-starting kernel is worse than one that keeps trying.
+/// </summary>
+public class and_the_kernel_is_not_up_yet_for_the_first_connect : given.a_connection_that_lost_a_working_kernel
+{
+    Exception _first;
+    Exception _second;
+
+    async Task Because()
+    {
+        _kernelIsReachable = false;
+        _first = await Catch.Exception(_connection.Connect);
+        _second = await Catch.Exception(_connection.Connect);
+    }
+
+    [Fact] void should_surface_the_failure_to_the_first_caller() => _first.ShouldBeOfExactType<UnableToResolveClientUri>();
+
+    [Fact] void should_not_arm_the_back_off_before_a_connection_has_ever_been_made() =>
+        _second.ShouldBeOfExactType<UnableToResolveClientUri>();
+
+    [Fact] void should_keep_attempting_for_every_caller() => _resolveAttempts.ShouldEqual(2);
+}

--- a/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_watchdog_reconnects_within_the_back_off.cs
+++ b/Source/Clients/Connections.Specs/for_ChronicleConnection/when_connecting/and_the_watchdog_reconnects_within_the_back_off.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections.for_ChronicleConnection.when_connecting;
+
+/// <summary>
+/// The back-off keeps callers off an unreachable kernel, but the watchdog is what brings the connection back and
+/// paces itself with its own retry schedule. Holding it to the caller-facing back-off refused it before it dialed
+/// anything, so it burned its attempts and the connection could never recover on its own.
+/// </summary>
+public class and_the_watchdog_reconnects_within_the_back_off : given.a_connection_that_lost_a_working_kernel
+{
+    Exception _callerResult;
+
+    async Task Because()
+    {
+        await ConnectThenLoseTheKernel();
+
+        // A caller fails and starts the back-off.
+        await Catch.Exception(_connection.Connect);
+
+        // The watchdog reconnects immediately afterwards - well inside the window a caller is refused in.
+        await Catch.Exception(_connection.Reconnect);
+
+        _callerResult = await Catch.Exception(_connection.Connect);
+    }
+
+    [Fact] void should_let_the_watchdog_attempt() => _resolveAttempts.ShouldEqual(2);
+    [Fact] void should_still_refuse_a_caller_within_the_back_off() => _callerResult.ShouldBeOfExactType<ConnectionUnavailable>();
+}

--- a/Source/Clients/Connections/ChronicleConnection.cs
+++ b/Source/Clients/Connections/ChronicleConnection.cs
@@ -59,12 +59,14 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     readonly ILoadBalancerStrategy _loadBalancerStrategy;
     readonly SemaphoreSlim _connectLock = new(1, 1);
     readonly ConnectionWatchdog _watchDog;
+    readonly TimeProvider _timeProvider;
     ChronicleServerAddress? _currentServerAddress;
     GrpcChannel? _channel;
     IConnectionService? _connectionService;
     IServices _services;
     IDisposable? _keepAliveSubscription;
     TaskCompletionSource? _connectTcs;
+    DateTimeOffset? _lastConnectFailure;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ChronicleConnection"/> class.
@@ -87,6 +89,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     /// <param name="skipKeepAlive">Whether to skip the keep-alive handshake on connect. Useful for short-lived clients like CLIs.</param>
     /// <param name="serverAddressResolver">Optional <see cref="IChronicleServerAddressResolver"/> for resolving server addresses. Defaults to <see cref="ChronicleServerAddressResolver"/>.</param>
     /// <param name="loadBalancerStrategy">Optional <see cref="ILoadBalancerStrategy"/> for selecting among multiple servers. Defaults to the strategy named by the connection string, or least-connections.</param>
+    /// <param name="timeProvider">Optional <see cref="TimeProvider"/> used to time the back-off after a failed connect. Defaults to the system clock.</param>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 #pragma warning disable CA1068 // CancellationToken parameters must come last
     public ChronicleConnection(
@@ -107,8 +110,10 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
         bool skipCompatibilityCheck = false,
         bool skipKeepAlive = false,
         IChronicleServerAddressResolver? serverAddressResolver = null,
-        ILoadBalancerStrategy? loadBalancerStrategy = null)
+        ILoadBalancerStrategy? loadBalancerStrategy = null,
+        TimeProvider? timeProvider = null)
     {
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _skipTlsValidation = skipTlsValidation;
         _skipCompatibilityCheck = skipCompatibilityCheck;
         _skipKeepAlive = skipKeepAlive;
@@ -180,6 +185,14 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ConnectionTimedOut">Thrown when the connect attempt, or the wait for one already in flight, exceeds the connect timeout.</exception>
+    /// <exception cref="ConnectionUnavailable">Thrown when a recent attempt failed and the back-off after it has not elapsed yet.</exception>
+    /// <remarks>
+    /// Every failure mode here has to end in a return or a throw. A client whose reconnect never completes used to
+    /// absorb the thread of every caller instead: the connect lock was waited on without a deadline, so callers
+    /// queued behind each attempt as well as their own, and an arrival rate above the connect timeout grew that
+    /// queue without bound (#3948).
+    /// </remarks>
     public async Task Connect()
     {
         if (Lifecycle.IsConnected)
@@ -187,7 +200,15 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
             return;
         }
 
-        await _connectLock.WaitAsync(_cancellationToken);
+        ThrowIfWithinConnectFailureBackoff();
+
+        var connectTimeout = TimeSpan.FromSeconds(_connectTimeout);
+        if (!await _connectLock.WaitAsync(connectTimeout, _cancellationToken))
+        {
+            RecordConnectFailure();
+            throw new ConnectionTimedOut();
+        }
+
         try
         {
             if (Lifecycle.IsConnected)
@@ -195,11 +216,45 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
                 return;
             }
 
+            // The attempt we queued behind may have just failed. Paying for our own full attempt on top of the
+            // wait we already served is what turned one unreachable kernel into a thread per caller.
+            ThrowIfWithinConnectFailureBackoff();
+
             await ConnectInternal();
+            _lastConnectFailure = null;
+        }
+        catch
+        {
+            RecordConnectFailure();
+            throw;
         }
         finally
         {
             _connectLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Records that a connect attempt failed, starting the back-off window that makes subsequent callers fail fast.
+    /// </summary>
+    void RecordConnectFailure() => _lastConnectFailure = _timeProvider.GetUtcNow();
+
+    /// <summary>
+    /// Fail immediately while the back-off after a failed connect attempt is still running.
+    /// </summary>
+    /// <exception cref="ConnectionUnavailable">Thrown when the back-off has not elapsed.</exception>
+    /// <remarks>
+    /// Without this every caller pays the full connect timeout on its own thread for as long as the kernel stays
+    /// unreachable. The window is the connect timeout, so at most one attempt per timeout probes the kernel while
+    /// the watchdog keeps reconnecting in the background - and a caller learns the connection is down at once
+    /// rather than by waiting for it.
+    /// </remarks>
+    void ThrowIfWithinConnectFailureBackoff()
+    {
+        var lastFailure = _lastConnectFailure;
+        if (lastFailure is not null && _timeProvider.GetUtcNow() - lastFailure.Value < TimeSpan.FromSeconds(_connectTimeout))
+        {
+            throw new ConnectionUnavailable(_connectionString.Redacted);
         }
     }
 
@@ -306,13 +361,17 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
 
         try
         {
-            await _connectTcs.Task.WaitAsync(TimeSpan.FromSeconds(_connectTimeout));
+            await _connectTcs.Task.WaitAsync(TimeSpan.FromSeconds(_connectTimeout), _timeProvider);
             _logger.Connected();
             await Lifecycle.Connected();
         }
         catch (TimeoutException)
         {
+            // Returning normally here reported success while the lifecycle stayed disconnected, so there was no
+            // failure state to observe and no back-off to apply - the next call simply re-entered and paid the
+            // timeout again (#3948). The watchdog still starts below and keeps reconnecting in the background.
             _logger.TimedOut();
+            throw new ConnectionTimedOut();
         }
         finally
         {

--- a/Source/Clients/Connections/ChronicleConnection.cs
+++ b/Source/Clients/Connections/ChronicleConnection.cs
@@ -67,6 +67,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     IDisposable? _keepAliveSubscription;
     TaskCompletionSource? _connectTcs;
     DateTimeOffset? _lastConnectFailure;
+    bool _hasEverConnected;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ChronicleConnection"/> class.
@@ -134,7 +135,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
         _watchDog = new ConnectionWatchdog(
             tasks,
             OnSessionDropped,
-            Connect,
+            Reconnect,
             loggerFactory.CreateLogger<ConnectionWatchdog>(),
             cancellationToken);
 
@@ -193,14 +194,31 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     /// queued behind each attempt as well as their own, and an arrival rate above the connect timeout grew that
     /// queue without bound (#3948).
     /// </remarks>
-    public async Task Connect()
+    public Task Connect() => Connect(respectFailureBackoff: true);
+
+    /// <summary>
+    /// Reconnect on behalf of the watchdog, which must always get to attempt.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// The watchdog is the thing that recovers the connection, and it paces itself with its own backoff. Holding it
+    /// to the caller-facing one meant it was refused before it dialed anything, so it burned its attempts on a
+    /// connection that could then never come back - every later call kept failing against a kernel that was
+    /// reachable again.
+    /// </remarks>
+    internal async Task Reconnect() => await Connect(respectFailureBackoff: false);
+
+    async Task Connect(bool respectFailureBackoff)
     {
         if (Lifecycle.IsConnected)
         {
             return;
         }
 
-        ThrowIfWithinConnectFailureBackoff();
+        if (respectFailureBackoff)
+        {
+            ThrowIfWithinConnectFailureBackoff();
+        }
 
         var connectTimeout = TimeSpan.FromSeconds(_connectTimeout);
         if (!await _connectLock.WaitAsync(connectTimeout, _cancellationToken))
@@ -218,7 +236,10 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
 
             // The attempt we queued behind may have just failed. Paying for our own full attempt on top of the
             // wait we already served is what turned one unreachable kernel into a thread per caller.
-            ThrowIfWithinConnectFailureBackoff();
+            if (respectFailureBackoff)
+            {
+                ThrowIfWithinConnectFailureBackoff();
+            }
 
             await ConnectInternal();
             _lastConnectFailure = null;
@@ -237,7 +258,19 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
     /// <summary>
     /// Records that a connect attempt failed, starting the back-off window that makes subsequent callers fail fast.
     /// </summary>
-    void RecordConnectFailure() => _lastConnectFailure = _timeProvider.GetUtcNow();
+    /// <remarks>
+    /// Only once a connection has actually been established. A kernel that is not up yet while its client starts is
+    /// ordinary - the client is expected to keep trying and come good - so the failure state deliberately does not
+    /// arm before the first successful connect. What #3948 reports is the other case: a connection that worked and
+    /// then stopped recovering, where every later call paid for an attempt of its own.
+    /// </remarks>
+    void RecordConnectFailure()
+    {
+        if (_hasEverConnected)
+        {
+            _lastConnectFailure = _timeProvider.GetUtcNow();
+        }
+    }
 
     /// <summary>
     /// Fail immediately while the back-off after a failed connect attempt is still running.
@@ -339,6 +372,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
         if (_skipKeepAlive)
         {
             _logger.Connected();
+            _hasEverConnected = true;
             await Lifecycle.Connected();
             return;
         }
@@ -363,6 +397,7 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
         {
             await _connectTcs.Task.WaitAsync(TimeSpan.FromSeconds(_connectTimeout), _timeProvider);
             _logger.Connected();
+            _hasEverConnected = true;
             await Lifecycle.Connected();
         }
         catch (TimeoutException)
@@ -370,8 +405,15 @@ public sealed class ChronicleConnection : IChronicleConnection, IChronicleServic
             // Returning normally here reported success while the lifecycle stayed disconnected, so there was no
             // failure state to observe and no back-off to apply - the next call simply re-entered and paid the
             // timeout again (#3948). The watchdog still starts below and keeps reconnecting in the background.
+            //
+            // Only once a connection has been established, though. A kernel that has not come up yet while its
+            // client starts is ordinary, and a host that cannot boot through it is worse than one that keeps
+            // trying - so the first connect keeps waiting on the watchdog rather than failing its caller.
             _logger.TimedOut();
-            throw new ConnectionTimedOut();
+            if (_hasEverConnected)
+            {
+                throw new ConnectionTimedOut();
+            }
         }
         finally
         {

--- a/Source/Clients/Connections/ConnectionUnavailable.cs
+++ b/Source/Clients/Connections/ConnectionUnavailable.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Connections;
+
+/// <summary>
+/// Exception that gets thrown when a call needs the Chronicle connection while a recent attempt to establish it failed.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ConnectionUnavailable"/> class.
+/// </remarks>
+/// <param name="connectionString">The redacted connection string the client is configured with.</param>
+public class ConnectionUnavailable(string connectionString)
+    : Exception($"The Chronicle connection to '{connectionString}' is unavailable - the last attempt to connect failed and the client is retrying in the background. Retry the call, or report the client as unhealthy.");

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/given/a_reducer_current_read_model_must_be_nullable_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/given/a_reducer_current_read_model_must_be_nullable_analyzer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerCurrentReadModelMustBeNullableAnalyzer.given;
+
+public class a_reducer_current_read_model_must_be_nullable_analyzer : Specification
+{
+    protected static string CreateSource(string usage)
+    {
+        return string.Join(Environment.NewLine,
+        [
+            "#nullable enable",
+            "using System;",
+            "using System.Threading.Tasks;",
+            "using Cratis.Chronicle.Concepts.Events;",
+            "using Cratis.Chronicle.Reducers;",
+            "",
+            "namespace Cratis.Chronicle.Concepts.Events",
+            "{",
+            "    [AttributeUsage(AttributeTargets.Class)]",
+            "    public sealed class EventTypeAttribute : Attribute",
+            "    {",
+            "    }",
+            "}",
+            "",
+            "namespace Cratis.Chronicle.Reducers",
+            "{",
+            "    public interface IReducer",
+            "    {",
+            "    }",
+            "",
+            "    public interface IReducerFor<TReadModel> : IReducer",
+            "    {",
+            "    }",
+            "}",
+            "",
+            "namespace Sample",
+            "{",
+            usage,
+            "}"
+        ]);
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_analyzing_reducer_methods/and_the_current_read_model_is_not_nullable.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_analyzing_reducer_methods/and_the_current_read_model_is_not_nullable.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerCurrentReadModelMustBeNullableAnalyzer.when_analyzing_reducer_methods;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3947 — a handler promising a non-null current read
+/// model was silently left out of dispatch, so its events were never applied.
+/// </summary>
+public class and_the_current_read_model_is_not_nullable : given.a_reducer_current_read_model_must_be_nullable_analyzer
+{
+    const string Usage = """
+    [EventType]
+    public class SomethingHappened { }
+
+    public class TheReadModel { }
+
+    public class TheReducer : Cratis.Chronicle.Reducers.IReducerFor<TheReadModel>
+    {
+        public TheReadModel Reduce(SomethingHappened @event, {|#0:TheReadModel current|}) => current;
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerCurrentReadModelMustBeNullableAnalyzer>.VerifyAnalyzer(
+        CreateSource(Usage),
+        new ExpectedDiagnostic(DiagnosticIds.ReducerCurrentReadModelMustBeNullable, DiagnosticSeverity.Warning, "Reduce", "TheReadModel"));
+
+    [Fact] Task should_report_that_the_current_read_model_must_be_nullable() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_analyzing_reducer_methods/and_the_current_read_model_is_nullable.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_analyzing_reducer_methods/and_the_current_read_model_is_nullable.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.CodeAnalysis.Specs.Testing;
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerCurrentReadModelMustBeNullableAnalyzer.when_analyzing_reducer_methods;
+
+public class and_the_current_read_model_is_nullable : given.a_reducer_current_read_model_must_be_nullable_analyzer
+{
+    const string Usage = """
+    [EventType]
+    public class SomethingHappened { }
+
+    public class TheReadModel { }
+
+    public class TheReducer : Cratis.Chronicle.Reducers.IReducerFor<TheReadModel>
+    {
+        public TheReadModel Reduce(SomethingHappened @event, TheReadModel? current) => current!;
+    }
+    """;
+
+    Task _result;
+
+    void Because() => _result = AnalyzerVerifier<CodeAnalysis.Analyzers.ReducerCurrentReadModelMustBeNullableAnalyzer>.VerifyAnalyzer(CreateSource(Usage));
+
+    [Fact] Task should_not_report_anything() => _result;
+}

--- a/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_creating_analyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis.Specs/Analyzers/for_ReducerCurrentReadModelMustBeNullableAnalyzer/when_creating_analyzer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.CodeAnalysis.Specs.Analyzers.for_ReducerCurrentReadModelMustBeNullableAnalyzer;
+
+public class when_creating_analyzer : Specification
+{
+    CodeAnalysis.Analyzers.ReducerCurrentReadModelMustBeNullableAnalyzer _analyzer;
+
+    void Establish() => _analyzer = new CodeAnalysis.Analyzers.ReducerCurrentReadModelMustBeNullableAnalyzer();
+
+    [Fact] void should_have_supported_diagnostics() => _analyzer.SupportedDiagnostics.ShouldNotBeEmpty();
+    [Fact] void should_support_chr0051_diagnostic() => _analyzer.SupportedDiagnostics.Any(d => d.Id == DiagnosticIds.ReducerCurrentReadModelMustBeNullable).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerCurrentReadModelMustBeNullableAnalyzer.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/Analyzers/ReducerCurrentReadModelMustBeNullableAnalyzer.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Cratis.Chronicle.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// Analyzer that checks a reducer method accepts a nullable current read model.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReducerCurrentReadModelMustBeNullableAnalyzer : DiagnosticAnalyzer
+{
+    static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.ReducerCurrentReadModelMustBeNullable,
+        title: "Reducer current read model parameter must be nullable",
+        messageFormat: "Reducer method '{0}' declares its current read model parameter as '{1}' rather than '{1}?'",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Chronicle passes null as the current read model for the event that brings an instance into existence, so a reducer method cannot promise the parameter is never null. Declare the parameter as nullable and handle the null case as the creation of the instance.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeMethod, SymbolKind.Method);
+    }
+
+    static void AnalyzeMethod(SymbolAnalysisContext context)
+    {
+        var methodSymbol = (IMethodSymbol)context.Symbol;
+
+        if (methodSymbol.MethodKind != MethodKind.Ordinary || methodSymbol.IsStatic)
+        {
+            return;
+        }
+
+        if (!WellKnownTypes.ImplementsIReducer(methodSymbol.ContainingType, context.Compilation))
+        {
+            return;
+        }
+
+        var readModelType = GetReadModelType(methodSymbol.ContainingType, context.Compilation);
+        if (readModelType is null)
+        {
+            return;
+        }
+
+        var parameters = methodSymbol.Parameters;
+        if (parameters.Length is < 2 or > 3)
+        {
+            return;
+        }
+
+        if (!WellKnownTypes.HasEventTypeAttribute(parameters[0].Type))
+        {
+            return;
+        }
+
+        var current = parameters[1];
+        if (!SymbolEqualityComparer.Default.Equals(current.Type, readModelType))
+        {
+            return;
+        }
+
+        // Only an explicit non-nullable annotation is a broken promise. In a #nullable disable context the
+        // annotation carries no claim at all, which is why Chronicle keeps dispatching to those methods.
+        if (current.NullableAnnotation != NullableAnnotation.NotAnnotated)
+        {
+            return;
+        }
+
+        var diagnostic = Diagnostic.Create(
+            Rule,
+            current.Locations.FirstOrDefault(),
+            methodSymbol.Name,
+            readModelType.Name);
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    static ITypeSymbol? GetReadModelType(INamedTypeSymbol reducerType, Compilation compilation)
+    {
+        var reducerForInterface = compilation.GetTypeByMetadataName(WellKnownTypes.IReducerForName);
+        if (reducerForInterface is null)
+        {
+            return null;
+        }
+
+        var closed = reducerType.AllInterfaces.FirstOrDefault(_ =>
+            _.IsGenericType && SymbolEqualityComparer.Default.Equals(_.OriginalDefinition, reducerForInterface));
+
+        return closed?.TypeArguments.FirstOrDefault();
+    }
+}

--- a/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/DiagnosticIds.cs
@@ -253,4 +253,9 @@ public static class DiagnosticIds
     /// A type is marked with both [EventType] and [EventTypeGenerationFor&lt;T&gt;].
     /// </summary>
     public const string EventTypeGenerationForCannotCombineWithEventType = "CHR0050";
+
+    /// <summary>
+    /// A reducer method declares its current read model parameter as non-nullable.
+    /// </summary>
+    public const string ReducerCurrentReadModelMustBeNullable = "CHR0051";
 }

--- a/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
+++ b/Source/Clients/DotNET.CodeAnalysis/WellKnownTypes.cs
@@ -85,6 +85,11 @@ public static class WellKnownTypes
     public const string IReducerName = "Cratis.Chronicle.Reducers.IReducer";
 
     /// <summary>
+    /// The full name of the generic IReducerFor interface.
+    /// </summary>
+    public const string IReducerForName = "Cratis.Chronicle.Reducers.IReducerFor`1";
+
+    /// <summary>
     /// The full name of the IAggregateRoot interface.
     /// </summary>
     /// <remarks>

--- a/Source/Clients/DotNET.Specs/Reducers/for_ReducerInvoker/when_creating_for/ReducerWithNonNullableCurrentReadModel.cs
+++ b/Source/Clients/DotNET.Specs/Reducers/for_ReducerInvoker/when_creating_for/ReducerWithNonNullableCurrentReadModel.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Reducers.for_ReducerInvoker.when_creating_for;
+
+public class ReducerWithNonNullableCurrentReadModel
+{
+    public Task<ReadModel> Reduce(MyEvent @event, ReadModel initial, EventContext context) => Task.FromResult<ReadModel>(null!);
+}

--- a/Source/Clients/DotNET.Specs/Reducers/for_ReducerInvoker/when_creating_for/reducer_with_non_nullable_current_read_model.cs
+++ b/Source/Clients/DotNET.Specs/Reducers/for_ReducerInvoker/when_creating_for/reducer_with_non_nullable_current_read_model.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Reducers.Validators;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Reducers.for_ReducerInvoker.when_creating_for;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3947 — a handler declaring a non-nullable current
+/// read model used to be dropped from dispatch without a word, leaving the reducer looking registered while none
+/// of its events were ever applied.
+/// </summary>
+public class reducer_with_non_nullable_current_read_model : Specification
+{
+    IClientArtifactsActivator _artifactActivator;
+    IEventTypes _eventTypes;
+    ReducerInvoker _invoker;
+    Exception _result;
+
+    void Establish()
+    {
+        _artifactActivator = Substitute.For<IClientArtifactsActivator>();
+        _artifactActivator.Activate(Arg.Any<IServiceProvider>(), typeof(ReducerWithNonNullableCurrentReadModel))
+            .Returns(callInfo => new ActivatedArtifact(
+                new ReducerWithNonNullableCurrentReadModel(),
+                typeof(ReducerWithNonNullableCurrentReadModel),
+                Substitute.For<ILogger<ActivatedArtifact>>()));
+        _eventTypes = new EventTypesForSpecifications([]);
+    }
+
+    void Because() => _result = Catch.Exception(() => _invoker = new ReducerInvoker(
+        _eventTypes,
+        _artifactActivator,
+        typeof(ReducerWithNonNullableCurrentReadModel),
+        typeof(ReadModel),
+        nameof(ReadModel)));
+
+    [Fact] void should_fail() => _result.ShouldNotBeNull();
+    [Fact] void should_not_create_the_invoker() => _invoker.ShouldBeNull();
+    [Fact] void should_say_the_current_read_model_must_be_nullable() => _result.ShouldBeOfExactType<ReducerMethodCurrentReadModelMustBeNullable>();
+    [Fact] void should_name_the_offending_method() => _result.Message.ShouldContain(nameof(ReducerWithNonNullableCurrentReadModel.Reduce));
+}

--- a/Source/Clients/DotNET/Reducers/ReducerInvoker.cs
+++ b/Source/Clients/DotNET/Reducers/ReducerInvoker.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Cratis.Chronicle.Events;
 using Cratis.Chronicle.Observation;
 using Cratis.Chronicle.ReadModels;
+using Cratis.Chronicle.Reducers.Validators;
 
 namespace Cratis.Chronicle.Reducers;
 
@@ -141,6 +142,11 @@ public class ReducerInvoker : IReducerInvoker
 
     static FrozenDictionary<Type, MethodInfo> BuildMethodsByEventType(Type targetType, Type readModelType, IEnumerable<Type> eventTypes)
     {
+        // A method that matches the reducer shape but declares its current read model as non-nullable used to be
+        // dropped from dispatch without a word, so its events were never applied and the reducer merely looked
+        // registered. Reject it here instead - it can only ever be a mistake (#3947).
+        ReducerMethodCurrentReadModelMustBeNullable.ThrowIfAnyMethodHasNonNullableCurrentReadModel(targetType, readModelType, eventTypes);
+
         var methodsByEventType = new Dictionary<Type, MethodInfo>();
 
         // Ordered so the reducer method that should win comes first, and claimed with TryAdd so it keeps the

--- a/Source/Clients/DotNET/Reducers/ReducerTypeExtensions.cs
+++ b/Source/Clients/DotNET/Reducers/ReducerTypeExtensions.cs
@@ -29,7 +29,25 @@ public static class ReducerTypeExtensions
     /// TReadModel {MethodName}(TEvent event, TReadModel? current)
     /// ]]>
     /// </remarks>
-    public static bool IsReducerMethod(this MethodInfo methodInfo, Type readModelType, IEnumerable<Type> eventTypes)
+    public static bool IsReducerMethod(this MethodInfo methodInfo, Type readModelType, IEnumerable<Type> eventTypes) =>
+        methodInfo.HasReducerMethodShape(readModelType, eventTypes) &&
+        !methodInfo.HasNonNullableCurrentReadModelParameter();
+
+    /// <summary>
+    /// Check if a <see cref="MethodInfo"/> is shaped like a reducer method, without considering the nullability of its current read model parameter.
+    /// </summary>
+    /// <param name="methodInfo"><see cref="MethodInfo"/> to check.</param>
+    /// <param name="readModelType">Type of read model.</param>
+    /// <param name="eventTypes">Known event types in the process.</param>
+    /// <returns>True if it has the shape of a reducer method, false if not.</returns>
+    /// <remarks>
+    /// This is the signature match on its own - return type, event type as first parameter, the read model as second
+    /// and an optional <see cref="EventContext"/> as third. A method that matches this but declares its current read
+    /// model as non-nullable is a reducer method the author got wrong, not a method that happens to look similar,
+    /// which is what lets <see cref="ReducerMethodCurrentReadModelMustBeNullable"/> report it instead of silently
+    /// dropping it from dispatch.
+    /// </remarks>
+    public static bool HasReducerMethodShape(this MethodInfo methodInfo, Type readModelType, IEnumerable<Type> eventTypes)
     {
         if (methodInfo.IsSpecialName)
         {
@@ -52,12 +70,6 @@ public static class ReducerTypeExtensions
             parameters[0].ParameterType.IsEventType(eventTypes) &&
             parameters[1].ParameterType.Equals(readModelType))
         {
-            var nullabilityContext = new NullabilityInfoContext();
-            if (nullabilityContext.Create(parameters[1]).ReadState == NullabilityState.NotNull)
-            {
-                return false;
-            }
-
             if (parameters.Length == 3)
             {
                 if (parameters[2].ParameterType == typeof(EventContext)) return true;
@@ -69,6 +81,28 @@ public static class ReducerTypeExtensions
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Check whether a reducer-shaped <see cref="MethodInfo"/> declares its current read model parameter as non-nullable.
+    /// </summary>
+    /// <param name="methodInfo"><see cref="MethodInfo"/> to check.</param>
+    /// <returns>True if the current read model parameter is statically non-nullable, false if not.</returns>
+    /// <remarks>
+    /// The current read model is null for the event that brings an instance into existence, so a non-nullable
+    /// declaration is a claim the reducer cannot keep. A method declared in a <c>#nullable disable</c> context makes
+    /// no claim either way and is not reported.
+    /// </remarks>
+    public static bool HasNonNullableCurrentReadModelParameter(this MethodInfo methodInfo)
+    {
+        var parameters = methodInfo.GetParameters();
+        if (parameters.Length < 2)
+        {
+            return false;
+        }
+
+        var nullabilityContext = new NullabilityInfoContext();
+        return nullabilityContext.Create(parameters[1]).ReadState == NullabilityState.NotNull;
     }
 
     /// <summary>

--- a/Source/Clients/DotNET/Reducers/Validators/ReducerMethodCurrentReadModelMustBeNullable.cs
+++ b/Source/Clients/DotNET/Reducers/Validators/ReducerMethodCurrentReadModelMustBeNullable.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Cratis.Chronicle.Reducers.Validators;
+
+/// <summary>
+/// Exception that gets thrown when a reducer method declares its current read model parameter as non-nullable.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of <see cref="ReducerMethodCurrentReadModelMustBeNullable"/>.
+/// </remarks>
+/// <param name="reducerType">The reducer type holding the violating method.</param>
+/// <param name="methodName">Name of the violating method.</param>
+/// <param name="readModelType">Type of the read model the reducer reduces to.</param>
+public class ReducerMethodCurrentReadModelMustBeNullable(Type reducerType, string methodName, Type readModelType)
+    : Exception($"Reducer method '{reducerType.Name}.{methodName}' declares its current read model parameter as '{readModelType.Name}' rather than '{readModelType.Name}?'. The current read model is null for the event that creates the instance, so the method must accept null. Change the parameter to '{readModelType.Name}?'.")
+{
+    /// <summary>
+    /// Throw if any reducer-shaped method on the type declares a non-nullable current read model parameter.
+    /// </summary>
+    /// <param name="reducerType">Reducer type to check.</param>
+    /// <param name="readModelType">Type of the read model the reducer reduces to.</param>
+    /// <param name="eventTypes">Known event types in the process.</param>
+    /// <exception cref="ReducerMethodCurrentReadModelMustBeNullable">Thrown when a method would never be dispatched to because of its current read model parameter.</exception>
+    public static void ThrowIfAnyMethodHasNonNullableCurrentReadModel(Type reducerType, Type readModelType, IEnumerable<Type> eventTypes)
+    {
+        var violating = reducerType
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .FirstOrDefault(method =>
+                method.HasReducerMethodShape(readModelType, eventTypes) &&
+                method.HasNonNullableCurrentReadModelParameter());
+
+        if (violating is not null)
+        {
+            throw new ReducerMethodCurrentReadModelMustBeNullable(reducerType, violating.Name, readModelType);
+        }
+    }
+}

--- a/Source/Clients/Testing.Specs/ReadModels/UsageLedger.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/UsageLedger.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+using Cratis.Chronicle.ReadModels;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Read model accumulating consumed capacity both at the root and broken down per period in a child
+/// collection, so that the same event feeds an <see cref="AddFromAttribute{TEvent}"/> at both levels.
+/// </summary>
+/// <param name="Id">Ledger identifier.</param>
+/// <param name="Name">The ledger name.</param>
+/// <param name="TotalConsumed">The total amount consumed across every period.</param>
+/// <param name="Periods">The per-period breakdown keyed by <see cref="UsageRecorded.Period"/>.</param>
+[Passive]
+[FromEvent<LedgerOpened>]
+public record UsageLedger(
+    Guid Id,
+    string Name,
+
+    [AddFrom<UsageRecorded>(nameof(UsageRecorded.Consumed))]
+    decimal TotalConsumed,
+
+    [ChildrenFrom<UsageRecorded>(key: nameof(UsageRecorded.Period), identifiedBy: nameof(UsagePeriod.Period))]
+    IEnumerable<UsagePeriod> Periods);

--- a/Source/Clients/Testing.Specs/ReadModels/UsagePeriod.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/UsagePeriod.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.ModelBound;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// A child line accumulating consumed capacity for one period.
+/// </summary>
+/// <param name="Period">The period, used as the child key.</param>
+/// <param name="Consumed">The accumulated amount consumed within the period.</param>
+public record UsagePeriod(
+    string Period,
+
+    [AddFrom<UsageRecorded>(nameof(UsageRecorded.Consumed))]
+    decimal Consumed);

--- a/Source/Clients/Testing.Specs/ReadModels/UsageRecorded.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/UsageRecorded.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.Testing.ReadModels;
+
+/// <summary>
+/// Test event recording consumed capacity against a named period, used to verify accumulating
+/// projections both at the root and inside a child collection.
+/// </summary>
+/// <param name="Period">The period the usage belongs to, used as the child key.</param>
+/// <param name="Consumed">The amount consumed.</param>
+[EventType]
+public record UsageRecorded(string Period, decimal Consumed);

--- a/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_a_child_property_accumulates_with_add_from.cs
+++ b/Source/Clients/Testing.Specs/ReadModels/for_ReadModelScenario/when_projecting_with_children_from/and_a_child_property_accumulates_with_add_from.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.ReadModels.for_ReadModelScenario.when_projecting_with_children_from;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3940 — the event that creates a child entry
+/// applied the child's property mappers twice, which is invisible for a plain set but doubles an
+/// accumulating <c>[AddFrom]</c>. The root-level accumulation on the same event must stay correct too.
+/// </summary>
+public class and_a_child_property_accumulates_with_add_from : Specification
+{
+    ReadModelScenario<UsageLedger> _scenario;
+    Guid _ledgerId;
+
+    void Establish()
+    {
+        _scenario = new ReadModelScenario<UsageLedger>();
+        _ledgerId = Guid.NewGuid();
+    }
+
+    async Task Because() =>
+        await _scenario.Given
+            .ForEventSource(_ledgerId)
+            .Events(
+                new LedgerOpened("Capacity"),
+                new UsageRecorded("2026-09", 12.5m),
+                new UsageRecorded("2026-09", 5m),
+                new UsageRecorded("2026-10", 2m));
+
+    [Fact] void should_have_an_instance() => _scenario.Instance.ShouldNotBeNull();
+    [Fact] void should_accumulate_the_root_total() => _scenario.Instance.TotalConsumed.ShouldEqual(19.5m);
+    [Fact] void should_have_a_period_per_distinct_key() => _scenario.Instance.Periods.Count().ShouldEqual(2);
+
+    [Fact] void should_accumulate_the_created_period_exactly_once() =>
+        _scenario.Instance.Periods.Single(_ => _.Period == "2026-09").Consumed.ShouldEqual(17.5m);
+
+    [Fact] void should_accumulate_a_period_created_by_a_later_event_exactly_once() =>
+        _scenario.Instance.Periods.Single(_ => _.Period == "2026-10").Consumed.ShouldEqual(2m);
+}

--- a/Source/Kernel/Core.Specs/Jobs/for_Job/when_resuming/and_the_job_was_left_running_with_every_step_completed.cs
+++ b/Source/Kernel/Core.Specs/Jobs/for_Job/when_resuming/and_the_job_was_left_running_with_every_step_completed.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.Jobs;
+using Cratis.Monads;
+using Moq;
+
+namespace Cratis.Chronicle.Jobs.for_Job.when_resuming;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3944 — a job persisted as Running with every step
+/// already accounted for used to report itself as already running, so nothing ever finalized it and the observer
+/// it belonged to could never resubscribe.
+/// </summary>
+public class and_the_job_was_left_running_with_every_step_completed : given.the_job
+{
+    JobStepId _jobStepId;
+    Mock<given.ISomeJobStep> _jobStep;
+    Result<ResumeJobSuccess, ResumeJobError> _result;
+
+    void Establish()
+    {
+        _job.ShouldBeResumable = true;
+        _jobStepId = Guid.Parse("3f3f3f3f-0000-0000-0000-000000000003");
+        _jobStep = AddJobStep(_jobStepId);
+        _jobStep.Setup(_ => _.Start(It.IsAny<GrainId>())).ReturnsAsync(Result<StartJobStepError>.Success());
+    }
+
+    async Task Because()
+    {
+        await _job.Start(new());
+
+        // The state the store was found in: the progress for the last step was written, the status that follows
+        // from it never was.
+        _job.CurrentState.Status = JobStatus.Running;
+        _job.CurrentState.Progress.TotalSteps = 1;
+        _job.CurrentState.Progress.SuccessfulSteps = 1;
+        _job.CurrentState.Progress.FailedSteps = 0;
+
+        _result = await _job.Resume();
+    }
+
+    [Fact] void should_report_the_resume_as_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_report_the_job_as_completed() => ((ResumeJobSuccess)_result).ShouldEqual(ResumeJobSuccess.JobIsCompleted);
+    [Fact] void should_finalize_the_job() => _job.CurrentState.Status.ShouldEqual(JobStatus.CompletedSuccessfully);
+    [Fact] void should_not_leave_the_job_running() => _job.CurrentState.Status.ShouldNotEqual(JobStatus.Running);
+}

--- a/Source/Kernel/Core/Jobs/Job.Steps.cs
+++ b/Source/Kernel/Core/Jobs/Job.Steps.cs
@@ -169,6 +169,31 @@ public abstract partial class Job<TRequest, TJobState>
     Task<Dictionary<JobStepId, IJobStep>> GetIdAndGrainReferenceForNonCompletedJobSteps() =>
         GetIdAndGrainReferenceJobSteps(JobStepStatus.Running, JobStepStatus.Scheduled, JobStepStatus.Unknown, JobStepStatus.Stopped);
 
+    /// <summary>
+    /// Recount the job's progress from the persisted state of its steps.
+    /// </summary>
+    /// <returns>Awaitable task.</returns>
+    /// <remarks>
+    /// The progress is maintained by counting step outcomes as they are reported, so an outcome that never reached
+    /// storage leaves it permanently short of the total and the job never finishes (#3944). The steps are the record
+    /// of what actually happened, so they are what a stalled job's progress is rebuilt from.
+    /// </remarks>
+    async Task ReconcileProgressFromJobSteps()
+    {
+        var getJobSteps = await Storage.JobSteps.GetForJob(JobId);
+        if (getJobSteps.TryGetException(out var exception))
+        {
+            _logger.FailedReconcilingProgressFromJobSteps(exception);
+            return;
+        }
+
+        var steps = getJobSteps.AsT0;
+        State.Progress.TotalSteps = steps.Count;
+        State.Progress.SuccessfulSteps = steps.Count(_ => _.Status is JobStepStatus.CompletedSuccessfully);
+        State.Progress.FailedSteps = steps.Count(_ => _.Status is JobStepStatus.CompletedWithFailure or JobStepStatus.Failed);
+        State.Progress.StoppedSteps = 0;
+    }
+
     IJobStep GetJobStepGrain(JobStepDetails details) => (GrainFactory.GetGrain(details.Type, details.Id, keyExtension: details.Key) as IJobStep)!;
     IJobStep GetJobStepGrain(JobStepState state) => (GrainFactory.GetGrain((Type)state.Type, state.Id.JobStepId, keyExtension: new JobStepKey(state.Id.JobId, JobKey.EventStore, JobKey.Namespace)) as IJobStep)!;
 

--- a/Source/Kernel/Core/Jobs/Job.cs
+++ b/Source/Kernel/Core/Jobs/Job.cs
@@ -163,6 +163,20 @@ public abstract partial class Job<TRequest, TJobState> : Grain<TJobState>, IJob<
             {
                 return Result.Failed<ResumeJobSuccess, ResumeJobError>(CannotResumeJobError.Unknown);
             }
+
+            // A job can be left persisted as running with every one of its steps already accounted for: the
+            // progress for the last step is written before the status that follows from it, so a silo that stops
+            // in between - or a completion handler that fails - leaves a state that contradicts itself. Nothing
+            // revisited it, and reporting it as already running kept it that way: the job stayed Running forever
+            // and its observer could never resubscribe (#3944). Resume is where both the kernel's rehydration and
+            // an observer's subscribe reach the job, so finalize it here rather than leaving it wedged.
+            if (State.Status is JobStatus.Running && State.Progress.IsCompleted)
+            {
+                _logger.FinalizingJobLeftRunningAfterAllStepsCompleted();
+                _ = await HandleCompletionResult(await HandleCompletion());
+                return ResumeJobSuccess.JobIsCompleted;
+            }
+
             if (JobIsRunning())
             {
                 return ResumeJobSuccess.JobAlreadyRunning;
@@ -186,6 +200,18 @@ public abstract partial class Job<TRequest, TJobState> : Grain<TJobState>, IJob<
             if (_jobStepGrains is null or { Count: 0 })
             {
                 _jobStepGrains = await GetIdAndGrainReferenceForNonCompletedJobSteps();
+            }
+
+            // A prepared job with nothing left to start cannot make progress on its own, so resuming it only puts
+            // it back into Running for the next resume to find. That is the same permanent wedge as the state
+            // above, reached when the progress for a completed step was never persisted (#3944). The steps
+            // themselves are the record of what happened, so recount from them before finalizing.
+            if (_jobStepGrains.Count == 0)
+            {
+                _logger.FinalizingJobLeftRunningAfterAllStepsCompleted();
+                await ReconcileProgressFromJobSteps();
+                _ = await HandleCompletionResult(await HandleCompletion());
+                return ResumeJobSuccess.JobIsCompleted;
             }
 
             _logger.Resuming();

--- a/Source/Kernel/Core/Jobs/JobLogging.cs
+++ b/Source/Kernel/Core/Jobs/JobLogging.cs
@@ -21,6 +21,12 @@ internal static partial class JobLogMessages
     [LoggerMessage(LogLevel.Debug, "Resuming job")]
     internal static partial void Resuming(this ILogger<IJob> logger);
 
+    [LoggerMessage(LogLevel.Warning, "Job was left running with all of its steps already completed - finalizing it instead of resuming")]
+    internal static partial void FinalizingJobLeftRunningAfterAllStepsCompleted(this ILogger<IJob> logger);
+
+    [LoggerMessage(LogLevel.Warning, "Job failed recounting its progress from its job steps")]
+    internal static partial void FailedReconcilingProgressFromJobSteps(this ILogger<IJob> logger, Exception ex);
+
     [LoggerMessage(LogLevel.Debug, "Stopping job")]
     internal static partial void Stopping(this ILogger<IJob> logger);
 

--- a/Source/Kernel/Core/Projections/Engine/ProjectionEventContextExtensions.cs
+++ b/Source/Kernel/Core/Projections/Engine/ProjectionEventContextExtensions.cs
@@ -183,6 +183,11 @@ public static class ProjectionEventContextExtensions
                 if (!context.IsJoin && (!identifiedByProperty.IsSet ||
                                         !items.Contains(identifiedByProperty, childrenPropertyIndexer.Identifier)))
                 {
+                    // AddChild applies the property mappers itself - it has to, because the ChildAdded change it
+                    // records is what carries the new child's values all the way to the sink. Mapping again here
+                    // is invisible for a plain set (it writes the same value twice) but runs every accumulating
+                    // mapper a second time, so [AddFrom]/[SubtractFrom] on a child doubled on the very event that
+                    // created it (#3940).
                     context.Changeset.AddChild<ExpandoObject>(
                         childrenProperty,
                         identifiedByProperty,
@@ -190,7 +195,6 @@ public static class ProjectionEventContextExtensions
                         propertyMappers,
                         context.Key.ArrayIndexers,
                         childInitialState);
-                    context.Changeset.SetProperties(propertyMappers, context.Key.ArrayIndexers);
                     return;
                 }
 

--- a/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_beginning_a_replay/and_the_read_model_declares_indexes.cs
+++ b/Source/Kernel/Storage.MongoDB.Specs/Sinks/for_Sink/when_beginning_a_replay/and_the_read_model_declares_indexes.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Concepts.ReadModels;
+using Cratis.Chronicle.Storage.ReadModels;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Cratis.Chronicle.Storage.MongoDB.Sinks.for_Sink.when_beginning_a_replay;
+
+/// <summary>
+/// A replay fills a shadow collection that is renamed into place when it finishes, and a rename carries only the
+/// indexes that collection has of its own. The declared indexes therefore have to be created on it as the replay
+/// begins, or the read model comes back from a replay unindexed (#3942).
+/// </summary>
+public class and_the_read_model_declares_indexes : given.a_sink_with_indexes
+{
+    void Establish() => _indexCursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+
+    async Task Because() => await _sink.BeginReplay(
+        new ReplayContext(
+            new ReadModelType("SomethingId", ReadModelGeneration.First),
+            "Something",
+            "revert-Something",
+            DateTimeOffset.UtcNow));
+
+    [Fact] void should_begin_the_replay_on_the_collections() => _collections.Received(1).BeginReplay(Arg.Any<ReplayContext>());
+
+    [Fact] void should_create_the_declared_index() =>
+        _indexManager.Received(1).CreateOneAsync(
+            Arg.Is<CreateIndexModel<BsonDocument>>(model =>
+                model.Options.Name == $"chronicle_idx_{_indexedProperty.Path}"),
+            Arg.Any<CreateOneIndexOptions>(),
+            Arg.Any<CancellationToken>());
+}

--- a/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
+++ b/Source/Kernel/Storage.MongoDB/Sinks/Sink.cs
@@ -316,6 +316,13 @@ public class Sink(
     public async Task BeginReplay(ReplayContext context)
     {
         await collections.BeginReplay(context);
+
+        // A replay writes into its own shadow collection and that collection is renamed into place at the end,
+        // taking its own indexes with it - and only its own. Indexes were ensured once when the sink was built,
+        // against the collection that the swap replaces, so without this the promoted collection comes up with
+        // none of them until something rebuilds the sink. Recreating them is exactly what the declaration on the
+        // read model is for (#3942).
+        await EnsureIndexes();
         await BeginBulk();
     }
 
@@ -323,6 +330,7 @@ public class Sink(
     public async Task ResumeReplay(ReplayContext context)
     {
         await collections.ResumeReplay(context);
+        await EnsureIndexes();
         await BeginBulk();
     }
 


### PR DESCRIPTION
# Summary

A batch of failures that were all quiet in the same way: an accumulating projection produced wrong numbers without an error, a reducer looked registered while none of its events were applied, a job stayed running forever and blocked its observer from ever reconnecting, and a client that lost the kernel stopped failing calls and started consuming the threads that made them. Each is now either correct or loud.

## Added

- ASP.NET Core health check for the client connection, registered automatically by `AddCratisChronicle` under the name `chronicle` with the `chronicle` and `ready` tags. `AddChronicleHealthCheck(HealthStatus)` registers it explicitly and chooses the failure status (#3943)
- `CHR0051` reports a reducer method that declares its current read model as non-nullable (#3947)
- Documentation for the `[Index]` attribute, covering why the declaration lives on the read model and how it survives a replay (#3942)
- Documentation for the client health check (#3943)

## Changed

- A client call made while the connection is down now fails instead of blocking its thread. A connect timeout surfaces as `ConnectionTimedOut`, acquiring the connect lock is bounded by the connect timeout, and a failed attempt starts a back-off during which calls fail immediately with `ConnectionUnavailable`. The watchdog still reconnects in the background, so a kernel that comes back is reachable again without restarting the client (#3948)
- A reducer method whose current read model parameter is non-nullable is now rejected at registration rather than silently excluded from dispatch. The current read model is null for the event that creates an instance, so the declaration can only ever be a mistake. Methods in a `#nullable disable` context are unaffected (#3947)
- An ASP.NET Core host no longer fails to start when the kernel is briefly unreachable; the connection failure is logged and the health check reports it until the connection comes up (#3943)

## Fixed

- `[AddFrom<T>]` on a property of a `[ChildrenFrom<T>]` child no longer double-counts the event that creates the child entry. Accumulating child breakdowns produced exactly twice the value on the creating event, and every later event accumulated on top of that (#3940)
- A job left persisted as running with all of its steps already completed is now finalized instead of reported as already running. Such a job stayed wedged forever and its observer could never resubscribe, leaving reactors disconnected indefinitely (#3944)
- A read model's declared indexes are now recreated on the collection a replay fills, so they survive the swap that ends the replay instead of being absent until the sink is rebuilt (#3942)
