### PR TITLE
Take the current type universe in the .NET client

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Yarp" Version="13.4.6" />
     <!-- Cratis -->
-    <PackageVersion Include="Cratis.Fundamentals" Version="7.18.2" />
-    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.18.1" />
+    <PackageVersion Include="Cratis.Fundamentals" Version="7.19.1" />
+    <PackageVersion Include="Cratis.Metrics.Roslyn" Version="7.19.1" />
     <PackageVersion Include="Cratis.Arc" Version="22.7.0" />
     <PackageVersion Include="Cratis.Arc.Core" Version="22.7.0" />
     <PackageVersion Include="Cratis.Arc.EntityFrameworkCore" Version="22.7.0" />

--- a/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_derived_types_for_the_current_universe.cs
+++ b/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_derived_types_for_the_current_universe.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+
+namespace Cratis.Chronicle.for_TypeUniverse;
+
+public class when_getting_derived_types_for_the_current_universe : Specification
+{
+    IDerivedTypes _result;
+    IDerivedTypes _resultOfSecondCall;
+
+    void Because()
+    {
+        _result = TypeUniverse.CurrentDerivedTypes();
+        _resultOfSecondCall = TypeUniverse.CurrentDerivedTypes();
+    }
+
+    [Fact] void should_not_be_the_static_snapshot() => ReferenceEquals(_result, DerivedTypes.Instance).ShouldBeFalse();
+    [Fact] void should_reuse_the_instance_built_for_the_same_universe() => ReferenceEquals(_result, _resultOfSecondCall).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_a_container_with_type_discovery.cs
+++ b/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_a_container_with_type_discovery.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Chronicle.for_TypeUniverse;
+
+public class when_getting_the_universe_for_a_container_with_type_discovery : Specification
+{
+    ITypes _types;
+    ServiceProvider _serviceProvider;
+    ITypes _result;
+
+    void Establish()
+    {
+        _types = Substitute.For<ITypes>();
+        _serviceProvider = new ServiceCollection().AddSingleton(_types).BuildServiceProvider();
+    }
+
+    void Because() => _result = TypeUniverse.For(_serviceProvider);
+
+    void Destroy() => _serviceProvider.Dispose();
+
+    [Fact] void should_return_the_universe_from_the_container() => ReferenceEquals(_result, _types).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_a_container_without_type_discovery.cs
+++ b/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_a_container_without_type_discovery.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Chronicle.for_TypeUniverse;
+
+public class when_getting_the_universe_for_a_container_without_type_discovery : Specification
+{
+    ServiceProvider _serviceProvider;
+    ITypes _result;
+    ITypes _current;
+
+    void Establish() => _serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+    void Because()
+    {
+        _result = TypeUniverse.For(_serviceProvider);
+        _current = TypesServiceCollectionExtensions.CurrentTypeUniverse();
+    }
+
+    void Destroy() => _serviceProvider.Dispose();
+
+    [Fact] void should_return_the_current_type_universe() => ReferenceEquals(_result, _current).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_the_default_service_provider.cs
+++ b/Source/Clients/DotNET.Specs/for_TypeUniverse/when_getting_the_universe_for_the_default_service_provider.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Chronicle.for_TypeUniverse;
+
+public class when_getting_the_universe_for_the_default_service_provider : Specification
+{
+    DefaultServiceProvider _serviceProvider;
+    ITypes _result;
+    ITypes _current;
+
+    void Establish() => _serviceProvider = new DefaultServiceProvider();
+
+    void Because()
+    {
+        _result = TypeUniverse.For(_serviceProvider);
+        _current = TypesServiceCollectionExtensions.CurrentTypeUniverse();
+    }
+
+    [Fact] void should_return_the_current_type_universe() => ReferenceEquals(_result, _current).ShouldBeTrue();
+}

--- a/Source/Clients/DotNET/ChronicleClient.cs
+++ b/Source/Clients/DotNET/ChronicleClient.cs
@@ -312,9 +312,10 @@ public class ChronicleClient : IChronicleClient, IDisposable
             { ProcessMetadataKey, Environment.ProcessPath ?? string.Empty }
         });
 
+        var types = TypeUniverse.For(_serviceProvider);
         var complianceMetadataResolver = new ComplianceMetadataResolver(
-            new InstancesOf<ICanProvideComplianceMetadataForType>(Types.Types.Instance, _serviceProvider),
-            new InstancesOf<ICanProvideComplianceMetadataForProperty>(Types.Types.Instance, _serviceProvider));
+            new InstancesOf<ICanProvideComplianceMetadataForType>(types, _serviceProvider),
+            new InstancesOf<ICanProvideComplianceMetadataForProperty>(types, _serviceProvider));
         var jsonSchemaGenerator = new JsonSchemaGenerator(complianceMetadataResolver, _namingPolicy);
         var concurrencyScopeStrategies = new ConcurrencyScopeStrategies(Options.ConcurrencyOptions, _serviceProvider);
         var artifactActivator = new ClientArtifactsActivator(_serviceProvider, _loggerFactory);

