### PR TITLE
Superseded by #4009: Publish client artifacts only after complete initialization

### DIFF
--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/given/an_artifacts_provider.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/given/an_artifacts_provider.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Chronicle.Events;
+using Cratis.Chronicle.Events.Constraints;
+using Cratis.Chronicle.Events.Migrations;
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider.given;
+
+public class an_artifacts_provider : Specification
+{
+    protected ICanProvideAssembliesForDiscovery _assembliesProvider;
+    protected DefaultClientArtifactsProvider _provider;
+    protected TypeInfo[] _definedTypes;
+
+    void Establish()
+    {
+        _definedTypes = [typeof(ClientArtifactDiscovered).GetTypeInfo(), typeof(EventTypeMigration<,>).GetTypeInfo()];
+        _assembliesProvider = Substitute.For<ICanProvideAssembliesForDiscovery>();
+        _assembliesProvider.DefinedTypes.Returns(_ => _definedTypes);
+        _provider = new(_assembliesProvider);
+    }
+
+    protected IEnumerable<Type>[] ReadArtifacts() =>
+    [
+        _provider.EventTypes,
+        _provider.Projections,
+        _provider.ModelBoundProjections,
+        _provider.Reactors,
+        _provider.ReadModelReactors,
+        _provider.Reducers,
+        _provider.ReactorMiddlewares,
+        _provider.ComplianceForTypesProviders,
+        _provider.ComplianceForPropertiesProviders,
+        _provider.AdditionalEventInformationProviders,
+        _provider.ConstraintTypes,
+        _provider.UniqueConstraints,
+        _provider.UniqueEventTypeConstraints,
+        _provider.RemoveConstraintEventTypes,
+        _provider.EventSeeders,
+        _provider.EventTypeMigrators
+    ];
+
+    /// <summary>
+    /// Represents discovery of a client artifact.
+    /// </summary>
+    /// <param name="Name">The artifact name.</param>
+    [EventType]
+    [Unique]
+    [RemoveConstraint(nameof(ClientArtifactDiscovered))]
+    public record ClientArtifactDiscovered([property: Unique] string Name);
+
+    /// <summary>
+    /// Represents discovery of a replacement client artifact during a retry.
+    /// </summary>
+    [EventType]
+    public record ReplacementClientArtifactDiscovered;
+}

--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_initializing_artifacts.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_initializing_artifacts.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Migrations;
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider;
+
+public class when_initializing_artifacts : given.an_artifacts_provider
+{
+    IEnumerable<Type>[] _artifacts;
+    IEnumerable<Type>[] _cachedArtifacts;
+    int _definitionReads;
+    int _initialDefinitionReads;
+
+    void Establish() => _assembliesProvider.DefinedTypes.Returns(_ =>
+    {
+        _definitionReads++;
+        return _definedTypes;
+    });
+
+    void Because()
+    {
+        _artifacts = ReadArtifacts();
+        _initialDefinitionReads = _definitionReads;
+        _definedTypes = [];
+        _cachedArtifacts = ReadArtifacts();
+    }
+
+    [Fact] void should_discover_event_types() => _provider.EventTypes.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+    [Fact] void should_populate_property_constraints() => _provider.UniqueConstraints.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+    [Fact] void should_populate_event_type_constraints() => _provider.UniqueEventTypeConstraints.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+    [Fact] void should_populate_removed_constraints() => _provider.RemoveConstraintEventTypes.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+    [Fact] void should_populate_the_last_artifact_collection() => _provider.EventTypeMigrators.ShouldContainOnly(typeof(EventTypeMigration<,>));
+    [Fact] void should_cache_every_artifact_collection() => _artifacts.Zip(_cachedArtifacts).All(_ => ReferenceEquals(_.First, _.Second)).ShouldBeTrue();
+    [Fact] void should_initialize_assemblies_once() => _assembliesProvider.Received(1).Initialize();
+    [Fact] void should_not_repeat_type_discovery() => _definitionReads.ShouldEqual(_initialDefinitionReads);
+}

