### PR TITLE
Fix Compatibility runtime closure in embedded test packages

### DIFF
--- a/.github/scripts/verify-consumer-smoke.sh
+++ b/.github/scripts/verify-consumer-smoke.sh
@@ -53,9 +53,9 @@ cat > "$WORK_DIR/nuget.config" <<CONFIG
 CONFIG
 
 # Arc floats to whatever is current, because that is what an application installing both gets today.
-# Both testing packages are included: they carry their own type registrations, and a mismatch there
-# reaches every consumer's specs rather than their production code.
-cat > "$WORK_DIR/Consumer.csproj" <<PROJECT
+# Keep separate consumers: one embedded kernel package must not supply an assembly missing from the other.
+mkdir -p "$WORK_DIR/Testing" "$WORK_DIR/XUnitIntegration"
+cat > "$WORK_DIR/Testing/Consumer.csproj" <<PROJECT
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -68,6 +68,24 @@ cat > "$WORK_DIR/Consumer.csproj" <<PROJECT
     <PackageReference Include="Cratis.Arc" Version="*" />
     <PackageReference Include="Cratis.Arc.Chronicle" Version="*" />
     <PackageReference Include="Cratis.Arc.Chronicle.Testing" Version="*" />
+    <Compile Include="../Program.cs" Link="Program.cs" />
+  </ItemGroup>
+</Project>
+PROJECT
+
+cat > "$WORK_DIR/XUnitIntegration/Consumer.csproj" <<PROJECT
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Cratis.Chronicle" Version="$CHRONICLE_VERSION" />
+    <PackageReference Include="Cratis.Chronicle.XUnit.Integration" Version="$CHRONICLE_VERSION" />
+    <PackageReference Include="Cratis.Arc" Version="*" />
+    <PackageReference Include="Cratis.Arc.Chronicle" Version="*" />
+    <Compile Include="../Program.cs" Link="Program.cs" />
   </ItemGroup>
 </Project>
 PROJECT
@@ -91,14 +109,15 @@ Console.WriteLine($"Registered {services.Count} services.");
 return 0;
 PROGRAM
 
-echo "Installing Chronicle $CHRONICLE_VERSION beside the current Arc packages and starting it..."
-if dotnet run --project "$WORK_DIR/Consumer.csproj" > "$WORK_DIR/run.log" 2>&1; then
-    tail -1 "$WORK_DIR/run.log"
-    echo "Chronicle $CHRONICLE_VERSION and the current Arc packages start together."
-    exit 0
-fi
-
-echo "::error::Chronicle $CHRONICLE_VERSION and the current Arc packages do not work together. An application installing both would fail on startup, before any of its own code runs. If Arc is behind, bump and release Arc rather than changing Chronicle."
-echo "--- output ---"
-tail -30 "$WORK_DIR/run.log"
-exit 1
+for consumer in Testing XUnitIntegration; do
+    echo "Installing Chronicle $CHRONICLE_VERSION ($consumer) beside the current Arc packages and starting it..."
+    if dotnet run --project "$WORK_DIR/$consumer/Consumer.csproj" > "$WORK_DIR/$consumer/run.log" 2>&1; then
+        tail -1 "$WORK_DIR/$consumer/run.log"
+        echo "Chronicle $CHRONICLE_VERSION ($consumer) and the current Arc packages start together."
+    else
+        echo "::error::Chronicle $CHRONICLE_VERSION ($consumer) and the current Arc packages failed consumer startup. Inspect the exception below before assigning the failure to either package family."
+        echo "--- output ---"
+        tail -30 "$WORK_DIR/$consumer/run.log"
+        exit 1
+    fi
+done

