### PR TITLE
Fix event schema rename rejection and nested migration properties

### DIFF
--- a/.ai/skills/event-type-migrations/SKILL.md
+++ b/.ai/skills/event-type-migrations/SKILL.md
@@ -60,6 +60,10 @@ public class OrderPlacedV1ToV2 : EventTypeMigration<OrderPlaced, OrderPlacedV1>
 
 The property builder exposes `DefaultValue`, `RenamedFrom`, `Split`, and `Combine` — use them to express the change declaratively. Both `Upcast` and `Downcast` are abstract on the base, so both must be implemented (`Downcast` may be a no-op `builder.Properties(_ => { })` when no consumer needs the gen-1 shape).
 
+**A property inside a nested value object is addressed by the expression you'd write anyway** — `pb.DefaultValue(_ => _.Price.Description, "unspecified")`. The expression becomes the path `Price.Description`: reading walks into the object, writing creates the objects along the way. That also restructures a payload — `RenamedFrom(_ => _.Price.Amount, e => e.Amount)` moves a top-level value into the object it now belongs to. A path that resolves to nothing is rejected at registration with `InvalidMigrationPropertyForEventType`.
+
+> **Adding or removing an *optional* property — at any depth — needs the migration class but no property operations in it.** Chronicle converts a payload by walking the *target* generation's schema, so upcasting materializes the new property as absent and downcasting drops it, on their own. An empty `Upcast`/`Downcast` pair is the correct and complete migration there; the class only has to exist so the generation chain is complete. Reach for `DefaultValue` when absent is the wrong answer and you want a specific value.
+
 ### 2b. When the *values* changed meaning, declare a value map
 
 The operations above move values between properties. When a value itself means something different in the new generation — an enum renumbered, a status code set replaced — override **`MapValues`** on the migration instead. It is declared once and applied forward when upcasting and inverted when downcasting:
@@ -88,6 +92,7 @@ For three generations, write two migrations (`1→2`, `2→3`) — each only kno
 | Adding a nullable value type to handle "missing old data" | Analyzer-flagged anti-pattern; use a migration default |
 | A migration that throws on a null/missing old field | Old events may lack fields entirely — null-coalesce / default |
 | Splitting one event into two inside `Upcast` | `Upcast` returns one event; model a split as a reactor/command, not a schema migration |
+| Reaching for an API to build a new nested value from the old one | There isn't one, and there doesn't need to be — a migration is a declarative descriptor evaluated kernel-side against JSON, with no CLR types. Address the inner property directly (`_ => _.Price.Description`), or leave the migration empty when the property is optional |
 
 ## Quality gate
 

--- a/Documentation/client-snippets/migrations/dotnet-client/nested-property.md
+++ b/Documentation/client-snippets/migrations/dotnet-client/nested-property.md
@@ -1,0 +1,25 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+public sealed record MigrationsDotnetClientNestedPrice(decimal Amount, string Description);
+
+public sealed record MigrationsDotnetClientNestedPriceV1(decimal Amount);
+
+[EventType("dotnet-client-nested-price-set", generation: 2)]
+public record MigrationsDotnetClientNestedPriceSet(MigrationsDotnetClientNestedPrice Price);
+
+[EventTypeGenerationFor<MigrationsDotnetClientNestedPriceSet>(1)]
+public record MigrationsDotnetClientNestedPriceSetV1(MigrationsDotnetClientNestedPriceV1 Price);
+
+public class MigrationsDotnetClientNestedPriceSetMigration : EventTypeMigration<MigrationsDotnetClientNestedPriceSet, MigrationsDotnetClientNestedPriceSetV1>
+{
+    public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientNestedPriceSet, MigrationsDotnetClientNestedPriceSetV1> builder) =>
+        builder.Properties(pb => pb.DefaultValue(m => m.Price.Description, "unspecified"));
+
+    public override void Downcast(IEventMigrationBuilder<MigrationsDotnetClientNestedPriceSetV1, MigrationsDotnetClientNestedPriceSet> builder)
+    {
+        // Description does not exist in generation 1 - the schema drops it on the way back
+    }
+}
+```

--- a/Documentation/client-snippets/migrations/dotnet-client/no-operations.md
+++ b/Documentation/client-snippets/migrations/dotnet-client/no-operations.md
@@ -1,0 +1,27 @@
+```csharp
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Migrations;
+
+public sealed record MigrationsDotnetClientOptionalNote(string Text, string? Author = null);
+
+public sealed record MigrationsDotnetClientOptionalNoteV1(string Text);
+
+[EventType("dotnet-client-optional-note-added", generation: 2)]
+public record MigrationsDotnetClientNoteAdded(MigrationsDotnetClientOptionalNote Note);
+
+[EventTypeGenerationFor<MigrationsDotnetClientNoteAdded>(1)]
+public record MigrationsDotnetClientNoteAddedV1(MigrationsDotnetClientOptionalNoteV1 Note);
+
+public class MigrationsDotnetClientNoteAddedMigration : EventTypeMigration<MigrationsDotnetClientNoteAdded, MigrationsDotnetClientNoteAddedV1>
+{
+    // Author is optional, so the target generation's schema fills it in on the way up
+    // and drops it on the way down. The class only has to exist.
+    public override void Upcast(IEventMigrationBuilder<MigrationsDotnetClientNoteAdded, MigrationsDotnetClientNoteAddedV1> builder)
+    {
+    }
+
+    public override void Downcast(IEventMigrationBuilder<MigrationsDotnetClientNoteAddedV1, MigrationsDotnetClientNoteAdded> builder)
+    {
+    }
+}
+```

--- a/Documentation/client-snippets/read-models/indexing/declaring.md
+++ b/Documentation/client-snippets/read-models/indexing/declaring.md
@@ -1,0 +1,10 @@
+```csharp
+using Cratis.Chronicle.ReadModels;
+
+[ReadModel]
+public record ReadModelsIndexingOrder(
+    Guid Id,
+    [property: Index] Guid CustomerId,
+    [property: Index] string Number,
+    decimal Total);
+```

--- a/Documentation/client-snippets/read-models/indexing/declaring.md
+++ b/Documentation/client-snippets/read-models/indexing/declaring.md
@@ -4,7 +4,7 @@ using Cratis.Chronicle.ReadModels;
 [ReadModel]
 public record ReadModelsIndexingOrder(
     Guid Id,
-    [property: Index] Guid CustomerId,
-    [property: Index] string Number,
+    [Index] Guid CustomerId,
+    [Index] string Number,
     decimal Total);
 ```