--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_reentering_artifact_discovery.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_reentering_artifact_discovery.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider;
+
+public class when_reentering_artifact_discovery : given.an_artifacts_provider
+{
+    Exception _error;
+    IEnumerable<Type> _reentrantArtifacts;
+    IEnumerable<Type> _eventTypes;
+    int _definitionReads;
+
+    void Establish() => _assembliesProvider.DefinedTypes.Returns(_ =>
+    {
+        // The event types are already populated, but the remaining artifacts are not ready.
+        if (++_definitionReads == 2) _reentrantArtifacts = _provider.EventTypes;
+        return _definedTypes;
+    });
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _ = _provider.EventTypes);
+        _eventTypes = _provider.EventTypes;
+    }
+
+    [Fact] void should_reject_reentrant_access() => _error.ShouldNotBeNull();
+    [Fact] void should_not_expose_already_populated_artifacts() => _reentrantArtifacts.ShouldBeNull();
+    [Fact] void should_retry_initialization() => _assembliesProvider.Received(2).Initialize();
+    [Fact] void should_discover_artifacts_on_retry() => _eventTypes.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+}

--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_reentering_assembly_initialization.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_reentering_assembly_initialization.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider;
+
+public class when_reentering_assembly_initialization : given.an_artifacts_provider
+{
+    Exception _error;
+    IEnumerable<Type> _reentrantArtifacts;
+    IEnumerable<Type> _eventTypes;
+    int _attempts;
+
+    void Establish() => _assembliesProvider.When(_ => _.Initialize()).Do(_ =>
+    {
+        // Reenter only once so a missing guard fails assertions instead of overflowing the stack.
+        if (++_attempts == 1) _reentrantArtifacts = _provider.EventTypes;
+    });
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _ = _provider.EventTypes);
+        _eventTypes = _provider.EventTypes;
+    }
+
+    [Fact] void should_reject_reentrant_access() => _error.ShouldNotBeNull();
+    [Fact] void should_explain_the_initialization_cycle() => (_error?.Message).ShouldEqual("Client artifacts cannot be accessed reentrantly during initialization. Complete assembly discovery before accessing client artifacts.");
+    [Fact] void should_not_return_partial_artifacts() => _reentrantArtifacts.ShouldBeNull();
+    [Fact] void should_allow_a_later_retry() => _attempts.ShouldEqual(2);
+    [Fact] void should_discover_artifacts_on_retry() => _eventTypes.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+}

--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_retrying_failed_artifact_discovery.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_retrying_failed_artifact_discovery.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Cratis.Chronicle.Events.Migrations;
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider;
+
+public class when_retrying_failed_artifact_discovery : given.an_artifacts_provider
+{
+    Exception _failure;
+    Exception _error;
+    IEnumerable<Type> _eventTypes;
+    int _definitionReads;
+
+    void Establish()
+    {
+        _failure = new Exception("Artifact discovery failed after discovering event types.");
+        _assembliesProvider.DefinedTypes.Returns(_ =>
+        {
+            if (++_definitionReads == 2) throw _failure;
+            return _definedTypes;
+        });
+    }
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _ = _provider.EventTypes);
+        _definedTypes = [typeof(ReplacementClientArtifactDiscovered).GetTypeInfo(), typeof(EventTypeMigration<,>).GetTypeInfo()];
+        _eventTypes = _provider.EventTypes;
+    }
+
+    [Fact] void should_propagate_the_original_failure() => _error.ShouldEqual(_failure);
+    [Fact] void should_retry_assembly_initialization() => _assembliesProvider.Received(2).Initialize();
+    [Fact] void should_replace_the_unpublished_event_types() => _eventTypes.ShouldContainOnly(typeof(ReplacementClientArtifactDiscovered));
+    [Fact] void should_recompute_dependent_constraints() => _provider.UniqueConstraints.ShouldBeEmpty();
+    [Fact] void should_complete_the_last_discovery_step() => _provider.EventTypeMigrators.ShouldContainOnly(typeof(EventTypeMigration<,>));
+}

