### PR TITLE
Preserve empty and populated query results after deserialization

### DIFF
--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/given/an_event_sequence_with_a_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/given/an_event_sequence_with_a_wire_response.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using ProtoBuf;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.given;
+
+public class an_event_sequence_with_a_wire_response : an_event_sequence
+{
+    protected QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>> _wireResponse;
+
+    protected void RespondWith(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>> response)
+    {
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, response);
+        stream.Position = 0;
+        _wireResponse = Serializer.Deserialize<QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>>(stream);
+
+        _sequences.FromSequenceNumber(Arg.Any<Contracts.Sequences.FromSequenceNumberRequest>(), CallContext.Default).Returns(_wireResponse);
+        _sequences.ForEventSourceIdAndEventTypes(Arg.Any<Contracts.Sequences.ForEventSourceIdAndEventTypesRequest>(), CallContext.Default).Returns(_wireResponse);
+    }
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/and_deserializing_events.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/and_deserializing_events.cs
@@ -9,7 +9,7 @@ using ProtoBuf.Grpc;
 
 namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
 
-public class and_deserializing_events : given.an_event_sequence
+public class and_deserializing_events : given.an_event_sequence_with_a_wire_response
 {
     EventSourceId _eventSourceId;
     List<EventType> _eventTypes;
@@ -52,7 +52,8 @@ public class and_deserializing_events : given.an_event_sequence
                 CorrelationId = Guid.NewGuid(),
                 Causation = [],
                 CausedBy = new Contracts.Sequences.Identity(),
-                Tags = []
+                Tags = [],
+                Subject = $"synthetic-subject-{idx}"
             },
             Content = JsonSerializer.Serialize(evt, JsonSerializerOptions.Default)
         }).ToList();
@@ -61,9 +62,7 @@ public class and_deserializing_events : given.an_event_sequence
             .When(_ => _.ForEventSourceIdAndEventTypes(Arg.Any<Contracts.Sequences.ForEventSourceIdAndEventTypesRequest>(), CallContext.Default))
             .Do(callInfo => _request = callInfo.Arg<Contracts.Sequences.ForEventSourceIdAndEventTypesRequest>());
 
-        _sequences
-            .ForEventSourceIdAndEventTypes(Arg.Any<Contracts.Sequences.ForEventSourceIdAndEventTypesRequest>(), CallContext.Default)
-            .Returns(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.NewGuid(), contractEvents));
+        RespondWith(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.NewGuid(), contractEvents));
     }
 
     async Task Because() => _result = await _eventSequence.GetForEventSourceIdAndEventTypes(_eventSourceId, _eventTypes);
@@ -73,6 +72,10 @@ public class and_deserializing_events : given.an_event_sequence
     [Fact] void should_pass_event_types() => _request.EventTypeIds.ShouldEqual(string.Join(',', _eventTypes.Select(_ => _.Id.Value)));
     [Fact] void should_return_correct_number_of_events() => _result.Count.ShouldEqual(_expectedEvents.Count);
     [Fact] void should_deserialize_all_events_correctly() => _result.Select(e => (e.Content as TestEvent)?.Name).ShouldEqual(_expectedEvents.Select(e => e.Name));
