### PR TITLE
Leave unreadable event values unconverted instead of failing the partition

### DIFF
--- a/Source/Kernel/Core.Specs/Projections/Engine/Expressions/EventValues/for_EventValueProviderExpressionResolvers/when_converting_a_string_the_target_type_cannot_read.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Expressions/EventValues/for_EventValueProviderExpressionResolvers/when_converting_a_string_the_target_type_cannot_read.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Projections.Engine.Expressions;
+using Cratis.Chronicle.Schemas;
+using Microsoft.Extensions.Logging;
+
+namespace Cratis.Chronicle.Projections.Engine.Expressions.EventValues.for_EventValueProviderExpressionResolvers;
+
+public class when_converting_a_string_the_target_type_cannot_read : given.an_appended_event
+{
+    EventValueProviderExpressionResolvers _resolvers;
+    object _result;
+
+    void Establish()
+    {
+        _resolvers = new(new TypeFormats(), Substitute.For<ILogger<EventValueProviderExpressionResolvers>>());
+        ((IDictionary<string, object?>)@event.Content)["Payload"] = "acme-renamed";
+    }
+
+    void Because() => _result = _resolvers.Resolve(new JsonSchemaProperty { Type = JsonObjectType.String, Format = "object-id" }, "Payload")(@event);
+
+    [Fact] void should_leave_the_value_unconverted() => _result.ShouldEqual("acme-renamed");
+}

--- a/Source/Kernel/Core.Specs/Projections/Engine/Expressions/EventValues/for_EventValueProviderExpressionResolvers/when_converting_a_string_the_target_type_cannot_read.cs
+++ b/Source/Kernel/Core.Specs/Projections/Engine/Expressions/EventValues/for_EventValueProviderExpressionResolvers/when_converting_a_string_the_target_type_cannot_read.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Cratis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Cratis.Chronicle.Projections.Engine.Expressions;
 using Cratis.Chronicle.Schemas;
 using Microsoft.Extensions.Logging;
 

--- a/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -59,6 +59,24 @@ public partial class EventValueProviderExpressionResolvers(ITypeFormats typeForm
             return null!;
         }
 
+        if (input is string text && schemaProperty.Type == JsonObjectType.String)
+        {
+            // A value that cannot be converted is left as-is rather than thrown over: historical
+            // events can legitimately carry values no current type reads (renamed identifiers,
+            // deleted lookups), and a read-side key resolver must survive them. Conversions that
+            // already succeed keep working; only the hard TypeConversion.Convert failure - a
+            // FormatException, InvalidCast or NotSupported shape - degrades to the raw value.
+            try
+            {
+                return TypeConversion.Convert(schemaProperty.GetTargetTypeForJsonSchemaProperty(typeFormats) ?? typeof(string), input);
+            }
+            catch (Exception ex) when (ex is FormatException or InvalidCastException or NotSupportedException)
+            {
+                logger.EventValueLeftUnconverted(text, schemaProperty.Name, ex.Message);
+                return input;
+            }
+        }
+
         if (input is ExpandoObject)
         {
             var expandoObject = (input as IDictionary<string, object>)!;

--- a/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolversLogging.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolversLogging.cs
@@ -16,4 +16,7 @@ internal static partial class EventValueProviderExpressionResolversLogging
 {
     [LoggerMessage(LogLevel.Error, "Unsupported event value expression: {Expression} for target property type: {TargetPropertyType}")]
     internal static partial void UnsupportedEventValueExpression(this ILogger<EventValueProviderExpressionResolvers> logger, string expression, JsonObjectType targetPropertyType);
+
+    [LoggerMessage(LogLevel.Warning, "Leaving event value '{Value}' unconverted for schema property {Name}: {Reason}")]
+    internal static partial void EventValueLeftUnconverted(this ILogger<EventValueProviderExpressionResolvers> logger, string value, string name, string reason);
 }


### PR DESCRIPTION
## Summary

A historical event can legitimately carry a key value no current type reads: the Studio hierarchy read model keys projects by a string property whose schema format resolves to a Guid, and a project renamed after the key scheme changed replays `ProjectRenamed('Acme Renamed')` through it. `Convert()` threw `FormatException` out of the key resolver, which quarantines the partition and freezes every consumer behind it - Studio lost two Backend Specs checks to exactly this, on content unrelated to the change under test.

For string inputs where the target-typed conversion fails, the resolver now logs and yields the raw value - the read model sees the identifier as it was stored. Successful conversions are untouched. Covered by a spec asserting an unreadable value passes through as-is.