--- a/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_retrying_failed_assembly_initialization.cs
+++ b/Source/Clients/DotNET.Specs/for_DefaultClientArtifactsProvider/when_retrying_failed_assembly_initialization.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Events.Migrations;
+
+namespace Cratis.Chronicle.for_DefaultClientArtifactsProvider;
+
+public class when_retrying_failed_assembly_initialization : given.an_artifacts_provider
+{
+    Exception _failure;
+    Exception _error;
+    IEnumerable<Type> _eventTypes;
+    int _attempts;
+
+    void Establish()
+    {
+        _failure = new Exception("Assembly discovery failed.");
+        _assembliesProvider.When(_ => _.Initialize()).Do(_ =>
+        {
+            if (++_attempts == 1) throw _failure;
+        });
+    }
+
+    void Because()
+    {
+        _error = Catch.Exception(() => _ = _provider.EventTypes);
+        _eventTypes = _provider.EventTypes;
+    }
+
+    [Fact] void should_propagate_the_original_failure() => _error.ShouldEqual(_failure);
+    [Fact] void should_retry_assembly_initialization() => _attempts.ShouldEqual(2);
+    [Fact] void should_not_cache_an_empty_snapshot() => _eventTypes.ShouldContainOnly(typeof(ClientArtifactDiscovered));
+    [Fact] void should_complete_all_discovery_steps_on_retry() => _provider.EventTypeMigrators.ShouldContainOnly(typeof(EventTypeMigration<,>));
+}

--- a/Source/Clients/DotNET/DefaultClientArtifactsProvider.cs
+++ b/Source/Clients/DotNET/DefaultClientArtifactsProvider.cs
@@ -21,6 +21,8 @@ namespace Cratis.Chronicle;
 /// </summary>
 /// <remarks>
 /// This will use type discovery through the provided <see cref="ICanProvideAssembliesForDiscovery"/>.
+/// Concurrent readers wait until all artifacts have been initialized. Failed initialization is retried on the next access.
+/// Accessing artifacts from the initializing thread before initialization completes throws <see cref="ReentrantClientArtifactsInitialization"/>.
 /// </remarks>
 /// <remarks>
 /// Initializes a new instance of the <see cref="DefaultClientArtifactsProvider"/> class.
@@ -39,7 +41,8 @@ public class DefaultClientArtifactsProvider(ICanProvideAssembliesForDiscovery as
 #else
     readonly Lock _initLock = new();
 #endif
-    bool _initialized;
+    volatile bool _initialized;
+    bool _initializing;
     IEnumerable<Type> _eventTypes = [];
     IEnumerable<Type> _projections = [];
     IEnumerable<Type> _modelBoundProjections = [];
@@ -217,6 +220,10 @@ public class DefaultClientArtifactsProvider(ICanProvideAssembliesForDiscovery as
         }
     }
 