--- a/Documentation/client-snippets/read-models/indexing/nested.md
+++ b/Documentation/client-snippets/read-models/indexing/nested.md
@@ -2,7 +2,7 @@
 using Cratis.Chronicle.ReadModels;
 
 public record ReadModelsIndexingOrderLine(
-    [property: Index] Guid ProductId,
+    [Index] Guid ProductId,
     int Quantity);
 
 [ReadModel]

--- a/Documentation/client-snippets/read-models/indexing/nested.md
+++ b/Documentation/client-snippets/read-models/indexing/nested.md
@@ -1,0 +1,12 @@
+```csharp
+using Cratis.Chronicle.ReadModels;
+
+public record ReadModelsIndexingOrderLine(
+    [property: Index] Guid ProductId,
+    int Quantity);
+
+[ReadModel]
+public record ReadModelsIndexingOrderWithLines(
+    Guid Id,
+    IEnumerable<ReadModelsIndexingOrderLine> Lines);
+```

--- a/Documentation/migrations/dotnet-client.mdx
+++ b/Documentation/migrations/dotnet-client.mdx
@@ -59,6 +59,26 @@ Provides a literal default for a property that did not exist in the source gener
 
 <ChronicleClientTabs snippet="migrations/dotnet-client/default-value" />
 
+## Properties inside a nested object
+
+An event's payload is rarely flat — a value object groups related values, and that inner record evolves on its own schedule. Every operation above addresses such a property by the expression you would write anyway:
+
+<ChronicleClientTabs snippet="migrations/dotnet-client/nested-property" />
+
+The expression becomes the path `Price.Description`, and Chronicle resolves it segment by segment: reading walks into the object, writing creates the objects along the way when the stored payload does not carry them yet. That also lets a migration restructure a payload — `RenamedFrom(m => m.Price.Amount, e => e.Amount)` moves a value that used to sit at the top level into the object it now belongs to.
+
+A path that goes nowhere is rejected at registration with `InvalidMigrationPropertyForEventType`, naming the path so you can see which segment is wrong.
+
+## When you need no operations at all
+
+Adding or removing an **optional** property — at any depth — needs a migration class, but no property operations inside it:
+
+<ChronicleClientTabs snippet="migrations/dotnet-client/no-operations" />
+
+This looks like something is missing, and it isn't. Chronicle converts a payload by walking the *target* generation's schema: upcasting materializes a property the older payload never carried as absent, and downcasting drops one the older generation does not declare. The class only has to exist so the generation chain is complete — see [Validation: missing migrators](./validation).
+
+Reach for `DefaultValue` when absent is the wrong answer and you want a specific value instead.
+
 ## MapValues
 
 The four operations above move values between properties. `MapValues` changes the values themselves — it says which value in one generation is which value in the other, which is what you need when an enum is renumbered or a code set is replaced wholesale.

--- a/Documentation/read-models/indexing.md
+++ b/Documentation/read-models/indexing.md
@@ -16,14 +16,7 @@ persisted to, every time the container is built.
 
 Put `[Index]` on the property — or, for a record, on the constructor parameter:
 
-```csharp
-[ReadModel]
-public record Order(
-    OrderId Id,
-    [Index] CustomerId CustomerId,
-    [Index] OrderNumber Number,
-    decimal Total);
-```
+<ChronicleClientTabs snippet="read-models/indexing/declaring" />
 
 The key of a read model does not need `[Index]` — the store already indexes it.
 
@@ -32,16 +25,7 @@ The key of a read model does not need `[Index]` — the store already indexes it
 Indexes are collected by walking the read model, so a property on a nested object or on a child
 collection's element type is indexed at its full path:
 
