### PR TITLE
Fix cross-agent project concern links

### DIFF
--- a/.cratis/ai/rules/project.md
+++ b/.cratis/ai/rules/project.md
@@ -6,10 +6,10 @@ The canonical project context for this repository: what is true only here. Share
 
 Read every concern below before working in this repository. Together they are the project-owned instructions and override conflicting shared guidance.
 
-- [Running the local stack](project/running-the-local-stack.md)
-- [Workbench credentials (local development)](project/workbench-credentials-local-development.md)
-- [Verifying Workbench behavior](project/verifying-workbench-behavior.md)
-- [Checking the Workbench's lint](project/checking-the-workbench-s-lint.md)
-- [The wire protocol is generated from Core — don't think about the protocol](project/the-wire-protocol-is-generated-from-core-don-t-think-about-the-protocol.md)
-- [AI-assisted development](project/ai-assisted-development.md)
-- [Chronicle documentation authoring](project/chronicle-documentation-authoring.md)
+- [Running the local stack](.cratis/ai/rules/project/running-the-local-stack.md)
+- [Workbench credentials (local development)](.cratis/ai/rules/project/workbench-credentials-local-development.md)
+- [Verifying Workbench behavior](.cratis/ai/rules/project/verifying-workbench-behavior.md)
+- [Checking the Workbench's lint](.cratis/ai/rules/project/checking-the-workbench-s-lint.md)
+- [The wire protocol is generated from Core — don't think about the protocol](.cratis/ai/rules/project/the-wire-protocol-is-generated-from-core-don-t-think-about-the-protocol.md)
+- [AI-assisted development](.cratis/ai/rules/project/ai-assisted-development.md)
+- [Chronicle documentation authoring](.cratis/ai/rules/project/chronicle-documentation-authoring.md)


### PR DESCRIPTION
## Fixed
- Make every project concern link repository-root-relative so it resolves through symlinked `AGENTS.md`, `CLAUDE.md`, and native harness adapters.
- Keep every concern file project-owned and outside the managed manifest.

## Verification
- Every linked concern exists.
- `git diff --check` passes.