+    /// <summary>
+    /// Ensures that all artifacts are initialized before they are published to readers.
+    /// </summary>
+    /// <exception cref="ReentrantClientArtifactsInitialization">Artifact access reenters initialization on the initializing thread.</exception>
     void EnsureInitialized()
     {
         if (_initialized) return;
@@ -225,24 +232,37 @@ public class DefaultClientArtifactsProvider(ICanProvideAssembliesForDiscovery as
         {
             if (_initialized) return;
 
-            _initialized = true;
-            assembliesProvider.Initialize();
-            _eventTypes = assembliesProvider.DefinedTypes.Where(_ => _.HasAttribute<EventTypeAttribute>() || _.HasAttribute<EventTypeGenerationForAttribute>()).ToArray();
-            _complianceForTypesProviders = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(ICanProvideComplianceMetadataForType) && _.IsAssignableTo(typeof(ICanProvideComplianceMetadataForType))).ToArray();
-            _complianceForPropertiesProviders = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(ICanProvideComplianceMetadataForProperty) && _.IsAssignableTo(typeof(ICanProvideComplianceMetadataForProperty))).ToArray();
-            _projections = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IProjectionFor<>))).ToArray();
-            _modelBoundProjections = assembliesProvider.DefinedTypes.Where(_ => _.HasModelBoundProjectionAttributes()).ToArray();
-            _reactors = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReactor>() && !_.IsGenericType).ToArray();
-            _readModelReactors = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReadModelReactor>() && !_.IsGenericType).ToArray();
-            _reactorMiddlewares = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReactorMiddleware>()).ToArray();
-            _reducers = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IReducerFor<>)) && !_.IsGenericType).ToArray();
-            _additionalEventInformationProviders = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<ICanProvideAdditionalEventInformation>()).ToArray();
-            _constraintTypes = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(IConstraint) && _.IsAssignableTo(typeof(IConstraint))).ToArray();
-            _uniqueConstraints = _eventTypes.Where(_ => _.GetProperties().Any(p => p.HasAttribute<UniqueAttribute>())).ToArray();
-            _uniqueEventTypeConstraints = _eventTypes.Where(_ => _.HasAttribute<UniqueAttribute>()).ToArray();
-            _removeConstraintEventTypes = _eventTypes.Where(_ => _.HasAttribute<RemoveConstraintAttribute>()).ToArray();
-            _eventSeeders = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<ICanSeedEvents>()).ToArray();
-            _eventTypeMigrators = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IEventTypeMigrationFor<>))).ToArray();
+            // Only the initializing thread can reenter this lock; other readers wait for it.
+            if (_initializing) throw new ReentrantClientArtifactsInitialization();
+
+            _initializing = true;
+            try
+            {
+                assembliesProvider.Initialize();
+                _eventTypes = assembliesProvider.DefinedTypes.Where(_ => _.HasAttribute<EventTypeAttribute>() || _.HasAttribute<EventTypeGenerationForAttribute>()).ToArray();
+                _complianceForTypesProviders = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(ICanProvideComplianceMetadataForType) && _.IsAssignableTo(typeof(ICanProvideComplianceMetadataForType))).ToArray();
+                _complianceForPropertiesProviders = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(ICanProvideComplianceMetadataForProperty) && _.IsAssignableTo(typeof(ICanProvideComplianceMetadataForProperty))).ToArray();
+                _projections = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IProjectionFor<>))).ToArray();
+                _modelBoundProjections = assembliesProvider.DefinedTypes.Where(_ => _.HasModelBoundProjectionAttributes()).ToArray();
+                _reactors = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReactor>() && !_.IsGenericType).ToArray();
+                _readModelReactors = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReadModelReactor>() && !_.IsGenericType).ToArray();
+                _reactorMiddlewares = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<IReactorMiddleware>()).ToArray();
+                _reducers = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IReducerFor<>)) && !_.IsGenericType).ToArray();
+                _additionalEventInformationProviders = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<ICanProvideAdditionalEventInformation>()).ToArray();
+                _constraintTypes = assembliesProvider.DefinedTypes.Where(_ => _ != typeof(IConstraint) && _.IsAssignableTo(typeof(IConstraint))).ToArray();
+                _uniqueConstraints = _eventTypes.Where(_ => _.GetProperties().Any(p => p.HasAttribute<UniqueAttribute>())).ToArray();
+                _uniqueEventTypeConstraints = _eventTypes.Where(_ => _.HasAttribute<UniqueAttribute>()).ToArray();
+                _removeConstraintEventTypes = _eventTypes.Where(_ => _.HasAttribute<RemoveConstraintAttribute>()).ToArray();
+                _eventSeeders = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface<ICanSeedEvents>()).ToArray();
+                _eventTypeMigrators = assembliesProvider.DefinedTypes.Where(_ => _.HasInterface(typeof(IEventTypeMigrationFor<>))).ToArray();
+
+                // Publish all artifact arrays together only after every discovery step succeeds.
+                _initialized = true;
+            }
+            finally
+            {
+                _initializing = false;
+            }
         }
     }
 }

--- a/Source/Clients/DotNET/ReentrantClientArtifactsInitialization.cs
+++ b/Source/Clients/DotNET/ReentrantClientArtifactsInitialization.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Cratis.Chronicle;
+
+/// <summary>
+/// The exception that is thrown when client artifact discovery accesses artifacts on the initializing thread before initialization completes.
+/// </summary>
+public class ReentrantClientArtifactsInitialization()
+    : Exception("Client artifacts cannot be accessed reentrantly during initialization. Complete assembly discovery before accessing client artifacts.");


### PR DESCRIPTION
<!-- chronicle-pr-resolution-3996 -->
> **Superseded — not a merge candidate.**

The client artifact publication fix, retry/reentrancy coverage, and added concurrent-reader regression were included in #4009 and shipped in v18.1.0. The old missing-label and Docker checks belong to this obsolete branch; the release passed its required checks. Do not merge it separately.

Closure is pending the repository's package-cleanup access safeguards. The branch is retained to avoid losing historical work.

---

## Fixed

- Keep client artifact discovery complete and retryable after initialization failures (#3994).
- Reject reentrant discovery access instead of exposing partially initialized artifacts (#3994).
