### PR TITLE
Fix Kotlin sourcesJar implicit-dependency failure on embedDescriptorSet

### DIFF
--- a/Source/Clients/Kotlin/build.gradle.kts
+++ b/Source/Clients/Kotlin/build.gradle.kts
@@ -104,3 +104,14 @@ mavenPublishing {
         }
     }
 }
+
+// The sources jar (registered by signAllPublications() above, but only once the maven-publish plugin's own
+// afterEvaluate callback runs) packages the main source set's resources, which now include the generated
+// directory embedDescriptorSet writes into - without this, Gradle's implicit-dependency validation fails the
+// build because nothing orders the two tasks relative to each other. afterEvaluate defers this until after
+// that callback has had a chance to register the task.
+afterEvaluate {
+    tasks.named("sourcesJar") {
+        dependsOn(embedDescriptorSet)
+    }
+}


### PR DESCRIPTION
### Fixed

- The Kotlin client's \`sourcesJar\` task packages the main source set's resources, which include the generated directory \`embedDescriptorSet\` writes the canonical descriptor set into. Nothing declared that task ordering for \`sourcesJar\` (only \`processResources\` had it), so Gradle's implicit-dependency validation failed the v17.0.1 release's Kotlin publish. Verified locally with \`gradle sourcesJar\` and \`gradle build\`.

This is build-script configuration only; the published Kotlin artifact's content is unaffected.