### PR TITLE
Never let the graceful string conversion throw its own cast

### DIFF
--- a/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
+++ b/Source/Kernel/Core/Projections/Engine/Expressions/EventValues/EventValueProviderExpressionResolvers.cs
@@ -66,15 +66,20 @@ public partial class EventValueProviderExpressionResolvers(ITypeFormats typeForm
             // deleted lookups), and a read-side key resolver must survive them. Conversions that
             // already succeed keep working; only the hard TypeConversion.Convert failure - a
             // FormatException, InvalidCast or NotSupported shape - degrades to the raw value.
+            // Throwing from the graceful path itself is never acceptable - this runs inside the
+            // partition-consuming pipeline, and any exception there quarantines the partition.
+            string converted;
             try
             {
-                return TypeConversion.Convert(schemaProperty.GetTargetTypeForJsonSchemaProperty(typeFormats) ?? typeof(string), input);
+                converted = (string)TypeConversion.Convert(schemaProperty.GetTargetTypeForJsonSchemaProperty(typeFormats) ?? typeof(string), input);
             }
             catch (Exception ex) when (ex is FormatException or InvalidCastException or NotSupportedException)
             {
                 logger.EventValueLeftUnconverted(text, schemaProperty.Name, ex.Message);
                 return input;
             }
+
+            return converted;
         }
 
         if (input is ExpandoObject)


### PR DESCRIPTION
## Summary

Follow-up tightening on #4022: the graceful conversion path itself could throw its own cast back into the partition-consuming pipeline. A Guid-targeted value that converted by some path demanded the string form back for the key, and the cast lived outside the guard. The branch now converts-and-casts inside the try, so any failure of either step yields the stored value.

Verified: Testing.Specs 518/518, Core.Specs event-value resolvers green.