--- a/Documentation/contributing/integration-tests.md
+++ b/Documentation/contributing/integration-tests.md
@@ -20,6 +20,18 @@ When you provide no runtime arguments, the suite defaults to:
 | Client | `Integration/Client` | Runs the shared .NET integration specifications in either `inprocess` or `outofprocess` mode, with runtime storage selected through command-line arguments. |
 | API (out-of-process) | `Integration/Api` | Runs a full Chronicle server via Docker and tests the HTTP/gRPC client against it. |
 
+## Checking packed test-package startup
+
+Before publishing locally packed packages, check startup from outside the repository:
+
+```bash
+bash .github/scripts/verify-consumer-smoke.sh "$CHRONICLE_VERSION" "$LOCAL_PACKAGE_FEED"
+```
+
+Set `CHRONICLE_VERSION` to the candidate version and `LOCAL_PACKAGE_FEED` to the directory containing its NuGet packages. The check requires the .NET SDK and NuGet access, but not Docker. It starts two separate applications: one using Chronicle.Testing with Arc.Chronicle.Testing, and one using Chronicle.XUnit.Integration without either Testing package. Both must complete `AddCratisArcCore()` type discovery.
+
+Each test package carries its own embedded kernel runtime assemblies, including Compatibility. Do not add a separate Compatibility package to the consumer. Testing one package alongside the other can hide a missing runtime assembly, so keep the two consumer graphs separate. This startup check does not replace the kernel/storage integration suites below.
+
 ## Running the Tests
 
 ### From the command line

--- a/Source/Clients/Testing/Testing.csproj
+++ b/Source/Clients/Testing/Testing.csproj
@@ -22,6 +22,9 @@
             <Aliases>KernelConcepts</Aliases>
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
+        <ProjectReference Include="../../Kernel/Compatibility/Compatibility.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
         <ProjectReference Include="../../Kernel/Core/Core.csproj">
             <Aliases>KernelCore</Aliases>
             <PrivateAssets>all</PrivateAssets>

--- a/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
+++ b/Source/Clients/XUnit.Integration/XUnit.Integration.csproj
@@ -23,6 +23,9 @@
             <Aliases>KernelConcepts</Aliases>
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
+        <ProjectReference Include="../../Kernel/Compatibility/Compatibility.csproj">
+            <PrivateAssets>all</PrivateAssets>
+        </ProjectReference>
         <ProjectReference Include="../../Kernel/Core/Core.csproj">
             <Aliases>KernelCore</Aliases>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Summary

Testing and XUnit.Integration consumers now include the required Compatibility runtime assembly and start without a missing-assembly error.

## Fixed

- Include `Cratis.Chronicle.Compatibility.dll` in both Chronicle.Testing and Chronicle.XUnit.Integration so each package starts independently beside Arc (#3968).

The embedded package closure follows direct private project references. Compatibility was previously only transitive, so it was omitted from the package output and `AddCratisArcCore()` type discovery failed before consumer application code ran.

## Verification

The consumer smoke check starts two independent applications: Testing with Arc.Chronicle.Testing, and XUnit.Integration without either Testing package. Both exercise `AddCratisArcCore()`, preventing one embedded package from masking a missing assembly in the other. The pre-publication workflow packs candidate packages before running this check.

Local candidate-package controls reproduced the original missing-assembly startup failure, passed with the fix, failed when either private reference was removed, and passed again when restored. The affected projects built in Debug and Release with zero warnings and errors. Testing passed 446 specs and XUnit.Integration passed 66 specs in each configuration. Current pull-request CI is green for the full .NET integration matrix, client and gRPC verification, CodeQL, Markdown Verification, semver-label verification, spec-retention verification, and work-record verification.

## Limitations

The focused local builds disabled gRPC/proto generation and redirected proxy output; full current pull-request CI supplies the broader build and integration signal. The aggregate documentation-site check could not run because `Documentation/web/package.json` is absent in this checkout; repository Markdown Verification passed, but that is not aggregate-site proof.

Pre-merge evidence does not establish NuGet publication, Docker publication, live deployment, or downstream Ada adoption.

Fixes #3968