+    [Fact] void should_deserialize_all_event_values_correctly() => _result.Select(e => ((TestEvent)e.Content).Value).ShouldEqual(_expectedEvents.Select(e => e.Value));
+    [Fact] void should_preserve_the_subjects() => _result.Select(e => e.Context.Subject.Value).ShouldEqual(["synthetic-subject-0", "synthetic-subject-1"]);
+    [Fact] void should_preserve_empty_tags() => _result.SelectMany(e => e.Context.Tags).ShouldBeEmpty();
+    [Fact] void should_preserve_empty_causation() => _result.SelectMany(e => e.Context.Causation).ShouldBeEmpty();
 
     record TestEvent(string Name, int Value);
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_a_failed_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_a_failed_wire_response.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
+
+public class with_a_failed_wire_response : given.an_event_sequence_with_a_wire_response
+{
+    Exception _error;
+
+    void Establish() => RespondWith(new() { ExceptionMessages = ["Synthetic query failure"] });
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []));
+
+    [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
+    [Fact] void should_receive_no_data() => _wireResponse.Data.ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_a_transport_failure.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_a_transport_failure.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Grpc.Core;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
+
+public class with_a_transport_failure : given.an_event_sequence
+{
+    RpcException _transportError;
+    Exception _error;
+
+    void Establish()
+    {
+        _transportError = new(new Status(StatusCode.Unavailable, "Synthetic transport failure"));
+        _sequences.ForEventSourceIdAndEventTypes(Arg.Any<Contracts.Sequences.ForEventSourceIdAndEventTypesRequest>(), CallContext.Default)
+            .Returns(Task.FromException<QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>>(_transportError));
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []));
+
+    [Fact] void should_preserve_the_transport_failure() => _error.ShouldEqual(_transportError);
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_empty_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_empty_wire_response.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
+
+public class with_an_empty_wire_response : given.an_event_sequence_with_a_wire_response
+{
+    IImmutableList<AppendedEvent> _result;
+
+    void Establish() => RespondWith(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.Empty, []));
+
+    async Task Because() => _result = await _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []);
+
+    [Fact] void should_receive_a_successful_query() => _wireResponse.IsSuccess.ShouldBeTrue();
+    [Fact] void should_receive_an_absent_repeated_field() => _wireResponse.Data.ShouldBeNull();
+    [Fact] void should_return_an_empty_history() => _result.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_empty_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_empty_wire_response.cs
@@ -16,6 +16,6 @@ public class with_an_empty_wire_response : given.an_event_sequence_with_a_wire_r
     async Task Because() => _result = await _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []);
 
     [Fact] void should_receive_a_successful_query() => _wireResponse.IsSuccess.ShouldBeTrue();
-    [Fact] void should_receive_an_absent_repeated_field() => _wireResponse.Data.ShouldBeNull();
+    [Fact] void should_deserialize_an_empty_collection() => _wireResponse.Data.ShouldBeEmpty();
     [Fact] void should_return_an_empty_history() => _result.ShouldBeEmpty();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_invalid_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_invalid_wire_response.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Cratis.Chronicle.Contracts.Queries;
-using Cratis.Chronicle.Events;
 
-namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
 
 public class with_an_invalid_wire_response : given.an_event_sequence_with_a_wire_response
 {
@@ -12,7 +11,7 @@ public class with_an_invalid_wire_response : given.an_event_sequence_with_a_wire
 
     void Establish() => RespondWith(new() { ValidationResults = [new() { Message = "Synthetic validation failure" }] });
 
-    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []));
 
     [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
     [Fact] void should_preserve_the_validation_results() => ((QueryFailed)_error).ValidationResults.ShouldEqual(_wireResponse.ValidationResults);

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_unauthorized_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_for_event_source_id_and_event_types/with_an_unauthorized_wire_response.cs
@@ -5,15 +5,14 @@ using Cratis.Chronicle.Contracts.Queries;
 
 namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_for_event_source_id_and_event_types;
 
-public class with_a_failed_wire_response : given.an_event_sequence_with_a_wire_response
+public class with_an_unauthorized_wire_response : given.an_event_sequence_with_a_wire_response
 {
     Exception _error;
 
-    void Establish() => RespondWith(new() { ExceptionMessages = ["Synthetic query failure"], ExceptionStackTrace = "Synthetic originating stack" });
+    void Establish() => RespondWith(new() { IsAuthorized = false });
 
     async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetForEventSourceIdAndEventTypes("synthetic-source", []));
 
     [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
-    [Fact] void should_preserve_the_exception_messages() => ((QueryFailed)_error).ExceptionMessages.ShouldEqual(_wireResponse.ExceptionMessages);
-    [Fact] void should_preserve_the_originating_stack() => ((QueryFailed)_error).ExceptionStackTrace.ShouldEqual(_wireResponse.ExceptionStackTrace);
+    [Fact] void should_remain_unauthorized() => _wireResponse.IsAuthorized.ShouldBeFalse();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/and_deserializing_single_event.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/and_deserializing_single_event.cs
@@ -9,7 +9,7 @@ using ProtoBuf.Grpc;
 
 namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
 
-public class and_deserializing_single_event : given.an_event_sequence
+public class and_deserializing_single_event : given.an_event_sequence_with_a_wire_response
 {
     EventSequenceNumber _sequenceNumber;
     EventType _eventType;
@@ -40,7 +40,8 @@ public class and_deserializing_single_event : given.an_event_sequence
                 CorrelationId = Guid.NewGuid(),
                 Causation = [],
                 CausedBy = new Contracts.Sequences.Identity(),
-                Tags = []
+                Tags = [],
+                Subject = "synthetic-subject"
             },
             Content = JsonSerializer.Serialize(_expectedEvent, JsonSerializerOptions.Default)
         };
@@ -49,9 +50,7 @@ public class and_deserializing_single_event : given.an_event_sequence
             .When(_ => _.FromSequenceNumber(Arg.Any<Contracts.Sequences.FromSequenceNumberRequest>(), CallContext.Default))
             .Do(callInfo => _request = callInfo.Arg<Contracts.Sequences.FromSequenceNumberRequest>());
 
-        _sequences
-            .FromSequenceNumber(Arg.Any<Contracts.Sequences.FromSequenceNumberRequest>(), CallContext.Default)
-            .Returns(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.NewGuid(), [contractEvent]));
+        RespondWith(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.NewGuid(), [contractEvent]));
     }
 
     async Task Because() => _result = await _eventSequence.GetFromSequenceNumber(_sequenceNumber);
@@ -59,6 +58,9 @@ public class and_deserializing_single_event : given.an_event_sequence
     [Fact] void should_call_service() => _request.ShouldNotBeNull();
     [Fact] void should_pass_correct_sequence_number() => _request.FromEventSequenceNumber.ShouldEqual((ulong)_sequenceNumber);
     [Fact] void should_return_one_event() => _result.Count.ShouldEqual(1);
+    [Fact] void should_preserve_the_subject() => _result[0].Context.Subject.Value.ShouldEqual("synthetic-subject");
+    [Fact] void should_preserve_empty_tags() => _result[0].Context.Tags.ShouldBeEmpty();
+    [Fact] void should_preserve_empty_causation() => _result[0].Context.Causation.ShouldBeEmpty();
     [Fact] void should_deserialize_content_correctly() => ((_result[0].Content as TestEvent)?.Name).ShouldEqual(_expectedEvent.Name);
     [Fact] void should_deserialize_content_value_correctly() => ((_result[0].Content as TestEvent)?.Value).ShouldEqual(_expectedEvent.Value);
     [Fact] void should_return_event_with_correct_context() => _result[0].Context.SequenceNumber.ShouldEqual(_sequenceNumber);

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_a_failed_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_a_failed_wire_response.cs
@@ -6,14 +6,15 @@ using Cratis.Chronicle.Events;
 
 namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
 
