### PR TITLE
Fix in-process kernel test pipeline convention-DI fallback

### DIFF
--- a/Source/Clients/Testing/EventSequences/EventLogNotAvailableInKernelPipeline.cs
+++ b/Source/Clients/Testing/EventSequences/EventLogNotAvailableInKernelPipeline.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// The exception that is thrown when something calls a member of <see cref="NoOpEventLog"/> beyond
+/// <see cref="NoOpEventLog.AppendOperations"/> - the kernel's own commands append directly through the grain and
+/// never touch the client event log, so nothing should reach here.
+/// </summary>
+public class EventLogNotAvailableInKernelPipeline() : Exception(
+    "The client event log is not available inside the in-process kernel command pipeline - kernel commands append through the grain directly.");

--- a/Source/Clients/Testing/EventSequences/EventScenario.cs
+++ b/Source/Clients/Testing/EventSequences/EventScenario.cs
@@ -21,6 +21,7 @@ using Cratis.Execution;
 using Cratis.Json;
 using Cratis.Serialization;
 using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
 using InMemoryClosedStreamsConstraintStorage = Cratis.Chronicle.Storage.InMemory.Events.Constraints.ClosedStreamsConstraintStorage;
 using InMemoryEventSequenceStorage = Cratis.Chronicle.Storage.InMemory.EventSequences.EventSequenceStorage;
 using InMemoryIdentityStorage = Cratis.Chronicle.Storage.InMemory.Identities.IdentityStorage;