--- a/Source/Clients/DotNET/EventStore.cs
+++ b/Source/Clients/DotNET/EventStore.cs
@@ -123,6 +123,7 @@ public class EventStore : IEventStore
         _correlationIdAccessor = correlationIdAccessor;
         _concurrencyScopeStrategies = concurrencyScopeStrategies;
         _activitySource = serviceProvider.GetRequiredKeyedService<IActivitySource<EventSequence>>(ClientActivity.SourceName);
+        var types = TypeUniverse.For(serviceProvider);
         EventTypes = new EventTypes(this, schemaGenerator, clientArtifactsProvider, eventTypeMigrators, enableEventTypeGenerationValidation);
         UnitOfWorkManager = new UnitOfWorkManager(
             this,
@@ -172,7 +173,7 @@ public class EventStore : IEventStore
             identityProvider,
             serviceProvider.GetRequiredKeyedService<IActivitySource<Reactors.Reactors>>(ClientActivity.SourceName),
             reactorSideEffectHandlers,
-            new ReactorContextValuesBuilder(new InstancesOf<IReactorContextValuesProvider>(Types.Types.Instance, serviceProvider)),
+            new ReactorContextValuesBuilder(new InstancesOf<IReactorContextValuesProvider>(types, serviceProvider)),
             new ReactorMethodArgumentsResolver(),
             loggerFactory.CreateLogger<Reactors.Reactors>(),
             loggerFactory);