-public class with_an_invalid_wire_response : given.an_event_sequence_with_a_wire_response
+public class with_a_failed_wire_response : given.an_event_sequence_with_a_wire_response
 {
     Exception _error;
 
-    void Establish() => RespondWith(new() { ValidationResults = [new() { Message = "Synthetic validation failure" }] });
+    void Establish() => RespondWith(new() { ExceptionMessages = ["Synthetic query failure"], ExceptionStackTrace = "Synthetic originating stack" });
 
     async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
 
     [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
-    [Fact] void should_preserve_the_validation_results() => ((QueryFailed)_error).ValidationResults.ShouldEqual(_wireResponse.ValidationResults);
+    [Fact] void should_preserve_the_exception_messages() => ((QueryFailed)_error).ExceptionMessages.ShouldEqual(_wireResponse.ExceptionMessages);
+    [Fact] void should_preserve_the_originating_stack() => ((QueryFailed)_error).ExceptionStackTrace.ShouldEqual(_wireResponse.ExceptionStackTrace);
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_a_transport_failure.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_a_transport_failure.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Events;
+using Grpc.Core;
+using ProtoBuf.Grpc;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
+
+public class with_a_transport_failure : given.an_event_sequence
+{
+    RpcException _transportError;
+    Exception _error;
+
+    void Establish()
+    {
+        _transportError = new(new Status(StatusCode.Unavailable, "Synthetic transport failure"));
+        _sequences.FromSequenceNumber(Arg.Any<Contracts.Sequences.FromSequenceNumberRequest>(), CallContext.Default)
+            .Returns(Task.FromException<QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>>(_transportError));
+    }
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
+
+    [Fact] void should_preserve_the_transport_failure() => _error.ShouldEqual(_transportError);
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_empty_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_empty_wire_response.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
+
+public class with_an_empty_wire_response : given.an_event_sequence_with_a_wire_response
+{
+    IImmutableList<AppendedEvent> _result;
+
+    void Establish() => RespondWith(QueryResult<IEnumerable<Contracts.Sequences.AppendedEventResponse>>.Success(Guid.Empty, []));
+
+    async Task Because() => _result = await _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First);
+
+    [Fact] void should_receive_a_successful_query() => _wireResponse.IsSuccess.ShouldBeTrue();
+    [Fact] void should_receive_an_absent_repeated_field() => _wireResponse.Data.ShouldBeNull();
+    [Fact] void should_return_an_empty_history() => _result.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_empty_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_empty_wire_response.cs
@@ -16,6 +16,6 @@ public class with_an_empty_wire_response : given.an_event_sequence_with_a_wire_r
     async Task Because() => _result = await _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First);
 
     [Fact] void should_receive_a_successful_query() => _wireResponse.IsSuccess.ShouldBeTrue();
-    [Fact] void should_receive_an_absent_repeated_field() => _wireResponse.Data.ShouldBeNull();
+    [Fact] void should_deserialize_an_empty_collection() => _wireResponse.Data.ShouldBeEmpty();
     [Fact] void should_return_an_empty_history() => _result.ShouldBeEmpty();
 }

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_invalid_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_invalid_wire_response.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
+
+public class with_an_invalid_wire_response : given.an_event_sequence_with_a_wire_response
+{
+    Exception _error;
+
+    void Establish() => RespondWith(new() { ValidationResults = [new() { Message = "Synthetic validation failure" }] });
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
+
+    [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
+    [Fact] void should_receive_no_data() => _wireResponse.Data.ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_unauthorized_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_unauthorized_wire_response.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Events;
+
+namespace Cratis.Chronicle.EventSequences.for_EventSequence.when_getting_from_sequence_number;
+
+public class with_an_unauthorized_wire_response : given.an_event_sequence_with_a_wire_response
+{
+    Exception _error;
+
+    void Establish() => RespondWith(new() { IsAuthorized = false });
+
+    async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
+
+    [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
+    [Fact] void should_receive_no_data() => _wireResponse.Data.ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_unauthorized_wire_response.cs
+++ b/Source/Clients/DotNET.Specs/EventSequences/for_EventSequence/when_getting_from_sequence_number/with_an_unauthorized_wire_response.cs
@@ -15,5 +15,5 @@ public class with_an_unauthorized_wire_response : given.an_event_sequence_with_a
     async Task Because() => _error = await Catch.Exception(() => _eventSequence.GetFromSequenceNumber(EventSequenceNumber.First));
 
     [Fact] void should_preserve_the_query_failure() => _error.ShouldBeOfExactType<QueryFailed>();
-    [Fact] void should_receive_no_data() => _wireResponse.Data.ShouldBeNull();
+    [Fact] void should_remain_unauthorized() => _wireResponse.IsAuthorized.ShouldBeFalse();
 }

--- a/Source/Clients/DotNET.Specs/Queries/for_QueryResult/given/collection_query_results.cs
+++ b/Source/Clients/DotNET.Specs/Queries/for_QueryResult/given/collection_query_results.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Contracts.Sequences;
+using ProtoBuf;
+
+namespace Cratis.Chronicle.Queries.for_QueryResult.given;
+
+public class collection_query_results : Specification
+{
+    protected static QueryResult<IEnumerable<AppendedEventResponse>> RoundTrip(params AppendedEventResponse[] events)
+    {
+        var before = QueryResult<IEnumerable<AppendedEventResponse>>.Success(Guid.Empty, events);
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, before);
+        stream.Position = 0;
+        return Serializer.Deserialize<QueryResult<IEnumerable<AppendedEventResponse>>>(stream);
+    }
+}

--- a/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_mutating_a_collection/with_another_query_result.cs
+++ b/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_mutating_a_collection/with_another_query_result.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Contracts.Sequences;
+
+namespace Cratis.Chronicle.Queries.for_QueryResult.when_mutating_a_collection;
+
+public class with_another_query_result : Specification
+{
+    QueryResult<IEnumerable<AppendedEventResponse>> _first;
+    QueryResult<IEnumerable<AppendedEventResponse>> _second;
+    QueryResult<IEnumerable<AppendedEventResponse>> _createdAfterMutation;
+    AppendedEventResponse _event;
+
+    void Establish()
+    {
+        _first = new();
+        _second = new();
+        _event = new() { Content = """{"name":"added"}""", Context = new() { Subject = "added-subject" } };
+    }
+
+    void Because()
+    {
+        ((ICollection<AppendedEventResponse>)_first.Data).Add(_event);
+        _createdAfterMutation = new();
+    }
+
+    [Fact] void should_add_the_event_to_the_first_result() => _first.Data.ShouldEqual([_event]);
+    [Fact] void should_not_change_another_existing_result() => _second.Data.ShouldBeEmpty();
+    [Fact] void should_not_change_the_default_for_later_results() => _createdAfterMutation.Data.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_a_missing_single_entity.cs
+++ b/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_a_missing_single_entity.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Contracts.Sequences;
+using ProtoBuf;
+
+namespace Cratis.Chronicle.Queries.for_QueryResult.when_round_tripping;
+
+public class with_a_missing_single_entity : Specification
+{
+    QueryResult<AppendedEventResponse?> _result;
+
+    void Because()
+    {
+        var before = QueryResult<AppendedEventResponse?>.Success(Guid.Empty, null);
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, before);
+        stream.Position = 0;
+        _result = Serializer.Deserialize<QueryResult<AppendedEventResponse?>>(stream);
+    }
+
+    [Fact] void should_stay_successful() => _result.IsSuccess.ShouldBeTrue();
+    [Fact] void should_preserve_the_missing_entity() => _result.EnsureSuccess().ShouldBeNull();
+}

--- a/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_concurrent_collections.cs
+++ b/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_concurrent_collections.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Contracts.Sequences;
+
+namespace Cratis.Chronicle.Queries.for_QueryResult.when_round_tripping;
+
+public class with_concurrent_collections : given.collection_query_results
+{
+    QueryResult<IEnumerable<AppendedEventResponse>>[] _results;
+    QueryResult<IEnumerable<AppendedEventResponse>> _empty;
+
+    async Task Because()
+    {
+        _results = await Task.WhenAll(Enumerable.Range(0, 8).Select(index => Task.Run(() => RoundTrip(new AppendedEventResponse
+        {
+            Content = $$"""{"index":{{index}}}""",
+            Context = new() { Subject = $"subject-{index}" }
+        })))).WaitAsync(TimeSpan.FromSeconds(10));
+        _empty = RoundTrip();
+    }
+
+    [Fact] void should_keep_each_results_own_content() => _results.Select(_ => _.Data.Single().Content).ShouldEqual(Enumerable.Range(0, 8).Select(index => $$"""{"index":{{index}}}"""));
+    [Fact] void should_keep_each_results_own_subject() => _results.Select(_ => _.Data.Single().Context.Subject).ShouldEqual(Enumerable.Range(0, 8).Select(index => $"subject-{index}"));
+    [Fact] void should_return_an_empty_collection_after_concurrent_results() => _empty.Data.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_successive_collections.cs
+++ b/Source/Clients/DotNET.Specs/Queries/for_QueryResult/when_round_tripping/with_successive_collections.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Cratis. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Cratis.Chronicle.Contracts.Queries;
+using Cratis.Chronicle.Contracts.Sequences;
+
+namespace Cratis.Chronicle.Queries.for_QueryResult.when_round_tripping;
+
+public class with_successive_collections : given.collection_query_results
+{
+    QueryResult<IEnumerable<AppendedEventResponse>> _first;
+    QueryResult<IEnumerable<AppendedEventResponse>> _second;
+    QueryResult<IEnumerable<AppendedEventResponse>> _empty;
+
+    void Because()
+    {
+        _first = RoundTrip(new AppendedEventResponse { Content = """{"name":"first"}""", Context = new() { Subject = "first-subject" } });
+        _second = RoundTrip(new AppendedEventResponse { Content = """{"name":"second"}""", Context = new() { Subject = "second-subject" } });
+        _empty = RoundTrip();
+    }
+
+    [Fact] void should_keep_only_the_first_content_in_the_first_result() => _first.Data.Select(_ => _.Content).ShouldEqual(["""{"name":"first"}"""]);
+    [Fact] void should_keep_only_the_first_subject_in_the_first_result() => _first.Data.Select(_ => _.Context.Subject).ShouldEqual(["first-subject"]);
+    [Fact] void should_keep_only_the_second_content_in_the_second_result() => _second.Data.Select(_ => _.Content).ShouldEqual(["""{"name":"second"}"""]);
+    [Fact] void should_keep_only_the_second_subject_in_the_second_result() => _second.Data.Select(_ => _.Context.Subject).ShouldEqual(["second-subject"]);
+    [Fact] void should_return_an_empty_collection_after_populated_results() => _empty.Data.ShouldBeEmpty();
+}

--- a/Source/Clients/DotNET/Events/AppendedEventConverters.cs
+++ b/Source/Clients/DotNET/Events/AppendedEventConverters.cs
@@ -94,19 +94,19 @@ internal static class AppendedEventConverters
     /// <summary>
     /// Convert to a client version of a collection of <see cref="Contracts.Sequences.AppendedEventResponse"/>.
     /// </summary>
-    /// <param name="events">Collection of <see cref="Contracts.Sequences.AppendedEventResponse"/> to convert from.</param>
+    /// <param name="events">Successful query data; protobuf represents an empty repeated field as null.</param>
     /// <param name="eventStore">The <see cref="EventStoreName"/> the events belong to.</param>
     /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the events belong to.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes"/> for resolving event types.</param>
     /// <param name="jsonSerializerOptions">JSON serializer options to use.</param>
     /// <returns>An immutable collection of <see cref="AppendedEvent"/>.</returns>
     internal static IImmutableList<AppendedEvent> ToClient(
-        this IEnumerable<Contracts.Sequences.AppendedEventResponse> events,
+        this IEnumerable<Contracts.Sequences.AppendedEventResponse>? events,
         EventStoreName eventStore,
         EventStoreNamespaceName @namespace,
         IEventTypes eventTypes,
         JsonSerializerOptions jsonSerializerOptions) =>
-        events.Select(_ => _.ToClient(eventStore, @namespace, eventTypes, jsonSerializerOptions)).ToImmutableList();
+        (events ?? []).Select(_ => _.ToClient(eventStore, @namespace, eventTypes, jsonSerializerOptions)).ToImmutableList();
 
     /// <summary>
     /// Convert to a client version of a collection of <see cref="Contracts.ReadModelExplorer.Event"/>.

--- a/Source/Clients/DotNET/Events/AppendedEventConverters.cs
+++ b/Source/Clients/DotNET/Events/AppendedEventConverters.cs
@@ -94,19 +94,19 @@ internal static class AppendedEventConverters
     /// <summary>
     /// Convert to a client version of a collection of <see cref="Contracts.Sequences.AppendedEventResponse"/>.
     /// </summary>
-    /// <param name="events">Successful query data; protobuf represents an empty repeated field as null.</param>
+    /// <param name="events">Collection of <see cref="Contracts.Sequences.AppendedEventResponse"/> to convert from.</param>
     /// <param name="eventStore">The <see cref="EventStoreName"/> the events belong to.</param>
     /// <param name="namespace">The <see cref="EventStoreNamespaceName"/> the events belong to.</param>
     /// <param name="eventTypes">The <see cref="IEventTypes"/> for resolving event types.</param>
     /// <param name="jsonSerializerOptions">JSON serializer options to use.</param>
     /// <returns>An immutable collection of <see cref="AppendedEvent"/>.</returns>
     internal static IImmutableList<AppendedEvent> ToClient(
-        this IEnumerable<Contracts.Sequences.AppendedEventResponse>? events,
+        this IEnumerable<Contracts.Sequences.AppendedEventResponse> events,
         EventStoreName eventStore,
         EventStoreNamespaceName @namespace,
         IEventTypes eventTypes,
         JsonSerializerOptions jsonSerializerOptions) =>
-        (events ?? []).Select(_ => _.ToClient(eventStore, @namespace, eventTypes, jsonSerializerOptions)).ToImmutableList();
+        events.Select(_ => _.ToClient(eventStore, @namespace, eventTypes, jsonSerializerOptions)).ToImmutableList();
 
     /// <summary>
     /// Convert to a client version of a collection of <see cref="Contracts.ReadModelExplorer.Event"/>.

--- a/Source/Kernel/Contracts/Queries/QueryResult.cs
+++ b/Source/Kernel/Contracts/Queries/QueryResult.cs
@@ -12,11 +12,6 @@ namespace Cratis.Chronicle.Contracts.Queries;
 [ProtoContract]
 public class QueryResult<TData>
 {
-    static readonly TData _emptyCollectionOrDefault =
-        typeof(TData).IsGenericType && typeof(TData).GetGenericTypeDefinition() == typeof(IEnumerable<>)
-            ? (TData)(object)Array.CreateInstance(typeof(TData).GetGenericArguments()[0], 0)
-            : default!;
-
     /// <summary>
     /// Gets or sets the correlation id associated with the query.
     /// </summary>
@@ -52,7 +47,10 @@ public class QueryResult<TData>
     /// Gets or sets the data returned by the query.
     /// </summary>
     [ProtoMember(6)]
-    public TData Data { get; set; } = _emptyCollectionOrDefault;
+    public TData Data { get; set; } =
+        typeof(TData).IsGenericType && typeof(TData).GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            ? (TData)Activator.CreateInstance(typeof(List<>).MakeGenericType(typeof(TData).GetGenericArguments()[0]))!
+            : default!;
 
     /// <summary>
     /// Gets whether the query executed successfully.


### PR DESCRIPTION
## Fixed

- Preserve empty query collections after .NET client deserialization (#4025)
- Deserialize populated query collections without throwing (#4025)
- Keep query results independent across successive and concurrent queries (#4025)