-```csharp
-[ReadModel]
-public record Order(
-    OrderId Id,
-    IEnumerable<OrderLine> Lines);
-
-public record OrderLine(
-    [Index] ProductId ProductId,
-    int Quantity);
-```
+<ChronicleClientTabs snippet="read-models/indexing/nested" />
 
 This declares an index on `lines.productId`. The path uses the naming policy the client is
 configured with, the same one that decides how the properties are stored.

--- a/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_a_segment_is_missing.cs
+++ b/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_a_segment_is_missing.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_JsonPropertyPaths.when_resolving;
+
+public class and_a_segment_is_missing : Specification
+{
+    JsonObject _root;
+    bool _resolved;
+    JsonNode _value;
+
+    void Establish() => _root = new JsonObject { ["price"] = new JsonObject { ["amount"] = 42 } };
+
+    void Because() => _resolved = JsonPropertyPaths.TryResolve(_root, "price.description", out _value);
+
+    [Fact] void should_not_resolve() => _resolved.ShouldBeFalse();
+    [Fact] void should_not_return_a_value() => _value.ShouldBeNull();
+}

--- a/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_the_path_is_nested.cs
+++ b/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_the_path_is_nested.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_JsonPropertyPaths.when_resolving;
+
+public class and_the_path_is_nested : Specification
+{
+    JsonObject _root;
+    bool _resolved;
+    JsonNode _value;
+
+    void Establish() => _root = new JsonObject
+    {
+        ["price"] = new JsonObject { ["amount"] = 42, ["description"] = "a thing" }
+    };
+
+    void Because() => _resolved = JsonPropertyPaths.TryResolve(_root, "price.description", out _value);
+
+    [Fact] void should_resolve() => _resolved.ShouldBeTrue();
+    [Fact] void should_return_the_nested_value() => _value.GetValue<string>().ShouldEqual("a thing");
+}

--- a/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_the_value_is_null.cs
+++ b/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_resolving/and_the_value_is_null.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_JsonPropertyPaths.when_resolving;
+
+/// <summary>
+/// Present-but-null is present. A default value fills in a property the payload does not carry, not one that
+/// carries no value, so the two have to stay distinguishable.
+/// </summary>
+public class and_the_value_is_null : Specification
+{
+    JsonObject _root;
+    bool _resolved;
+    JsonNode _value;
+
+    void Establish() => _root = new JsonObject { ["price"] = new JsonObject { ["description"] = null } };
+
+    void Because() => _resolved = JsonPropertyPaths.TryResolve(_root, "price.description", out _value);
+
+    [Fact] void should_resolve() => _resolved.ShouldBeTrue();
+    [Fact] void should_return_null() => _value.ShouldBeNull();
+}

--- a/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_setting/and_the_nested_object_already_exists.cs
+++ b/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_setting/and_the_nested_object_already_exists.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_JsonPropertyPaths.when_setting;
+
+public class and_the_nested_object_already_exists : Specification
+{
+    JsonObject _root;
+
+    void Establish() => _root = new JsonObject
+    {
+        ["price"] = new JsonObject { ["amount"] = 42 }
+    };
+
+    void Because() => JsonPropertyPaths.Set(_root, "price.description", JsonValue.Create("a thing"));
+
+    [Fact] void should_write_the_value() => _root["price"]!["description"]!.GetValue<string>().ShouldEqual("a thing");
+    [Fact] void should_keep_the_siblings() => _root["price"]!["amount"]!.GetValue<int>().ShouldEqual(42);
+}