@@ -235,7 +236,7 @@ public class EventStore : IEventStore
 
         var readModelReactorInvoker = new ReadModels.ReadModelReactorInvoker(
             reactorSideEffectHandlers,
-            new ReactorContextValuesBuilder(new InstancesOf<IReactorContextValuesProvider>(Types.Types.Instance, serviceProvider)),
+            new ReactorContextValuesBuilder(new InstancesOf<IReactorContextValuesProvider>(types, serviceProvider)),
             loggerFactory.CreateLogger<ReadModels.ReadModelReactorInvoker>());
 
         ReadModelReactors = new ReadModels.ReadModelReactors(

--- a/Source/Clients/DotNET/Events/EventSerializer.cs
+++ b/Source/Clients/DotNET/Events/EventSerializer.cs
@@ -30,7 +30,7 @@ public class EventSerializer : IEventSerializer
     /// <param name="artifactActivator"><see cref="IServiceProvider"/> for resolving instances.</param>
     /// <param name="eventTypes"><see cref="IEventTypes"/> for resolving event types.</param>
     /// <param name="serializerOptions">The common <see creF="JsonSerializerOptions"/>.</param>
-    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> for serializing polymorphic event content adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the global <see cref="DerivedTypes.Instance"/>.</param>
+    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> for serializing polymorphic event content adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the derived types of the current type universe.</param>
     public EventSerializer(
         IClientArtifactsProvider clientArtifacts,
         IClientArtifactsActivator artifactActivator,
@@ -53,7 +53,7 @@ public class EventSerializer : IEventSerializer
         // discriminator and concrete subtype properties are dropped and the value serializes as its base type.
         if (!_serializerOptions.Converters.Any(converter => converter is DerivedTypeJsonConverterFactory))
         {
-            _serializerOptions.Converters.Add(new DerivedTypeJsonConverterFactory(derivedTypes ?? DerivedTypes.Instance));
+            _serializerOptions.Converters.Add(new DerivedTypeJsonConverterFactory(derivedTypes ?? TypeUniverse.CurrentDerivedTypes()));
         }
 
         var providers = new List<ICanProvideAdditionalEventInformation>();

--- a/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
+++ b/Source/Clients/DotNET/Projections/ModelBound/ChildrenDefinitionExtensions.cs
@@ -742,7 +742,7 @@ static class ChildrenDefinitionExtensions
             return childType;
         }
 
-        var implementations = Types.Types.Instance.All
+        var implementations = TypeUniverse.Current.All
             .Where(type => !type.IsAbstract && !type.IsInterface &&
                            childType.IsAssignableFrom(type) &&
                            Attribute.IsDefined(type, typeof(DerivedTypeAttribute)))

--- a/Source/Clients/DotNET/Reactors/SideEffects/EventStoreReactorSideEffectHandlerInstances.cs
+++ b/Source/Clients/DotNET/Reactors/SideEffects/EventStoreReactorSideEffectHandlerInstances.cs
@@ -21,7 +21,7 @@ internal sealed class EventStoreReactorSideEffectHandlerInstances(IServiceProvid
         typeof(MixedSideEffectsResultHandler)
     ];
 
-    readonly Type[] _otherHandlerTypes = Types.Types.Instance
+    readonly Type[] _otherHandlerTypes = TypeUniverse.For(serviceProvider)
         .FindMultiple<IReactorSideEffectHandler>()
         .Where(type => !_eventTypeRegistryHandlerTypes.Contains(type))
         .ToArray();

--- a/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
+++ b/Source/Clients/DotNET/Schemas/JsonSchemaGenerator.cs
@@ -34,11 +34,11 @@ public class JsonSchemaGenerator : IJsonSchemaGenerator
     /// </summary>
     /// <param name="metadataResolver"><see cref="IComplianceMetadataResolver"/> for resolving metadata.</param>
     /// <param name="namingPolicy"><see cref="INamingPolicy"/> to use for converting names during serialization.</param>
-    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> used to recognize polymorphic base types adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the global <see cref="DerivedTypes.Instance"/>.</param>
+    /// <param name="derivedTypes"><see cref="IDerivedTypes"/> used to recognize polymorphic base types adorned with <see cref="DerivedTypeAttribute"/>. Defaults to the derived types of the current type universe.</param>
     public JsonSchemaGenerator(IComplianceMetadataResolver metadataResolver, INamingPolicy namingPolicy, IDerivedTypes? derivedTypes = null)
     {
         _metadataResolver = metadataResolver;
-        _derivedTypes = derivedTypes ?? DerivedTypes.Instance;
+        _derivedTypes = derivedTypes ?? TypeUniverse.CurrentDerivedTypes();
         _typeFormats = new TypeFormats();
 
         var resolver = new DefaultJsonTypeInfoResolver();

--- a/Source/Clients/DotNET/TypeUniverse.cs
+++ b/Source/Clients/DotNET/TypeUniverse.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Serialization;
+using Cratis.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cratis.Chronicle;
+
+/// <summary>
+/// Resolves the set of types the client discovers artifacts and providers from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Cratis.Types.Types.Instance"/> and <see cref="Cratis.Serialization.DerivedTypes.Instance"/>
+/// are static fields, so each is a snapshot of the generated type-discovery registry taken the first time
+/// anything touches it. Generated providers register from module initializers that only run once the
+/// assembly closure walk reaches their assembly, and that walk happens after such a first touch - so a
+/// client reading those statics can hold a universe missing every provider the walk brings in later. It
+/// fails silently: a shorter <see cref="ITypes.FindMultiple{T}"/> result is indistinguishable from a
+/// feature nobody wrote.
+/// </para>
+/// <para>
+/// A host wired through dependency injection has an <see cref="ITypes"/> in its container, and that one is
+/// authoritative for it. A bare <see cref="ChronicleClient"/> has no container to ask and takes Fundamentals'
+/// current default universe instead - the same instance <c>AddTypeDiscovery()</c> registers, rebuilt when
+/// the registered provider set grows.
+/// </para>
+/// </remarks>
+internal static class TypeUniverse
+{
+    static CachedDerivedTypes? _derivedTypes;
+
+    /// <summary>
+    /// Gets the current default type universe, outside any container.
+    /// </summary>
+    internal static ITypes Current => TypesServiceCollectionExtensions.CurrentTypeUniverse();
+
+    /// <summary>
+    /// Gets the type universe for a service provider - the one in its container when it has one, and the
+    /// current default universe when it does not.
+    /// </summary>
+    /// <param name="serviceProvider"><see cref="IServiceProvider"/> to get the universe for.</param>
+    /// <returns>The <see cref="ITypes"/> to discover from.</returns>
+    internal static ITypes For(IServiceProvider serviceProvider)
+    {
+        // DefaultServiceProvider answers IsService with true for every type and activates by default
+        // constructor, so asking it for an interface throws rather than resolving. It is the "no container"
+        // case by construction, so it is excluded here rather than probed.
+        if (serviceProvider is not DefaultServiceProvider &&
+            serviceProvider.GetService(typeof(IServiceProviderIsService)) is IServiceProviderIsService serviceProviderIsService &&
+            serviceProviderIsService.IsService(typeof(ITypes)) &&
+            serviceProvider.GetService(typeof(ITypes)) is ITypes types)
+        {
+            return types;
+        }
+
+        return Current;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="IDerivedTypes"/> for the current default type universe.
+    /// </summary>
+    /// <returns>The <see cref="IDerivedTypes"/> to resolve polymorphic types with.</returns>
+    /// <remarks>
+    /// Building one walks every discovered type, so the result is held for as long as the universe it was
+    /// built from is the current one - which is for the rest of the process once the provider set settles.
+    /// </remarks>
+    internal static IDerivedTypes CurrentDerivedTypes()
+    {
+        var types = Current;
+        var cached = Volatile.Read(ref _derivedTypes);
+        if (cached is not null && ReferenceEquals(cached.Universe, types))
+        {
+            return cached.DerivedTypes;
+        }
+
+        var derivedTypes = new DerivedTypes(types);
+        Volatile.Write(ref _derivedTypes, new CachedDerivedTypes(types, derivedTypes));
+        return derivedTypes;
+    }
+
+    sealed record CachedDerivedTypes(ITypes Universe, IDerivedTypes DerivedTypes);
+}


### PR DESCRIPTION
## Changed

- `Cratis.Fundamentals` and `Cratis.Metrics.Roslyn` move to 7.19.1 (#3998)

## Fixed

- The .NET client no longer reads the static type-universe snapshot, so reactor context value providers, compliance metadata providers, reactor side-effect handlers and polymorphic `[DerivedType]` children in assemblies discovered after its first touch are found instead of silently missed (#3998)
