### PR TITLE
Track managed Pi adapters

### DIFF
--- a/.pi/agents
+++ b/.pi/agents
@@ -1,0 +1,1 @@
+../.cratis/ai/agents

--- a/.pi/extensions
+++ b/.pi/extensions
@@ -1,0 +1,1 @@
+../.cratis/ai/harnesses/pi/extensions

--- a/.pi/prompts/add-business-rule.md
+++ b/.pi/prompts/add-business-rule.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-business-rule.prompt.md

--- a/.pi/prompts/add-concept.md
+++ b/.pi/prompts/add-concept.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-concept.prompt.md

--- a/.pi/prompts/add-ef-migration.md
+++ b/.pi/prompts/add-ef-migration.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-ef-migration.prompt.md

--- a/.pi/prompts/add-projection.md
+++ b/.pi/prompts/add-projection.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-projection.prompt.md

--- a/.pi/prompts/add-reactor.md
+++ b/.pi/prompts/add-reactor.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-reactor.prompt.md

--- a/.pi/prompts/add-reducer.md
+++ b/.pi/prompts/add-reducer.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/add-reducer.prompt.md

--- a/.pi/prompts/audit-hooks.md
+++ b/.pi/prompts/audit-hooks.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/audit-hooks.prompt.md

--- a/.pi/prompts/check-doc-drift.md
+++ b/.pi/prompts/check-doc-drift.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/check-doc-drift.prompt.md

--- a/.pi/prompts/code-review.md
+++ b/.pi/prompts/code-review.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/code-review.prompt.md

--- a/.pi/prompts/new-feature.md
+++ b/.pi/prompts/new-feature.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/new-feature.prompt.md

--- a/.pi/prompts/new-vertical-slice.md
+++ b/.pi/prompts/new-vertical-slice.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/new-vertical-slice.prompt.md

--- a/.pi/prompts/review-pr.md
+++ b/.pi/prompts/review-pr.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/review-pr.prompt.md

--- a/.pi/prompts/review-skill.md
+++ b/.pi/prompts/review-skill.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/review-skill.prompt.md

--- a/.pi/prompts/scaffold-feature.md
+++ b/.pi/prompts/scaffold-feature.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/scaffold-feature.prompt.md

--- a/.pi/prompts/ship-changes.md
+++ b/.pi/prompts/ship-changes.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/ship-changes.prompt.md

--- a/.pi/prompts/verify-ai-setup.md
+++ b/.pi/prompts/verify-ai-setup.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/verify-ai-setup.prompt.md

--- a/.pi/prompts/write-documentation.md
+++ b/.pi/prompts/write-documentation.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/write-documentation.prompt.md

--- a/.pi/prompts/write-specs.md
+++ b/.pi/prompts/write-specs.md
@@ -1,0 +1,1 @@
+../../.cratis/ai/prompts/write-specs.prompt.md

--- a/.pi/skills
+++ b/.pi/skills
@@ -1,0 +1,1 @@
+../.cratis/ai/skills


### PR DESCRIPTION
## Fixed
- Force-track the managed `.pi` adapters that the repository's existing ignore rules hid.
- Ensure Pi receives managed agents, prompts, skills, rules, hooks, and subagent support after a fresh clone.

## Verification
- `cratis ai status` reports no updates or modified managed files.
- `.pi/agents`, `.pi/extensions`, `.pi/prompts`, and `.pi/skills` resolve the shared corpus.