--- a/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_setting/and_the_nested_object_does_not_exist.cs
+++ b/Source/Infrastructure.Specs/Json/for_JsonPropertyPaths/when_setting/and_the_nested_object_does_not_exist.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json.for_JsonPropertyPaths.when_setting;
+
+/// <summary>
+/// A migration adding a value inside a nested object is written into a payload that may not carry that object yet,
+/// so the objects along the way are created rather than treated as an error.
+/// </summary>
+public class and_the_nested_object_does_not_exist : Specification
+{
+    JsonObject _root;
+
+    void Establish() => _root = [];
+
+    void Because() => JsonPropertyPaths.Set(_root, "price.description", JsonValue.Create("unspecified"));
+
+    [Fact] void should_create_the_nested_object() => _root["price"].ShouldBeOfExactType<JsonObject>();
+    [Fact] void should_write_the_value_inside_it() => _root["price"]!["description"]!.GetValue<string>().ShouldEqual("unspecified");
+    [Fact] void should_not_create_a_dotted_top_level_key() => _root.ContainsKey("price.description").ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_nested_object_title_differs.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_nested_object_title_differs.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// A value object nested inside an event carries a title of its own once it is generated as a named schema, and
+/// renaming that record is no more of a payload change than renaming the event's own (#3926).
+/// </summary>
+public class and_a_nested_object_title_differs : Specification
+{
+    const string Stored = """{"type":"object","properties":{"price":{"type":"object","title":"PriceV1","properties":{"amount":{"type":"number"}}}}}""";
+    const string Generated = """{"type":"object","properties":{"price":{"type":"object","title":"Price","properties":{"amount":{"type":"number"}}}}}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_differs_alongside_the_title.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_a_property_differs_alongside_the_title.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// Tolerating the title must not tolerate anything alongside it - a real shape change still needs a new
+/// generation, whether or not the type was renamed at the same time (#3926).
+/// </summary>
+public class and_a_property_differs_alongside_the_title : Specification
+{
+    const string Stored = """{"type":"object","properties":{"width":{"type":"integer","format":"int32"}},"title":"ThingResized"}""";
+    const string Generated = """{"type":"object","properties":{"width":{"type":"string"}},"title":"WidgetResized"}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_not_consider_them_compatible() => _result.ShouldBeFalse();
+}

--- a/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_they_differ_only_by_the_title.cs
+++ b/Source/Infrastructure.Specs/Schemas/for_JsonSchemaCompatibilityExtensions/when_checking_if_a_schema_is_compatible/and_they_differ_only_by_the_title.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Schemas.for_JsonSchemaCompatibilityExtensions.when_checking_if_a_schema_is_compatible;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3926 — the title carries the CLR record name, so
+/// comparing it made renaming a record a breaking schema change even with its event type identifier pinned. It
+/// describes nothing about the stored payload.
+/// </summary>
+public class and_they_differ_only_by_the_title : Specification
+{
+    const string Stored = """{"type":"object","properties":{"width":{"type":"integer","format":"int32"}},"required":["width"],"title":"ThingResized"}""";
+    const string Generated = """{"type":"object","properties":{"width":{"type":"integer","format":"int32"}},"required":["width"],"title":"WidgetResized"}""";
+
+    bool _result;
+
+    void Because() => _result = JsonSchema.FromJson(Stored).IsCompatibleWith(JsonSchema.FromJson(Generated));
+
+    [Fact] void should_consider_them_compatible() => _result.ShouldBeTrue();
+}

--- a/Source/Infrastructure/Json/JsonPropertyPaths.cs
+++ b/Source/Infrastructure/Json/JsonPropertyPaths.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Cratis.Chronicle.Json;
+
+/// <summary>
+/// Reads and writes a JSON object through a dotted property path.
+/// </summary>
+/// <remarks>
+/// A property path addresses a value by walking objects segment by segment, so <c>Price.Description</c> means the
+/// <c>Description</c> of the <c>Price</c> object rather than a top-level property whose name contains a dot. Event
+/// type migrations have always produced such paths from a nested property expression; the kernel read and wrote
+/// them flat, so a nested migration either failed validation or silently wrote a top-level key with a dot in its
+/// name that the target generation's schema then discarded (#3949).
+/// </remarks>
+public static class JsonPropertyPaths
+{
+    const char Separator = '.';
+
+    /// <summary>
+    /// Resolves the value a dotted property path addresses.
+    /// </summary>
+    /// <param name="root">The <see cref="JsonObject"/> to resolve within.</param>
+    /// <param name="path">The dotted property path.</param>
+    /// <param name="value">When this returns <see langword="true"/>, the value the path addresses - which may itself be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when every segment of the path resolved; otherwise <see langword="false"/>.</returns>
+    public static bool TryResolve(JsonObject root, string path, out JsonNode? value)
+    {
+        value = null;
+
+        var segments = Split(path);
+        JsonNode? current = root;
+
+        for (var index = 0; index < segments.Length; index++)
+        {
+            if (current is not JsonObject currentObject ||
+                !currentObject.TryGetPropertyValue(segments[index], out var next))
+            {
+                return false;
+            }
+
+            current = next;
+        }
+
+        value = current;
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a value at the dotted property path, creating the objects along the way.
+    /// </summary>
+    /// <param name="root">The <see cref="JsonObject"/> to write into.</param>
+    /// <param name="path">The dotted property path.</param>
+    /// <param name="value">The value to write, which may be <see langword="null"/>.</param>
+    /// <remarks>
+    /// A segment that is missing, or that holds something other than an object, is replaced by a fresh object so the
+    /// remaining segments have somewhere to live. Writing into a payload whose nested object has not been created
+    /// yet - which is exactly what a migration adding a value inside one does - is the normal case, not an error.
+    /// </remarks>
+    public static void Set(JsonObject root, string path, JsonNode? value)
+    {
+        var segments = Split(path);
+        var current = root;
+
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            var segment = segments[index];
+            if (current[segment] is not JsonObject next)
+            {
+                next = [];
+                current[segment] = next;
+            }
+
+            current = next;
+        }
+
+        current[segments[^1]] = value;
+    }
+
+    /// <summary>
+    /// Splits a dotted property path into its segments.
+    /// </summary>
+    /// <param name="path">The dotted property path.</param>
+    /// <returns>The segments of the path.</returns>
+    public static string[] Split(string path) => path.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+}

--- a/Source/Infrastructure/Schemas/JsonSchemaCompatibilityExtensions.cs
+++ b/Source/Infrastructure/Schemas/JsonSchemaCompatibilityExtensions.cs
@@ -15,6 +15,7 @@ public static class JsonSchemaCompatibilityExtensions
     const string EnumerationKey = "enum";
     const string EnumerationNamesKey = "x-enumNames";
     const string FormatKey = "format";
+    const string TitleKey = "title";
 
     /// <summary>
     /// Determines whether a newly generated schema is a compatible evolution of an already stored one.
@@ -39,6 +40,14 @@ public static class JsonSchemaCompatibilityExtensions
     /// different matter, because a stored value then denotes nothing or something else, so those stay a breaking
     /// change that needs a new generation and a value map to state what the old values now mean.
     /// </para>
+    /// <para>
+    /// The third is the <c>title</c>, which the client derives from the CLR type name. It says nothing about the
+    /// shape of a stored payload - the event type identifier names the type and the properties describe the data -
+    /// so comparing it made the CLR name load-bearing, which is exactly what pinning an identifier with
+    /// <c>[EventType("...")]</c> is documented to prevent. Renaming a record while pinning its identifier read as a
+    /// breaking schema change, and so did the documented generational escape hatch, whose previous generation has to
+    /// be a separate and therefore differently named type (#3926).
+    /// </para>
     /// </remarks>
     public static bool IsCompatibleWith(this JsonSchema stored, JsonSchema generated)
     {
@@ -48,8 +57,43 @@ public static class JsonSchemaCompatibilityExtensions
         StripNullableFormatMarkers(storedNode);
         StripNullableFormatMarkers(generatedNode);
 
+        StripTitles(storedNode);
+        StripTitles(generatedNode);
+
         return TryEraseCompatibleEnumerations(storedNode, generatedNode) &&
             storedNode?.ToJsonString() == generatedNode?.ToJsonString();
+    }
+
+    /// <summary>
+    /// Strips every <c>title</c> declaration from a schema node.
+    /// </summary>
+    /// <param name="node">The <see cref="JsonNode"/> to strip, which may be <see langword="null"/>.</param>
+    /// <remarks>
+    /// The title carries the CLR type name, not anything about the payload, so it is removed from both sides rather
+    /// than compared. It stays in the stored schema for the tooling that reads it.
+    /// </remarks>
+    internal static void StripTitles(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject jsonObject:
+                jsonObject.Remove(TitleKey);
+
+                foreach (var property in jsonObject.ToArray())
+                {
+                    StripTitles(property.Value);
+                }
+
+                break;
+
+            case JsonArray jsonArray:
+                foreach (var item in jsonArray.ToArray())
+                {
+                    StripTitles(item);
+                }
+
+                break;
+        }
     }
 
     /// <summary>

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_nested_property/and_a_default_value_targets_it.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_nested_property/and_a_default_value_targets_it.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_nested_property;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3949 — a default value targeting a property inside a
+/// nested object used to be written as a top-level key literally named "price.description", which the target
+/// generation's schema then discarded. The failure was silent: registration succeeded and the value simply never
+/// appeared.
+/// </summary>
+public class and_a_default_value_targets_it : given.all_dependencies
+{
+    JsonObject _upcasted;
+
+    async Task Establish()
+    {
+        _eventType = new EventType(Guid.NewGuid().ToString(), 1);
+        _content = new JsonObject { ["price"] = new JsonObject { ["amount"] = 42 } };
+
+        var gen1Schema = await JsonSchema.FromJsonAsync("{}");
+        var gen2Schema = await JsonSchema.FromJsonAsync("{}");
+
+        _eventTypesStorage.GetDefinition(_eventType.Id).Returns(new EventTypeDefinition(
+            _eventType.Id,
+            EventTypeOwner.None,
+            false,
+            [
+                new EventTypeGenerationDefinition(1, gen1Schema),
+                new EventTypeGenerationDefinition(2, gen2Schema)
+            ],
+            [
+                new EventTypeMigrationDefinition(
+                    1,
+                    2,
+                    [],
+                    new JsonObject
+                    {
+                        ["price.description"] = new JsonObject { [WellKnownExpressions.DefaultValue] = "unspecified" }
+                    },
+                    [])
+            ]));
+
+        _expandoObjectConverter
+            .ToExpandoObject(Arg.Any<JsonObject>(), gen2Schema)
+            .Returns(callInfo =>
+            {
+                _upcasted = callInfo.Arg<JsonObject>();
+                return new ExpandoObject();
+            });
+    }
+
+    async Task Because() => await _eventTypeMigrations.MigrateToAllGenerations(_eventStoreName, _eventType, _content, _contentAsExpandoObject);
+
+    [Fact] void should_have_upcasted() => _upcasted.ShouldNotBeNull();
+    [Fact] void should_write_the_default_inside_the_nested_object() => _upcasted["price"]!["description"]!.GetValue<string>().ShouldEqual("unspecified");
+    [Fact] void should_not_write_a_dotted_top_level_key() => _upcasted.ContainsKey("price.description").ShouldBeFalse();
+    [Fact] void should_keep_the_existing_nested_value() => _upcasted["price"]!["amount"]!.GetValue<int>().ShouldEqual(42);
+}

