### PR TITLE
Fix in-process kernel command scope isolation

### DIFF
--- a/Documentation/testing/index.mdx
+++ b/Documentation/testing/index.mdx
@@ -20,6 +20,8 @@ In Cratis applications, Chronicle tests usually sit inside [Cratis Specification
 
 Use `Cratis.Testing` instead of `Cratis.Chronicle.Testing` when the same spec also tests Arc commands.
 
+Application command execution scopes, including Chronicle transactions, belong to the outer Arc command pipeline. The in-process kernel does not discover or invoke your application's `ICommandExecutionScope` implementations when processing an event append. Your application scopes still run around the application command; you do not need to register their dependencies with the kernel test harness.
+
 ## Topics
 
 | Guide | Description |

--- a/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/AppendConsumerEvent.cs
+++ b/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/AppendConsumerEvent.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands.ModelBound;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Testing.EventSequences;
+
+namespace Cratis.Chronicle.Testing.for_InProcessCommandPipeline;
+
+[Command]
+public record AppendConsumerEvent(EventSourceId EventSourceId)
+{
+    public async Task Handle(EventScenario scenario)
+    {
+        var result = await scenario.EventLog.Append(EventSourceId, new TestEvent("from consumer"));
+        result.ShouldBeSuccessful();
+    }
+}

--- a/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/ConsumerCommandScope.cs
+++ b/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/ConsumerCommandScope.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Chronicle.Testing.for_InProcessCommandPipeline;
+
+public class ConsumerCommandScope(IConsumerScope consumerScope) : ICommandExecutionScope
+{
+    public void Begin(CommandContext context) => consumerScope.Begin(context);
+
+    public Task Complete(CommandContext context, CommandResult result)
+    {
+        consumerScope.Complete(context, result);
+        return Task.CompletedTask;
+    }
+}

--- a/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/IConsumerScope.cs
+++ b/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/IConsumerScope.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc.Commands;
+
+namespace Cratis.Chronicle.Testing.for_InProcessCommandPipeline;
+
+public interface IConsumerScope
+{
+    void Begin(CommandContext context);
+    void Complete(CommandContext context, CommandResult result);
+}

--- a/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/when_appending_from_a_consumer_command.cs
+++ b/Source/Clients/Testing.Specs/for_InProcessCommandPipeline/when_appending_from_a_consumer_command.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Arc;
+using Cratis.Arc.Commands;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Testing.EventSequences;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Chronicle.Testing.for_InProcessCommandPipeline;
+
+public class when_appending_from_a_consumer_command : Specification, IDisposable
+{
+    EventScenario _scenario;
+    ServiceProvider _provider;
+    IConsumerScope _consumerScope;
+    EventSourceId _eventSourceId;
+    CommandResult _result;
+
+    void Establish()
+    {
+        _scenario = new EventScenario();
+        _eventSourceId = EventSourceId.New();
+        _consumerScope = Substitute.For<IConsumerScope>();
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddLogging();
+        services.Configure<ArcOptions>(_ => { });
+        services.AddCratisArcCore();
+        services.AddSingleton(_scenario);
+        services.AddSingleton(_consumerScope);
+        _provider = services.BuildServiceProvider();
+    }
+
+    async Task Because() => _result = await _provider.GetRequiredService<ICommandPipeline>().Execute(new AppendConsumerEvent(_eventSourceId));
+
+    [Fact] void should_discover_the_consumer_scope_in_the_outer_pipeline() => _provider.GetRequiredService<IInstancesOf<ICommandExecutionScope>>().Select(_ => _.GetType()).ShouldContain(typeof(ConsumerCommandScope));
+    [Fact] void should_succeed() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_not_fail_resolving_consumer_dependencies() => _result.ExceptionMessages.ShouldBeEmpty();
+    [Fact] void should_begin_only_the_outer_command_scope() => _consumerScope.Received(1).Begin(Arg.Any<CommandContext>());
+    [Fact] void should_complete_only_the_outer_command_scope() => _consumerScope.Received(1).Complete(Arg.Any<CommandContext>(), Arg.Is<CommandResult>(_ => _.IsSuccess));
+    [Fact] async Task should_store_the_event_through_the_kernel_pipeline() => await _scenario.EventSequence.ShouldHaveAppendedEvent<TestEvent>(_eventSourceId, _ => _.Value == "from consumer");
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _scenario.Dispose();
+    }
+}

--- a/Source/Clients/Testing/InProcessCommandPipeline.cs
+++ b/Source/Clients/Testing/InProcessCommandPipeline.cs
@@ -9,6 +9,7 @@ using Cratis.Arc.Authorization;
 using Cratis.Arc.Commands;
 using Cratis.Chronicle.Storage;
 using Cratis.Chronicle.Testing.EventSequences;
+using Cratis.Types;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using KernelRequestCausation = KernelCore::Cratis.Chronicle.Sequences.RequestCausation;
@@ -47,6 +48,7 @@ internal static class InProcessCommandPipeline
         services.AddLogging();
         services.Configure<ArcOptions>(_ => { });
         services.AddCratisArcCore();
+        services.AddSingleton<IInstancesOf<ICommandExecutionScope>>(new KnownInstancesOf<ICommandExecutionScope>());
         services.AddSingleton(grainFactory);
         services.AddSingleton(storage);
         services.AddSingleton(jsonSerializerOptions);


### PR DESCRIPTION
## Fixed

- Chronicle in-process tests no longer run consumer command execution scopes inside the kernel pipeline; avoids missing EventStoreName resolution and unintended nested consumer transactions. (#3973)

Fixes #3973