@@ -185,7 +186,16 @@ public class EventScenario(
                 NullLogger<KernelCore::Cratis.Chronicle.Compliance.JsonComplianceManager>.Instance),
             new ExpandoObjectConverter(new TypeFormats()));
         var sequencesService = new KernelGrpc::Cratis.Chronicle.Services.Sequences.EventSequences(
-            InProcessCommandPipeline.Create(grainFactory, storage, jsonSerializerOptions),
+            InProcessCommandPipeline.Create(
+                grainFactory,
+                storage,
+                jsonSerializerOptions,
+                services =>
+                {
+                    services.AddSingleton<IUnitOfWorkManager>(new NoOpUnitOfWorkManager());
+                    services.AddSingleton<IEventLog>(new NoOpEventLog());
+                    services.AddSingleton(Defaults.Instance.EventTypes);
+                }),
             storage,
             eventCompliance,
             jsonSerializerOptions,

--- a/Source/Clients/Testing/EventSequences/NoOpEventLog.cs
+++ b/Source/Clients/Testing/EventSequences/NoOpEventLog.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Execution;
+using Cratis.Monads;
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// Represents a no-op <see cref="IEventLog"/> for the in-process kernel command pipeline.
+/// </summary>
+/// <remarks>
+/// <c>AddCratisArcCore</c> discovers every <c>ICommandExecutionScope</c> across the whole process, not just the
+/// ones a given service collection cares about - an Arc.Chronicle consumer's transactional command scope is
+/// discovered here too, even though this pipeline only ever executes the kernel's own commands, which append
+/// directly through the grain and never touch the client event log. Without a registration, that scope falls back
+/// to auto-activating the real client <c>EventLog</c>, which needs a live connection this in-process kernel does
+/// not have. This satisfies the resolution harmlessly instead - only <see cref="AppendOperations"/> is ever
+/// actually read, to subscribe for immediate-append failures that never occur here.
+/// </remarks>
+internal sealed class NoOpEventLog : IEventLog
+{
+    /// <inheritdoc/>
+    public EventSequenceId Id => EventSequenceId.Log;
+
+    /// <inheritdoc/>
+    public IObservable<IEnumerable<AppendedEventWithResult>> AppendOperations { get; } = Observable.Never<IEnumerable<AppendedEventWithResult>>();
+
+    /// <inheritdoc/>
+    public ITransactionalEventSequence Transactional => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<IImmutableList<AppendedEvent>> GetForEventSourceIdAndEventTypes(EventSourceId eventSourceId, IEnumerable<EventType> filterEventTypes, EventStreamType? eventStreamType = default, EventStreamId? eventStreamId = default, EventSourceType? eventSourceType = default) =>
+        throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<bool> HasEventsFor(EventSourceId eventSourceId) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<IImmutableList<AppendedEvent>> GetFromSequenceNumber(EventSequenceNumber sequenceNumber, EventSourceId? eventSourceId = default, IEnumerable<EventType>? filterEventTypes = default) =>
+        throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<EventSequenceNumber> GetNextSequenceNumber() => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<EventSequenceNumber> GetTailSequenceNumber(
+        EventSourceId? eventSourceId = default,
+        EventSourceType? eventSourceType = default,
+        EventStreamType? eventStreamType = default,
+        EventStreamId? eventStreamId = default,
+        IEnumerable<EventType>? filterEventTypes = default) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<EventSequenceNumber> GetTailSequenceNumberForObserver(Type type) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<AppendResult> Append(
+        EventSourceId eventSourceId,
+        object @event,
+        EventStreamType? eventStreamType = default,
+        EventStreamId? eventStreamId = default,
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default,
+        IEnumerable<string>? tags = default,
+        ConcurrencyScope? concurrencyScope = default,
+        DateTimeOffset? occurred = default,
+        Subject? subject = default) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<AppendManyResult> AppendMany(
+        EventSourceId eventSourceId,
+        IEnumerable<object> events,
+        EventStreamType? eventStreamType = default,
+        EventStreamId? eventStreamId = default,
+        EventSourceType? eventSourceType = default,
+        CorrelationId? correlationId = default,
+        IEnumerable<string>? tags = default,
+        ConcurrencyScope? concurrencyScope = default,
+        DateTimeOffset? occurred = default,
+        Subject? subject = default) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<AppendManyResult> AppendMany(
+        IEnumerable<EventForEventSourceId> events,
+        CorrelationId? correlationId = default,
+        IEnumerable<string>? tags = default,
+        IDictionary<EventSourceId, ConcurrencyScope>? concurrencyScopes = default) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task Revise(EventSequenceNumber sequenceNumber, object @event) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task Redact(EventSequenceNumber sequenceNumber, RedactionReason reason) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task Redact(EventSourceId eventSourceId, RedactionReason reason, params Type[] clrEventTypes) => throw new EventLogNotAvailableInKernelPipeline();
+
+    /// <inheritdoc/>
+    public Task<Result<EventSequenceNumber, CompleteStreamError>> CompleteStream(EventStreamType eventStreamType, EventStreamId eventStreamId) =>
+        throw new EventLogNotAvailableInKernelPipeline();
+}

--- a/Source/Clients/Testing/EventSequences/NoOpUnitOfWorkManager.cs
+++ b/Source/Clients/Testing/EventSequences/NoOpUnitOfWorkManager.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Cratis.Chronicle.Auditing;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.EventSequences;
+using Cratis.Chronicle.EventSequences.Concurrency;
+using Cratis.Chronicle.Transactions;
+using Cratis.Execution;
+
+namespace Cratis.Chronicle.Testing.EventSequences;
+
+/// <summary>
+/// Represents a no-op <see cref="IUnitOfWorkManager"/> for the in-process kernel command pipeline.
+/// </summary>
+/// <remarks>
+/// <c>AddCratisArcCore</c> discovers every <c>ICommandExecutionScope</c> across the
+/// whole process, not just the ones a given service collection cares about - an Arc.Chronicle consumer's
+/// transactional command scope is discovered here too, even though this pipeline only ever executes the kernel's
+/// own commands, which append directly through the grain and never touch a unit of work. Without a registration,
+/// that scope falls back to auto-activating the real client <c>EventStore</c>, which needs a live connection this
+/// in-process kernel does not have. This satisfies the resolution harmlessly instead.
+/// </remarks>
+internal sealed class NoOpUnitOfWorkManager : IUnitOfWorkManager
+{
+    /// <inheritdoc/>
+    public IUnitOfWork Current => throw new NoUnitOfWorkHasBeenStarted();
+
+    /// <inheritdoc/>
+    public bool HasCurrent => false;
+
+    /// <inheritdoc/>
+    public bool TryGetFor(CorrelationId correlationId, [MaybeNullWhen(false)] out IUnitOfWork unitOfWork)
+    {
+        unitOfWork = default;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public IUnitOfWork Begin(CorrelationId correlationId) => new NoOpUnitOfWork(correlationId);
+
+    /// <inheritdoc/>
+    public void SetCurrent(IUnitOfWork unitOfWork)
+    {
+    }
+
+    sealed class NoOpUnitOfWork(CorrelationId correlationId) : IUnitOfWork
+    {
+        public bool IsCompleted => true;
+        public CorrelationId CorrelationId => correlationId;
+        public bool IsSuccess => true;
+
+        public void AddEvent(
+            EventSequenceId eventSequenceId,
+            EventSourceId eventSourceId,
+            object @event,
+            Causation causation,
+            EventStreamType? eventStreamType = default,
+            EventStreamId? eventStreamId = default,
+            EventSourceType? eventSourceType = default,
+            ConcurrencyScope? concurrencyScope = default,
+            IEnumerable<string>? tags = default,
+            DateTimeOffset? occurred = default,
+            Subject? subject = default)
+        {
+        }
+
+        public IEnumerable<object> GetEvents() => [];
+        public IEnumerable<ConstraintViolation> GetConstraintViolations() => [];
+        public IEnumerable<ConcurrencyViolation> GetConcurrencyViolations() => [];
+        public IEnumerable<AppendError> GetAppendErrors() => [];
+        public Task Commit() => Task.CompletedTask;
+        public Task Rollback() => Task.CompletedTask;
+        public void OnCompleted(Action<IUnitOfWork> callback)
+        {
+        }
+
+        public bool TryGetLastCommittedEventSequenceNumber([NotNullWhen(true)] out EventSequenceNumber? eventSequenceNumber)
+        {
+            eventSequenceNumber = default;
+            return false;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Source/Clients/Testing/Events/EventStoreForTesting.cs
+++ b/Source/Clients/Testing/Events/EventStoreForTesting.cs
@@ -43,6 +43,7 @@ using Cratis.Json;
 using Cratis.Serialization;
 using Cratis.Traces;
 using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using EventStoreSubscriptionsImpl = Cratis.Chronicle.EventStoreSubscriptions.EventStoreSubscriptions;
 using ExternalServicesImpl = Cratis.Chronicle.ExternalServices.ExternalServices;
@@ -405,7 +406,16 @@ public class EventStoreForTesting : IEventStore
             new ExpandoObjectConverter(new TypeFormats()));
 
         var sequencesService = new KernelGrpc::Cratis.Chronicle.Services.Sequences.EventSequences(
-            InProcessCommandPipeline.Create(grainFactory, storage, _jsonSerializerOptions),
+            InProcessCommandPipeline.Create(
+                grainFactory,
+                storage,
+                _jsonSerializerOptions,
+                services =>
+                {
+                    services.AddSingleton<IUnitOfWorkManager>(new NoOpUnitOfWorkManager());
+                    services.AddSingleton<IEventLog>(new NoOpEventLog());
+                    services.AddSingleton<IEventTypes>(_eventTypes);
+                }),
             storage,
             eventCompliance,
             _jsonSerializerOptions,

--- a/Source/Clients/Testing/TestingServices.cs
+++ b/Source/Clients/Testing/TestingServices.cs
@@ -31,6 +31,7 @@ using Cratis.Chronicle.Contracts.Seeding;
 using Cratis.Chronicle.Json;
 using Cratis.Chronicle.Schemas;
 using Cratis.Chronicle.Storage;
+using Cratis.Chronicle.Transactions;
 using Cratis.Traces;
 using Cratis.Types;
 using Microsoft.Extensions.DependencyInjection;
@@ -154,6 +155,17 @@ internal sealed class TestingServices : IServices
                         null!,
                         new KernelWebhookMediatorImpl(null!, jsonSerializerOptions),
                         Options.Create(new KernelCore::Cratis.Chronicle.Configuration.ChronicleOptions())));
+
+                    // AddCratisArcCore discovers every ICommandExecutionScope across the whole process, not just the
+                    // ones this pipeline cares about - an Arc.Chronicle consumer's transactional command scope is
+                    // discovered here too, even though this pipeline only ever executes the kernel's own commands,
+                    // which append directly through the grain and never touch a unit of work. Without a
+                    // registration, that scope falls back to auto-activating the real client EventStore, which
+                    // needs a live connection this in-process kernel does not have. This satisfies the resolution
+                    // harmlessly instead.
+                    services.AddSingleton<IUnitOfWorkManager>(new EventSequences.NoOpUnitOfWorkManager());
+                    services.AddSingleton<Cratis.Chronicle.EventSequences.IEventLog>(new EventSequences.NoOpEventLog());
+                    services.AddSingleton(Defaults.Instance.EventTypes);
                 }));
 
         _observers = new(() => new KernelObserversService(grainFactory, storage));


### PR DESCRIPTION
## Fixed

- Commands whose kernel-side handling depends on `IUnitOfWorkManager`, `IEventLog`, or `IEventTypes` (any consumer combining Arc.Chronicle's `TransactionalCommandScope`/`*CommandResponseValueHandler` types with `Cratis.Chronicle.Testing`) failed to resolve inside the in-process kernel command pipeline used by `EventScenario`, `EventStoreForTesting`, and `TestingServices` - those interfaces fell back to auto-activating the real client implementations, which need a live connection the in-process kernel does not have.

## Test plan

- [x] `dotnet build` (Debug/Release) - zero warnings, zero errors
- [x] Full downstream consumer spec suite (719 specs exercising `CommandScenario`, `TransactionalCommandScope`, and every `*CommandResponseValueHandler`) passes against a locally packed `Cratis.Chronicle.Testing` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)