--- a/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_nested_property/and_a_rename_moves_a_value_into_it.cs
+++ b/Source/Kernel/Core.Specs/EventSequences/Migrations/for_EventTypeMigrations/when_migrating_with_a_nested_property/and_a_rename_moves_a_value_into_it.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Dynamic;
+using System.Text.Json.Nodes;
+using Cratis.Chronicle.Concepts;
+using Cratis.Chronicle.Concepts.Events;
+using Cratis.Chronicle.Schemas;
+
+namespace Cratis.Chronicle.EventSequences.Migrations.for_EventTypeMigrations.when_migrating_with_a_nested_property;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3949 — a rename addressing either end of the move by
+/// a nested path resolved to nothing, so restructuring a payload could not be expressed at all.
+/// </summary>
+public class and_a_rename_moves_a_value_into_it : given.all_dependencies
+{
+    JsonObject _upcasted;
+
+    async Task Establish()
+    {
+        _eventType = new EventType(Guid.NewGuid().ToString(), 1);
+        _content = new JsonObject { ["amount"] = 42 };
+
+        var gen1Schema = await JsonSchema.FromJsonAsync("{}");
+        var gen2Schema = await JsonSchema.FromJsonAsync("{}");
+
+        _eventTypesStorage.GetDefinition(_eventType.Id).Returns(new EventTypeDefinition(
+            _eventType.Id,
+            EventTypeOwner.None,
+            false,
+            [
+                new EventTypeGenerationDefinition(1, gen1Schema),
+                new EventTypeGenerationDefinition(2, gen2Schema)
+            ],
+            [
+                new EventTypeMigrationDefinition(
+                    1,
+                    2,
+                    [],
+                    new JsonObject
+                    {
+                        ["price.amount"] = new JsonObject { [WellKnownExpressions.Rename] = "amount" }
+                    },
+                    [])
+            ]));
+
+        _expandoObjectConverter
+            .ToExpandoObject(Arg.Any<JsonObject>(), gen2Schema)
+            .Returns(callInfo =>
+            {
+                _upcasted = callInfo.Arg<JsonObject>();
+                return new ExpandoObject();
+            });
+    }
+
+    async Task Because() => await _eventTypeMigrations.MigrateToAllGenerations(_eventStoreName, _eventType, _content, _contentAsExpandoObject);
+
+    [Fact] void should_have_upcasted() => _upcasted.ShouldNotBeNull();
+    [Fact] void should_write_the_value_into_the_nested_object() => _upcasted["price"]!["amount"]!.GetValue<int>().ShouldEqual(42);
+    [Fact] void should_not_write_a_dotted_top_level_key() => _upcasted.ContainsKey("price.amount").ShouldBeFalse();
+}

