### PR TITLE
Honor [Index] on a record's positional parameter

### DIFF
--- a/Documentation/read-models/indexing.md
+++ b/Documentation/read-models/indexing.md
@@ -27,6 +27,11 @@ public record Order(
 
 The key of a read model does not need `[Index]` — the store already indexes it.
 
+Both forms declare the same thing, so `[property: Index]` on a positional parameter is equivalent to the
+shorthand above and there is no reason to prefer it. C# binds a bare attribute on a positional record
+parameter to the *parameter* rather than the property, and Chronicle looks in both places for exactly that
+reason — the same way it does for `[Subject]`.
+
 ## Nested and child properties
 
 Indexes are collected by walking the read model, so a property on a nested object or on a child

--- a/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/with_indexes_declared_on_record_parameters.cs
+++ b/Source/Clients/DotNET.Specs/ReadModels/for_ReadModels/when_registering/with_indexes_declared_on_record_parameters.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.ReadModels;
+using Cratis.Chronicle.Projections;
+
+namespace Cratis.Chronicle.ReadModels.for_ReadModels.when_registering;
+
+/// <summary>
+/// The record shorthand — <c>[Index]</c> on a positional parameter, which is the form the documentation
+/// recommends and the one everybody writes.
+/// </summary>
+/// <remarks>
+/// It collected nothing before, and did so silently: <see cref="IndexAttribute"/> is valid on a property and
+/// on a parameter, C# binds it to the parameter on a positional record, and only properties were looked at.
+/// The declaration compiled, registered, and produced no index — indistinguishable in the source from one
+/// that works. Measured on a production store, every registered read model carried an empty index list.
+/// </remarks>
+public class with_indexes_declared_on_record_parameters : given.all_dependencies_with_configured_sink
+{
+    record MyReadModel(Guid Id, [property: Index] Guid ExplicitlyOnProperty, [Index] Guid OnParameter, Guid NotIndexed);
+
+    Contracts.ReadModels.IReadModels _readModelsService;
+    RegisterManyRequest _capturedRequest;
+    IProjectionHandler _projectionHandler;
+
+    void Establish()
+    {
+        _projectionHandler = Substitute.For<IProjectionHandler>();
+        _projectionHandler.ReadModelType.Returns(typeof(MyReadModel));
+        _projectionHandler.Id.Returns(new ProjectionId(Guid.NewGuid().ToString()));
+
+        _projections.GetAllHandlers().Returns([_projectionHandler]);
+        _reducers.GetAllHandlers().Returns([]);
+
+        _readModelsService = Substitute.For<Contracts.ReadModels.IReadModels>();
+        _services.ReadModels.Returns(_readModelsService);
+        _readModelsService.When(_ => _.RegisterMany(Arg.Any<RegisterManyRequest>()))
+            .Do(_ => _capturedRequest = _.Arg<RegisterManyRequest>());
+    }
+
+    async Task Because() => await _readModels.Register();
+
+    IEnumerable<string> IndexedPaths => _capturedRequest.ReadModels[0].Indexes.Select(index => index.PropertyPath);
+
+    [Fact] void should_index_the_property_targeted_declaration() => IndexedPaths.ShouldContain("ExplicitlyOnProperty");
+    [Fact] void should_index_the_record_parameter_declaration() => IndexedPaths.ShouldContain("OnParameter");
+    [Fact] void should_not_index_an_undeclared_property() => IndexedPaths.ShouldNotContain("NotIndexed");
+    [Fact] void should_not_index_the_key() => IndexedPaths.ShouldNotContain("Id");
+}

--- a/Source/Clients/DotNET/ReadModels/ReadModels.cs
+++ b/Source/Clients/DotNET/ReadModels/ReadModels.cs
@@ -483,13 +483,20 @@ public class ReadModels(
         }
         visitedTypes.Add(type);
 
+        // The record shorthand — [Index] on a positional parameter, without the property: target. The
+        // attribute is valid on both a property and a parameter, and C# binds it to the *parameter* on a
+        // positional record whenever the attribute allows it, so looking only at properties misses the form
+        // the documentation recommends — and misses it silently, producing no index at all. The same
+        // shorthand is honored for [Subject] (see SubjectResolver), so a reader expects it here too.
+        var indexedParameterNames = IndexedParameterNames(type);
+
         foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             var propertyPath = string.IsNullOrEmpty(prefix)
                 ? namingPolicy.GetPropertyName(property.Name)
                 : $"{prefix}.{namingPolicy.GetPropertyName(property.Name)}";
 
-            if (Attribute.IsDefined(property, typeof(IndexAttribute)))
+            if (Attribute.IsDefined(property, typeof(IndexAttribute)) || indexedParameterNames.Contains(property.Name))
             {
                 indexes.Add(new IndexDefinition { PropertyPath = propertyPath });
             }
@@ -510,6 +517,17 @@ public class ReadModels(
                 // Recurse into complex types
                 CollectIndexes(propertyType, propertyPath, indexes, visitedTypes);
             }
+        }
+
+        static HashSet<string> IndexedParameterNames(Type type)
+        {
+            var primaryConstructor = type.GetConstructors().MaxBy(constructor => constructor.GetParameters().Length);
+
+            return primaryConstructor is null
+                ? []
+                : [.. primaryConstructor.GetParameters()
+                    .Where(parameter => parameter.IsDefined(typeof(IndexAttribute), inherit: false))
+                    .Select(parameter => parameter.Name!)];
         }
     }
 }


### PR DESCRIPTION
# Summary

`[Index]` on a positional record parameter — the form the documentation recommends — declared nothing. `IndexAttribute` is valid on both a property and a parameter, and C# binds a bare attribute on a positional record parameter to the *parameter*, while index collection looked only at properties.

It failed silently, which is what made it expensive: the declaration compiles, registers, and `EnsureIndexes` runs against an empty list, so an index that was never created is indistinguishable in the source from one that was. Measured on a production store, all 78 registered read models carried an empty index list and not one declared index existed.

## Fixed
- `[Index]` on a record's positional constructor parameter now declares an index, as the documentation says it does. Previously only `[property: Index]` worked, and the difference was invisible — nothing reported that a declaration had produced no index. (#3954)