--- a/Source/Kernel/Core/EventSequences/Migrations/EventMigrationExpressions.cs
+++ b/Source/Kernel/Core/EventSequences/Migrations/EventMigrationExpressions.cs
@@ -25,7 +25,7 @@ internal static class EventMigrationExpressions
         var separator = config["separator"]?.GetValue<string>() ?? string.Empty;
         var part = config["part"]?.GetValue<int>() ?? 0;
 
-        if (source is null || !content.TryGetPropertyValue(source, out var sourceNode) || sourceNode is null)
+        if (source is null || !JsonPropertyPaths.TryResolve(content, source, out var sourceNode) || sourceNode is null)
             return JsonValue.Create(string.Empty);
 
         var sourceValue = sourceNode.GetValue<string>();
@@ -51,7 +51,7 @@ internal static class EventMigrationExpressions
         foreach (var source in sources)
         {
             var propertyName = source?.GetValue<string>();
-            if (propertyName != null && content.TryGetPropertyValue(propertyName, out var node) && node != null)
+            if (propertyName != null && JsonPropertyPaths.TryResolve(content, propertyName, out var node) && node != null)
             {
                 if (!first)
                     builder.Append(separator);
@@ -70,7 +70,7 @@ internal static class EventMigrationExpressions
     /// <returns>The value, or <see langword="null"/> when the source generation did not carry it.</returns>
     public static JsonNode? EvaluateRename(JsonObject content, string? oldName)
     {
-        if (oldName is null || !content.TryGetPropertyValue(oldName, out var value))
+        if (oldName is null || !JsonPropertyPaths.TryResolve(content, oldName, out var value))
             return null;
         return value?.DeepClone();
     }
@@ -93,7 +93,7 @@ internal static class EventMigrationExpressions
         value = null;
 
         var source = config["source"]?.GetValue<string>();
-        if (source is null || !content.TryGetPropertyValue(source, out var sourceNode))
+        if (source is null || !JsonPropertyPaths.TryResolve(content, source, out var sourceNode))
         {
             return false;
         }

--- a/Source/Kernel/Core/EventSequences/Migrations/EventTypeMigrations.cs
+++ b/Source/Kernel/Core/EventSequences/Migrations/EventTypeMigrations.cs
@@ -197,18 +197,22 @@ public class EventTypeMigrations(
             result = JsonNode.Parse(content.ToJsonString())?.AsObject() ?? new JsonObject();
         }
 
-        // Apply custom expression results (split / combine / rename)
+        // Apply custom expression results (split / combine / rename). The property name is a path, so a target
+        // inside a nested object is written where it belongs instead of becoming a top-level key with a dot in
+        // its name that the target generation's schema then discards (#3949).
         foreach (var (propertyName, value) in customResults)
         {
-            result[propertyName] = value?.DeepClone();
+            JsonPropertyPaths.Set(result, propertyName, value?.DeepClone());
         }
 
         // Apply default values for any properties that are absent from the result
         foreach (var (propertyName, defaultValue) in defaultValues)
         {
-            if (!result.ContainsKey(propertyName))
+            // Present-but-null still counts as present, exactly as the flat containment check it replaces did -
+            // a default fills in a property the payload does not carry, not one that carries no value.
+            if (!JsonPropertyPaths.TryResolve(result, propertyName, out _))
             {
-                result[propertyName] = defaultValue?.DeepClone();
+                JsonPropertyPaths.Set(result, propertyName, defaultValue?.DeepClone());
             }
         }
 

--- a/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
+++ b/Source/Kernel/Core/Services/EventTypes/EventTypes.cs
@@ -8,6 +8,7 @@ using Cratis.Chronicle.Concepts.Events;
 using Cratis.Chronicle.Contracts.Events;
 using Cratis.Chronicle.Events.EventSequences.Migrations;
 using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Patterns;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
@@ -282,18 +283,19 @@ internal sealed class EventTypes(
 
     static void ValidatePropertyKeys(string eventTypeId, JsonObject jmesPath, JsonSchema schema, uint generation, string direction)
     {
-        var schemaProperties = schema.ActualProperties.Select(p => p.Key).ToHashSet();
-
         foreach (var property in jmesPath)
         {
-            // DefaultValue introduces a brand-new property to the target generation.
-            // The auto-generated schema for that generation may be empty, so skip validation.
-            if (property.Value is JsonObject expr && expr.ContainsKey(WellKnownExpressions.DefaultValue))
+            // DefaultValue introduces a property to the target generation, and the auto-generated schema for that
+            // generation can be empty - so a key that resolves nowhere is only accepted when there is nothing to
+            // resolve it against. Skipping the check outright let a nested default through to a kernel that then
+            // dropped the value silently, which is worse than either outcome (#3949).
+            if (property.Value is JsonObject expr && expr.ContainsKey(WellKnownExpressions.DefaultValue) &&
+                schema.ActualProperties.Count == 0)
             {
                 continue;
             }
 
-            if (!schemaProperties.Contains(property.Key))
+            if (!SchemaDeclaresPath(schema, property.Key))
             {
                 throw new InvalidMigrationPropertyForEventType(eventTypeId, property.Key, generation, direction);
             }
@@ -302,18 +304,44 @@ internal sealed class EventTypes(
 
     static void ValidateExpressionSources(string eventTypeId, JsonObject jmesPath, JsonSchema sourceSchema, uint sourceGeneration, string direction)
     {
-        var schemaProperties = new HashSet<string>(sourceSchema.ActualProperties.Select(p => p.Key));
-
         foreach (var entry in jmesPath)
         {
             foreach (var prop in ExtractSourceProperties(entry.Value))
             {
-                if (!schemaProperties.Contains(prop))
+                if (!SchemaDeclaresPath(sourceSchema, prop))
                 {
                     throw new InvalidMigrationPropertyForEventType(eventTypeId, prop, sourceGeneration, direction);
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Gets whether a schema declares the property a dotted path addresses.
+    /// </summary>
+    /// <param name="schema">The <see cref="JsonSchema"/> to resolve within.</param>
+    /// <param name="path">The dotted property path a migration carries.</param>
+    /// <returns><see langword="true"/> when every segment of the path is declared; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// A migration built from a nested property expression carries a path rather than a name, so resolving it
+    /// against the top-level property map alone reported that the property did not exist when it existed one level
+    /// down (#3949).
+    /// </remarks>
+    static bool SchemaDeclaresPath(JsonSchema schema, string path)
+    {
+        var current = schema;
+
+        foreach (var segment in JsonPropertyPaths.Split(path))
+        {
+            if (!current.ActualProperties.TryGetValue(segment, out var property))
+            {
+                return false;
+            }
+
+            current = property.ActualSchema;
+        }
+
+        return true;
     }
 
     static IEnumerable<string> ExtractSourceProperties(JsonNode? value)

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_a_migration_targets_a_nested_property.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_a_migration_targets_a_nested_property.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+/// <summary>
+/// Regression for https://github.com/Cratis/Chronicle/issues/3949 — a migration built from a nested property
+/// expression carries a path rather than a name, and resolving it against the top-level property map alone
+/// reported that the property did not exist when it existed one level down.
+/// </summary>
+public class and_a_migration_targets_a_nested_property : given.all_dependencies
+{
+    Exception _exception;
+
+    const string SchemaGen1 = """{"type":"object","properties":{"price":{"type":"object","properties":{"amount":{"type":"number"}}}}}""";
+    const string SchemaGen2 = """{"type":"object","properties":{"price":{"type":"object","properties":{"amount":{"type":"number"},"description":{"type":"string"}}}}}""";
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 2 },
+                    Schema = SchemaGen2,
+                    Migrations =
+                    {
+                        new EventTypeMigrationDefinition
+                        {
+                            FromGeneration = 1,
+                            ToGeneration = 2,
+                            UpcastJmesPath = """{"price.description":{"$defaultValue":"unspecified"}}""",
+                            DowncastJmesPath = """{"price.amount":"@.price.amount"}"""
+                        }
+                    },
+                    Generations =
+                    {
+                        new EventTypeGenerationDefinition { Generation = 1, Schema = SchemaGen1 },
+                        new EventTypeGenerationDefinition { Generation = 2, Schema = SchemaGen2 }
+                    }
+                }
+            ]
+        }));
+
+    [Fact] void should_accept_the_nested_path() => _exception.ShouldBeNull();
+}

--- a/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_a_migration_targets_a_nested_property_that_does_not_exist.cs
+++ b/Source/Kernel/Services.Specs/Services/EventTypes/for_EventTypes/when_registering/and_a_migration_targets_a_nested_property_that_does_not_exist.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Events;
+
+namespace Cratis.Chronicle.Services.Events.for_EventTypes.when_registering;
+
+/// <summary>
+/// Resolving a nested path must still reject one that goes nowhere. A default value used to skip validation
+/// outright, which let a path the kernel could not honour through to a silent drop at conversion time (#3949).
+/// </summary>
+public class and_a_migration_targets_a_nested_property_that_does_not_exist : given.all_dependencies
+{
+    Exception _exception;
+
+    const string SchemaGen1 = """{"type":"object","properties":{"price":{"type":"object","properties":{"amount":{"type":"number"}}}}}""";
+    const string SchemaGen2 = """{"type":"object","properties":{"price":{"type":"object","properties":{"amount":{"type":"number"}}}}}""";
+
+    async Task Because() =>
+        _exception = await Catch.Exception(async () => await _subject.Register(new RegisterEventTypesRequest
+        {
+            EventStore = "test-store",
+            Types =
+            [
+                new EventTypeRegistration
+                {
+                    Type = new() { Id = "some-event", Generation = 2 },
+                    Schema = SchemaGen2,
+                    Migrations =
+                    {
+                        new EventTypeMigrationDefinition
+                        {
+                            FromGeneration = 1,
+                            ToGeneration = 2,
+                            UpcastJmesPath = """{"price.nonExistent":{"$defaultValue":"unspecified"}}""",
+                            DowncastJmesPath = "{}"
+                        }
+                    },
+                    Generations =
+                    {
+                        new EventTypeGenerationDefinition { Generation = 1, Schema = SchemaGen1 },
+                        new EventTypeGenerationDefinition { Generation = 2, Schema = SchemaGen2 }
+                    }
+                }
+            ]
+        }));
+
+    [Fact] void should_throw_invalid_migration_property() => _exception.ShouldBeOfExactType<InvalidMigrationPropertyForEventType>();
+}


### PR DESCRIPTION
# Summary

Two ways an event schema change could not be expressed. Renaming a record broke registration even with its identifier pinned, so a pure refactor crash-looped against any store a prior release had populated — and the documented escape hatch failed the same way, leaving hand-deleting registry documents as the only remedy. Separately, a migration could not address anything inside a nested value object: the operation either failed naming a property that does exist one level down, or, for a default value, succeeded and silently wrote nothing.

## Changed

- The JSON Schema `title` is no longer part of the schema comparison that guards `EventTypeSchemaChanged`. It carries the CLR record name, so comparing it made renaming a record a breaking change despite a pinned `[EventType("...")]` identifier and an unchanged property set. It stays in the stored schema for tooling (#3926)
- An event type migration can now address a property inside a nested object — `pb.DefaultValue(m => m.Price.Description, "unspecified")` writes where it belongs, and `pb.RenamedFrom(m => m.Price.Amount, e => e.Amount)` moves a top-level value into the object it now belongs to. Registration validates such a path segment by segment and rejects one that resolves nowhere (#3949)
- A `DefaultValue` whose target the generation's schema does not declare is now rejected at registration instead of skipped. Validation still exempts a default when the target generation has no schema to resolve against (#3949)

## Fixed

- A migration built from a nested property expression no longer fails registration with `InvalidMigrationPropertyForEventType` naming a property that exists one level down (#3949)
- A `DefaultValue` targeting a nested property no longer writes a top-level key with a dot in its name that the target generation's schema then discards, leaving old events upcasting with the value missing and no error anywhere (#3949)

## Added

- Documentation for addressing a nested property in a migration, and for the case that needs no property operations at all — adding or removing an *optional* property at any depth, where the target generation's schema drives both the filling and the dropping (#3949)
